### PR TITLE
refactor(container,wshandler): bring every block under rank A (T13-T18)

### DIFF
--- a/src/klangk/klangk/container/admission.py
+++ b/src/klangk/klangk/container/admission.py
@@ -128,6 +128,45 @@ MACHINE_MEMORY_TTL_SECONDS = 300.0
 machine_memory_cache: dict[str, tuple[float, int | None]] = {}
 
 
+def _machine_memory_of(entry) -> int | None:
+    """Configured machine memory in bytes when parseable and sane
+    (>= the 64 MiB unit-mismatch floor), else None."""
+    try:
+        value = int(entry["Memory"])
+    except (KeyError, TypeError, ValueError):
+        return None
+    if value < _MIN_MACHINE_MEMORY_BYTES:
+        return None
+    return value
+
+
+def _default_machine_memory(machines: list) -> int | None:
+    """Memory of the machine flagged ``Default: true``."""
+    for entry in machines:
+        if entry.get("Default") is True:
+            mem = _machine_memory_of(entry)
+            if mem is not None:
+                return mem
+    return None
+
+
+def _named_machine_memory(machines: list) -> int | None:
+    """Memory of the canonical default-named machine."""
+    for entry in machines:
+        if entry.get("Name") == "podman-machine-default":
+            mem = _machine_memory_of(entry)
+            if mem is not None:
+                return mem
+    return None
+
+
+def _single_machine_memory(machines: list) -> int | None:
+    """Memory of the one machine in an exactly-one-machine setup."""
+    if len(machines) == 1:
+        return _machine_memory_of(machines[0])
+    return None
+
+
 def _pick_machine_memory(machines) -> int | None:
     """Pick the machine whose configured memory caps the measurement.
 
@@ -140,28 +179,14 @@ def _pick_machine_memory(machines) -> int | None:
     """
     if not isinstance(machines, list) or not machines:
         return None
-
-    def memory_of(entry) -> int | None:
-        try:
-            value = int(entry["Memory"])
-        except (KeyError, TypeError, ValueError):
-            return None
-        if value < _MIN_MACHINE_MEMORY_BYTES:
-            return None
-        return value
-
-    for entry in machines:
-        if entry.get("Default") is True:
-            mem = memory_of(entry)
-            if mem is not None:
-                return mem
-    for entry in machines:
-        if entry.get("Name") == "podman-machine-default":
-            mem = memory_of(entry)
-            if mem is not None:
-                return mem
-    if len(machines) == 1:
-        return memory_of(machines[0])
+    for pick in (
+        _default_machine_memory,
+        _named_machine_memory,
+        _single_machine_memory,
+    ):
+        mem = pick(machines)
+        if mem is not None:
+            return mem
     return None
 
 
@@ -181,6 +206,30 @@ async def run_podman_json(*cmd: str):
     if proc.returncode != 0:
         raise OSError(f"{' '.join(cmd)} exited {proc.returncode}")
     return json.loads(out.decode(errors="replace"))
+
+
+def _fresh_cache_entry(
+    podman_bin: str, now
+) -> tuple[float, int | None] | None:
+    """The machine-memory cache entry when still fresh, else None."""
+    entry = machine_memory_cache.get(podman_bin)
+    if entry is None or now() - entry[0] >= MACHINE_MEMORY_TTL_SECONDS:
+        return None
+    return entry
+
+
+async def _measure_machine_memory(podman_bin: str, runner) -> int | None:
+    """Fresh machine-memory cap via ``machine ls``; None on any
+    failure (no podman, no machine, unparseable output)."""
+    if runner is None:
+        runner = run_podman_json
+    try:
+        machines = await runner(
+            podman_bin, "machine", "ls", "--format", "json"
+        )
+    except (OSError, ValueError):
+        return None
+    return _pick_machine_memory(machines)
 
 
 async def podman_machine_memory_bytes(
@@ -205,19 +254,10 @@ async def podman_machine_memory_bytes(
     """
     if _now is None:
         _now = time.monotonic
-    cached = machine_memory_cache.get(podman_bin)
-    if cached is not None and _now() - cached[0] < MACHINE_MEMORY_TTL_SECONDS:
+    cached = _fresh_cache_entry(podman_bin, _now)
+    if cached is not None:
         return cached[1]
-    if runner is None:
-        runner = run_podman_json
-    try:
-        machines = await runner(
-            podman_bin, "machine", "ls", "--format", "json"
-        )
-    except (OSError, ValueError):
-        cap = None
-    else:
-        cap = _pick_machine_memory(machines)
+    cap = await _measure_machine_memory(podman_bin, runner)
     machine_memory_cache[podman_bin] = (_now(), cap)
     return cap
 
@@ -358,6 +398,16 @@ class AdmissionControl:
             or registry.workspace_operation_in_flight(ws_id)
         )
 
+    def _committed_sibling_count(
+        self, registry, owned: list[str], workspace_id: str
+    ) -> int:
+        """Owned workspaces other than *workspace_id* holding capacity."""
+        return sum(
+            1
+            for wid in owned
+            if wid != workspace_id and self._committed(registry, wid)
+        )
+
     async def check_user_quota(self, workspace_id: str, ws: dict) -> None:
         """Refuse starts past ``max_running_workspaces_per_user``.
 
@@ -374,11 +424,7 @@ class AdmissionControl:
             return
         registry = self.app.state.container_registry
         owned = await self._owned_ids(ws.get("user_id"))
-        running = sum(
-            1
-            for wid in owned
-            if wid != workspace_id and self._committed(registry, wid)
-        )
+        running = self._committed_sibling_count(registry, owned, workspace_id)
         if running >= limit:
             raise WorkspaceCapacityError(
                 f"workspace quota reached: {running} of this user's "
@@ -409,26 +455,42 @@ class AdmissionControl:
         bound it.
         """
         registry = self.app.state.container_registry
+        owner_id = (ws or {}).get("user_id")
+        owned = await self._owned_ids(owner_id)
+        return await self._sum_sibling_limits(registry, workspace_id, owned)
+
+    async def _sum_sibling_limits(
+        self, registry, workspace_id: str, owned: list[str]
+    ) -> int:
+        """Sum the resolved limits of the owned siblings that are
+        mid-start/stop (in flight) right now."""
         committed = 0
-        owned = await self._owned_ids((ws or {}).get("user_id"))
         for wid in owned:
             if wid == workspace_id:
                 continue
             if not registry.workspace_operation_in_flight(wid):
                 continue
-            sibling = (
-                await self.app.state.model.workspaces.get_workspace_by_id(wid)
-            )
-            if sibling is None:
-                continue
-            limit = resolve_memory_limit(self.app, sibling.get("settings"))
-            if not limit:
-                continue
-            try:
-                committed += parse_size_bytes(limit)
-            except ValueError:  # pragma: no cover — validated upstream
-                continue
+            limit_bytes = await self._sibling_limit_bytes(wid)
+            if limit_bytes is not None:
+                committed += limit_bytes
         return committed
+
+    async def _sibling_limit_bytes(self, wid: str) -> int | None:
+        """Resolved memory limit (bytes) of one sibling start, or None
+        when the row is gone or its limit is unset (unbounded) — an
+        unbounded commitment cannot be quantified."""
+        sibling = await self.app.state.model.workspaces.get_workspace_by_id(
+            wid
+        )
+        if sibling is None:
+            return None
+        limit = resolve_memory_limit(self.app, sibling.get("settings"))
+        if not limit:
+            return None
+        try:
+            return parse_size_bytes(limit)
+        except ValueError:  # pragma: no cover — validated upstream
+            return None
 
     async def check_host_memory(
         self,
@@ -453,19 +515,8 @@ class AdmissionControl:
         # Parsed outside the measurement guard: a malformed limit string
         # is a config error (surfaced as such), not "unmeasurable".
         limit_bytes = parse_size_bytes(limit)
-        try:
-            available = await available_memory_bytes(
-                self.app.state.settings.podman_bin or "podman"
-            )
-        except (OSError, ValueError) as e:
-            if not self._warned_unmeasurable:
-                self._warned_unmeasurable = True
-                logger.warning(
-                    "Admission memory check degraded: cannot measure host "
-                    "memory availability (%s); allowing starts without "
-                    "the capacity check",
-                    e,
-                )
+        available = await self._measure_available_bytes()
+        if available is None:
             return
         # A measurement that works again re-arms the warning.
         self._warned_unmeasurable = False
@@ -484,3 +535,21 @@ class AdmissionControl:
                 "free host memory, or lower the workspace memory limit "
                 "(KLANGKD_CONTAINER_MEMORY_LIMIT)."
             )
+
+    async def _measure_available_bytes(self) -> int | None:
+        """Available host memory bytes, or None when unmeasurable on
+        this platform (fail-open, with a one-time degradation warning)."""
+        try:
+            return await available_memory_bytes(
+                self.app.state.settings.podman_bin or "podman"
+            )
+        except (OSError, ValueError) as e:
+            if not self._warned_unmeasurable:
+                self._warned_unmeasurable = True
+                logger.warning(
+                    "Admission memory check degraded: cannot measure host "
+                    "memory availability (%s); allowing starts without "
+                    "the capacity check",
+                    e,
+                )
+            return None

--- a/src/klangk/klangk/container/crash.py
+++ b/src/klangk/klangk/container/crash.py
@@ -79,6 +79,41 @@ _SIGNAL_NAMES = {
 _DEAD_STATES = frozenset({"exited", "stopped", "dead"})
 
 
+def _oom_death(memory_limit: str | None, exit_code) -> tuple[str, str]:
+    """(cause, message) for an OOM kill, naming the limit when known."""
+    if memory_limit:
+        return (
+            "oom",
+            f"OOM-killed at {memory_limit} memory limit "
+            f"(exit code {exit_code})",
+        )
+    return "oom", f"OOM-killed (exit code {exit_code})"
+
+
+def _signal_death(exit_code: int) -> tuple[str, str] | None:
+    """(cause, message) when the exit code is a signal death (128+n),
+    else None."""
+    if exit_code <= 128:
+        return None
+    signal_name = _SIGNAL_NAMES.get(exit_code - 128)
+    if signal_name is None:
+        return None
+    return "exited", f"killed by {signal_name} (exit code {exit_code})"
+
+
+def _exit_death(exit_code) -> tuple[str, str]:
+    """(cause, message) for a plain (non-OOM) process exit."""
+    if exit_code is None:
+        return "exited", "main process exited (no exit code recorded)"
+    if exit_code == 0:
+        return "exited", "main process exited cleanly (code 0)"
+    if isinstance(exit_code, int):
+        signal = _signal_death(exit_code)
+        if signal is not None:
+            return signal
+    return "exited", f"main process exited with code {exit_code}"
+
+
 def classify_death(
     info: dict | None, memory_limit: str | None = None
 ) -> tuple[str, str]:
@@ -97,22 +132,8 @@ def classify_death(
     state = info.get("State") or {}
     exit_code = state.get("ExitCode")
     if state.get("OOMKilled"):
-        if memory_limit:
-            return (
-                "oom",
-                f"OOM-killed at {memory_limit} memory limit "
-                f"(exit code {exit_code})",
-            )
-        return "oom", f"OOM-killed (exit code {exit_code})"
-    if exit_code is None:
-        return "exited", "main process exited (no exit code recorded)"
-    if exit_code == 0:
-        return "exited", "main process exited cleanly (code 0)"
-    if isinstance(exit_code, int) and exit_code > 128:
-        signal_name = _SIGNAL_NAMES.get(exit_code - 128)
-        if signal_name:
-            return "exited", f"killed by {signal_name} (exit code {exit_code})"
-    return "exited", f"main process exited with code {exit_code}"
+        return _oom_death(memory_limit, exit_code)
+    return _exit_death(exit_code)
 
 
 class RestartTracker:
@@ -133,18 +154,20 @@ class RestartTracker:
         self.next_attempt_at: float | None = None
         self.gave_up_at: float | None = None
 
+    def _phase(self) -> str:
+        """The tracker's display state."""
+        if self.gave_up_at is not None:
+            return "crash-loop"
+        if self.next_attempt_at is not None:
+            return "backing-off"
+        if self.last_started_at is not None:
+            return "recovering"
+        return "dead"
+
     def status(self) -> dict:
         """API shape for the /status endpoint and list annotation."""
-        if self.gave_up_at is not None:
-            state = "crash-loop"
-        elif self.next_attempt_at is not None:
-            state = "backing-off"
-        elif self.last_started_at is not None:
-            state = "recovering"
-        else:
-            state = "dead"
         out: dict = {
-            "state": state,
+            "state": self._phase(),
             "attempts": self.attempts,
             "last_cause": self.last_cause,
         }
@@ -344,16 +367,12 @@ class CrashRecoveryMonitor:
         reset the tracker of a stable survivor."""
         registry = self.app.state.container_registry
         # Post-await revalidation: skip anything the world moved under.
-        if registry.states.get(ws_id) is not state:
-            return  # state replaced/removed (rebind, user start/stop)
-        if state.container_id != cid:
-            return  # rebound to a fresh container — not our death
-        if ws_id in registry.stopping:
-            return  # an expected stop is now in flight
-        if registry.stop_epoch.get(ws_id, 0) != epoch:
-            return  # a stop began AND completed during the listing
+        if not self._snapshot_still_current(
+            registry, ws_id, state, cid, epoch
+        ):
+            return
         observed = liveness.get(cid)
-        if observed is not None and observed not in _DEAD_STATES:
+        if self._liveness_alive(observed):
             # Alive (running / created / paused / ...): nothing to do.
             self.maybe_reset_tracker(ws_id)
             return
@@ -376,6 +395,27 @@ class CrashRecoveryMonitor:
                 ws_id,
                 e,
             )
+
+    def _snapshot_still_current(
+        self, registry, ws_id: str, state, cid: str, epoch: int
+    ) -> bool:
+        """Whether the sweep snapshot row is still the live truth after
+        the liveness listing's await."""
+        if registry.states.get(ws_id) is not state:
+            return False  # state replaced/removed (rebind, user start/stop)
+        if state.container_id != cid:
+            return False  # rebound to a fresh container — not our death
+        if ws_id in registry.stopping:
+            return False  # an expected stop is now in flight
+        if registry.stop_epoch.get(ws_id, 0) != epoch:
+            return False  # a stop began AND completed during the listing
+        return True
+
+    @staticmethod
+    def _liveness_alive(observed) -> bool:
+        """True when an observed liveness state means alive (running /
+        created / paused / ...) rather than dead or absent."""
+        return observed is not None and observed not in _DEAD_STATES
 
     def maybe_reset_tracker(self, ws_id: str) -> None:
         """Drop the retry counter once a restarted container is stable.
@@ -485,9 +525,7 @@ class CrashRecoveryMonitor:
     ) -> None:
         """Post-teardown disposition: interleaved user action wins (no
         restart), else disabled-recovery / crash-loop / schedule-restart."""
-        if (
-            epoch is not None and registry.stop_epoch.get(ws_id, 0) != epoch
-        ) or registry.states.get(ws_id) is not None:
+        if self._user_action_interleaved(registry, ws_id, epoch):
             logger.info(
                 "Workspace %s: user action interleaved with death "
                 "handling; not recording crash state or restarting",
@@ -518,6 +556,22 @@ class CrashRecoveryMonitor:
         self.broadcast_death_event(ws_id, cause, message, tracker)
 
     @staticmethod
+    def _stop_epoch_moved(registry, ws_id: str, epoch: int | None) -> bool:
+        """True when a stop began and completed since *epoch* was
+        captured."""
+        return epoch is not None and registry.stop_epoch.get(ws_id, 0) != epoch
+
+    def _user_action_interleaved(
+        self, registry, ws_id: str, epoch: int | None
+    ) -> bool:
+        """True when a user action raced the death handling and owns the
+        workspace now: a stop began/completed during the awaits, or a
+        start re-created registry state."""
+        if self._stop_epoch_moved(registry, ws_id, epoch):
+            return True
+        return registry.states.get(ws_id) is not None
+
+    @staticmethod
     def _death_guards_pass(
         registry, ws_id: str, state, container_id: str, epoch: int | None
     ) -> bool:
@@ -529,7 +583,7 @@ class CrashRecoveryMonitor:
             return False  # workspace state gone or rebound (user action raced)
         if ws_id in registry.stopping:
             return False  # an expected stop is in flight
-        if epoch is not None and registry.stop_epoch.get(ws_id, 0) != epoch:
+        if CrashRecoveryMonitor._stop_epoch_moved(registry, ws_id, epoch):
             return False  # a stop began and completed during detection
         return True
 
@@ -585,76 +639,116 @@ class CrashRecoveryMonitor:
                 delay,
             )
             await asyncio.sleep(delay)
-            if self.trackers.get(ws_id) is not tracker:
-                return  # superseded by a user action
-            if not self.enabled:
-                tracker.next_attempt_at = None
+            if self._restart_abort(ws_id, tracker):
                 return
-            # Start-refusal check (#2527): a graceful restart's drain
-            # must stick — crash recovery would otherwise re-start the
-            # workspace under the recycling runtime.
-            blocked = (
-                self.app.state.container_registry.new_starts_blocked_reason()
-            )
-            if blocked:
-                tracker.next_attempt_at = None
-                logger.info(
-                    "Workspace %s: restart suppressed (%s)",
-                    ws_id,
-                    blocked,
-                )
-                return
-            ws = None
-            try:
-                ws = await self.app.state.model.workspaces.get_workspace_by_id(
-                    ws_id
-                )
-            except Exception as e:  # pragma: no cover - defensive
-                logger.warning(
-                    "Workspace %s restart: lookup failed: %s", ws_id, e
-                )
+            ws = await self._restartable_workspace(ws_id)
             if ws is None:
-                # Deleted (or unreadable) while backing off — abandon.
-                self.trackers.pop(ws_id, None)
-                logger.info(
-                    "Workspace %s no longer exists; abandoning restart",
-                    ws_id,
-                )
                 return
-            try:
-                cid, _status = await self.app.state.workspaces.start_workspace(
-                    ws, cause=CAUSE_CRASH_RESTART
-                )
-                tracker.last_started_at = time.time()
-                tracker.next_attempt_at = None
-                logger.info(
-                    "Workspace %s restarted after unexpected death "
-                    "(attempt %d, container %s)",
-                    ws_id,
-                    attempt,
-                    cid[:12],
-                )
+            if await self._restart_or_retry(ws_id, tracker, attempt, ws):
                 return
-            except asyncio.CancelledError:
-                raise
-            except Exception as e:
-                logger.warning(
-                    "Workspace %s restart attempt %d failed: %s",
-                    ws_id,
-                    attempt,
-                    e,
-                )
-                if tracker.attempts >= self.max_retries:
-                    tracker.gave_up_at = time.time()
-                    tracker.next_attempt_at = None
-                    logger.warning(
-                        "Workspace %s: crash-loop — %d restart attempt(s) "
-                        "exhausted; leaving stopped",
-                        ws_id,
-                        tracker.attempts,
-                    )
-                    return
-                # Loop: next backoff (the counter doubling continues).
+            # Loop: next backoff (the counter doubling continues).
+
+    def _restart_abort(self, ws_id: str, tracker: RestartTracker) -> bool:
+        """True when the pending restart must abort now: superseded by a
+        user action (silent, marker left), disabled mid-flight (marker
+        cleared), or start-refused by a drain (#2527, logged + marker
+        cleared)."""
+        if self.trackers.get(ws_id) is not tracker:
+            return True  # superseded by a user action
+        if not self.enabled:
+            tracker.next_attempt_at = None
+            return True
+        blocked = self.app.state.container_registry.new_starts_blocked_reason()
+        if blocked:
+            tracker.next_attempt_at = None
+            logger.info(
+                "Workspace %s: restart suppressed (%s)",
+                ws_id,
+                blocked,
+            )
+            return True
+        return False
+
+    async def _restartable_workspace(self, ws_id: str) -> dict | None:
+        """The workspace row to restart, or None when it was deleted (or
+        unreadable) — the tracker is dropped and the restart abandoned."""
+        try:
+            ws = await self.app.state.model.workspaces.get_workspace_by_id(
+                ws_id
+            )
+        except Exception as e:  # pragma: no cover - defensive
+            logger.warning("Workspace %s restart: lookup failed: %s", ws_id, e)
+            return None
+        if ws is None:
+            self.trackers.pop(ws_id, None)
+            logger.info(
+                "Workspace %s no longer exists; abandoning restart",
+                ws_id,
+            )
+        return ws
+
+    async def _restart_or_retry(
+        self, ws_id: str, tracker: RestartTracker, attempt: int, ws: dict
+    ) -> bool:
+        """Start the restarted workspace once; True when the loop should
+        stop (restarted, or crash-loop terminal), False to loop into the
+        next backoff. Reraises CancelledError."""
+        try:
+            await self._start_restarted_workspace(ws_id, tracker, attempt, ws)
+            return True
+        except asyncio.CancelledError:
+            raise
+        except Exception as e:
+            return self._on_restart_failure(ws_id, tracker, attempt, e)
+
+    async def _start_restarted_workspace(
+        self, ws_id: str, tracker: RestartTracker, attempt: int, ws: dict
+    ) -> None:
+        """One successful restart: record the stability anchor and log."""
+        cid, _status = await self.app.state.workspaces.start_workspace(
+            ws, cause=CAUSE_CRASH_RESTART
+        )
+        tracker.last_started_at = time.time()
+        tracker.next_attempt_at = None
+        logger.info(
+            "Workspace %s restarted after unexpected death "
+            "(attempt %d, container %s)",
+            ws_id,
+            attempt,
+            cid[:12],
+        )
+
+    def _on_restart_failure(
+        self,
+        ws_id: str,
+        tracker: RestartTracker,
+        attempt: int,
+        exc: Exception,
+    ) -> bool:
+        """Log a failed attempt; True when the loop should stop
+        (crash-loop terminal), False to retry with the next backoff."""
+        logger.warning(
+            "Workspace %s restart attempt %d failed: %s",
+            ws_id,
+            attempt,
+            exc,
+        )
+        if tracker.attempts < self.max_retries:
+            return False
+        self._give_up_restart(ws_id, tracker)
+        return True
+
+    def _give_up_restart(self, ws_id: str, tracker: RestartTracker) -> None:
+        """Mark the tracker crash-loop terminal; the workspace stays
+        stopped."""
+        tracker.gave_up_at = time.time()
+        tracker.next_attempt_at = None
+        logger.warning(
+            "Workspace %s: crash-loop — %d restart attempt(s) "
+            "exhausted; leaving stopped",
+            ws_id,
+            tracker.attempts,
+        )
 
     # --- events ---
 

--- a/src/klangk/klangk/container/crash.py
+++ b/src/klangk/klangk/container/crash.py
@@ -678,7 +678,7 @@ class CrashRecoveryMonitor:
             )
         except Exception as e:  # pragma: no cover - defensive
             logger.warning("Workspace %s restart: lookup failed: %s", ws_id, e)
-            return None
+            ws = None
         if ws is None:
             self.trackers.pop(ws_id, None)
             logger.info(

--- a/src/klangk/klangk/container/eviction.py
+++ b/src/klangk/klangk/container/eviction.py
@@ -94,6 +94,18 @@ def _read_int_file(path: str) -> int:
 _CGROUP_LIMIT_UNLIMITED = 1 << 60
 
 
+def _cgroup_usage(cgroup_dir: str) -> tuple[int, int, int] | None:
+    """(limit, current, inactive_file) from whichever cgroup version
+    is present; None when there is no finite limit / nothing readable."""
+    try:
+        v2_max = _v2_memory_limit(cgroup_dir)
+        if v2_max is not None:
+            return _cgroup_v2_usage(cgroup_dir, v2_max)
+        return _cgroup_v1_usage(cgroup_dir)
+    except (OSError, ValueError):
+        return None
+
+
 def cgroup_memory_headroom(
     cgroup_dir: str = "/sys/fs/cgroup",
 ) -> tuple[int, int] | None:
@@ -111,19 +123,13 @@ def cgroup_memory_headroom(
     page cache is excluded), the same approximation k8s uses for node
     pressure. A limit smaller than the floor is ignored.
     """
-    try:
-        v2_max = _v2_memory_limit(cgroup_dir)
-        if v2_max is not None:
-            limit, current, inactive_file = _cgroup_v2_usage(
-                cgroup_dir, v2_max
-            )
-        else:
-            limit, current, inactive_file = _cgroup_v1_usage(cgroup_dir)
-    except (OSError, ValueError):
+    usage = _cgroup_usage(cgroup_dir)
+    if usage is None:
         return None
+    limit, current, inactive_file = usage
     # "0" (or a bogus negative) is not a limit — e.g. a transient
     # memory.max=0 during container teardown. Ignore, meminfo governs.
-    if limit is None or limit <= 0:
+    if limit <= 0:
         return None
     working_set = max(0, current - inactive_file)
     if working_set > limit:
@@ -178,6 +184,32 @@ def stat_value(stat_path: str, names: tuple[str, ...]) -> int:
     return 0
 
 
+def _vm_stat_pages(vm_stat_output: str) -> dict[str, int]:
+    """``{counter: pages}`` from vm_stat's lines ("Pages free: 12345.")."""
+    pages: dict[str, int] = {}
+    for line in vm_stat_output.splitlines():
+        name, colon, value = line.partition(":")
+        if not colon:
+            continue
+        value = value.strip().rstrip(".")
+        if value.isdigit():
+            pages[name.strip()] = int(value)
+    return pages
+
+
+def _vm_stat_available_pages(pages: dict[str, int]) -> int:
+    """(free + inactive + speculative) page count; raises ValueError
+    when any counter is missing."""
+    try:
+        return (
+            pages["Pages free"]
+            + pages["Pages inactive"]
+            + pages["Pages speculative"]
+        )
+    except KeyError:
+        raise ValueError("vm_stat output lacks page counters") from None
+
+
 def parse_vm_stat(
     vm_stat_output: str, page_size: int, total_bytes: int
 ) -> float:
@@ -189,24 +221,26 @@ def parse_vm_stat(
     Raises ``ValueError`` when the page counters are missing — callers
     treat unmeasurable as "skip this cycle".
     """
-    pages: dict[str, int] = {}
-    for line in vm_stat_output.splitlines():
-        # "Pages free:                               12345."
-        name, colon, value = line.partition(":")
-        if not colon:
-            continue
-        value = value.strip().rstrip(".")
-        if value.isdigit():
-            pages[name.strip()] = int(value)
-    free = pages.get("Pages free")
-    inactive = pages.get("Pages inactive")
-    speculative = pages.get("Pages speculative")
-    if free is None or inactive is None or speculative is None:
-        raise ValueError("vm_stat output lacks page counters")
+    pages = _vm_stat_pages(vm_stat_output)
+    available_pages = _vm_stat_available_pages(pages)
     if total_bytes <= 0 or page_size <= 0:
         raise ValueError("vm_stat parse got non-positive total/page size")
-    available = (free + inactive + speculative) * page_size
+    available = available_pages * page_size
     return min(available / total_bytes, 1.0)
+
+
+def _header_page_size(header: str) -> int:
+    """Page size parsed from the header ("Mach Virtual Memory
+    Statistics: (page size of 16384 bytes)"), or 0 when unparseable."""
+    page_size = 0
+    if "page size of" in header and "bytes" in header:
+        try:
+            page_size = int(
+                header.split("page size of")[1].split("bytes")[0].strip()
+            )
+        except ValueError:
+            page_size = 0
+    return page_size
 
 
 def vm_stat_page_size(vm_stat_output: str) -> int:
@@ -218,16 +252,8 @@ def vm_stat_page_size(vm_stat_output: str) -> int:
     direction would evict on healthy memory. Unmeasurable (skip the
     cycle) is the safe failure.
     """
-    # "Mach Virtual Memory Statistics: (page size of 16384 bytes)"
     header = vm_stat_output.splitlines()[0] if vm_stat_output else ""
-    page_size = 0
-    if "page size of" in header and "bytes" in header:
-        try:
-            page_size = int(
-                header.split("page size of")[1].split("bytes")[0].strip()
-            )
-        except ValueError:
-            page_size = 0
+    page_size = _header_page_size(header)
     if page_size <= 0:
         raise ValueError("vm_stat header lacks a parseable page size")
     return page_size
@@ -398,29 +424,40 @@ class MemoryPressureEvictor:
         the conservative reading of "never stop idle workspaces".
         """
         registry = self.app.state.container_registry
-        sockets = self.app.state.sockets
-        candidates = []
-        for ws_id, state in registry.states.items():
-            if ws_id in registry.stopping:
-                continue
-            # A start/stop in flight (the per-workspace lock is held)
-            # means the workspace is mid-transition: a reconnecting
-            # workspace's container is tracked from podman create but
-            # has no subscriber until container_ready, so without this
-            # check an armed evictor stops the fresh container under
-            # the connecting client (#2527 e2e flake).
-            if registry.workspace_operation_in_flight(ws_id):
-                continue
-            if state.get_idle_timeout() == 0:
-                continue
-            session = sockets.sessions.get(ws_id)
-            if session and (
-                session.subscribers or session.browser_subscribers
-            ):
-                continue
-            candidates.append(state)
+        candidates = [
+            state
+            for ws_id, state in registry.states.items()
+            if self._evictable(ws_id, state)
+        ]
         candidates.sort(key=lambda s: s.last_activity)
         return candidates
+
+    def _evictable(self, ws_id: str, state) -> bool:
+        """Whether one tracked workspace is an eviction candidate."""
+        registry = self.app.state.container_registry
+        if ws_id in registry.stopping:
+            return False
+        # A start/stop in flight (the per-workspace lock is held)
+        # means the workspace is mid-transition: a reconnecting
+        # workspace's container is tracked from podman create but
+        # has no subscriber until container_ready, so without this
+        # check an armed evictor stops the fresh container under
+        # the connecting client (#2527 e2e flake).
+        if registry.workspace_operation_in_flight(ws_id):
+            return False
+        if state.get_idle_timeout() == 0:
+            return False
+        return not self._has_live_subscribers(ws_id)
+
+    def _has_live_subscribers(self, ws_id: str) -> bool:
+        """True when the workspace has any live terminal/browser
+        subscriber. Every workspace client holds the same workspace
+        WebSocket (``session.subscribers``), so the subscriber set
+        covers terminal and browser clients alike (#2627 review)."""
+        session = self.app.state.sockets.sessions.get(ws_id)
+        return bool(
+            session and (session.subscribers or session.browser_subscribers)
+        )
 
     async def evict_one(self, fraction: float) -> bool:
         """Gracefully stop the least-recently-active idle workspace.
@@ -519,22 +556,7 @@ class MemoryPressureEvictor:
         """
         percent = fraction * 100
         if pressured:
-            if percent >= self._recovery:
-                logger.info(
-                    "Host memory recovered (%.1f%% available >= %.1f%%) "
-                    "— ending eviction episode",
-                    percent,
-                    self._recovery,
-                )
-                self._warned_no_evictable = False
-                self._evicted_this_episode = 0
-                return 0, False
-            if percent < self._threshold:
-                await self.evict_one(fraction)
-            # Between threshold and recovery: hold — memory is being
-            # reclaimed (an eviction may still be in flight); evicting
-            # again here is what flap-prevention exists to avoid.
-            return below, pressured
+            return await self._step_pressured(fraction, below)
         if percent < self._threshold:
             below += 1
             if below >= self._sustain_polls:
@@ -550,6 +572,32 @@ class MemoryPressureEvictor:
                 return 0, True
             return below, pressured
         return 0, pressured
+
+    async def _step_pressured(
+        self, fraction: float, below: int
+    ) -> tuple[int, bool]:
+        """One step inside an open episode: evict one workspace per poll
+        while still below threshold; the episode closes only when
+        availability rises to the recovery threshold (strictly above
+        threshold — the gap is the hysteresis that prevents
+        flap-eviction at the boundary)."""
+        percent = fraction * 100
+        if percent >= self._recovery:
+            logger.info(
+                "Host memory recovered (%.1f%% available >= %.1f%%) "
+                "— ending eviction episode",
+                percent,
+                self._recovery,
+            )
+            self._warned_no_evictable = False
+            self._evicted_this_episode = 0
+            return 0, False
+        if percent < self._threshold:
+            await self.evict_one(fraction)
+        # Between threshold and recovery: hold — memory is being
+        # reclaimed (an eviction may still be in flight); evicting
+        # again here is what flap-prevention exists to avoid.
+        return below, True
 
     async def run(self) -> None:
         """Poll loop: measure, sustain, evict, hysteresis.
@@ -591,18 +639,25 @@ class MemoryPressureEvictor:
             # path that breaks *later* (transient today, permanent next
             # week) still says so.
             warned_unreadable = False
-            try:
-                below, pressured = await self._handle_measurement(
-                    fraction, below, pressured
-                )
-            except asyncio.CancelledError:
-                raise
-            except Exception:
-                # The eviction action must never kill the loop: a host at
-                # <10% available is exactly where fork (podman exec)
-                # fails with OSError — skipping one cycle is fine, dying
-                # silently for the process lifetime is not (#2627 review).
-                logger.warning(
-                    "Memory-pressure eviction cycle failed (skipped)",
-                    exc_info=True,
-                )
+            below, pressured = await self._step_state_machine(
+                fraction, below, pressured
+            )
+
+    async def _step_state_machine(
+        self, fraction: float, below: int, pressured: bool
+    ) -> tuple[int, bool]:
+        """One guarded state-machine step. The eviction action must
+        never kill the loop: a host at <10% available is exactly where
+        fork (podman exec) fails with OSError — skipping one cycle is
+        fine, dying silently for the process lifetime is not (#2627
+        review)."""
+        try:
+            return await self._handle_measurement(fraction, below, pressured)
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            logger.warning(
+                "Memory-pressure eviction cycle failed (skipped)",
+                exc_info=True,
+            )
+            return below, pressured

--- a/src/klangk/klangk/container/health.py
+++ b/src/klangk/klangk/container/health.py
@@ -17,6 +17,12 @@ logger = logging.getLogger(__name__)
 HEALTH_MESSAGE_MAX_BYTES = 512
 
 
+def _trimmed_body(err: str, out: str) -> str:
+    """The failure reason text: stderr first (where shells/diagnostics
+    write their failures), then stdout, both stripped."""
+    return (err or "").strip() or (out or "").strip()
+
+
 def unhealthy_message(rc: int, out: str, err: str) -> str:
     """Build a bounded failure reason from a check's exit code/output.
 
@@ -26,8 +32,8 @@ def unhealthy_message(rc: int, out: str, err: str) -> str:
     verbose check can't grow memory unbounded across workspaces --
     the goal is "why did it fail", not a full transcript (#1088).
     """
-    body = (err or "").strip() or (out or "").strip()
-    if body and len(body) > HEALTH_MESSAGE_MAX_BYTES:
+    body = _trimmed_body(err, out)
+    if len(body) > HEALTH_MESSAGE_MAX_BYTES:
         body = "..." + body[-HEALTH_MESSAGE_MAX_BYTES:]
     return f"exited {rc}: {body}" if body else f"exited {rc}"
 
@@ -121,26 +127,9 @@ class HealthMonitor:
         ``docs/features/health-check.md``).  Errors and timeouts count
         as ``"unhealthy"``.
         """
-        owner_id = state.owner_id
-        if owner_id is None:
-            return "unhealthy", "no owner recorded for workspace"
-        if state.per_handle_home:
-            handle = await self.app.state.model.users.get_user_handle(owner_id)
-            if not handle:
-                return "unhealthy", f"owner {owner_id} has no handle"
-            # Resolve the owner's container home the same way
-            # start_workspace does, so the check runs in the right
-            # HOME rather than as root in /.
-            ws = self.app.state.workspaces
-            ws_home = ws.home_path(state.workspace_id)
-            user_home, _created = await ws.ensure_home_symlink(
-                ws_home, handle, owner_id
-            )
-        else:
-            # Shared layout (#2169 chunk 2, #2720): one home for every
-            # connection — the check probes the workspace's shared
-            # /home/klangk; no per-owner symlink to resolve.
-            user_home = SHARED_HOME
+        user_home, failure = await self._resolve_check_home(state)
+        if failure:
+            return "unhealthy", failure
         cid_short = state.container_id[:12]
         logger.debug(
             "Health check: container %s (workspace %s) running %r",
@@ -168,6 +157,33 @@ class HealthMonitor:
             return "healthy", ""
         return "unhealthy", unhealthy_message(rc, out, err)
 
+    async def _resolve_check_home(
+        self, state: ContainerState
+    ) -> tuple[str | None, str]:
+        """(HOME for the probe, failure message). HOME is None only
+        when the failure message is set (no owner, or an owner without
+        a handle)."""
+        owner_id = state.owner_id
+        if owner_id is None:
+            return None, "no owner recorded for workspace"
+        if state.per_handle_home:
+            handle = await self.app.state.model.users.get_user_handle(owner_id)
+            if not handle:
+                return None, f"owner {owner_id} has no handle"
+            # Resolve the owner's container home the same way
+            # start_workspace does, so the check runs in the right
+            # HOME rather than as root in /.
+            ws = self.app.state.workspaces
+            ws_home = ws.home_path(state.workspace_id)
+            user_home, _created = await ws.ensure_home_symlink(
+                ws_home, handle, owner_id
+            )
+            return user_home, ""
+        # Shared layout (#2169 chunk 2, #2720): one home for every
+        # connection — the check probes the workspace's shared
+        # /home/klangk; no per-owner symlink to resolve.
+        return SHARED_HOME, ""
+
     async def _check_workspace(self, state: ContainerState) -> None:
         """Poll one workspace, record the reason, and broadcast on change."""
         new_status, message = await self._run_one(state)
@@ -177,7 +193,7 @@ class HealthMonitor:
         # failure (mirrors Docker HEALTHCHECK --start-period).  A
         # healthy result is still recorded below so a fast-booting
         # service is marked up the moment it actually responds.
-        if new_status == "unhealthy" and self._in_startup_grace(state):
+        if self._within_startup_grace(state, new_status):
             logger.debug(
                 "Health check for workspace %s (container %s) failing "
                 "but within startup grace (%.0fs elapsed); not flagging "
@@ -194,18 +210,30 @@ class HealthMonitor:
         state.health_message = message if new_status == "unhealthy" else None
         state.health_checked_at = time.time()
         if new_status == "unhealthy":
-            # Log the reason at info on a fresh transition (so it's
-            # visible without debug logs), debug on steady-state polls
-            # so a persistently-broken check doesn't spam at info (#1088).
-            log = logger.info if old_status != "unhealthy" else logger.debug
-            log(
-                "Health check for workspace %s (container %s) unhealthy: %s",
-                state.workspace_id,
-                state.container_id[:12],
-                message,
-            )
+            self._log_health_failure(state, old_status, message)
         if new_status != old_status:
             await self._broadcast(state, new_status, state.health_message)
+
+    def _within_startup_grace(
+        self, state: ContainerState, new_status: str
+    ) -> bool:
+        """True when an unhealthy result lands inside the startup grace
+        window — an expected boot failure, not an outage."""
+        return new_status == "unhealthy" and self._in_startup_grace(state)
+
+    def _log_health_failure(
+        self, state: ContainerState, old_status: str, message: str
+    ) -> None:
+        """Log the reason at info on a fresh unhealthy transition (so
+        it's visible without debug logs), debug on steady-state polls
+        so a persistently-broken check doesn't spam at info (#1088)."""
+        log = logger.info if old_status != "unhealthy" else logger.debug
+        log(
+            "Health check for workspace %s (container %s) unhealthy: %s",
+            state.workspace_id,
+            state.container_id[:12],
+            message,
+        )
 
     async def _emit(
         self,
@@ -303,9 +331,7 @@ class HealthMonitor:
             registry = self.app.state.container_registry
             await asyncio.sleep(registry.health_check_interval)
             for state in list(registry.states.values()):
-                if not state.health_check:
-                    continue
-                if not self._setup_complete(state):
+                if not self._eligible_for_check(state):
                     continue
                 try:
                     await self._check_workspace(state)
@@ -316,6 +342,13 @@ class HealthMonitor:
                         e,
                     )
             self._send_heartbeats()
+
+    def _eligible_for_check(self, state: ContainerState) -> bool:
+        """True when a workspace has a check configured and setup has
+        finished (running during setup would report false negatives —
+        the service isn't running yet because setup.sh hasn't installed
+        it)."""
+        return bool(state.health_check) and self._setup_complete(state)
 
     def _send_heartbeats(self) -> None:
         """Fan health heartbeats to opt-in connections."""

--- a/src/klangk/klangk/container/idle.py
+++ b/src/klangk/klangk/container/idle.py
@@ -75,29 +75,41 @@ class IdleMonitor:
                 pass
             now = time.time()
             for cid, wid in self._idle_overdue(now):
-                logger.info(
-                    "Stopping idle container %s (workspace %s)",
-                    cid,
-                    wid,
-                )
-                state = registry.states.get(wid)
-                if state:
-                    await self._run_idle_callbacks(state, wid)
-                await registry.notify_workspace_killed(wid, container_id=cid)
-                await registry.stop_and_remove_container(
-                    cid, cause=CAUSE_IDLE_TIMEOUT
-                )
-
+                await self._stop_idle_workspace(registry, cid, wid)
             # Periodic orphan sidecar-token sweep (#2309): reclaim
             # ws-tokens/<id> files whose workspace row is gone. Piggybacks
             # on this loop (no separate task); self-throttled to scan at
             # most every ORPHAN_TOKEN_SWEEP_INTERVAL.
-            if now - last_token_sweep >= ORPHAN_TOKEN_SWEEP_INTERVAL:
-                last_token_sweep = now
-                try:
-                    await registry.sweep_orphaned_sidecar_tokens()
-                except Exception as e:
-                    logger.warning("Orphan sidecar-token sweep failed: %s", e)
+            last_token_sweep = await self._sweep_tokens_if_due(
+                registry, last_token_sweep, now
+            )
+
+    async def _stop_idle_workspace(self, registry, cid: str, wid: str) -> None:
+        """Notify + stop one idle workspace's container."""
+        logger.info(
+            "Stopping idle container %s (workspace %s)",
+            cid,
+            wid,
+        )
+        state = registry.states.get(wid)
+        if state:
+            await self._run_idle_callbacks(state, wid)
+        await registry.notify_workspace_killed(wid, container_id=cid)
+        await registry.stop_and_remove_container(cid, cause=CAUSE_IDLE_TIMEOUT)
+
+    async def _sweep_tokens_if_due(
+        self, registry, last_sweep: float, now: float
+    ) -> float:
+        """Run the orphan sidecar-token sweep when due; returns the
+        (possibly advanced) last-sweep timestamp. A failing sweep still
+        advances it."""
+        if now - last_sweep >= ORPHAN_TOKEN_SWEEP_INTERVAL:
+            try:
+                await registry.sweep_orphaned_sidecar_tokens()
+            except Exception as e:
+                logger.warning("Orphan sidecar-token sweep failed: %s", e)
+            return now
+        return last_sweep
 
     def _cleanup_interval(self) -> float:
         """Half the smallest active idle timeout (floor 2s), else the

--- a/src/klangk/klangk/container/registry.py
+++ b/src/klangk/klangk/container/registry.py
@@ -152,18 +152,27 @@ async def safe_remove(podman_inst, container_id: str, *, what: str) -> bool:
         return False
 
 
+def _parse_host_port(entry) -> int | None:
+    """Host port from one PortBindings entry, or None when unreadable."""
+    try:
+        return int(entry["HostPort"])
+    except (KeyError, ValueError, TypeError):
+        return None
+
+
+def _host_port_entries(bindings: dict):
+    """Flatten PortBindings' {port: [entries]} into the entries."""
+    for ports_list in bindings.values():
+        for entry in ports_list or []:
+            yield entry
+
+
 def host_bound_ports(info: dict) -> set[int]:
     """Host ports published by an inspected container (from HostConfig
     PortBindings)."""
     bindings = info.get("HostConfig", {}).get("PortBindings") or {}
-    bound = set()
-    for ports_list in bindings.values():
-        for entry in ports_list or []:
-            try:
-                bound.add(int(entry["HostPort"]))
-            except (KeyError, ValueError, TypeError):
-                pass
-    return bound
+    ports = map(_parse_host_port, _host_port_entries(bindings))
+    return {port for port in ports if port is not None}
 
 
 async def remove_stale_container(
@@ -183,6 +192,47 @@ async def remove_stale_container(
             stale_id[:12],
             del_exc,
         )
+
+
+def _resolved_under_root(resolved: str, roots) -> bool:
+    """True when a resolved path equals or lives under an allowed root."""
+    return any(
+        resolved == root or resolved.startswith(root + "/") for root in roots
+    )
+
+
+def _labeled_workspace_ident(c: dict) -> str | None:
+    """Ident of a listed container when it is a workspace container
+    (the network sidecar shares the workspace label)."""
+    labels = c.get("Labels") or {}
+    if labels.get("klangk.role") != "workspace":
+        return None
+    return container_ident(c) or None
+
+
+def _owner_pid_label(c: dict) -> int | None:
+    """Parsed ``klangk.pid`` label, or None when absent/unparseable."""
+    label = (c.get("Labels") or {}).get("klangk.pid")
+    if not label:
+        return None
+    try:
+        return int(label)
+    except (TypeError, ValueError):
+        return None
+
+
+def _dead_owner_pid(c: dict) -> int | None:
+    """Owner pid when the container's ``klangk.pid`` label names a dead
+    process, else None (liveness undecidable or owner alive: leave it)."""
+    owner_pid = _owner_pid_label(c)
+    if owner_pid is None or owner_pid <= 0 or pid_alive(owner_pid):
+        return None
+    return owner_pid
+
+
+def _wanted_host_ports(publish: list[tuple[int, int]]) -> set[int]:
+    """Host ports from a publish list of (host, container) pairs."""
+    return {host_port for host_port, _container_port in publish}
 
 
 class ContainerRegistry(NetworkSidecarMixin):
@@ -335,21 +385,40 @@ class ContainerRegistry(NetworkSidecarMixin):
                 return True
         return False
 
+    def _validate_mount_shape(self, spec: str, parts: list[str]) -> str | None:
+        """Structural checks: 2-3 parts, non-empty source, absolute dest."""
+        if len(parts) < 2 or len(parts) > 3:
+            return (
+                f"Invalid mount {spec!r}: expected source:dest or "
+                "source:dest:options"
+            )
+        if not parts[0]:
+            return f"Invalid mount {spec!r}: source is empty"
+        if not parts[1].startswith("/"):
+            return (
+                f"Invalid mount {spec!r}: container path must be absolute "
+                "(start with /)"
+            )
+        return None
+
+    def _validate_mount_options(self, spec: str, options: str) -> str | None:
+        """The 3rd field must be a comma list of known options."""
+        for opt in options.split(","):
+            if opt and opt not in _VALID_MOUNT_OPTIONS:
+                return f"Invalid mount {spec!r}: unknown option {opt!r}"
+        return None
+
     def validate_mount_spec(self, spec: str) -> str | None:
         """Validate a container mount spec string."""
         parts = spec.split(":")
-        if len(parts) < 2 or len(parts) > 3:
-            return f"Invalid mount {spec!r}: expected source:dest or source:dest:options"
-        source, dest = parts[0], parts[1]
-        if not source:
-            return f"Invalid mount {spec!r}: source is empty"
-        if not dest.startswith("/"):
-            return f"Invalid mount {spec!r}: container path must be absolute (start with /)"
+        error = self._validate_mount_shape(spec, parts)
+        if error:
+            return error
         if len(parts) == 3:
-            options = parts[2]
-            for opt in options.split(","):
-                if opt and opt not in _VALID_MOUNT_OPTIONS:
-                    return f"Invalid mount {spec!r}: unknown option {opt!r}"
+            error = self._validate_mount_options(spec, parts[2])
+            if error:
+                return error
+        source = parts[0]
         if is_named_volume(source):
             return self._validate_named_volume_source(spec, source)
         return self._validate_bind_source(spec, source)
@@ -377,10 +446,7 @@ class ContainerRegistry(NetworkSidecarMixin):
         if not self.allowed_mount_roots:
             return None
         resolved = os.path.realpath(source)
-        if any(
-            resolved == root or resolved.startswith(root + "/")
-            for root in self.allowed_mount_roots
-        ):
+        if _resolved_under_root(resolved, self.allowed_mount_roots):
             return None
         allowed = ", ".join(self.allowed_mount_roots)
         return (
@@ -572,8 +638,27 @@ class ContainerRegistry(NetworkSidecarMixin):
             state.container_id = container_id
         self._cid_to_wsid[container_id] = workspace_id
         state.record_activity()
-        # Health-monitoring metadata (#1015).  Always refresh so a
-        # config change (or a recreated container) is picked up.
+        self._apply_track_metadata(
+            state,
+            health_check=health_check,
+            owner_id=owner_id,
+            setup_state=setup_state,
+            per_handle_home=per_handle_home,
+        )
+        if was_new:
+            self._notify_status_changed(workspace_id, True)
+
+    def _apply_track_metadata(
+        self,
+        state: ContainerState,
+        *,
+        health_check: str | None,
+        owner_id: str | None,
+        setup_state: str | None,
+        per_handle_home: bool | None,
+    ) -> None:
+        """Refresh health-monitoring metadata (#1015). Always refreshed
+        so a config change (or a recreated container) is picked up."""
         state.health_check = health_check
         if owner_id is not None:
             state.owner_id = owner_id
@@ -581,8 +666,6 @@ class ContainerRegistry(NetworkSidecarMixin):
             state.setup_state = setup_state
         if per_handle_home is not None:
             state.per_handle_home = per_handle_home
-        if was_new:
-            self._notify_status_changed(workspace_id, True)
 
     def record_activity(self, container_id: str) -> None:
         ws_id = self._cid_to_wsid.get(container_id)
@@ -1062,47 +1145,72 @@ class ContainerRegistry(NetworkSidecarMixin):
             # that may legitimately create a fresh container.
             return None
         for c in containers:
-            labels = c.get("Labels") or {}
-            if labels.get("klangk.role") != "workspace":
-                continue  # the network sidecar shares the workspace label
-            ident = container_ident(c)
-            if not ident:
+            ident = _labeled_workspace_ident(c)
+            if ident is None:
                 continue
-            running = str(c.get("State", "")).lower() == "running"
-            if not running:
-                await self.app.state.podman.remove_container(ident)
-                logger.info(
-                    "workspace-open: removed stopped labeled container %s "
-                    "for workspace %s, will recreate",
-                    ident[:12],
-                    workspace_id[:8],
-                )
+            if str(c.get("State", "")).lower() != "running":
+                await self._remove_stopped_labeled(workspace_id, ident)
                 continue
-            # Adopt the running container — this is exactly what a fresh
-            # connect does with a current id, and why a reconnect after a
-            # failed restart self-heals today (#2676).
-            if self.app.state.settings.fips_mode:
-                await self._fips_gate(workspace_id, ident)
-            await self.app.state.model.workspaces.update_workspace_container(
-                workspace_id, ident
-            )
-            self.track_activity(
-                ident,
+            return await self._adopt_running_labeled(
                 workspace_id,
+                t_start,
+                ident,
                 health_check=health_check,
                 owner_id=owner_id,
                 setup_state=setup_state,
                 per_handle_home=per_handle_home,
             )
-            logger.info(
-                "workspace-open: DONE — adopted running labeled container "
-                "%s for stale-id workspace %s: %.3fs",
-                ident[:12],
-                workspace_id[:8],
-                time.monotonic() - t_start,
-            )
-            return ident, "connected"
         return None
+
+    async def _remove_stopped_labeled(
+        self, workspace_id: str, ident: str
+    ) -> None:
+        """Remove a stopped labeled workspace container so the create
+        path's sidecar pre-remove can't be refused for a still-attached
+        dependent."""
+        await self.app.state.podman.remove_container(ident)
+        logger.info(
+            "workspace-open: removed stopped labeled container %s "
+            "for workspace %s, will recreate",
+            ident[:12],
+            workspace_id[:8],
+        )
+
+    async def _adopt_running_labeled(
+        self,
+        workspace_id: str,
+        t_start: float,
+        ident: str,
+        *,
+        health_check: str | None,
+        owner_id: str | None,
+        setup_state: str | None,
+        per_handle_home: bool,
+    ) -> tuple[str, str]:
+        """Adopt the running labeled container — exactly what a fresh
+        connect does with a current id, and why a reconnect after a
+        failed restart self-heals today (#2676)."""
+        if self.app.state.settings.fips_mode:
+            await self._fips_gate(workspace_id, ident)
+        await self.app.state.model.workspaces.update_workspace_container(
+            workspace_id, ident
+        )
+        self.track_activity(
+            ident,
+            workspace_id,
+            health_check=health_check,
+            owner_id=owner_id,
+            setup_state=setup_state,
+            per_handle_home=per_handle_home,
+        )
+        logger.info(
+            "workspace-open: DONE — adopted running labeled container "
+            "%s for stale-id workspace %s: %.3fs",
+            ident[:12],
+            workspace_id[:8],
+            time.monotonic() - t_start,
+        )
+        return ident, "connected"
 
     async def _reconcile_ports(
         self, workspace_id: str, num_ports: int
@@ -1317,7 +1425,7 @@ class ContainerRegistry(NetworkSidecarMixin):
             "Port conflict starting %s, cleaning stale containers",
             container_name,
         )
-        wanted_ports = {hp for hp, _cp in publish}
+        wanted_ports = _wanted_host_ports(publish)
         stale = await podman.list_containers(
             f"klangk.instance={self.app.state.util.instance_id()}"
         )
@@ -1365,23 +1473,29 @@ class ContainerRegistry(NetworkSidecarMixin):
             await self._resolve_port_conflict(
                 cid, container_name, publish, self.app.state.podman
             )
-            # Retry with back-off; ports may linger in TIME_WAIT after the
-            # previous container's pasta process exits.
-            last_exc = exc
-            for delay in (0.5, 1.5):
-                await asyncio.sleep(delay)
-                try:
-                    await self.app.state.podman.start_container(
-                        cid, hooks_dir=hooks_dir
-                    )
-                    last_exc = None
-                    break
-                except podman.PodmanError as retry_exc:
-                    if not self._is_port_conflict(retry_exc):
-                        raise
-                    last_exc = retry_exc
-            if last_exc is not None:
-                raise last_exc
+            # Retry with back-off; ports may linger in TIME_WAIT after
+            # the previous container's pasta process exits.
+            await self._retry_start_after_conflict(
+                cid, hooks_dir=hooks_dir, last_exc=exc
+            )
+
+    async def _retry_start_after_conflict(
+        self, cid: str, *, hooks_dir: list[str] | None, last_exc: Exception
+    ) -> None:
+        """Retry a port-conflicted start with back-off, re-raising the
+        conflict when every retry fails (fails closed)."""
+        for delay in (0.5, 1.5):
+            await asyncio.sleep(delay)
+            try:
+                await self.app.state.podman.start_container(
+                    cid, hooks_dir=hooks_dir
+                )
+                return
+            except podman.PodmanError as retry_exc:
+                if not self._is_port_conflict(retry_exc):
+                    raise
+                last_exc = retry_exc
+        raise last_exc
 
     def _sidecar_requirements(
         self,
@@ -1411,13 +1525,29 @@ class ContainerRegistry(NetworkSidecarMixin):
         sidecar_required = egress_mode == EGRESS_MODE_INTERACTIVE or bool(
             allowed_domains or rejected_domains
         )
-        sidecar_optional = (
+        sidecar_optional = self._sidecar_optional_egress(
+            egress_mode, sidecar_required
+        )
+        return sidecar_required, sidecar_required or sidecar_optional
+
+    def _sidecar_optional_egress(
+        self, egress_mode: str, sidecar_required: bool
+    ) -> bool:
+        """Whether allow-mode egress wants the sidecar when one is
+        configured (#2406): ``allow`` requests permissiveness, not
+        filtering — it runs the sidecar when one is set up (off-list
+        egress logged via the consent pipeline, ``rejected_domains``
+        enforced at the sidecar DNS layer) but degrades to unrestricted
+        when filtering isn't configured. Fail-closing an allow-mode
+        workspace would be wrong (it never asked to be locked down), so
+        allow is best-effort, not mandatory — unlike interactive /
+        list-declaring workspaces, which fail-closed."""
+        return (
             egress_mode == EGRESS_MODE_ALLOW
             and not sidecar_required
             and self.network_sidecar_enabled()
             and bool(self.app.state.settings.userns)
         )
-        return sidecar_required, sidecar_required or sidecar_optional
 
     async def _build_start_config(
         self, spec: ContainerStartSpec, host_ports: list[int]
@@ -1657,50 +1787,26 @@ class ContainerRegistry(NetworkSidecarMixin):
         are unpacked.
         """
         workspace_id = spec.workspace_id
-        existing_container_id = spec.existing_container_id
         num_ports = spec.num_ports
         image = spec.image
-        user_id = spec.user_id
-        health_check = spec.health_check
         setup_state = spec.setup_state
         service_command = spec.service_command
         allowed_domains = spec.allowed_domains
         rejected_domains = spec.rejected_domains
         egress_mode = spec.egress_mode
         t_start = time.monotonic()
-        resolved_image = image or self.image_name
-        if resolved_image not in self.allowed_images:
-            raise ValueError(
-                f"Image {resolved_image!r} is not in the allowed "
-                f"list: {sorted(self.allowed_images)}"
-            )
+        resolved_image = self._resolved_start_image(image)
 
         sidecar_required, needs_sidecar = self._sidecar_requirements(
             egress_mode, allowed_domains, rejected_domains
         )
 
         # Reuse a running container or remove a stopped one.
-        if existing_container_id:
-            result = await self.handle_existing_container(
-                existing_container_id,
-                workspace_id,
-                t_start,
-                health_check=health_check,
-                owner_id=user_id,
-                setup_state=setup_state,
-                per_handle_home=spec.per_handle_home,
-            )
-            if result is not None:
-                # Re-track a sidecar'd workspace's network sidecar on reconnect.
-                # _ws_with_network_sidecar is in-memory and lost on a process
-                # restart; without this, a reconnect-then-stop would skip
-                # stop_network_sidecar (only the create path added it before)
-                # and leak the sidecar until the next start's force-remove or
-                # the instance reaper. A sidecar'd workspace always has a live
-                # sidecar (fail-closed), so needs_sidecar => re-track.
-                if needs_sidecar:
-                    self._ws_with_network_sidecar.add(workspace_id)
-                return result
+        result = await self._reuse_existing_container(
+            spec, workspace_id, t_start, needs_sidecar
+        )
+        if result is not None:
+            return result
 
         # Start-refusal gate (#2527): while a graceful restart's drain
         # flag is set, every *new* container creation through this single
@@ -1814,6 +1920,50 @@ class ContainerRegistry(NetworkSidecarMixin):
         )
         return container_id, "created"
 
+    def _resolved_start_image(self, image: str | None) -> str:
+        """The image to start, validated against the allowed list."""
+        resolved = image or self.image_name
+        if resolved not in self.allowed_images:
+            raise ValueError(
+                f"Image {resolved!r} is not in the allowed "
+                f"list: {sorted(self.allowed_images)}"
+            )
+        return resolved
+
+    async def _reuse_existing_container(
+        self,
+        spec: ContainerStartSpec,
+        workspace_id: str,
+        t_start: float,
+        needs_sidecar: bool,
+    ) -> tuple[str, str] | None:
+        """Reuse a running container (or remove a stopped one); None
+        means no existing container / not reusable — continue with a
+        fresh create."""
+        if not spec.existing_container_id:
+            return None
+        result = await self.handle_existing_container(
+            spec.existing_container_id,
+            workspace_id,
+            t_start,
+            health_check=spec.health_check,
+            owner_id=spec.user_id,
+            setup_state=spec.setup_state,
+            per_handle_home=spec.per_handle_home,
+        )
+        if result is None:
+            return None
+        # Re-track a sidecar'd workspace's network sidecar on reconnect.
+        # _ws_with_network_sidecar is in-memory and lost on a process
+        # restart; without this, a reconnect-then-stop would skip
+        # stop_network_sidecar (only the create path added it before)
+        # and leak the sidecar until the next start's force-remove or
+        # the instance reaper. A sidecar'd workspace always has a live
+        # sidecar (fail-closed), so needs_sidecar => re-track.
+        if needs_sidecar:
+            self._ws_with_network_sidecar.add(workspace_id)
+        return result
+
     async def stop_and_remove_container(
         self,
         container_id: str,
@@ -1874,63 +2024,19 @@ class ContainerRegistry(NetworkSidecarMixin):
         # Netns owner captured before teardown pops it (#2915).
         netns = self._ws_netns_owner.get(ws_id)
         if ws_id:
-            self.stopping.add(ws_id)
-            # Bumped synchronously at stop ENTRY, before any await: the
-            # crash monitor snapshots the epoch around its awaits and
-            # re-checks it before scheduling a restart, so a stop that
-            # begins at any point during death detection/handling
-            # invalidates the restart — even if the stop fully completes
-            # before the scheduler re-checks (#2524 review).
-            self.stop_epoch[ws_id] = self.stop_epoch.get(ws_id, 0) + 1
-            self.crash.on_expected_stop(ws_id)
+            self._begin_expected_stop(ws_id)
         stopped = False
         torn_down = False
         try:
-            try:
-                await self.app.state.podman.remove_container(container_id)
-                logger.info("Stopped container %s", container_id)
-                stopped = True
-            except podman.PodmanError as e:
-                logger.warning(
-                    "Failed to stop container %s: %s",
-                    container_id,
-                    e,
-                )
+            stopped = await self._try_remove_container(container_id)
             # The caller (/stop, /delete) knows the workspace_id even when
             # this container isn't tracked in the in-memory registry
             # (started by autostart or a prior klangkd session, stopped
             # without a connect in this process).
             if ws_id:
-                async with self._get_workspace_lock(ws_id):
-                    # Re-verify under the lock: a racing start_container
-                    # may have re-bound this workspace to a new container
-                    # while we waited. Only tear down state we still own.
-                    # The check uses the live registry state (not the
-                    # reverse cid map) so it can tell a re-bound workspace
-                    # (state's container_id differs -- leave the fresh
-                    # sidecar generation alone, #2265) from an untracked
-                    # one (no state -- no racing start possible, so its
-                    # sidecar is safe to remove by label even though it
-                    # isn't in the in-memory set).
-                    current = self.states.get(ws_id)
-                    if current is None or current.container_id == container_id:
-                        # Remove the network sidecar (label-based, idempotent
-                        # -- a no-op for non-filtered workspaces or when
-                        # egress is disabled). Done for every non-rebound
-                        # stop so a sidecar started by autostart / a prior
-                        # session is cleaned up even if it isn't tracked in
-                        # _ws_with_network_sidecar (#2286).
-                        self._ws_with_network_sidecar.discard(ws_id)
-                        self._ws_netns_owner.pop(ws_id, None)
-                        await self.stop_network_sidecar(ws_id)
-                        self._cid_to_wsid.pop(container_id, None)
-                        self.revoke_workspace_browsers(ws_id)
-                        self.states.pop(ws_id, None)
-                        torn_down = True
-                    else:
-                        # Re-bound to a fresh container by a racing start:
-                        # the fresh container is not ours to stop.
-                        torn_down = False
+                torn_down = await self._teardown_registry_state(
+                    ws_id, container_id
+                )
             # Drop the per-container service-firing lock (#1188), then sweep
             # any other entries orphaned by container churn (e.g. a racing
             # re-bind that popped this container's mapping before teardown)
@@ -1940,7 +2046,7 @@ class ContainerRegistry(NetworkSidecarMixin):
             self.prune_service_session_locks(set(self._cid_to_wsid))
             # Gone via this call AND (untracked, or our registry state torn
             # down — i.e. not left alone by the rebind guard).
-            result = stopped if ws_id is None else (stopped and torn_down)
+            result = self._stop_outcome(ws_id, stopped, torn_down)
             await self.audit_stop(
                 ws_id,
                 container_id,
@@ -1958,6 +2064,87 @@ class ContainerRegistry(NetworkSidecarMixin):
                 # removes are slow and interleave) must still cancel it.
                 # Expected deaths never restart, no matter the ordering.
                 self.crash.on_expected_stop(ws_id)
+
+    def _begin_expected_stop(self, ws_id: str) -> None:
+        """Mark the workspace as stopping for the duration of the
+        removal below, so the crash monitor's sweep cannot misread the
+        in-flight removal as an unexpected death."""
+        self.stopping.add(ws_id)
+        # Bumped synchronously at stop ENTRY, before any await: the
+        # crash monitor snapshots the epoch around its awaits and
+        # re-checks it before scheduling a restart, so a stop that
+        # begins at any point during death detection/handling
+        # invalidates the restart — even if the stop fully completes
+        # before the scheduler re-checks (#2524 review).
+        self.stop_epoch[ws_id] = self.stop_epoch.get(ws_id, 0) + 1
+        self.crash.on_expected_stop(ws_id)
+
+    async def _try_remove_container(self, container_id: str) -> bool:
+        """Remove the container (stop + rm). A podman failure is logged
+        as a warning, not raised — the registry teardown still runs."""
+        try:
+            await self.app.state.podman.remove_container(container_id)
+            logger.info("Stopped container %s", container_id)
+            return True
+        except podman.PodmanError as e:
+            logger.warning(
+                "Failed to stop container %s: %s",
+                container_id,
+                e,
+            )
+            return False
+
+    async def _teardown_registry_state(
+        self, ws_id: str, container_id: str
+    ) -> bool:
+        """Under the per-workspace lock, tear down the registry state we
+        still own.
+
+        Re-check (via the live registry state) that this is still the
+        workspace's container: a racing ``start_container`` may already
+        have re-bound the workspace to a fresh container, in which case
+        we must not tear down the new state (or revoke its browsers, or
+        remove its sidecar). The check uses the live registry state (not
+        the reverse cid map) so it can tell a re-bound workspace
+        (state's container_id differs — leave the fresh sidecar
+        generation alone, #2265) from an untracked one (no state — no
+        racing start possible, so its sidecar is safe to remove by label
+        even though it isn't in the in-memory set).
+
+        Returns True when the registry state was torn down; False when a
+        racing start re-bound the workspace and the fresh container was
+        left alone.
+        """
+        async with self._get_workspace_lock(ws_id):
+            current = self.states.get(ws_id)
+            if current is None or current.container_id == container_id:
+                # Remove the network sidecar (label-based, idempotent --
+                # a no-op for non-filtered workspaces or when egress is
+                # disabled). Done for every non-rebound stop so a sidecar
+                # started by autostart / a prior session is cleaned up
+                # even if it isn't tracked in _ws_with_network_sidecar
+                # (#2286).
+                self._ws_with_network_sidecar.discard(ws_id)
+                self._ws_netns_owner.pop(ws_id, None)
+                await self.stop_network_sidecar(ws_id)
+                self._cid_to_wsid.pop(container_id, None)
+                self.revoke_workspace_browsers(ws_id)
+                self.states.pop(ws_id, None)
+                return True
+            # Re-bound to a fresh container by a racing start: the fresh
+            # container is not ours to stop.
+            return False
+
+    @staticmethod
+    def _stop_outcome(
+        ws_id: str | None, stopped: bool, torn_down: bool
+    ) -> bool:
+        """True when the container ended up gone via this call (see the
+        ``stop_and_remove_container`` docstring for why a re-bind counts
+        as not-gone)."""
+        if ws_id is None:
+            return stopped
+        return stopped and torn_down
 
     async def audit_stop(
         self,
@@ -2014,11 +2201,7 @@ class ContainerRegistry(NetworkSidecarMixin):
         /stop, drain, logout) always have it at hand.
         """
         state = self.states.get(workspace_id)
-        if (
-            container_id is not None
-            and state is not None
-            and state.container_id != container_id
-        ):
+        if self._killed_container_rebound(state, container_id):
             # Re-bound to a fresh container by a racing start: the
             # workspace is live; a death teardown would corrupt it.
             logger.info(
@@ -2030,12 +2213,35 @@ class ContainerRegistry(NetworkSidecarMixin):
             )
             return
         self._notify_status_changed(workspace_id, False)
-        # Close the container-death hole (#1175 item 2): emit a terminal
-        # ``running=False`` frame so consumers watching only service_health
-        # learn the service is down.  Only health-checked workspaces ever
-        # appeared on the stream, so only those get a terminal frame.
+        await self._broadcast_service_death(state, cause)
+        await self._fire_workspace_killed(workspace_id, container_id)
+
+    def _killed_container_rebound(
+        self, state: ContainerState | None, container_id: str | None
+    ) -> bool:
+        """True when the workspace is now tracked under a DIFFERENT
+        container (a racing user-driven start removed the dead one and
+        re-bound the workspace): this death is not ours to act on."""
+        return (
+            container_id is not None
+            and state is not None
+            and state.container_id != container_id
+        )
+
+    async def _broadcast_service_death(
+        self, state: ContainerState | None, cause: str | None
+    ) -> None:
+        """Emit a terminal ``running=False`` frame so consumers watching
+        only service_health learn the service is down (#1175 item 2).
+        Only health-checked workspaces ever appeared on the stream, so
+        only those get a terminal frame."""
         if state is not None and state.health_check is not None:
             await self.health.broadcast_death(state, message=cause)
+
+    async def _fire_workspace_killed(
+        self, workspace_id: str, container_id: str | None
+    ) -> None:
+        """Call the on_workspace_killed callback, logging any errors."""
         if self.on_workspace_killed:
             try:
                 await self.on_workspace_killed(workspace_id, container_id)
@@ -2369,45 +2575,33 @@ class ContainerRegistry(NetworkSidecarMixin):
             cid = container_ident(c)
             if not cid:
                 continue
-            labels = c.get("Labels") or {}
-            pid_label = labels.get("klangk.pid")
-            if not pid_label:
-                # Tolerant: no pid label → can't decide liveness → leave it.
-                continue
-            try:
-                owner_pid = int(pid_label)
-            except (TypeError, ValueError):
-                continue  # unparseable pid → treat as no label → leave it
-            if owner_pid <= 0 or pid_alive(owner_pid):
-                continue  # owner still running → leave it (#1556)
-            logger.info(
-                "Reaping dead-owner container %s "
-                "(owner pid %d no longer running)",
-                cid[:12],
-                owner_pid,
-            )
-            if await safe_remove(
-                self.app.state.podman, cid, what="dead-owner container"
-            ):
-                await self.record_reap(c)
+            owner_pid = _dead_owner_pid(c)
+            if owner_pid is None:
+                continue  # undecidable or owner alive → leave it
+            await self._reap_dead_owner_container(c, cid, owner_pid)
+
+    async def _reap_dead_owner_container(
+        self, c: dict, cid: str, owner_pid: int
+    ) -> None:
+        """Gracefully remove one dead-owner container, recording its
+        audit row on success (#2915 review)."""
+        logger.info(
+            "Reaping dead-owner container %s (owner pid %d no longer running)",
+            cid[:12],
+            owner_pid,
+        )
+        if await safe_remove(
+            self.app.state.podman, cid, what="dead-owner container"
+        ):
+            await self.record_reap(c)
 
     # --- Shutdown ---
 
     async def shutdown(self) -> None:
-        if self.cleanup_task:
-            self.cleanup_task.cancel()
-            try:
-                await self.cleanup_task
-            except asyncio.CancelledError:
-                pass
-            self.cleanup_task = None
-        if self.health_task:
-            self.health_task.cancel()
-            try:
-                await self.health_task
-            except asyncio.CancelledError:
-                pass
-            self.health.health_task = None
+        await self._cancel_and_await(self.cleanup_task)
+        self.cleanup_task = None
+        await self._cancel_and_await(self.health_task)
+        self.health.health_task = None
         # Crash monitor (#2524): stop the sweep and cancel any pending
         # delayed restarts — a shutdown-time restart would race the
         # container teardown below.
@@ -2417,6 +2611,26 @@ class ContainerRegistry(NetworkSidecarMixin):
             self.stop_and_remove_container(cid, cause=CAUSE_SHUTDOWN)
             for cid in tracked_ids
         ]
+        tasks += await self._shutdown_orphan_tasks(tracked_ids)
+        if tasks:
+            await asyncio.gather(*tasks, return_exceptions=True)
+
+    @staticmethod
+    async def _cancel_and_await(task) -> None:
+        """Cancel a background task and await its termination."""
+        if task is None:
+            return
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+
+    async def _shutdown_orphan_tasks(self, tracked_ids: set[str]) -> list:
+        """Stop tasks for labeled containers beyond the tracked set:
+        a prior-session workspace or its sidecar stopped at shutdown
+        must not vanish from the audit trail (#2915 review)."""
+        tasks = []
         try:
             containers = await self.app.state.podman.list_containers(
                 f"klangk.instance={self.app.state.util.instance_id()}"
@@ -2428,10 +2642,6 @@ class ContainerRegistry(NetworkSidecarMixin):
                         "Removing orphaned klangk container %s",
                         cid,
                     )
-                    # Labeled containers keep their stop row
-                    # (#2915 review) — a prior-session workspace or its
-                    # sidecar stopped at shutdown must not vanish from the
-                    # audit trail.
                     tasks.append(
                         self.sweep_stop_audited(c, cause=CAUSE_SHUTDOWN)
                     )
@@ -2440,5 +2650,4 @@ class ContainerRegistry(NetworkSidecarMixin):
             OSError,
         ) as e:
             logger.warning("Error listing orphaned containers: %s", e)
-        if tasks:
-            await asyncio.gather(*tasks, return_exceptions=True)
+        return tasks

--- a/src/klangk/klangk/container/sidecar.py
+++ b/src/klangk/klangk/container/sidecar.py
@@ -43,6 +43,11 @@ _NETWORK_SIDECAR_NFQUEUE = 5139
 ORPHAN_TOKEN_SWEEP_INTERVAL = 300
 
 
+def _first_container_name(c: dict) -> str:
+    names = c.get("Names") or []
+    return names[0] if names else ""
+
+
 def container_ident(c: dict) -> str:
     """Best-effort identifier for a ``podman ps`` container dict.
 
@@ -51,11 +56,17 @@ def container_ident(c: dict) -> str:
     present. Shared by the sidecar removal sweep and the registry reaps
     (#2548).
     """
-    ident = c.get("Id") or c.get("ID") or ""
-    if not ident:
-        names = c.get("Names") or []
-        ident = names[0] if names else ""
-    return ident
+    ident = c.get("Id") or c.get("ID")
+    return ident or _first_container_name(c)
+
+
+def labeled_role_ident(c: dict, role: str) -> str | None:
+    """Ident of a listed container when its ``klangk.role`` label is
+    *role*, else None (no ident / different role)."""
+    labels = c.get("Labels") or {}
+    if labels.get("klangk.role") != role:
+        return None
+    return container_ident(c) or None
 
 
 def labeled_workspace_id(c: dict) -> str | None:
@@ -73,6 +84,32 @@ def labeled_workspace_id(c: dict) -> str | None:
     if labels.get("klangk.role") != "workspace":
         return None
     return labels.get("klangk.workspace") or None
+
+
+def _remaining_sidecar_idents(containers: list[dict]) -> set[str]:
+    """Idents of the sidecar-role containers in a listing."""
+    return {
+        container_ident(c)
+        for c in containers
+        if (c.get("Labels") or {}).get("klangk.role") == "network-sidecar"
+    }
+
+
+def _forwarded_egress_env() -> list[str]:
+    """Operator-tunable sidecar env opts (TTL floor, sweep cadence, debug
+    RST, activity gate), forwarded when set in klangkd's environment —
+    see the notes in ``_network_sidecar_env``."""
+    forwarded = []
+    for opt in (
+        "KLANGKNETWORK_EGRESS_MIN_TTL",
+        "KLANGKNETWORK_EGRESS_SWEEP_INTERVAL",
+        "KLANGKNETWORK_EGRESS_DEBUG_RST",
+        "KLANGKNETWORK_EGRESS_ACTIVITY_GATE",
+    ):
+        value = os.environ.get(opt)
+        if value:
+            forwarded.append(f"{opt}={value}")
+    return forwarded
 
 
 class NetworkSidecarMixin:
@@ -161,26 +198,47 @@ class NetworkSidecarMixin:
         except Exception as e:
             logger.warning("Cannot list workspace ids for token sweep: %s", e)
             return 0
+        return self._unlink_orphaned_tokens(token_dir, names, existing)
+
+    def _unlink_orphaned_tokens(
+        self, token_dir: str, names: list[str], existing: set[str]
+    ) -> int:
+        """Unlink token files whose workspace row is gone; transient
+        ``.tmp`` files and non-files are skipped. Returns the count."""
         removed = 0
         for name in names:
-            # Skip transient write_sidecar_token temp files: unlinking one
-            # races the writer (os.replace would then FileNotFoundError).
-            if name.endswith(".tmp"):
-                continue
-            path = os.path.join(token_dir, name)
-            if not os.path.isfile(path):
-                continue
-            if name in existing:
-                continue
-            try:
-                os.unlink(path)
+            path = self._orphaned_token_path(token_dir, name, existing)
+            if path is not None and self._unlink_token_file(path, name):
                 removed += 1
-                logger.info("Removed orphaned sidecar token %s", name)
-            except OSError as e:
-                logger.warning(
-                    "Could not remove orphaned token %s: %s", name, e
-                )
         return removed
+
+    def _orphaned_token_path(
+        self, token_dir: str, name: str, existing: set[str]
+    ) -> str | None:
+        """Path of one token file to remove — not a transient ``.tmp``,
+        a real file, with no workspace row — or None to skip it.
+
+        Skipping ``.tmp`` matters: unlinking one races the writer
+        (os.replace would then FileNotFoundError)."""
+        if name.endswith(".tmp"):
+            return None
+        path = os.path.join(token_dir, name)
+        if not os.path.isfile(path):
+            return None
+        if name in existing:
+            return None
+        return path
+
+    def _unlink_token_file(self, path: str, name: str) -> bool:
+        """Unlink one orphaned token file; failures are logged and
+        swallowed so one stuck file never aborts the sweep."""
+        try:
+            os.unlink(path)
+            logger.info("Removed orphaned sidecar token %s", name)
+            return True
+        except OSError as e:
+            logger.warning("Could not remove orphaned token %s: %s", name, e)
+            return False
 
     async def start_network_sidecar(
         self,
@@ -259,16 +317,9 @@ class NetworkSidecarMixin:
             # race that made the iptables REJECT rule flaky. Safe to grant
             # here (unlike on the workspace): the sidecar runs only klangk's
             # own proxy, no untrusted code.
-            sidecar_kwargs = dict(
-                cap_add=["NET_ADMIN", "NET_RAW"],
-                dns=["1.1.1.1"],
-                env=env,
-                labels=labels,
-                publish=publish,
-                pull="missing",
+            sidecar_kwargs = self._sidecar_create_kwargs(
+                env, labels, publish, binds
             )
-            if binds:
-                sidecar_kwargs["binds"] = binds
             cid = await self.app.state.podman.create_container(
                 name, image, **sidecar_kwargs
             )
@@ -302,6 +353,22 @@ class NetworkSidecarMixin:
             )
             raise
 
+    def _sidecar_create_kwargs(
+        self, env: list[str], labels: dict, publish, binds: list[str]
+    ) -> dict:
+        """create_container kwargs for the network sidecar."""
+        kwargs = dict(
+            cap_add=["NET_ADMIN", "NET_RAW"],
+            dns=["1.1.1.1"],
+            env=env,
+            labels=labels,
+            publish=publish,
+            pull="missing",
+        )
+        if binds:
+            kwargs["binds"] = binds
+        return kwargs
+
     async def _remove_sidecar_attempts(
         self, workspace_id: str, containers: list[dict]
     ) -> list[tuple[str, podman.PodmanError]]:
@@ -309,11 +376,8 @@ class NetworkSidecarMixin:
         failed."""
         failures: list[tuple[str, podman.PodmanError]] = []
         for c in containers:
-            labels = c.get("Labels") or {}
-            if labels.get("klangk.role") != "network-sidecar":
-                continue
-            ident = container_ident(c)
-            if not ident:
+            ident = labeled_role_ident(c, "network-sidecar")
+            if ident is None:
                 continue
             exc = await self._force_remove_sidecar(workspace_id, ident)
             if exc is not None:
@@ -342,11 +406,7 @@ class NetworkSidecarMixin:
         remaining = await self._list_workspace_containers(workspace_id)
         if remaining is None:
             return None
-        remaining_sidecars = {
-            container_ident(c)
-            for c in remaining
-            if (c.get("Labels") or {}).get("klangk.role") == "network-sidecar"
-        }
+        remaining_sidecars = _remaining_sidecar_idents(remaining)
         return [(i, e) for i, e in failures if i in remaining_sidecars]
 
     def _network_sidecar_labels(
@@ -393,9 +453,8 @@ class NetworkSidecarMixin:
             if _NETWORK_SIDECAR_READY_TOKEN in logs:
                 ready = True
                 break
-            state = await self.app.state.podman.inspect_container(cid)
-            status = (state or {}).get("State", {}).get("Status", "")
-            if status in ("exited", "stopped"):
+            status = await self._sidecar_exit_status(cid)
+            if status:
                 raise podman.PodmanError(
                     500,
                     f"network sidecar {name} exited before the DNS proxy "
@@ -409,6 +468,14 @@ class NetworkSidecarMixin:
                 f"within {NETWORK_SIDECAR_READY_TIMEOUT:.0f}s; the "
                 "workspace would join an unfiltered netns",
             )
+
+    async def _sidecar_exit_status(self, cid: str) -> str:
+        """The sidecar's Status when it already exited/stopped, else ''."""
+        state = await self.app.state.podman.inspect_container(cid)
+        status = (state or {}).get("State", {}).get("Status", "")
+        if status in ("exited", "stopped"):
+            return status
+        return ""
 
     def _network_sidecar_env(
         self,
@@ -438,15 +505,7 @@ class NetworkSidecarMixin:
         # ACTIVITY_GATE (default 60s) likewise: the idle fuzz harness
         # (scripts/fuzz-idle.py, #2514) lowers it so the sidecar's
         # egress-activity bumps are observable at its seconds-scale timeouts.
-        for _opt in (
-            "KLANGKNETWORK_EGRESS_MIN_TTL",
-            "KLANGKNETWORK_EGRESS_SWEEP_INTERVAL",
-            "KLANGKNETWORK_EGRESS_DEBUG_RST",
-            "KLANGKNETWORK_EGRESS_ACTIVITY_GATE",
-        ):
-            _v = os.environ.get(_opt)
-            if _v:
-                env.append(f"{_opt}={_v}")
+        env.extend(_forwarded_egress_env())
         binds = []
         # #2242/#2311: consent recording runs for every filtered workspace
         # when the consent stack is wired, regardless of egress_mode -- the
@@ -456,21 +515,27 @@ class NetworkSidecarMixin:
         # (write_sidecar_token), not baked in env (it rotates). The sweeper
         # attribute gates the stack being present at all.
         if getattr(self.app.state, "consent_sweeper", None) is not None:
-            port = self.app.state.settings.egress_port
-            env.append(
-                "KLANGKNETWORK_EGRESS_CONSENT_URL="
-                f"http://host.containers.internal:{port}"
-                "/internal/egress-consent/events"
-            )
-            env.append(
-                f"KLANGKNETWORK_EGRESS_NFQUEUE_NUM={_NETWORK_SIDECAR_NFQUEUE}"
-            )
-            token = self.app.state.auth.create_workspace_token(workspace_id)
-            self.write_sidecar_token(workspace_id, token)
-            binds.append(
-                f"{self._sidecar_token_path(workspace_id)}"
-                ":/run/klangk/workspace-token:ro"
-            )
+            consent_env, binds = self._consent_stack_env(workspace_id)
+            env.extend(consent_env)
+        return env, binds
+
+    def _consent_stack_env(
+        self, workspace_id: str
+    ) -> tuple[list[str], list[str]]:
+        """(env entries, binds) wiring the sidecar to the consent stack."""
+        port = self.app.state.settings.egress_port
+        env = [
+            "KLANGKNETWORK_EGRESS_CONSENT_URL="
+            f"http://host.containers.internal:{port}"
+            "/internal/egress-consent/events",
+            f"KLANGKNETWORK_EGRESS_NFQUEUE_NUM={_NETWORK_SIDECAR_NFQUEUE}",
+        ]
+        token = self.app.state.auth.create_workspace_token(workspace_id)
+        self.write_sidecar_token(workspace_id, token)
+        binds = [
+            f"{self._sidecar_token_path(workspace_id)}"
+            ":/run/klangk/workspace-token:ro"
+        ]
         return env, binds
 
     def _network_sidecar_upstream(self) -> str:
@@ -618,11 +683,8 @@ class NetworkSidecarMixin:
         if containers is None:
             return
         for c in containers:
-            labels = c.get("Labels") or {}
-            if labels.get("klangk.role") != "workspace":
-                continue
-            ident = container_ident(c)
-            if not ident:
+            ident = labeled_role_ident(c, "workspace")
+            if ident is None:
                 continue
             try:
                 await self.app.state.podman.remove_container(ident, force=True)

--- a/src/klangk/klangk/container/spec.py
+++ b/src/klangk/klangk/container/spec.py
@@ -231,6 +231,19 @@ def resolve_tmp_size(app, workspace_settings: dict | None) -> str | None:
     )
 
 
+def _missing_hosting_value(
+    hosting_hostname: str | None,
+    hosting_proto: str | None,
+    hosting_base_path: str | None,
+) -> bool:
+    """True when any hosting value is omitted (the floor is needed)."""
+    return (
+        hosting_hostname is None
+        or hosting_proto is None
+        or hosting_base_path is None
+    )
+
+
 def hosting_floor(
     app,
     hosting_hostname: str | None,
@@ -239,10 +252,8 @@ def hosting_floor(
 ) -> tuple[str, str, str]:
     """Fill any omitted hosting value with the resolver's floor
     (``derive_hosting_info`` with no request)."""
-    if (
-        hosting_hostname is None
-        or hosting_proto is None
-        or hosting_base_path is None
+    if _missing_hosting_value(
+        hosting_hostname, hosting_proto, hosting_base_path
     ):
         h, p, b = app.state.util.derive_hosting_info(None, None)
         # Use ``is None`` (not ``or``): an explicit empty base_path
@@ -394,46 +405,96 @@ async def _ensure_named_volume(app, user_id, podman, source: str) -> None:
     validate an existing one belongs to this instance and user."""
     info = await podman.inspect_volume(source)
     if info is None:
-        labels = {
-            "klangk.managed": "true",
-            "klangk.instance": app.state.util.instance_id(),
-        }
-        if user_id:
-            labels["klangk.user-id"] = user_id
-            # Per-user volume quota (#2972): this start-path auto-create
-            # is the second door that mints user-owned volumes (the
-            # POST /volumes route is the first) — a user at quota must
-            # not bypass the cap by adding mounts to a workspace. Same
-            # per-user lock as the route, so a concurrent API create
-            # and this start cannot each pass a cap they jointly exceed.
-            # The ValueError surfaces as a clear start error
-            # (registry.start_container maps it).
-            quota = app.state.settings.volume_quota_per_user
-            if quota > 0:
-                async with podman.volume_create_lock(user_id):
-                    count = await podman.count_user_volumes(
-                        app.state.util.instance_id(), user_id
-                    )
-                    if count >= quota:
-                        raise ValueError(
-                            f"volume quota reached: {count} of this "
-                            "user's volumes already exist and the server "
-                            f"caps it at {quota} "
-                            "(KLANGKD_VOLUME_QUOTA_PER_USER); remove a "
-                            "volume mount or delete a volume first"
-                        )
-                    await podman.create_volume(source, labels)
-                return
-        await podman.create_volume(source, labels)
+        await _create_named_volume(app, user_id, podman, source)
         return
+    _validate_volume_ownership(app, user_id, source, info)
+
+
+async def _create_named_volume(app, user_id, podman, source: str) -> None:
+    """Create a named volume, instance-labelled and owner-tagged."""
+    labels = {
+        "klangk.managed": "true",
+        "klangk.instance": app.state.util.instance_id(),
+    }
+    if user_id:
+        labels["klangk.user-id"] = user_id
+        quota = app.state.settings.volume_quota_per_user
+        if quota > 0:
+            await _create_volume_under_quota(
+                app, user_id, podman, source, labels, quota
+            )
+            return
+    await podman.create_volume(source, labels)
+
+
+async def _create_volume_under_quota(
+    app, user_id, podman, source: str, labels: dict, quota: int
+) -> None:
+    """Create one volume under the per-user lock, refusing at the cap.
+
+    Per-user volume quota (#2972): this start-path auto-create is the
+    second door that mints user-owned volumes (the POST /volumes route
+    is the first) — a user at quota must not bypass the cap by adding
+    mounts to a workspace. Same per-user lock as the route, so a
+    concurrent API create and this start cannot each pass a cap they
+    jointly exceed. The ValueError surfaces as a clear start error
+    (registry.start_container maps it).
+    """
+    async with podman.volume_create_lock(user_id):
+        count = await podman.count_user_volumes(
+            app.state.util.instance_id(), user_id
+        )
+        if count >= quota:
+            raise ValueError(
+                f"volume quota reached: {count} of this "
+                "user's volumes already exist and the server "
+                f"caps it at {quota} "
+                "(KLANGKD_VOLUME_QUOTA_PER_USER); remove a "
+                "volume mount or delete a volume first"
+            )
+        await podman.create_volume(source, labels)
+
+
+def _foreign_volume_owner(vol_owner: str | None, user_id: str | None) -> bool:
+    """True when the volume is tagged to a different user than the
+    starter (both must be known to compare)."""
+    return bool(vol_owner) and bool(user_id) and vol_owner != user_id
+
+
+def _validate_volume_ownership(
+    app, user_id: str | None, source: str, info: dict
+) -> None:
+    """An existing volume must belong to this instance and user."""
     vol_labels = info.get("Labels") or {}
     if vol_labels.get("klangk.instance") != app.state.util.instance_id():
         raise ValueError(
             f"Volume {source!r} is not managed by this klangk instance"
         )
     vol_owner = vol_labels.get("klangk.user-id")
-    if vol_owner and user_id and vol_owner != user_id:
+    if _foreign_volume_owner(vol_owner, user_id):
         raise ValueError(f"Volume {source!r} belongs to another user")
+
+
+async def _ensure_one_volume(
+    app, user_id: str | None, podman, mount_spec: str
+) -> None:
+    """Create/validate the source of one extra mount."""
+    source = mount_spec.split(":")[0]
+    if is_named_volume(source):
+        # Defense in depth (#3018): validate_mount_spec already
+        # rejects unsafe names at the API boundary, but a row
+        # created before that gate (or written by another path)
+        # must never reach podman argv either — _ensure_named_volume
+        # appends the name verbatim to the command line.
+        if not valid_volume_name(source):
+            raise ValueError(
+                f"Volume name {source!r} is not podman-safe "
+                "(must start alphanumeric, contain only "
+                "[a-zA-Z0-9_.-], and be at most 64 chars)"
+            )
+        await _ensure_named_volume(app, user_id, podman, source)
+    elif not os.path.exists(source):
+        raise ValueError(f"Bind mount source does not exist: {source}")
 
 
 async def ensure_volumes(
@@ -446,22 +507,7 @@ async def ensure_volumes(
     if not extra_mounts:
         return
     for mount_spec in extra_mounts:
-        source = mount_spec.split(":")[0]
-        if is_named_volume(source):
-            # Defense in depth (#3018): validate_mount_spec already
-            # rejects unsafe names at the API boundary, but a row
-            # created before that gate (or written by another path)
-            # must never reach podman argv either — _ensure_named_volume
-            # appends the name verbatim to the command line.
-            if not valid_volume_name(source):
-                raise ValueError(
-                    f"Volume name {source!r} is not podman-safe "
-                    "(must start alphanumeric, contain only "
-                    "[a-zA-Z0-9_.-], and be at most 64 chars)"
-                )
-            await _ensure_named_volume(app, user_id, podman, source)
-        elif not os.path.exists(source):
-            raise ValueError(f"Bind mount source does not exist: {source}")
+        await _ensure_one_volume(app, user_id, podman, mount_spec)
 
 
 async def nix_binds(

--- a/src/klangk/klangk/wshandler/connection.py
+++ b/src/klangk/klangk/wshandler/connection.py
@@ -385,26 +385,7 @@ class Connection:
         await self.handle_workspace_disconnect()
 
         t_container = time.monotonic()
-        try:
-            await self.start_workspace_container(workspace_id, workspace)
-        except ValueError as exc:
-            send_error(self.sock, str(exc))
-            return
-        except NodeDrainingError as exc:
-            # Draining node (#2527): a graceful restart is in progress
-            # and new starts are disabled; existing workspaces keep
-            # running. Error frame, not a drop.
-            send_error(self.sock, str(exc))
-            return
-        except WorkspaceCapacityError as exc:
-            # Capacity refusal (#2525): the host cannot fit the
-            # workspace's memory limit or the user hit the running
-            # quota. Error frame with the actionable message ("stop a
-            # workspace first / free host memory") and a machine-
-            # readable ``code`` so the UI can render it as a capacity
-            # refusal rather than a generic failure — not a drop; the
-            # client stays connected and can retry once capacity frees.
-            send_error(self.sock, str(exc), code="capacity")
+        if not await self._start_workspace_or_refuse(workspace_id, workspace):
             return
         logger.info(
             "workspace-open: start or reuse container "
@@ -417,12 +398,7 @@ class Connection:
             workspace_id
         )
         status = getattr(self, "container_status", "created")
-        container_name, ports_str = format_container_info(
-            workspace_id,
-            ports,
-            self.app.state.util.instance_id(),
-            (self.workspace or {}).get("name") or "",
-        )
+        container_name, ports_str = self._container_label(workspace_id, ports)
         status_msg = {
             "connected": f"Connected to running container "
             f"{container_name}{ports_str}",
@@ -469,6 +445,45 @@ class Connection:
         self.workspace_id = None
         self.container_id = None
 
+    async def _start_workspace_or_refuse(
+        self, workspace_id: str, workspace: dict
+    ) -> bool:
+        """Start (or reuse) the workspace's container, mapping each
+        refusal to an error frame; True to proceed."""
+        try:
+            await self.start_workspace_container(workspace_id, workspace)
+            return True
+        except ValueError as exc:
+            send_error(self.sock, str(exc))
+            return False
+        except NodeDrainingError as exc:
+            # Draining node (#2527): a graceful restart is in progress
+            # and new starts are disabled; existing workspaces keep
+            # running. Error frame, not a drop.
+            send_error(self.sock, str(exc))
+            return False
+        except WorkspaceCapacityError as exc:
+            # Capacity refusal (#2525): the host cannot fit the
+            # workspace's memory limit or the user hit the running
+            # quota. Error frame with the actionable message ("stop a
+            # workspace first / free host memory") and a machine-
+            # readable ``code`` so the UI can render it as a capacity
+            # refusal rather than a generic failure — not a drop; the
+            # client stays connected and can retry once capacity frees.
+            send_error(self.sock, str(exc), code="capacity")
+            return False
+
+    def _container_label(
+        self, workspace_id: str, ports: list
+    ) -> tuple[str, str]:
+        """(container_name, ports_str) for status messages."""
+        return format_container_info(
+            workspace_id,
+            ports,
+            self.app.state.util.instance_id(),
+            (self.workspace or {}).get("name") or "",
+        )
+
     async def handle_restart_container(self) -> None:
         """Restart a stopped container (e.g., after idle timeout)."""
         if not self.workspace_id:
@@ -495,10 +510,7 @@ class Connection:
             session, self.sock, "container_restart", "Restarting container..."
         )
 
-        try:
-            await self.cleanup()
-        except WS_ERRORS as e:
-            logger.warning("Cleanup error during restart: %s", e)
+        await self._cleanup_logging_errors()
 
         # Always read the workspace fresh from the DB (#2676): the cached
         # self.workspace dict can carry a stale container_id (an unclean
@@ -514,48 +526,56 @@ class Connection:
             send_error(self.sock, "Workspace not found", code="not_found")
             return
 
+        if not await self._restart_workspace_or_refuse(
+            workspace_id, workspace
+        ):
+            return
+        await self._announce_restarted_container(workspace_id)
+
+    async def _cleanup_logging_errors(self) -> None:
+        """Cleanup, warning (not raising) on a WS error mid-restart."""
+        try:
+            await self.cleanup()
+        except WS_ERRORS as e:
+            logger.warning("Cleanup error during restart: %s", e)
+
+    async def _restart_workspace_or_refuse(
+        self, workspace_id: str, workspace: dict
+    ) -> bool:
+        """Start the restarted container, mapping each refusal to an
+        error frame; True to proceed with the announcement."""
         try:
             await self.start_workspace_container(workspace_id, workspace)
+            return True
         except NodeDrainingError as exc:
             # Draining node (#2527) — same clear refusal on the WS restart
             # path as the API's 503.
             send_error(self.sock, str(exc))
-            return
+            return False
         except WorkspaceCapacityError as exc:
             # Capacity refusal (#2525) — same clear refusal on the WS
             # restart path as the API's 503, with the machine-readable
             # capacity code.
             send_error(self.sock, str(exc), code="capacity")
-            return
+            return False
         except (PodmanError, ValueError) as exc:
             # A failed (re)start must not drop the whole WebSocket with a
             # traceback (#2676) — the user's session survives and can retry;
             # the error frame surfaces the actionable podman message.
             send_error(self.sock, f"Container restart failed: {exc}")
-            return
-        await self._announce_restarted_container(workspace_id)
+            return False
 
     async def _announce_restarted_container(self, workspace_id) -> None:
         """Record activity, re-bind sibling connections to the new
         container, and broadcast the container_ready frame (#3008)."""
         self.app.state.container_registry.record_activity(self.container_id)
 
-        # Update container_id on ALL connections to this workspace
-        # so they don't try to exec into the old (removed) container.
-        new_cid = self.container_id
-        for sock, conn in list(self.app.state.sockets.connections.items()):
-            if conn.workspace_id == workspace_id and conn is not self:
-                conn.container_id = new_cid
+        self._rebind_sibling_connections(workspace_id, self.container_id)
 
         ports = await self.app.state.container_registry.get_workspace_ports(
             workspace_id
         )
-        container_name, ports_str = format_container_info(
-            workspace_id,
-            ports,
-            self.app.state.util.instance_id(),
-            (self.workspace or {}).get("name") or "",
-        )
+        container_name, ports_str = self._container_label(workspace_id, ports)
         status_msg = f"Container restarted {container_name}{ports_str}"
 
         timeout_mins = (
@@ -576,6 +596,13 @@ class Connection:
             "Container restarted via restart_container command for workspace %s",
             workspace_id,
         )
+
+    def _rebind_sibling_connections(self, workspace_id: str, new_cid) -> None:
+        """Update container_id on ALL other connections to this workspace
+        so they don't try to exec into the old (removed) container."""
+        for sock, conn in list(self.app.state.sockets.connections.items()):
+            if conn.workspace_id == workspace_id and conn is not self:
+                conn.container_id = new_cid
 
     async def has_perm(self, perm: str) -> bool:
         """Check if the connected user has a workspace permission."""
@@ -673,26 +700,7 @@ class Connection:
             await self.app.state.model.users.set_user_handle(
                 self.user["id"], handle
             )
-            # Update the per-workspace symlink (per-handle layout only;
-            # the shared layout has no per-user symlink and its home is
-            # the constant SHARED_HOME — nothing to refresh, #2720).
-            workspace = self.workspace
-            if workspace and workspace.get("per_handle_home", True):
-                workspace_home = self.app.state.workspaces.home_path(
-                    self.workspace_id
-                )
-                (
-                    container_home,
-                    created,
-                ) = await self.app.state.workspaces.ensure_home_symlink(
-                    workspace_home, handle, self.user["id"]
-                )
-                if created and self.container_id:
-                    await self.app.state.workspaces.populate_home_skel(
-                        self.container_id,
-                        self.user["id"],
-                    )
-                self._user_home = container_home
+            await self._refresh_handle_home(handle)
             self.sock.send_json(
                 {
                     "type": "handle_set",
@@ -708,15 +716,32 @@ class Connection:
                 }
             )
 
+    async def _refresh_handle_home(self, handle: str) -> None:
+        """Update the per-workspace symlink and home reference for a new
+        handle (per-handle layout only; the shared layout has no per-user
+        symlink and its home is the constant SHARED_HOME — nothing to
+        refresh, #2720)."""
+        workspace = self.workspace
+        if not (workspace and workspace.get("per_handle_home", True)):
+            return
+        workspace_home = self.app.state.workspaces.home_path(self.workspace_id)
+        (
+            container_home,
+            created,
+        ) = await self.app.state.workspaces.ensure_home_symlink(
+            workspace_home, handle, self.user["id"]
+        )
+        if created and self.container_id:
+            await self.app.state.workspaces.populate_home_skel(
+                self.container_id,
+                self.user["id"],
+            )
+        self._user_home = container_home
+
     async def cleanup(self) -> None:
         # Remove idle callback
         workspace_id = self.workspace_id
-        idle_cb = self._idle_cb
-        if workspace_id and idle_cb:
-            self.app.state.container_registry.remove_idle_callback(
-                workspace_id, idle_cb
-            )
-            self._idle_cb = None
+        self._remove_idle_callback(workspace_id)
 
         # Revoke per-connection browser registrations
         self.app.state.container_registry.revoke_browser(self.sock)
@@ -740,3 +765,12 @@ class Connection:
                 # Lock is released by remove_subscriber, so use the
                 # lock-acquiring version.
                 await self.app.state.sockets.remove_session(workspace_id)
+
+    def _remove_idle_callback(self, workspace_id) -> None:
+        """Drop this connection's idle callback, if armed."""
+        idle_cb = self._idle_cb
+        if workspace_id and idle_cb:
+            self.app.state.container_registry.remove_idle_callback(
+                workspace_id, idle_cb
+            )
+            self._idle_cb = None

--- a/src/klangk/klangk/wshandler/controllers.py
+++ b/src/klangk/klangk/wshandler/controllers.py
@@ -292,20 +292,24 @@ class SshAgentForwarder:
         if proc is None or proc.stdout is None:
             return
         try:
-            while True:
-                data = await proc.stdout.read(65536)
-                if not data:
-                    break
-                self._conn.sock.send_json(
-                    {
-                        "type": "ssh_agent_response",
-                        "data": base64.b64encode(data).decode("ascii"),
-                    }
-                )
+            await self._relay_stream(proc.stdout)
         except asyncio.CancelledError:
             logger.debug("SSH agent output relay cancelled")
         except OSError as e:
             logger.warning("SSH agent output relay error: %s", e)
+
+    async def _relay_stream(self, stdout) -> None:
+        """Relay socat stdout frames to the client, base64-encoded."""
+        while True:
+            data = await stdout.read(65536)
+            if not data:
+                break
+            self._conn.sock.send_json(
+                {
+                    "type": "ssh_agent_response",
+                    "data": base64.b64encode(data).decode("ascii"),
+                }
+            )
 
     async def data(self, msg: dict) -> None:
         """Write data from the CLI's local agent into socat stdin."""
@@ -325,20 +329,8 @@ class SshAgentForwarder:
 
     async def stop(self) -> None:
         """Clean up the SSH agent relay process."""
-        if self.task is not None:
-            self.task.cancel()
-            try:
-                await self.task
-            except asyncio.CancelledError:
-                pass
-            self.task = None
-        if self.proc is not None:
-            try:
-                self.proc.kill()
-                await self.proc.wait()
-            except ProcessLookupError:
-                logger.debug("SSH agent process already exited")
-            self.proc = None
+        await self._cancel_task()
+        await self._kill_proc()
         container_id = self._conn.container_id
         # Reap the in-container socat directly. ``proc.kill()`` above sends
         # SIGKILL to the local ``podman exec`` handle, which does NOT reliably
@@ -349,29 +341,56 @@ class SshAgentForwarder:
         # (same ``pkill -f`` ``start()`` uses) guarantees the container-side
         # process is gone before we remove the socket (#2001).
         if self.socket and container_id:
-            # Best-effort teardown: a failure here (container already gone,
-            # podman subprocess can't launch) must not break disconnect.
-            # ``exec_container`` runs ``check=False`` so non-zero exits don't
-            # raise; this catches the remaining launch/IO failures.
-            try:
-                await self._conn.app.state.podman.exec_container(
-                    container_id,
-                    ["pkill", "-f", f"UNIX-LISTEN:{self.socket}"],
-                )
-            except Exception as e:  # best-effort reap
-                logger.debug("Failed to reap SSH agent socat: %s", e)
-            try:
-                await self._conn.app.state.podman.exec_container(
-                    container_id,
-                    ["rm", "-f", self.socket],
-                )
-            except Exception as e:
-                logger.warning(
-                    "Failed to remove SSH agent socket %s: %s",
-                    self.socket,
-                    e,
-                )
+            await self._reap_container_socat(container_id)
         self.socket = None
+
+    async def _cancel_task(self) -> None:
+        """Cancel and await the output-forwarding task."""
+        if self.task is None:
+            return
+        self.task.cancel()
+        try:
+            await self.task
+        except asyncio.CancelledError:
+            pass
+        self.task = None
+
+    async def _kill_proc(self) -> None:
+        """Kill the local podman-exec handle (already-exited is fine)."""
+        if self.proc is None:
+            return
+        try:
+            self.proc.kill()
+            await self.proc.wait()
+        except ProcessLookupError:
+            logger.debug("SSH agent process already exited")
+        self.proc = None
+
+    async def _reap_container_socat(self, container_id: str) -> None:
+        """Kill the in-container socat listener and remove the socket.
+
+        Best-effort teardown: a failure here (container already gone,
+        podman subprocess can't launch) must not break disconnect.
+        ``exec_container`` runs ``check=False`` so non-zero exits don't
+        raise; this catches the remaining launch/IO failures."""
+        try:
+            await self._conn.app.state.podman.exec_container(
+                container_id,
+                ["pkill", "-f", f"UNIX-LISTEN:{self.socket}"],
+            )
+        except Exception as e:  # best-effort reap
+            logger.debug("Failed to reap SSH agent socat: %s", e)
+        try:
+            await self._conn.app.state.podman.exec_container(
+                container_id,
+                ["rm", "-f", self.socket],
+            )
+        except Exception as e:
+            logger.warning(
+                "Failed to remove SSH agent socket %s: %s",
+                self.socket,
+                e,
+            )
 
 
 class ExecController:
@@ -502,10 +521,7 @@ class ExecController:
                         "data": base64.b64encode(data).decode("ascii"),
                     }
                 )
-                if self._conn.container_id:
-                    self._conn.app.state.container_registry.record_activity(
-                        self._conn.container_id
-                    )
+                self._record_activity()
             # Process exited — send exit code
             self._conn.sock.send_json(
                 {
@@ -521,6 +537,13 @@ class ExecController:
             logger.error("Exec output forwarding error: %s", e)
         finally:
             await self.claim_and_stop()
+
+    def _record_activity(self) -> None:
+        """Record container activity when a container is attached."""
+        if self._conn.container_id:
+            self._conn.app.state.container_registry.record_activity(
+                self._conn.container_id
+            )
 
 
 class TerminalController:
@@ -718,17 +741,8 @@ class TerminalController:
         if not self._conn.container_id:
             logger.info("handle_terminal_start: no container_id, skipping")
             return
-        # Debounce: if the last terminal start was very recent, skip.
-        # This prevents rapid retry loops when the PTY exits immediately.
-        now = time.monotonic()
-        if hasattr(self._conn, "_last_terminal_start"):
-            if now - self._conn._last_terminal_start < 2.0:
-                logger.warning(
-                    "Ignoring rapid terminal_start (%.1fs since last)",
-                    now - self._conn._last_terminal_start,
-                )
-                return
-        self._conn._last_terminal_start = now
+        if self._recently_started():
+            return
         if self._conn._user_home is None:
             send_error(self._conn.sock, "Handle not set")
             return
@@ -758,26 +772,7 @@ class TerminalController:
         # interactive shell now; the service command is fired separately
         # in ``_start_terminal`` (after the shell session is up) so a
         # post-setup ``terminal_start`` still triggers it (#1033).
-        ws = self._conn.workspace
-        # Wire SSH_AUTH_SOCK to the deterministic per-user agent-socket path
-        # on EVERY terminal, whether or not a relay is active yet (#2001).
-        # The var is inert until a relay binds this path (which only happens
-        # when the client opts into forwarding), so pre-pointing it here means
-        # a base session created before the relay starts — the TUI path opens
-        # the tmux session, then spawns `klangk shell -A` which starts the
-        # relay — already has it set, and goes live the moment the relay binds.
-        # A reconnect to an existing session inherits it from that first
-        # creation. No per-creation-path special-casing.
-        session = TerminalSession(
-            self._conn.container_id,
-            session_name=self._conn.user["id"],
-            user_home=self._conn._user_home,
-            user_id=self._conn.user["id"],
-            user_handle=self._conn.user.get("handle"),
-            ssh_agent_socket=ssh_agent_socket_path(self._conn.user["id"]),
-            terminal=self._conn.app.state.terminal,
-            workspace_name=ws.get("name") if ws else None,
-        )
+        session = self._new_session()
 
         browser_id = msg.get("browser_id")
         self._register_browser(browser_id)
@@ -868,6 +863,45 @@ class TerminalController:
 
         self.task = asyncio.create_task(_start_terminal())
 
+    def _recently_started(self) -> bool:
+        """True when the last terminal start was very recent — skip, to
+        prevent rapid retry loops when the PTY exits immediately."""
+        now = time.monotonic()
+        if hasattr(self._conn, "_last_terminal_start"):
+            if now - self._conn._last_terminal_start < 2.0:
+                logger.warning(
+                    "Ignoring rapid terminal_start (%.1fs since last)",
+                    now - self._conn._last_terminal_start,
+                )
+                return True
+        self._conn._last_terminal_start = now
+        return False
+
+    def _new_session(self) -> TerminalSession:
+        """A TerminalSession for this connection's interactive shell.
+
+        Wires SSH_AUTH_SOCK to the deterministic per-user agent-socket
+        path on EVERY terminal, whether or not a relay is active yet
+        (#2001): the var is inert until a relay binds this path (which
+        only happens when the client opts into forwarding), so
+        pre-pointing it here means a base session created before the
+        relay starts — the TUI path opens the tmux session, then spawns
+        `klangk shell -A` which starts the relay — already has it set,
+        and goes live the moment the relay binds. A reconnect to an
+        existing session inherits it from that first creation. No
+        per-creation-path special-casing."""
+        ws = self._conn.workspace
+        return TerminalSession(
+            self._conn.container_id,
+            session_name=self._conn.user["id"],
+            user_home=self._conn._user_home,
+            user_id=self._conn.user["id"],
+            user_handle=self._conn.user.get("handle"),
+            ssh_agent_socket=ssh_agent_socket_path(self._conn.user["id"]),
+            terminal=self._conn.app.state.terminal,
+            workspace_name=ws.get("name") if ws else None,
+        )
+
     async def browser_reattach(self, msg: dict) -> None:
         """Re-register the browser ID and update the container's tmux env.
 
@@ -907,30 +941,39 @@ class TerminalController:
 
     async def input(self, msg: dict) -> None:
         t0 = time.monotonic()
-        session = self.session
-        if session is None or not session.is_alive:
-            logger.warning("terminal_input: no session or not alive")
-            return
         data = msg.get("data", "")
-        if len(data) > MAX_INPUT_SIZE:
-            logger.warning(
-                "terminal_input too large (%d bytes), dropping", len(data)
-            )
-            return
-        if session.read_only and not is_allowed_read_only_input(data):
-            # Read-only spectators may only send the terminal-protocol
-            # responses tmux needs to complete initialization (DA,
-            # color, cursor-position, XTVERSION, XTGETTCAP reports).
-            # User typing and arbitrary escape sequences — notably OSC
-            # 52 clipboard read/write — are dropped (#1716).
+        if self._session_rejects_input(self.session, data):
             return
         self._conn.app.state.container_registry.record_activity(
             self._conn.container_id
         )
-        await session.write(data)
+        await self.session.write(data)
         elapsed = time.monotonic() - t0
         if elapsed > 0.1:
             logger.warning("terminal_input SLOW: %.3fs", elapsed)
+
+    def _session_rejects_input(self, session, data: str) -> bool:
+        """True when an input frame must not reach the session (no live
+        session, oversize, or read-only content, #1716)."""
+        if session is None or not session.is_alive:
+            logger.warning("terminal_input: no session or not alive")
+            return True
+        return self._content_rejected(session, data)
+
+    def _content_rejected(self, session, data: str) -> bool:
+        """Oversize frames, and read-only spectators' non-protocol input,
+        are dropped."""
+        if len(data) > MAX_INPUT_SIZE:
+            logger.warning(
+                "terminal_input too large (%d bytes), dropping", len(data)
+            )
+            return True
+        # Read-only spectators may only send the terminal-protocol
+        # responses tmux needs to complete initialization (DA,
+        # color, cursor-position, XTVERSION, XTGETTCAP reports).
+        # User typing and arbitrary escape sequences — notably OSC
+        # 52 clipboard read/write — are dropped (#1716).
+        return session.read_only and not is_allowed_read_only_input(data)
 
     async def resize(self, msg: dict) -> None:
         self.cols = msg.get("cols", 80)
@@ -1039,16 +1082,7 @@ class TerminalController:
 
     async def new_window(self, msg: dict) -> None:
         t0 = time.monotonic()
-        if not self._conn.container_id or not self._conn._user_home:
-            return
-        # #3022: own-window frames exec into the container targeting the
-        # caller's tmux session by its bare name (``user_id``). A
-        # spectator's joiner session is named ``user_id-<hex>`` and tmux
-        # ``-t`` PREFIX-matches, so the bare name resolves into the
-        # joiner's GROUPED session — whose window list is the group's,
-        # i.e. the owner's. An ungated new_window injects a window into
-        # the owner's session.
-        if await refused_without_perm(self._conn, "code-in-isolation"):
+        if not await self._own_windows_allowed():
             return
 
         session_name = self.tmux_session_name()
@@ -1072,23 +1106,14 @@ class TerminalController:
 
     async def select_window(self, msg: dict) -> None:
         t0 = time.monotonic()
-        if not self._conn.container_id or not self._conn._user_home:
-            return
-        # #3022: own-window management needs the own-terminal permission
-        # (the frontend's own-tab strip is the same gate).
-        if await refused_without_perm(self._conn, "code-in-isolation"):
+        if not await self._own_windows_allowed():
             return
 
         # Use this connection's grouped session so select-window only
         # affects this client, not other connections to the same workspace.
-        session = self.session
-        session_name = (
-            session.tmux_session_name
-            if session and session.tmux_session_name
-            else self.tmux_session_name()
-        )
+        session_name = self._grouped_session_name()
         # Prefer @N window_id (stable); fall back to index for compat.
-        target: int | str = msg.get("window_id") or msg.get("index", 0)
+        target: int | str = self._window_target(msg)
         try:
             await self._conn.app.state.terminal.select_window(
                 self._conn.container_id,
@@ -1105,18 +1130,12 @@ class TerminalController:
             send_error(self._conn.sock, "Failed to select window")
 
     async def close_window(self, msg: dict) -> None:
-        if not self._conn.container_id or not self._conn._user_home:
-            return
-        # #3022: closing a window of a spectator's grouped joiner session
-        # (reached via tmux's prefix-matching ``-t``) closes it for the
-        # whole group — spectators must not be able to kill the owner's
-        # windows.
-        if await refused_without_perm(self._conn, "code-in-isolation"):
+        if not await self._own_windows_allowed():
             return
 
         session_name = self.tmux_session_name()
         # Prefer @N window_id (stable); fall back to index for compat (#1965).
-        target: int | str = msg.get("window_id") or msg.get("index", 0)
+        target: int | str = self._window_target(msg)
         try:
             terminal = self._conn.app.state.terminal
             windows = await terminal.list_windows(
@@ -1141,11 +1160,7 @@ class TerminalController:
             send_error(self._conn.sock, "Failed to close window")
 
     async def rename_window(self, msg: dict) -> None:
-        if not self._conn.container_id or not self._conn._user_home:
-            return
-        # #3022: renaming rewrites the group's shared window list for
-        # everyone (tmux ``-t`` prefix-matches into the joiner session).
-        if await refused_without_perm(self._conn, "code-in-isolation"):
+        if not await self._own_windows_allowed():
             return
 
         session_name = self.tmux_session_name()
@@ -1173,22 +1188,12 @@ class TerminalController:
             send_error(self._conn.sock, "Failed to rename window")
 
     async def list_windows(self) -> None:
-        if not self._conn.container_id or not self._conn._user_home:
-            return
-        # #3022: enumerating the caller's own windows is own-terminal
-        # territory; the shared-terminal list rides its own gated frame
-        # (list_shared_terminals).
-        if await refused_without_perm(self._conn, "code-in-isolation"):
+        if not await self._own_windows_allowed():
             return
 
         # Use this connection's grouped session so the active flag
         # reflects this client's view, not the base session's.
-        session = self.session
-        session_name = (
-            session.tmux_session_name
-            if session and session.tmux_session_name
-            else self.tmux_session_name()
-        )
+        session_name = self._grouped_session_name()
         try:
             windows = await self._conn.app.state.terminal.list_windows(
                 self._conn.container_id,
@@ -1255,15 +1260,7 @@ class TerminalController:
         # tearing the terminal down cancels the start task even after
         # output forwarding took over ``self.output_task`` -- otherwise
         # the start task could be orphaned mid-transaction (#1250).
-        for attr in ("task", "output_task"):
-            task = getattr(self, attr)
-            if task:
-                task.cancel()
-                try:
-                    await task
-                except asyncio.CancelledError:
-                    pass
-                setattr(self, attr, None)
+        await self._cancel_terminal_tasks()
         await self.claim_and_stop()
         # Broadcast viewer change so other users see updated viewer list
         if was_viewing and self._conn.workspace_id:
@@ -1274,6 +1271,44 @@ class TerminalController:
                 self._conn.broadcast_shared_terminals(ws_session)
         # Reset debounce so the next explicit start isn't blocked.
         self._conn._last_terminal_start = 0
+
+    async def _cancel_terminal_tasks(self) -> None:
+        """Cancel and clear the start and output-forwarding tasks."""
+        for attr in ("task", "output_task"):
+            task = getattr(self, attr)
+            if task:
+                task.cancel()
+                try:
+                    await task
+                except asyncio.CancelledError:
+                    pass
+                setattr(self, attr, None)
+
+    async def _own_windows_allowed(self) -> bool:
+        """Gate own-window operations (#3022): an attached container, a
+        resolved handle, and the own-terminal permission. Own-window
+        frames exec into the container targeting the caller's tmux
+        session by its bare name (``user_id``); a spectator's joiner
+        session is named ``user_id-<hex>`` and tmux ``-t`` PREFIX-matches,
+        so the bare name resolves into the joiner's GROUPED session —
+        whose window list is the group's, i.e. the owner's. An ungated
+        own-window frame mutates the owner's session."""
+        if not self._conn.container_id or not self._conn._user_home:
+            return False
+        return not await refused_without_perm(self._conn, "code-in-isolation")
+
+    def _grouped_session_name(self) -> str:
+        """This connection's grouped session name, so an operation only
+        affects this client, not other connections to the same workspace."""
+        session = self.session
+        if session and session.tmux_session_name:
+            return session.tmux_session_name
+        return self.tmux_session_name()
+
+    @staticmethod
+    def _window_target(msg: dict) -> int | str:
+        """Prefer @N window_id (stable); fall back to index for compat."""
+        return msg.get("window_id") or msg.get("index", 0)
 
     async def forward_output(self, session: TerminalSession) -> None:
         """Forward terminal output to the frontend via WebSocket."""
@@ -1287,10 +1322,7 @@ class TerminalController:
                 self._conn.sock.send_json(
                     {"type": "terminal_output", "data": data}
                 )
-                if self._conn.container_id:
-                    self._conn.app.state.container_registry.record_activity(
-                        self._conn.container_id
-                    )
+                self._record_activity()
             # Stream ended — the tmux session exited (not necessarily the
             # container). Don't send container_stopped; the idle timeout
             # or shutdown button handles actual container death.
@@ -1308,6 +1340,13 @@ class TerminalController:
                 pass
         finally:
             await self.claim_and_stop()
+
+    def _record_activity(self) -> None:
+        """Record container activity when a container is attached."""
+        if self._conn.container_id:
+            self._conn.app.state.container_registry.record_activity(
+                self._conn.container_id
+            )
 
 
 class SharedTerminalController:
@@ -1351,11 +1390,7 @@ class SharedTerminalController:
         """
         windows = ws_session.terminal_windows.get(user_id, [])
         match = next(
-            (
-                w
-                for w in windows
-                if w.get("id") == window_id and (not shared or w.get("shared"))
-            ),
+            (w for w in windows if self._window_matches(w, window_id, shared)),
             None,
         )
         if match is None:
@@ -1363,27 +1398,25 @@ class SharedTerminalController:
             return None
         return match
 
+    @staticmethod
+    def _window_matches(w: dict, window_id: str, shared: bool) -> bool:
+        """A candidate window matches by id, and — when joining — only
+        when already shared."""
+        if w.get("id") != window_id:
+            return False
+        return not shared or w.get("shared")
+
     async def share_window(self, msg: dict) -> None:
         """Mark one of the user's own windows as shared."""
 
-        if not self._conn.container_id or not self._conn._user_home:
+        if not self._attached():
             return
-        if not await self._conn.has_perm("share-terminals"):
-            send_error(self._conn.sock, "Permission denied")
+        if not await self._perm_or_deny("share-terminals"):
             return
-        window_id = msg.get("window_id", "")
-        if not window_id:
-            send_error(self._conn.sock, "Window ID required")
+        resolved = self._find_own_window(msg, self._conn.user["id"])
+        if resolved is None:
             return
-        user_id = self._conn.user["id"]
-        ws_session = self._conn.app.state.sockets.get_session(
-            self._conn.workspace_id
-        )
-        if not ws_session:
-            return
-        match = self.find_window(ws_session, user_id, window_id)
-        if match is None:
-            return
+        match, ws_session = resolved
         match["shared"] = True
         self.broadcast_shared_terminals(ws_session)
 
@@ -1396,23 +1429,13 @@ class SharedTerminalController:
         member whose permission was revoked after sharing (#2875).
         """
 
-        if not self._conn.container_id or not self._conn._user_home:
+        if not self._attached():
             return
 
-        window_id = msg.get("window_id", "")
-        if not window_id:
-            send_error(self._conn.sock, "Window ID required")
+        resolved = self._find_own_window(msg, self._conn.user["id"])
+        if resolved is None:
             return
-        user_id = self._conn.user["id"]
-        session_name = self._conn.tmux_session_name()
-        ws_session = self._conn.app.state.sockets.get_session(
-            self._conn.workspace_id
-        )
-        if not ws_session:
-            return
-        match = self.find_window(ws_session, user_id, window_id)
-        if match is None:
-            return
+        match, ws_session = resolved
         if not match.get("shared"):
             # Already unshared — a no-op (idempotent, and cheap if a
             # zero-permission client spams the command: no joiner
@@ -1420,6 +1443,50 @@ class SharedTerminalController:
             return
         match["shared"] = False
         # Kick spectators/collaborators
+        await self._kick_joiners(self._conn.tmux_session_name())
+        ws_session.broadcast(
+            {
+                "type": "shared_terminal_deleted",
+                "user_id": self._conn.user["id"],
+                "window_name": match["name"],
+                "window_id": msg.get("window_id", ""),
+            }
+        )
+        self.broadcast_shared_terminals(ws_session)
+
+    def _attached(self) -> bool:
+        """True when a container is attached and the user's handle is
+        resolved."""
+        return bool(self._conn.container_id and self._conn._user_home)
+
+    async def _perm_or_deny(self, perm: str) -> bool:
+        """True when the connection holds *perm* (sends "Permission
+        denied" when not)."""
+        if not await self._conn.has_perm(perm):
+            send_error(self._conn.sock, "Permission denied")
+            return False
+        return True
+
+    def _find_own_window(self, msg: dict, user_id: str):
+        """(match, ws_session) for the frame's window among the user's own
+        windows, or None when the workspace session/window is absent (an
+        error frame is sent for a missing window id or window)."""
+        window_id = msg.get("window_id", "")
+        if not window_id:
+            send_error(self._conn.sock, "Window ID required")
+            return None
+        ws_session = self._conn.app.state.sockets.get_session(
+            self._conn.workspace_id
+        )
+        if not ws_session:
+            return None
+        match = self.find_window(ws_session, user_id, window_id)
+        if match is None:
+            return None
+        return match, ws_session
+
+    async def _kick_joiners(self, session_name: str) -> None:
+        """Kill the window's joiner sessions (best-effort)."""
         try:
             await self._conn.app.state.terminal.kill_joiner_sessions(
                 self._conn.container_id,
@@ -1427,15 +1494,6 @@ class SharedTerminalController:
             )
         except Exception:
             logger.debug("Failed to kill joiner sessions", exc_info=True)
-        ws_session.broadcast(
-            {
-                "type": "shared_terminal_deleted",
-                "user_id": user_id,
-                "window_name": match["name"],
-                "window_id": window_id,
-            }
-        )
-        self.broadcast_shared_terminals(ws_session)
 
     @staticmethod
     async def _select_shared_window(
@@ -1480,38 +1538,19 @@ class SharedTerminalController:
             self._conn.user.get("email"),
             msg,
         )
-        if not self._conn.container_id or not self._conn._user_home:
+        if not self._attached():
             return
-        if not await self._conn.has_perm("spectate-on-shared-terminals"):
-            send_error(self._conn.sock, "Permission denied")
+        if not await self._perm_or_deny("spectate-on-shared-terminals"):
             return
-
-        owner_user_id = msg.get("user_id", "").strip()
-        window_id = msg.get("window_id", "").strip()
-        if not owner_user_id or not window_id:
-            send_error(self._conn.sock, "user_id and window_id required")
-            return
-
-        ws_session = self._conn.app.state.sockets.get_session(
-            self._conn.workspace_id
+        resolved = self._lookup_window(
+            msg, shared=True, error_msg="Shared terminal not found"
         )
-        if not ws_session:
+        if resolved is None:
             return
-        match = self.find_window(
-            ws_session,
-            owner_user_id,
-            window_id,
-            shared=True,
-            error_msg="Shared terminal not found",
-        )
-        if match is None:
-            return
+        owner_user_id, window_id, match, ws_session = resolved
         window_name = match["name"]
 
-        read_only = not (
-            await self._conn.has_perm("code-in-shared-terminals")
-            or await self._conn.has_perm("share-terminals")
-        )
+        read_only = await self._join_is_read_only()
 
         await self._conn.stop_terminal()
         self.viewing_shared = {
@@ -1520,28 +1559,9 @@ class SharedTerminalController:
         }
         # The service window (service-cmd) lives in the standalone
         # ``service`` tmux session (#1158), not a session named after the
-        # agent's user_id. Route agent-owned joins to that session so the
-        # grouped attach actually finds a target. Other windows keep joining
-        # the owner's user-named session as before (#1159).
-        join_target = (
-            SERVICE_SESSION
-            if owner_user_id == model.AGENT_USER_ID
-            else owner_user_id
-        )
-        session = TerminalSession(
-            self._conn.container_id,
-            session_name=self._conn.user["id"],
-            user_home=self._conn._user_home,
-            join_session=join_target,
-            read_only=read_only,
-            user_id=self._conn.user["id"],
-            user_handle=self._conn.user.get("handle"),
-            # Same deterministic path as the owner's interactive terminal
-            # (#2001): the joiner's shell gets its own per-user agent
-            # socket pre-wired, live the moment it forwards an agent.
-            ssh_agent_socket=ssh_agent_socket_path(self._conn.user["id"]),
-            terminal=self._conn.app.state.terminal,
-        )
+        # agent's user_id — see _join_target_for.
+        join_target = self._join_target_for(owner_user_id)
+        session = self._join_session(join_target, read_only)
         self._conn.terminal_session = session
         conn = self._conn
 
@@ -1583,6 +1603,98 @@ class SharedTerminalController:
                 )
 
         self._conn.terminal_task = asyncio.create_task(_start_shared())
+
+    def _shared_window_ids(self, msg: dict) -> tuple[str, str] | None:
+        """(owner_user_id, window_id) from the frame, or None after
+        sending the "required" refusal."""
+        owner_user_id = msg.get("user_id", "").strip()
+        window_id = msg.get("window_id", "").strip()
+        if not owner_user_id or not window_id:
+            send_error(self._conn.sock, "user_id and window_id required")
+            return None
+        return owner_user_id, window_id
+
+    def _lookup_window(self, msg: dict, *, shared: bool, error_msg: str):
+        """(owner_user_id, window_id, match, ws_session) for the frame's
+        window, or None after the refusal. *shared* restricts the match
+        to already-shared windows (joining another user's terminal)."""
+        ids = self._shared_window_ids(msg)
+        if ids is None:
+            return None
+        owner_user_id, window_id = ids
+        found = self._ws_window(
+            owner_user_id,
+            window_id,
+            shared=shared,
+            error_msg=error_msg,
+        )
+        if found is None:
+            return None
+        match, ws_session = found
+        return owner_user_id, window_id, match, ws_session
+
+    def _ws_window(
+        self,
+        owner_user_id: str,
+        window_id: str,
+        *,
+        shared: bool,
+        error_msg: str,
+    ):
+        """(match, ws_session) for the window in the workspace session, or
+        None when the session is absent or the window is missing (error
+        frame sent for the latter)."""
+        ws_session = self._conn.app.state.sockets.get_session(
+            self._conn.workspace_id
+        )
+        if not ws_session:
+            return None
+        match = self.find_window(
+            ws_session,
+            owner_user_id,
+            window_id,
+            shared=shared,
+            error_msg=error_msg,
+        )
+        if match is None:
+            return None
+        return match, ws_session
+
+    async def _join_is_read_only(self) -> bool:
+        """Joiners without write permissions get a read-only session."""
+        return not (
+            await self._conn.has_perm("code-in-shared-terminals")
+            or await self._conn.has_perm("share-terminals")
+        )
+
+    @staticmethod
+    def _join_target_for(owner_user_id: str) -> str:
+        """The tmux session a join attaches to: the standalone ``service``
+        session for agent-owned windows (the service window lives there,
+        #1158, not a session named after the agent's user_id), the
+        owner's user-named session otherwise (#1159)."""
+        if owner_user_id == model.AGENT_USER_ID:
+            return SERVICE_SESSION
+        return owner_user_id
+
+    def _join_session(
+        self, join_target: str, read_only: bool
+    ) -> TerminalSession:
+        """The joiner's TerminalSession for a shared window. Same
+        deterministic agent-socket path as the owner's interactive
+        terminal (#2001): the joiner's shell gets its own per-user
+        agent socket pre-wired, live the moment it forwards an agent."""
+        return TerminalSession(
+            self._conn.container_id,
+            session_name=self._conn.user["id"],
+            user_home=self._conn._user_home,
+            join_session=join_target,
+            read_only=read_only,
+            user_id=self._conn.user["id"],
+            user_handle=self._conn.user.get("handle"),
+            ssh_agent_socket=ssh_agent_socket_path(self._conn.user["id"]),
+            terminal=self._conn.app.state.terminal,
+        )
 
     async def list_shared_terminals(self) -> None:
 
@@ -1636,14 +1748,20 @@ class SharedTerminalController:
         # The newly created window is the active one. Identify it by its
         # window id (@N), not its name — names are display-only and may
         # duplicate, so a name match could hit the wrong window (#2192).
-        new_id = next(
-            (w["id"] for w in windows if w.get("active") and "id" in w),
-            None,
-        )
+        new_id = self._active_window_id(windows)
         # Sync with tmux to get proper window_id, then mark the new
         # window as shared.
         self._conn.sync_terminal_windows(windows)
         self._mark_window_shared(new_id)
+
+    @staticmethod
+    def _active_window_id(windows: list[dict]):
+        """The active window's id — names are display-only and may
+        duplicate, so a name match could hit the wrong window (#2192)."""
+        return next(
+            (w["id"] for w in windows if w.get("active") and "id" in w),
+            None,
+        )
 
     async def _resolve_shared_terminal(self, msg: dict) -> tuple | None:
         """Validate the delete-shared-terminal request and resolve it to
@@ -1652,33 +1770,31 @@ class SharedTerminalController:
         owner — may delete it: the owner_user_id comes from the client and
         must not be trusted blindly, otherwise any collaborator with the
         share-terminals permission could close other users' windows."""
-        if not self._conn.container_id:
+        if not await self._delete_request_allowed():
             return None
-        if not await self._conn.has_perm("share-terminals"):
-            send_error(self._conn.sock, "Permission denied")
+        ids = self._shared_window_ids(msg)
+        if ids is None:
             return None
-
-        owner_user_id = msg.get("user_id", "").strip()
-        window_id = msg.get("window_id", "").strip()
-        if not owner_user_id or not window_id:
-            send_error(self._conn.sock, "user_id and window_id required")
-            return None
+        owner_user_id, window_id = ids
         if not await self._may_delete_shared_terminal(owner_user_id):
             return None
-        ws_session = self._conn.app.state.sockets.get_session(
-            self._conn.workspace_id
-        )
-        if not ws_session:
-            return None
-        match = self.find_window(
-            ws_session,
+        found = self._ws_window(
             owner_user_id,
             window_id,
+            shared=False,
             error_msg="Terminal not found",
         )
-        if match is None:
+        if found is None:
             return None
+        match, ws_session = found
         return ws_session, owner_user_id, window_id, match["name"]
+
+    async def _delete_request_allowed(self) -> bool:
+        """Gate a delete-shared-terminal request: a container attached
+        and the share-terminals permission."""
+        if not self._conn.container_id:
+            return False
+        return await self._perm_or_deny("share-terminals")
 
     async def _close_shared_window(
         self, owner_user_id: str, window_id: str

--- a/src/klangk/klangk/wshandler/decider.py
+++ b/src/klangk/klangk/wshandler/decider.py
@@ -151,26 +151,14 @@ def _log_handshake_timing(t0: float, marks: list[tuple[str, float]]) -> None:
     )
 
 
-async def _dispatch_decider_message(
-    app,
-    registry,
-    safe_ws,
-    msg: dict,
-    workspace: str,
-    user_id: str,
-    decider_id: str,
-) -> None:
-    """Act on one parsed decider frame by its ``type``.
-
-    Unknown types are ignored. Raises whatever the per-type handler raises
-    (SlowClientError from sends is handled by the receive loop)."""
-    mtype = msg.get("type")
-    if mtype == "ping":
-        registry.touch(decider_id)
-        safe_ws.send_json({"type": "pong"})
-    elif mtype == "verdict":
+async def _dispatch_decision_frame(
+    app, safe_ws, msg, workspace, user_id, mtype
+) -> bool:
+    """Handle a verdict/revoke frame; False when *mtype* is neither."""
+    if mtype == "verdict":
         await _handle_verdict(app, safe_ws, msg, workspace, user_id)
-    elif mtype == "revoke":
+        return True
+    if mtype == "revoke":
         # #2339: drop the sidecar rule + mark the verdict revoked.
         # ok=False if it's not an active verdict, is outside this
         # decider's workspace, or the sidecar never acked the drop.
@@ -186,13 +174,52 @@ async def _dispatch_decider_message(
                 "ok": ok,
             }
         )
-    elif mtype == "pause":
+        return True
+    return False
+
+
+async def _dispatch_session_frame(
+    app, registry, safe_ws, msg, workspace, decider_id, mtype
+) -> bool:
+    """Handle a ping/pause/unpause frame; False when *mtype* is none of
+    them (unknown types are ignored)."""
+    if mtype == "ping":
+        registry.touch(decider_id)
+        safe_ws.send_json({"type": "pong"})
+        return True
+    if mtype == "pause":
         # #2332: pause interactive consent prompting for this
         # decider's workspace for a window.
         await _handle_pause(app, safe_ws, msg, workspace)
-    elif mtype == "unpause":
+        return True
+    if mtype == "unpause":
         # #2332: clear an active pause for this decider's workspace.
         await _handle_unpause(app, safe_ws, workspace)
+        return True
+    return False
+
+
+async def _dispatch_decider_message(
+    app,
+    registry,
+    safe_ws,
+    msg: dict,
+    workspace: str,
+    user_id: str,
+    decider_id: str,
+) -> None:
+    """Act on one parsed decider frame by its ``type``.
+
+    Unknown types are ignored. Raises whatever the per-type handler raises
+    (SlowClientError from sends is handled by the receive loop)."""
+    mtype = msg.get("type")
+    if await _dispatch_decision_frame(
+        app, safe_ws, msg, workspace, user_id, mtype
+    ):
+        return
+    await _dispatch_session_frame(
+        app, registry, safe_ws, msg, workspace, decider_id, mtype
+    )
 
 
 async def _decider_authenticate(websocket: WebSocket, app, _hs_mark):
@@ -212,6 +239,55 @@ async def _decider_authenticate(websocket: WebSocket, app, _hs_mark):
     return result
 
 
+_FRAME_DISCONNECTED = object()
+
+
+async def _receive_decider_frame(safe_ws):
+    """The next decoded dict frame; None on a malformed/non-dict message
+    to skip, or ``_FRAME_DISCONNECTED`` when the socket dropped."""
+    # Starlette raises RuntimeError ("WebSocket is not connected...")
+    # on a client disconnect during receive_text(); treat it the same
+    # as WebSocketDisconnect.
+    try:
+        raw = await safe_ws.receive_text()
+    except (WebSocketDisconnect, RuntimeError):
+        return _FRAME_DISCONNECTED
+    try:
+        msg = json.loads(raw)
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(msg, dict):
+        return None
+    return msg
+
+
+async def _dispatch_decider_frame(
+    app, registry, safe_ws, frame, workspace, user, decider_id
+) -> bool:
+    """Dispatch one frame; False when the client fell behind (the caller
+    breaks). Any other handler error is logged and swallowed — a single
+    bad verdict or transient send error must not tear down the whole
+    connection (and every other in-flight prompt on it)."""
+    mtype = frame.get("type")
+    try:
+        await _dispatch_decider_message(
+            app,
+            registry,
+            safe_ws,
+            frame,
+            workspace,
+            user["id"],
+            decider_id,
+        )
+    except SlowClientError:
+        # Outbound queue full -- the client can't keep up. Drop it
+        # (matches the main /ws handler's slow-client handling).
+        return False
+    except Exception:
+        logger.exception("consent decider: error handling %r message", mtype)
+    return True
+
+
 async def _decider_receive_loop(
     app,
     registry,
@@ -223,41 +299,16 @@ async def _decider_receive_loop(
     """Receive + dispatch decider frames until the socket drops or the
     client falls behind."""
     while True:
-        # Starlette raises RuntimeError ("WebSocket is not connected...")
-        # on a client disconnect during receive_text(); treat it the same
-        # as WebSocketDisconnect.
-        try:
-            raw = await safe_ws.receive_text()
-        except (WebSocketDisconnect, RuntimeError):
+        frame = await _receive_decider_frame(safe_ws)
+        if frame is _FRAME_DISCONNECTED:
             break
-        try:
-            msg = json.loads(raw)
-        except json.JSONDecodeError:
+        if frame is None:
             continue
-        if not isinstance(msg, dict):
-            continue
-        mtype = msg.get("type")
-        try:
-            await _dispatch_decider_message(
-                app,
-                registry,
-                safe_ws,
-                msg,
-                workspace,
-                user["id"],
-                decider_id,
-            )
-        except SlowClientError:
-            # Outbound queue full -- the client can't keep up. Drop it
-            # (matches the main /ws handler's slow-client handling).
+        ok = await _dispatch_decider_frame(
+            app, registry, safe_ws, frame, workspace, user, decider_id
+        )
+        if not ok:
             break
-        except Exception:
-            # A single bad verdict or transient send error must not tear
-            # down the whole connection (and every other in-flight prompt
-            # on it). Log + keep going.
-            logger.exception(
-                "consent decider: error handling %r message", mtype
-            )
 
 
 async def handle_consent_decider(websocket: WebSocket, app) -> None:
@@ -308,13 +359,7 @@ async def handle_consent_decider(websocket: WebSocket, app) -> None:
         # (resolve pops first) -- whereas snapshot-then-register would MISS
         # holds created in the gap (silent fail-close). Tolerate the duplicate
         # to never miss.
-        for frame in await app.state.consent_coordinator.snapshot(workspace):
-            safe_ws.send_json(frame)
-        # The in-effect rules snapshot (#2335 slice A): lets a decider joining
-        # mid-flight see what's currently allowed/denied, not just holds.
-        rules = await app.state.consent_coordinator.rules_frame(workspace)
-        if rules is not None:
-            safe_ws.send_json(rules)
+        await _replay_decider_snapshot(app, safe_ws, workspace)
         await _decider_receive_loop(
             app, registry, safe_ws, workspace, user, decider_id
         )
@@ -323,6 +368,18 @@ async def handle_consent_decider(websocket: WebSocket, app) -> None:
         # registration so the workspace reverts to static (#2308).
         registry.deregister(decider_id)
         await safe_ws.stop_sender()
+
+
+async def _replay_decider_snapshot(app, safe_ws, workspace) -> None:
+    """Replay the pending holds and the in-effect rules snapshot to a
+    just-registered decider (fan-in, #2244; rules slice A, #2335)."""
+    for frame in await app.state.consent_coordinator.snapshot(workspace):
+        safe_ws.send_json(frame)
+    # The in-effect rules snapshot (#2335 slice A): lets a decider joining
+    # mid-flight see what's currently allowed/denied, not just holds.
+    rules = await app.state.consent_coordinator.rules_frame(workspace)
+    if rules is not None:
+        safe_ws.send_json(rules)
 
 
 async def _handle_pause(app, safe_ws, msg, workspace) -> None:

--- a/src/klangk/klangk/wshandler/dispatch.py
+++ b/src/klangk/klangk/wshandler/dispatch.py
@@ -79,6 +79,20 @@ async def ws_authenticate(websocket: WebSocket, app):
     return result
 
 
+async def _dispatch_connection_command(conn, cmd, msg) -> bool:
+    """Dispatch a Connection-table command; False when *cmd* is not one."""
+    entry = WS_CONNECTION_COMMANDS.get(cmd)
+    if entry is None:
+        return False
+    method_name, takes_msg = entry
+    method = getattr(conn, method_name)
+    if takes_msg:
+        await method(msg)
+    else:
+        await method()
+    return True
+
+
 async def dispatch_ws_loop(conn, safe_ws, user: dict, app) -> None:
     """Receive/dispatch frames until the socket drops. Connection-command
     table first, then state-command table, else an error frame."""
@@ -93,20 +107,53 @@ async def dispatch_ws_loop(conn, safe_ws, user: dict, app) -> None:
         log_ws_msg("RECV", msg, user)
 
         cmd = msg.get("cmd")
-        entry = WS_CONNECTION_COMMANDS.get(cmd)
-        if entry is not None:
-            method_name, takes_msg = entry
-            method = getattr(conn, method_name)
-            if takes_msg:
-                await method(msg)
-            else:
-                await method()
+        if await _dispatch_connection_command(conn, cmd, msg):
+            continue
+        state_method = WS_STATE_COMMANDS.get(cmd)
+        if state_method is not None:
+            getattr(app.state.sockets, state_method)(msg, safe_ws)
         else:
-            state_method = WS_STATE_COMMANDS.get(cmd)
-            if state_method is not None:
-                getattr(app.state.sockets, state_method)(msg, safe_ws)
-            else:
-                send_error(safe_ws, f"Unknown command: {cmd}")
+            send_error(safe_ws, f"Unknown command: {cmd}")
+
+
+async def _send_connect_snapshots(safe_ws, app) -> None:
+    """Replay the connect-time snapshots to a just-connected socket."""
+    # Replay current health of every health-checked workspace the
+    # user can open so a pure-WS consumer (e.g. ``klangk monitor``)
+    # sees steady-state status immediately instead of being blind
+    # until the next transition (#1175 item 1). Scoped to the
+    # user's memberships (#1714).
+    await app.state.sockets.send_service_health_snapshot(safe_ws)
+    # #2661: replay any pending server stop/recycle schedule so a
+    # just-connected client can show the countdown immediately instead
+    # of waiting for the scheduler's next periodic broadcast. Guarded:
+    # minimal test apps may not wire the scheduler.
+    server_scheduler = getattr(app.state, "server_scheduler", None)
+    if server_scheduler is not None:
+        await server_scheduler.send_snapshot_to(safe_ws)
+
+
+async def _run_websocket_session(conn, safe_ws, user: dict, app) -> None:
+    """Dispatch frames until the socket drops, mapping the known
+    disconnect/slow-client failures to their log lines."""
+    try:
+        await _send_connect_snapshots(safe_ws, app)
+        await dispatch_ws_loop(conn, safe_ws, user, app)
+    except WebSocketDisconnect:
+        logger.info("WebSocket disconnected for user %s", user["email"])
+    except RuntimeError as e:
+        # Starlette raises RuntimeError("WebSocket is not connected...")
+        # when the client disconnects before or during receive_text().
+        logger.info("WebSocket disconnected for user %s: %s", user["email"], e)
+    except SlowClientError as e:
+        # Carry the reason: "outbound queue full" is a genuinely slow
+        # client, "sender stopped" is this connection already tearing down
+        # (#2623 — the distinction was invisible in CI logs before).
+        logger.warning(
+            "Slow client dropped for user %s (%s)", user["email"], e
+        )
+    except Exception as e:
+        logger.exception("WebSocket error: %s", e)
 
 
 async def handle_websocket(websocket: WebSocket, app) -> None:
@@ -126,37 +173,7 @@ async def handle_websocket(websocket: WebSocket, app) -> None:
     # snapshot (#1714) awaits DB queries, and a raise there used to
     # leak the sender task and skip conn.cleanup().
     try:
-        # Replay current health of every health-checked workspace the
-        # user can open so a pure-WS consumer (e.g. ``klangk monitor``)
-        # sees steady-state status immediately instead of being blind
-        # until the next transition (#1175 item 1). Scoped to the
-        # user's memberships (#1714).
-        await app.state.sockets.send_service_health_snapshot(safe_ws)
-        # #2661: replay any pending server stop/recycle schedule so a
-        # just-connected client can show the countdown immediately instead
-        # of waiting for the scheduler's next periodic broadcast. Guarded:
-        # minimal test apps may not wire the scheduler.
-        server_scheduler = getattr(app.state, "server_scheduler", None)
-        if server_scheduler is not None:
-            await server_scheduler.send_snapshot_to(safe_ws)
-
-        await dispatch_ws_loop(conn, safe_ws, user, app)
-
-    except WebSocketDisconnect:
-        logger.info("WebSocket disconnected for user %s", user["email"])
-    except RuntimeError as e:
-        # Starlette raises RuntimeError("WebSocket is not connected...")
-        # when the client disconnects before or during receive_text().
-        logger.info("WebSocket disconnected for user %s: %s", user["email"], e)
-    except SlowClientError as e:
-        # Carry the reason: "outbound queue full" is a genuinely slow
-        # client, "sender stopped" is this connection already tearing down
-        # (#2623 — the distinction was invisible in CI logs before).
-        logger.warning(
-            "Slow client dropped for user %s (%s)", user["email"], e
-        )
-    except Exception as e:
-        logger.exception("WebSocket error: %s", e)
+        await _run_websocket_session(conn, safe_ws, user, app)
     finally:
         await safe_ws.stop_sender()
         await conn.cleanup()

--- a/src/klangk/klangk/wshandler/session.py
+++ b/src/klangk/klangk/wshandler/session.py
@@ -71,6 +71,18 @@ def spawn_session_task(coro: Coroutine[Any, Any, Any]) -> asyncio.Task:
     return task
 
 
+def _merged_window_entry(w: dict, prev: dict | None) -> dict:
+    """One merged entry: shared flags carry over from the old entry, and
+    the agent's ``service-cmd`` window is shared by definition (#1114)."""
+    prev_shared = prev.get("shared", False) if prev else False
+    return {
+        "id": w["id"],
+        "name": w["name"],
+        "index": w["index"],
+        "shared": (w["name"] == SERVICE_CMD_WINDOW or prev_shared),
+    }
+
+
 def merge_window_entries(old: list[dict], windows: list[dict]) -> list[dict]:
     """Fold a fresh tmux ``list_windows`` result into the session map.
 
@@ -92,16 +104,7 @@ def merge_window_entries(old: list[dict], windows: list[dict]) -> list[dict]:
     old_by_id = {w["id"]: w for w in old if "id" in w}
     entries = []
     for w in windows:
-        prev = old_by_id.get(w["id"])
-        prev_shared = prev.get("shared", False) if prev else False
-        entries.append(
-            {
-                "id": w["id"],
-                "name": w["name"],
-                "index": w["index"],
-                "shared": (w["name"] == SERVICE_CMD_WINDOW or prev_shared),
-            }
-        )
+        entries.append(_merged_window_entry(w, old_by_id.get(w["id"])))
     return entries
 
 
@@ -169,26 +172,30 @@ def get_shared_terminals(ws_session, sockets: "WebSocketState") -> list[dict]:
     return terminals
 
 
+def _shared_ids(windows: list[dict]) -> set:
+    """Ids of the shared windows in a list."""
+    return {w["id"] for w in windows if w.get("shared") and "id" in w}
+
+
 def _shared_id_sets(
     old: list[dict], new_entries: list[dict]
 ) -> tuple[set, set]:
     """(old, new) sets of shared-window ids."""
-    old_shared = {w["id"] for w in old if w.get("shared") and "id" in w}
-    new_shared = {w["id"] for w in new_entries if w.get("shared")}
-    return old_shared, new_shared
+    return _shared_ids(old), _shared_ids(new_entries)
+
+
+def _shared_names(windows: list[dict]) -> set:
+    """(id, name) pairs of the shared windows in a list."""
+    return {
+        (w["id"], w["name"]) for w in windows if w.get("shared") and "id" in w
+    }
 
 
 def _shared_name_sets(
     old: list[dict], new_entries: list[dict]
 ) -> tuple[set, set]:
     """(old, new) sets of (id, name) pairs for shared windows."""
-    old_shared_names = {
-        (w["id"], w["name"]) for w in old if w.get("shared") and "id" in w
-    }
-    new_shared_names = {
-        (w["id"], w["name"]) for w in new_entries if w.get("shared")
-    }
-    return old_shared_names, new_shared_names
+    return _shared_names(old), _shared_names(new_entries)
 
 
 def _shared_set_changed(old: list[dict], new_entries: list[dict]) -> bool:
@@ -300,16 +307,7 @@ class WorkspaceSession:
         self.browser_subscribers.clear()
         self.terminal_windows.clear()
         self.agent_handle = None
-        # Cancel the token renewal loop so it doesn't keep renewing
-        # tokens for a container that has been killed or reset.
-        task = self._token_renewal_task
-        if task is not None and not task.done():
-            task.cancel()
-            try:
-                await task
-            except asyncio.CancelledError:
-                pass
-        self._token_renewal_task = None
+        await self._cancel_token_renewal()
         self.workspace_token_expiry = None
         if self._window_sync_handle is not None:
             self._window_sync_handle.cancel()
@@ -320,6 +318,18 @@ class WorkspaceSession:
             spawn_session_task(watcher.stop())
         self._last_windows.clear()
         self._window_generations.clear()
+
+    async def _cancel_token_renewal(self) -> None:
+        """Cancel the token renewal loop so it doesn't keep renewing
+        tokens for a container that has been killed or reset."""
+        task = self._token_renewal_task
+        if task is not None and not task.done():
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+        self._token_renewal_task = None
 
     async def add_subscriber(
         self,
@@ -430,7 +440,7 @@ class WorkspaceSession:
             return
         watcher = self._window_watcher
         if watcher is not None:
-            if watcher.container_id == self.container_id and watcher.alive:
+            if self._watcher_reusable(watcher):
                 return
             self._window_watcher = None
             spawn_session_task(watcher.stop())
@@ -440,6 +450,11 @@ class WorkspaceSession:
             self._schedule_window_sync,
         )
         spawn_session_task(self._window_watcher.start())
+
+    def _watcher_reusable(self, watcher) -> bool:
+        """True when the existing watcher is bound to the current
+        container and still alive."""
+        return watcher.container_id == self.container_id and watcher.alive
 
     def _schedule_window_sync(self) -> None:
         """Debounce a burst of control-mode events into one re-sync."""
@@ -485,96 +500,111 @@ class WorkspaceSession:
             return
         sockets = self.app.state.sockets
         terminal = self.app.state.terminal
-        user_ids = self._connected_user_ids(sockets)
-        for uid in user_ids:
-            # Stamp the apply generation before the exec (#2653): the
-            # list_windows below is a podman round-trip that can straddle
-            # a command handler's tmux mutation and its apply. If the
-            # counter moved by the time the exec returns, a newer list
-            # was applied while we were in flight and this snapshot is
-            # stale — applying it would revert the map, the baseline,
-            # and the client frames to the pre-mutation state.
-            generation = self._window_generations.get(uid, 0)
-            try:
-                windows = await terminal.list_windows(self.container_id, uid)
-            except Exception:
-                continue
-            if self._window_generations.get(uid, 0) != generation:
-                # Stale in-flight snapshot (#2653): the newer applied
-                # list already updated the map, the baseline, and the
-                # broadcasts; drop ours instead of reverting them.
-                continue
-            if self._last_windows.get(uid) == windows:
-                continue
-            self._last_windows[uid] = windows
-            # Update the in-memory map BEFORE broadcasting (#2633 CI
-            # race): share/unshare read terminal_windows, and a client
-            # acting on this frame must find every listed window in the
-            # map. Without this, a watcher frame that beat
-            # _start_terminal's sync left the map empty/stale and
-            # ``klangk terminal share`` blind-timed-out on the missing
-            # window.
-            shared_changed = self.apply_window_list(uid, windows)
-            self._send_windows_to_user(sockets, uid, windows)
-            # A rename/close/add that touched a shared window must also
-            # reach shared-terminal viewers: this path can be the first
-            # to apply the change (under load its list_windows exec can
-            # beat the command handler's), and the handler's own delta
-            # check would then see no change (#2651).
-            if shared_changed:
-                self.broadcast_shared_terminals()
+        for uid in self._connected_user_ids(sockets):
+            await self._sync_user_windows(uid, sockets, terminal)
+
+    async def _sync_user_windows(self, uid: str, sockets, terminal) -> None:
+        """Re-sync one user's windows, dropping a stale in-flight snapshot
+        (#2653) and a no-change one (#2161)."""
+        # Stamp the apply generation before the exec (#2653): the
+        # list_windows below is a podman round-trip that can straddle
+        # a command handler's tmux mutation and its apply. If the
+        # counter moved by the time the exec returns, a newer list
+        # was applied while we were in flight and this snapshot is
+        # stale — applying it would revert the map, the baseline,
+        # and the client frames to the pre-mutation state.
+        generation = self._window_generations.get(uid, 0)
+        try:
+            windows = await terminal.list_windows(self.container_id, uid)
+        except Exception:
+            return
+        if self._window_generations.get(uid, 0) != generation:
+            # Stale in-flight snapshot (#2653): the newer applied
+            # list already updated the map, the baseline, and the
+            # broadcasts; drop ours instead of reverting them.
+            return
+        if self._last_windows.get(uid) == windows:
+            return
+        self._last_windows[uid] = windows
+        # Update the in-memory map BEFORE broadcasting (#2633 CI
+        # race): share/unshare read terminal_windows, and a client
+        # acting on this frame must find every listed window in the
+        # map. Without this, a watcher frame that beat
+        # _start_terminal's sync left the map empty/stale and
+        # ``klangk terminal share`` blind-timed-out on the missing
+        # window.
+        shared_changed = self.apply_window_list(uid, windows)
+        self._send_windows_to_user(sockets, uid, windows)
+        # A rename/close/add that touched a shared window must also
+        # reach shared-terminal viewers: this path can be the first
+        # to apply the change (under load its list_windows exec can
+        # beat the command handler's), and the handler's own delta
+        # check would then see no change (#2651).
+        if shared_changed:
+            self.broadcast_shared_terminals()
 
     async def _token_renewal_loop(self) -> None:
         """Periodically renew the workspace token before it expires."""
         while True:
-            expiry = self.workspace_token_expiry
-            if expiry is None:
+            if not await self._token_renewal_step():
                 return
 
-            # Renew at 80% of the token lifetime.
-            lifetime = self.app.state.auth.workspace_token_expire_hours * 3600
-            delay = lifetime * 0.8
-            try:
-                await asyncio.sleep(delay)
-            except asyncio.CancelledError:
-                return
+    async def _token_renewal_step(self) -> bool:
+        """One renewal cycle; True to continue looping, False to stop."""
+        if self.workspace_token_expiry is None:
+            return False
+        # Renew at 80% of the token lifetime.
+        lifetime = self.app.state.auth.workspace_token_expire_hours * 3600
+        if not await self._sleep_or_stop(lifetime * 0.8):
+            return False
+        if self.container_id is None:
+            return False
+        if await self._renew_workspace_token():
+            return True
+        return await self._sleep_or_stop(60)
 
-            container_id = self.container_id
-            if container_id is None:
-                return
+    @staticmethod
+    async def _sleep_or_stop(delay: float) -> bool:
+        """Await a delay; False when cancelled (the caller should stop)."""
+        try:
+            await asyncio.sleep(delay)
+        except asyncio.CancelledError:
+            return False
+        return True
 
-            try:
-                new_token = self.app.state.auth.create_workspace_token(
-                    self.workspace_id
-                )
-                await self.app.state.terminal.set_workspace_token(
-                    container_id, new_token
-                )
-                # #2242: refresh the sidecar's bind-mounted token file too —
-                # it can't be exec-pushed (no token-setter in the sidecar
-                # image), so it reads this file on each consent POST.
-                self.app.state.container_registry.write_sidecar_token(
-                    self.workspace_id, new_token
-                )
-                self.workspace_token_expiry = datetime.now(
-                    timezone.utc
-                ) + timedelta(
-                    hours=self.app.state.auth.workspace_token_expire_hours
-                )
-                logger.info(
-                    "Renewed workspace token for %s",
-                    self.workspace_id,
-                )
-            except Exception:
-                logger.warning(
-                    "Failed to renew workspace token for %s, retrying in 60s",
-                    self.workspace_id,
-                    exc_info=True,
-                )
-                try:
-                    await asyncio.sleep(60)
-                except asyncio.CancelledError:
-                    return
+    async def _renew_workspace_token(self) -> bool:
+        """Mint and push a fresh workspace token; True on success, False
+        to retry after the backoff."""
+        try:
+            new_token = self.app.state.auth.create_workspace_token(
+                self.workspace_id
+            )
+            await self.app.state.terminal.set_workspace_token(
+                self.container_id, new_token
+            )
+            # #2242: refresh the sidecar's bind-mounted token file too —
+            # it can't be exec-pushed (no token-setter in the sidecar
+            # image), so it reads this file on each consent POST.
+            self.app.state.container_registry.write_sidecar_token(
+                self.workspace_id, new_token
+            )
+            self.workspace_token_expiry = datetime.now(
+                timezone.utc
+            ) + timedelta(
+                hours=self.app.state.auth.workspace_token_expire_hours
+            )
+            logger.info(
+                "Renewed workspace token for %s",
+                self.workspace_id,
+            )
+            return True
+        except Exception:
+            logger.warning(
+                "Failed to renew workspace token for %s, retrying in 60s",
+                self.workspace_id,
+                exc_info=True,
+            )
+            return False
 
     def broadcast_to_browsers(self, message: dict) -> int:
         """Send message to browser subscribers only, removing dead ones."""
@@ -837,13 +867,7 @@ class WebSocketState:
         socks = list(self.connections.keys())
         self.connections.clear()
 
-        # Cancel abandoned browser-delegate requests so they don't fire
-        # against state we're about to drop.
-        for fut, _sock in self.pending_browser_requests.values():
-            if not fut.done():
-                fut.cancel()
-        self.pending_browser_requests.clear()
-        self.streaming_browser_requests.clear()
+        self._cancel_pending_browser_requests()
 
         # Reset each workspace session (cancels token-renewal tasks,
         # clears subscriber sets) then drop the entries.
@@ -852,7 +876,20 @@ class WebSocketState:
         for session in sessions:
             await session.reset()
 
-        # Tell every client to reconnect (1012 = "service restart").
+        await self._close_all_sockets(socks)
+
+    def _cancel_pending_browser_requests(self) -> None:
+        """Cancel abandoned browser-delegate requests so they don't fire
+        against state we're about to drop."""
+        for fut, _sock in self.pending_browser_requests.values():
+            if not fut.done():
+                fut.cancel()
+        self.pending_browser_requests.clear()
+        self.streaming_browser_requests.clear()
+
+    @staticmethod
+    async def _close_all_sockets(socks) -> None:
+        """Tell every client to reconnect (1012 = "service restart")."""
         for sock in socks:
             try:
                 await sock.close(code=1012)
@@ -938,12 +975,7 @@ class WebSocketState:
         preload-then-evaluate shape ``permissions_for_resources`` uses)
         — a transition burst doesn't re-query identical paths per user.
         """
-        by_user: dict[str, list[tuple[SafeWebSocket, "Connection"]]] = {}
-        for sock, conn in self.connections.items():
-            uid = conn.user.get("id")
-            if uid is None:
-                continue
-            by_user.setdefault(uid, []).append((sock, conn))
+        by_user = self._connections_by_user(self.connections)
         if not by_user:
             return
         resource = f"/workspaces/{workspace_id}"
@@ -958,13 +990,31 @@ class WebSocketState:
                 resource, principals, "monitor-workspace", entries
             ):
                 continue
-            for sock, _conn in conns:
-                try:
-                    sock.send_json(message)
-                except WS_ERRORS:
-                    dead.append(sock)
+            dead += self._deliver_to_sockets(conns, message)
         for sock in dead:
             self.connections.pop(sock, None)
+
+    @staticmethod
+    def _connections_by_user(connections) -> dict:
+        """Authenticated connections grouped by user id."""
+        by_user: dict[str, list[tuple[SafeWebSocket, "Connection"]]] = {}
+        for sock, conn in connections.items():
+            uid = conn.user.get("id")
+            if uid is None:
+                continue
+            by_user.setdefault(uid, []).append((sock, conn))
+        return by_user
+
+    @staticmethod
+    def _deliver_to_sockets(conns, message: dict) -> list:
+        """Send *message* to each (sock, conn) pair; returns dead sockets."""
+        dead = []
+        for sock, _conn in conns:
+            try:
+                sock.send_json(message)
+            except WS_ERRORS:
+                dead.append(sock)
+        return dead
 
     async def notify_container_status(
         self,
@@ -1039,10 +1089,7 @@ class WebSocketState:
         """
         dead = []
         for sock, conn in self.connections.items():
-            uid = conn.user.get("id")
-            if uid is None or (user_id is not None and uid != user_id):
-                continue
-            if predicate is not None and not predicate(conn):
+            if not self._connection_matches(conn, user_id, predicate):
                 continue
             try:
                 sock.send_json(message)
@@ -1050,6 +1097,20 @@ class WebSocketState:
                 dead.append(sock)
         for sock in dead:
             self.connections.pop(sock, None)
+
+    @staticmethod
+    def _connection_matches(conn, user_id: str | None, predicate) -> bool:
+        """Whether a connection receives a fan-out message."""
+        uid = conn.user.get("id")
+        if not WebSocketState._user_targeted(uid, user_id):
+            return False
+        return predicate is None or predicate(conn)
+
+    @staticmethod
+    def _user_targeted(uid, user_id: str | None) -> bool:
+        """Whether the connection's user is the fan-out target
+        (None = every authenticated user)."""
+        return uid is not None and (user_id is None or uid == user_id)
 
     def notify_host_shutdown(self) -> None:
         """Broadcast host-shutdown to all connections (#2527).
@@ -1149,8 +1210,7 @@ class WebSocketState:
         from ``registry.states`` and thus skipped (the container-death
         hole is #1175 item 2).
         """
-        conn = self.connections.get(sock)
-        user_id = conn.user.get("id") if conn else None
+        user_id = self._snapshot_user_id(sock)
         if user_id is None:
             return
         registry = self.app.state.container_registry
@@ -1159,24 +1219,40 @@ class WebSocketState:
         # window must not be overwritten by a stale replay frame — the
         # per-workspace seq bumps on every emit and the state is dropped
         # on death, so a mismatch means a newer frame already went out.
-        candidates = [
-            (cs, cs.health_seq)
-            for cs in registry.states.values()
-            if cs.health_check is not None and cs.health_status is not None
-        ]
+        candidates = self._health_candidates(registry)
         if not candidates:
             return
-        acl = self.app.state.acl
-        principals = await acl.get_principals(user_id)
-        resources = [f"/workspaces/{cs.workspace_id}" for cs, _ in candidates]
-        allowed = await acl.permissions_for_resources(
-            resources, principals, ["monitor-workspace"]
-        )
+        allowed = await self._allowed_health_resources(candidates, user_id)
         for cs, seq in candidates:
             if not self._replay_service_health(
                 sock, registry, cs, seq, allowed
             ):
                 break
+
+    def _snapshot_user_id(self, sock) -> str | None:
+        """The connected user's id for the snapshot socket."""
+        conn = self.connections.get(sock)
+        return conn.user.get("id") if conn else None
+
+    @staticmethod
+    def _health_candidates(registry) -> list:
+        """(state, seq) pairs of workspaces the registry has already
+        checked (health_check configured, at least one poll done)."""
+        return [
+            (cs, cs.health_seq)
+            for cs in registry.states.values()
+            if cs.health_check is not None and cs.health_status is not None
+        ]
+
+    async def _allowed_health_resources(self, candidates, user_id) -> set:
+        """The candidate resources the user may observe
+        (``monitor-workspace``, #2783)."""
+        acl = self.app.state.acl
+        principals = await acl.get_principals(user_id)
+        resources = [f"/workspaces/{cs.workspace_id}" for cs, _ in candidates]
+        return await acl.permissions_for_resources(
+            resources, principals, ["monitor-workspace"]
+        )
 
     def send_health_heartbeats(self) -> None:
         """Send a liveness heartbeat to connections that opted in.
@@ -1307,16 +1383,7 @@ class WebSocketState:
         request_id = msg.get("id")
         if not request_id:
             return
-        # Streaming request: the response is the terminal "done" item.
-        stream_entry = self.streaming_browser_requests.get(request_id)
-        if stream_entry is not None:
-            queue, expected_sock = stream_entry
-            if self._wrong_connection(request_id, expected_sock, sender):
-                return
-            result = {
-                k: v for k, v in msg.items() if k not in ("id", "cmd", "type")
-            }
-            queue.put_nowait({"type": "done", "result": result})
+        if self._resolve_streaming_response(msg, request_id, sender):
             return
         entry = self.pending_browser_requests.get(request_id)
         if entry is None:
@@ -1329,6 +1396,28 @@ class WebSocketState:
         if self._wrong_connection(request_id, expected_sock, sender):
             return
         self.pending_browser_requests.pop(request_id, None)
+        self._complete_pending(future, msg)
+
+    def _resolve_streaming_response(
+        self, msg: dict, request_id: str, sender
+    ) -> bool:
+        """Resolve a streaming request's terminal "done" item; False
+        when *request_id* is not a streaming request."""
+        stream_entry = self.streaming_browser_requests.get(request_id)
+        if stream_entry is None:
+            return False
+        queue, expected_sock = stream_entry
+        if self._wrong_connection(request_id, expected_sock, sender):
+            return True
+        result = {
+            k: v for k, v in msg.items() if k not in ("id", "cmd", "type")
+        }
+        queue.put_nowait({"type": "done", "result": result})
+        return True
+
+    @staticmethod
+    def _complete_pending(future: asyncio.Future, msg: dict) -> None:
+        """Deliver the response unless the waiter already went away."""
         if not future.done():
             future.set_result(msg)
 

--- a/src/klangk/klangk/wshandler/sidecar.py
+++ b/src/klangk/klangk/wshandler/sidecar.py
@@ -34,13 +34,19 @@ from .safe_websocket import WS_ERRORS, SlowClientError, SafeWebSocket
 logger = logging.getLogger(__name__)
 
 
-async def authenticate_egress_socket(websocket: WebSocket, app) -> str | None:
-    """Validate the sidecar socket's workspace token; close and return None
-    on failure (forward_auth already checked the header on the egress site)."""
+def _egress_token(websocket: WebSocket) -> str | None:
+    """The workspace token from the Authorization header or ?token=."""
     authorization = websocket.headers.get("authorization", "")
     token = authorization[7:] if authorization.startswith("Bearer ") else None
     if not token:
         token = websocket.query_params.get("token")
+    return token
+
+
+async def authenticate_egress_socket(websocket: WebSocket, app) -> str | None:
+    """Validate the sidecar socket's workspace token; close and return None
+    on failure (forward_auth already checked the header on the egress site)."""
+    token = _egress_token(websocket)
     if not token:
         await websocket.close(code=4001, reason="Missing token")
         return None
@@ -72,23 +78,9 @@ async def handle_egress_sidecar(websocket: WebSocket, app) -> None:
     app.state.sidecar_connections.register(workspace_id, safe)
     relay_tasks: set[asyncio.Task] = set()
     try:
-        while True:
-            # Starlette raises RuntimeError ("WebSocket is not connected...")
-            # on a client disconnect during receive_text(); treat it the same
-            # as WebSocketDisconnect.
-            try:
-                raw = await websocket.receive_text()
-            except (WebSocketDisconnect, RuntimeError):
-                break
-            try:
-                msg = json.loads(raw)
-            except json.JSONDecodeError:
-                continue
-            if not isinstance(msg, dict):
-                continue
-            dispatch_sidecar_message(
-                app, safe, coordinator, workspace_id, relay_tasks, msg
-            )
+        await _sidecar_event_loop(
+            app, websocket, coordinator, workspace_id, safe, relay_tasks
+        )
     finally:
         # Sidecar gone (disconnect/restart/crash): drop its registration (any
         # in-flight revoke ack fails at once) + cancel in-flight relays.
@@ -96,6 +88,55 @@ async def handle_egress_sidecar(websocket: WebSocket, app) -> None:
         for task in list(relay_tasks):
             task.cancel()
         await safe.stop_sender()
+
+
+async def _sidecar_event_loop(
+    app,
+    websocket: WebSocket,
+    coordinator,
+    workspace_id: str,
+    safe: SafeWebSocket,
+    relay_tasks: set[asyncio.Task],
+) -> None:
+    """Receive and dispatch sidecar frames until the socket drops."""
+    while True:
+        stop, msg = await _receive_sidecar_frame(websocket)
+        if stop:
+            break
+        if msg is not None:
+            dispatch_sidecar_message(
+                app, safe, coordinator, workspace_id, relay_tasks, msg
+            )
+
+
+def _record_sidecar_activity(app, workspace_id: str) -> None:
+    """Record the sidecar's egress/network activity bump (#2479): an
+    egress-only workload bypasses klangkd, so without this its idle
+    timer would never advance and the container would be reaped
+    mid-egress. The sidecar flood-gates the frame; here the bump is a
+    single float write on this loop thread."""
+    state = app.state.container_registry.states.get(workspace_id)
+    if state is not None:
+        state.record_activity()
+
+
+async def _receive_sidecar_frame(websocket) -> tuple[bool, dict | None]:
+    """(stop, frame): stop on disconnect; a None frame is skipped
+    (malformed / non-dict)."""
+    try:
+        raw = await websocket.receive_text()
+    except (WebSocketDisconnect, RuntimeError):
+        # Starlette raises RuntimeError ("WebSocket is not connected...")
+        # on a client disconnect during receive_text(); treat it the same
+        # as WebSocketDisconnect.
+        return True, None
+    try:
+        msg = json.loads(raw)
+    except json.JSONDecodeError:
+        return False, None
+    if not isinstance(msg, dict):
+        return False, None
+    return False, msg
 
 
 def dispatch_sidecar_message(
@@ -116,14 +157,7 @@ def dispatch_sidecar_message(
         )
         return
     if mtype == "activity":
-        # Sidecar reports egress/network activity (#2479): an
-        # egress-only workload bypasses klangkd, so without this its
-        # idle timer would never advance and the container would be
-        # reaped mid-egress. The sidecar flood-gates the frame; here
-        # the bump is a single float write on this loop thread.
-        state = app.state.container_registry.states.get(workspace_id)
-        if state is not None:
-            state.record_activity()
+        _record_sidecar_activity(app, workspace_id)
         return
     if mtype != "egress":
         return
@@ -141,6 +175,13 @@ def dispatch_sidecar_message(
     task.add_done_callback(relay_tasks.discard)
 
 
+def _valid_dport(dport) -> bool:
+    """A dport is None or an int (bool excluded: it subclasses int)."""
+    if dport is None:
+        return True
+    return isinstance(dport, int) and not isinstance(dport, bool)
+
+
 def parse_egress_fields(msg: dict) -> tuple[str, str, int | None] | None:
     """(local_id, dst, dport) from an egress frame, or None on a malformed
     one."""
@@ -149,9 +190,7 @@ def parse_egress_fields(msg: dict) -> tuple[str, str, int | None] | None:
     dport = msg.get("dport")
     if not isinstance(local_id, str) or not isinstance(dst, str):
         return None
-    if dport is not None and (
-        not isinstance(dport, int) or isinstance(dport, bool)
-    ):
+    if not _valid_dport(dport):
         return None
     return local_id, dst, dport
 

--- a/src/klangk/klangk/wshandler/support.py
+++ b/src/klangk/klangk/wshandler/support.py
@@ -38,6 +38,27 @@ MAX_INPUT_SIZE = 16777216
 SEND_QUEUE_SIZE = 256
 
 
+def _ws_debug_label(user: dict | None) -> str:
+    """The optional [email] label for a debug log line."""
+    return f" [{user['email']}]" if user else ""
+
+
+def _terminal_io_debug(
+    direction: str, msg: dict, msg_type: str, user: dict | None
+) -> None:
+    """Log a terminal_output/terminal_input frame with a truncated data
+    preview (to avoid log spam)."""
+    data = msg.get("data", "")
+    preview = repr(data[:80]) + ("..." if len(data) > 80 else "")
+    logger.debug(
+        "WS %s%s: %s data=%s",
+        direction,
+        _ws_debug_label(user),
+        msg_type,
+        preview,
+    )
+
+
 def log_ws_msg(direction: str, msg: dict, user: dict | None = None) -> None:
     """Log a WebSocket message for debugging (KLANGKD_WEBSOCKET_DEBUG=1)."""
     if not WS_DEBUG:
@@ -45,13 +66,14 @@ def log_ws_msg(direction: str, msg: dict, user: dict | None = None) -> None:
     msg_type = msg.get("type") or msg.get("cmd") or "?"
     # Truncate terminal_output/terminal_input data to avoid log spam
     if msg_type in ("terminal_output", "terminal_input"):
-        data = msg.get("data", "")
-        preview = repr(data[:80]) + ("..." if len(data) > 80 else "")
-        who = f" [{user['email']}]" if user else ""
-        logger.debug("WS %s%s: %s data=%s", direction, who, msg_type, preview)
-    else:
-        who = f" [{user['email']}]" if user else ""
-        logger.debug("WS %s%s: %s", direction, who, json.dumps(msg)[:200])
+        _terminal_io_debug(direction, msg, msg_type, user)
+        return
+    logger.debug(
+        "WS %s%s: %s",
+        direction,
+        _ws_debug_label(user),
+        json.dumps(msg)[:200],
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -160,12 +182,20 @@ def broadcast_event(
         session.broadcast(frame)
     if not subscribed:
         sock.send_json(frame)
-    elif session is not None and sock not in session.subscribers:
+    elif _pruned_by_broadcast(session, sock, subscribed):
         # Subscribed before the broadcast but pruned by it: the acting
         # connection's send failed and its copy was dropped.
         logger.warning(
             "Acting socket missed %s broadcast (send failed, pruned)", name
         )
+
+
+def _pruned_by_broadcast(session, sock, subscribed: bool) -> bool:
+    """Whether the acting socket was subscribed before the broadcast but
+    pruned by it (its send failed and its copy was dropped)."""
+    return (
+        subscribed and session is not None and sock not in session.subscribers
+    )
 
 
 def format_idle_timeout(seconds: int | float) -> str:

--- a/src/klangk/klangk/wshandler/window_watcher.py
+++ b/src/klangk/klangk/wshandler/window_watcher.py
@@ -133,9 +133,7 @@ class WindowEventWatcher:
         # task is running now, so "constructed but never started" no
         # longer describes it (#3015 review).
         self._start_pending = False
-        if self._task is not None and not self._task.done():
-            return
-        if self._starting or self._stopped:
+        if self._start_in_flight_or_live():
             return
         self._starting = True
         try:
@@ -167,21 +165,38 @@ class WindowEventWatcher:
         self._proc = proc
         self._task = asyncio.create_task(self.read_loop())
 
+    def _start_in_flight_or_live(self) -> bool:
+        """True when a start would duplicate or race an existing one."""
+        if self._task is not None and not self._task.done():
+            return True
+        return self._starting or self._stopped
+
     async def read_loop(self) -> None:
-        proc = self._proc
-        if proc is None or proc.stdout is None:
+        stdout = self._reader_stream()
+        if stdout is None:
             return
         try:
-            while True:
-                raw = await proc.stdout.readline()
-                if not raw:
-                    return
-                if is_window_event(raw.decode(errors="replace").strip()):
-                    self._on_change()
+            await self._read_events(stdout)
         except asyncio.CancelledError:
             raise
         except Exception:
             logger.exception("WindowEventWatcher read loop error")
+
+    def _reader_stream(self):
+        """The proc's stdout, or None when the watcher never started."""
+        proc = self._proc
+        if proc is None or proc.stdout is None:
+            return None
+        return proc.stdout
+
+    async def _read_events(self, stdout) -> None:
+        """Read control-mode lines forever, firing on window events."""
+        while True:
+            raw = await stdout.readline()
+            if not raw:
+                return
+            if is_window_event(raw.decode(errors="replace").strip()):
+                self._on_change()
 
     async def stop(self) -> None:
         # Set the flag before reading any teardown state, so a start()

--- a/src/klangk/klangkd-tests/tests/test_crash_recovery.py
+++ b/src/klangk/klangkd-tests/tests/test_crash_recovery.py
@@ -1313,6 +1313,16 @@ class TestCrashBranchGaps2834:
             "main process exited with code 200",
         )
 
+    def test_non_int_exit_code_falls_back_to_plain_exit(self):
+        # A defensive non-int ExitCode (inspect payload from a future
+        # podman) must surface as the generic message, not raise on
+        # the > 128 comparison.
+        cause, msg = classify_death(inspect_dead(exit_code="137"))
+        assert (cause, msg) == (
+            "exited",
+            "main process exited with code 137",
+        )
+
     async def test_start_twice_keeps_single_task(self, crash_env):
         app_state = make_app_state(crash_env)
         monitor = app_state.state.container_registry.crash

--- a/src/klangk/klangkd-tests/tests/test_crash_recovery.py
+++ b/src/klangk/klangkd-tests/tests/test_crash_recovery.py
@@ -1315,8 +1315,8 @@ class TestCrashBranchGaps2834:
 
     def test_non_int_exit_code_falls_back_to_plain_exit(self):
         # A defensive non-int ExitCode (inspect payload from a future
-        # podman) must surface as the generic message, not raise on
-        # the > 128 comparison.
+        # podman) surfaces as the generic message: the isinstance guard
+        # skips the signal-kill classification for it.
         cause, msg = classify_death(inspect_dead(exit_code="137"))
         assert (cause, msg) == (
             "exited",


### PR DESCRIPTION
Tranches 13–18 of the #2845 A-ratchet (#3036): bring every rank-B block in the container subsystem and the `wshandler` package down to rank A (cyclomatic complexity ≤ 5). One commit per tranche, all pure extract-function refactors — no behavior change; full suite + 100% branch coverage green on each.

- **T13 — `container/registry.py` (13 blocks):** split `validate_mount_spec` (shape/options), `stop_and_remove_container` (expected-stop bookkeeping, removal, under-lock teardown, outcome), `notify_workspace_killed`, `reap_dead_owner_containers` (pid-label parsing), `shutdown` (task cancel, orphan sweep), `start_container_inner` (image validation, existing-container reuse), port-conflict retry, sidecar-requirement split.
- **T14 — container rest (21):** `admission.py` machine-memory pickers/cache/quota/sibling-limits, `sidecar.py` token sweep + readiness + env forwarding, `health.py` message/home resolution/eligibility, `spec.py` named-volume create/quota/ownership, `idle.py` per-workspace stop + token sweep.
- **T15 — eviction/crash (12):** cgroup-usage split, `vm_stat` parsing, evictable-candidate check, pressured/recovery state-machine steps; `classify_death` (OOM/exit/signal), tracker phase, sweep revalidation, restart-loop abort/retry helpers. Adds one `classify_death` test for a non-int exit code (the extracted isinstance guard's other branch).
- **T16 — `wshandler/controllers.py` (17):** own-window gate + grouped-session/target helpers shared across the terminal handlers; SSH-agent stop/reap split; shared-terminal lookup/join/delete resolution helpers.
- **T17 — `wshandler/session.py` (12):** window-entry merge, shared id/name sets, token-renewal step, per-user window sync, member fan-out grouping/delivery, fan-out match predicate, browser-response streaming resolution, health-snapshot candidates/ACL pass.
- **T18 — wshandler rest (18):** `connection.py` start/restart refusal mapping + handle-home refresh + sibling rebind; `sidecar.py` token/frame/dport parsing; `decider.py` decision/session dispatch split + receive loop; `window_watcher.py` reader split; `dispatch.py` connection-command dispatch + session runner; `support.py` debug logging split.

Closes #3036 (ticks the T13–T18 boxes of #2845).
