### PR TITLE
e2e: surface nonzero $? and pane tail in TIMEOUT:ready diagnostics

### DIFF
--- a/src/klangk/klangkc-tests/e2e-tests/test_terminal_windows_e2e.py
+++ b/src/klangk/klangkc-tests/e2e-tests/test_terminal_windows_e2e.py
@@ -107,11 +107,26 @@ def _expect_window_capture(ws_name, env, timeout=25):
     with no diagnostic (#3012). The pre-command fixed ``sleep 2`` is
     replaced by an executed-marker round-trip — the shell must actually
     run a command before the tmux query is sent — so a slow attach is
-    polled instead of guessed at.
+    polled instead of guessed at. The marker matches any exit status:
+    a nonzero ``$?`` used to present as an opaque ``TIMEOUT:ready`` after
+    the full timeout (#3037) — it now fails fast with ``READY-NONZERO``,
+    and a ready-stage timeout/eof appends a bounded tail of what the pane
+    actually printed, so a wrong-pane ping is identifiable in artifacts.
     """
     script = f"""
 set timeout {timeout}
 log_user 0
+proc ready_tail {{}} {{
+    global expect_out timeout
+    catch {{unset expect_out(buffer)}}
+    set timeout 1
+    expect {{
+        -re {{(?s).*}} {{}}
+        timeout {{}}
+    }}
+    if {{![info exists expect_out(buffer)]}} {{ return "" }}
+    return [string range $expect_out(buffer) end-399 end]
+}}
 spawn klangk shell {ws_name} --no-consent-popup
 expect {{
     -re {{\\$ }} {{}}
@@ -120,9 +135,14 @@ expect {{
 }}
 send "echo KLANGK_READY_\\$?\\r"
 expect {{
-    -re {{KLANGK_READY_0}} {{}}
-    timeout {{ puts "TIMEOUT:ready"; exit 1 }}
-    eof {{ puts "EOF:ready"; exit 1 }}
+    -re {{KLANGK_READY_([0-9]+)}} {{
+        if {{$expect_out(1,string) != 0}} {{
+            puts "READY-NONZERO:$expect_out(1,string)"
+            exit 1
+        }}
+    }}
+    timeout {{ puts "TIMEOUT:ready tail=<<[ready_tail]>>"; exit 1 }}
+    eof {{ puts "EOF:ready tail=<<[string range $expect_out(buffer) end-399 end]>>"; exit 1 }}
 }}
 send "echo W_S; tmux display-message -p '#I:#W'; echo W_E\\r"
 expect {{
@@ -171,7 +191,13 @@ def _cli_check_window(ws_name, env, timeout=25):
 
 
 def _cli_hold_and_check(ws_name, window_name, hold_seconds, env):
-    """Start CLI shell, check window before and after a hold period."""
+    """Start CLI shell, check window before and after a hold period.
+
+    Raises AssertionError carrying the expect diagnostic (stage tags and,
+    for the ready stage, a bounded pane-output tail, #3037) when either
+    capture stage fails — the tags used to be swallowed here, leaving
+    only an opaque ``CLI moved from None to None``.
+    """
     if window_name:
         cmd = f"klangk shell {ws_name} {window_name} --no-consent-popup"
     else:
@@ -179,6 +205,17 @@ def _cli_hold_and_check(ws_name, window_name, hold_seconds, env):
     script = f"""
 set timeout 30
 log_user 0
+proc ready_tail {{}} {{
+    global expect_out timeout
+    catch {{unset expect_out(buffer)}}
+    set timeout 1
+    expect {{
+        -re {{(?s).*}} {{}}
+        timeout {{}}
+    }}
+    if {{![info exists expect_out(buffer)]}} {{ return "" }}
+    return [string range $expect_out(buffer) end-399 end]
+}}
 spawn {cmd}
 expect {{
     -re {{\\$ }} {{}}
@@ -187,9 +224,14 @@ expect {{
 }}
 send "echo KLANGK_READY_\\$?\\r"
 expect {{
-    -re {{KLANGK_READY_0}} {{}}
-    timeout {{ puts "TIMEOUT:ready"; exit 1 }}
-    eof {{ puts "EOF:ready"; exit 1 }}
+    -re {{KLANGK_READY_([0-9]+)}} {{
+        if {{$expect_out(1,string) != 0}} {{
+            puts "READY-NONZERO:$expect_out(1,string)"
+            exit 1
+        }}
+    }}
+    timeout {{ puts "TIMEOUT:ready tail=<<[ready_tail]>>"; exit 1 }}
+    eof {{ puts "EOF:ready tail=<<[string range $expect_out(buffer) end-399 end]>>"; exit 1 }}
 }}
 send "echo BS; tmux display-message -p '#I:#W'; echo BE\\r"
 expect {{
@@ -229,6 +271,8 @@ wait
             before = line.split("=", 1)[1]
         elif line.startswith("AFTER="):
             after = line.split("=", 1)[1]
+    if before is None or after is None:
+        raise AssertionError(f"expect failed:\n{result.stdout}{result.stderr}")
     return before, after
 
 

--- a/src/klangk/klangkc-tests/e2e-tests/test_terminal_windows_e2e.py
+++ b/src/klangk/klangkc-tests/e2e-tests/test_terminal_windows_e2e.py
@@ -17,6 +17,7 @@ import json
 import logging
 import os
 import re
+import secrets
 import subprocess
 import time
 
@@ -107,18 +108,25 @@ def _expect_window_capture(ws_name, env, timeout=25):
     with no diagnostic (#3012). The pre-command fixed ``sleep 2`` is
     replaced by an executed-marker round-trip — the shell must actually
     run a command before the tmux query is sent — so a slow attach is
-    polled instead of guessed at. The marker matches any exit status:
-    a nonzero ``$?`` used to present as an opaque ``TIMEOUT:ready`` after
-    the full timeout (#3037) — it now fails fast with ``READY-NONZERO``,
-    and a ready-stage timeout/eof appends a bounded tail of what the pane
-    actually printed, so a wrong-pane ping is identifiable in artifacts.
+    polled instead of guessed at. The marker is nonced per invocation
+    (#3037): on a re-attach the tmux client redraws the pane, so a
+    previous invocation's marker line is in the stream — matching it
+    would misattribute a stale exit status and defeat the round-trip.
+    The marker matches any exit status: a nonzero ``$?`` used to present
+    as an opaque ``TIMEOUT:ready`` after the full timeout (#3037) — it
+    now fails fast with ``READY-NONZERO``, and a ready-stage
+    timeout/eof appends a bounded tail of what the pane actually
+    printed, so a wrong-pane ping is identifiable in artifacts.
     """
+    nonce = secrets.token_hex(4)
     script = f"""
 set timeout {timeout}
 log_user 0
 proc ready_tail {{}} {{
     global expect_out timeout
     catch {{unset expect_out(buffer)}}
+    # Shrinks the global timeout: every caller exits right after, so no
+    # later stage can inherit the 1s timeout.
     set timeout 1
     expect {{
         -re {{(?s).*}} {{}}
@@ -133,9 +141,9 @@ expect {{
     timeout {{ puts "TIMEOUT:prompt"; exit 1 }}
     eof {{ puts "EOF:prompt"; exit 1 }}
 }}
-send "echo KLANGK_READY_\\$?\\r"
+send "echo KLANGK_READY_{nonce}_\\$?\\r"
 expect {{
-    -re {{KLANGK_READY_([0-9]+)}} {{
+    -re {{KLANGK_READY_{nonce}_([0-9]+)}} {{
         if {{$expect_out(1,string) != 0}} {{
             puts "READY-NONZERO:$expect_out(1,string)"
             exit 1
@@ -168,7 +176,12 @@ wait
         )
     except subprocess.TimeoutExpired:
         return "EXPECT-TIMEOUT"
-    return result.stdout.strip()
+    out = result.stdout.strip()
+    if result.returncode != 0 and result.stderr.strip():
+        # A Tcl-level runtime error aborts the tag ``puts`` — without
+        # this the diagnostic would come back empty (#3037).
+        out = f"{out}\nstderr: {result.stderr.strip()}"
+    return out
 
 
 def _cli_check_window(ws_name, env, timeout=25):
@@ -202,12 +215,15 @@ def _cli_hold_and_check(ws_name, window_name, hold_seconds, env):
         cmd = f"klangk shell {ws_name} {window_name} --no-consent-popup"
     else:
         cmd = f"klangk shell {ws_name} --no-consent-popup"
+    nonce = secrets.token_hex(4)
     script = f"""
 set timeout 30
 log_user 0
 proc ready_tail {{}} {{
     global expect_out timeout
     catch {{unset expect_out(buffer)}}
+    # Shrinks the global timeout: every caller exits right after, so no
+    # later stage can inherit the 1s timeout.
     set timeout 1
     expect {{
         -re {{(?s).*}} {{}}
@@ -222,9 +238,9 @@ expect {{
     timeout {{ puts "TIMEOUT:prompt"; exit 1 }}
     eof {{ puts "EOF:prompt"; exit 1 }}
 }}
-send "echo KLANGK_READY_\\$?\\r"
+send "echo KLANGK_READY_{nonce}_\\$?\\r"
 expect {{
-    -re {{KLANGK_READY_([0-9]+)}} {{
+    -re {{KLANGK_READY_{nonce}_([0-9]+)}} {{
         if {{$expect_out(1,string) != 0}} {{
             puts "READY-NONZERO:$expect_out(1,string)"
             exit 1
@@ -664,8 +680,10 @@ puts "AFTER=$a1"
     def test_cli_reconnect_to_named_window(self):
         """CLI disconnect/reconnect to same named window works."""
         w1 = _cli_check_window(WS_NAME + " persist", self._env)
+        assert re.fullmatch(r"\d+:\S+", w1), f"First connect: {w1}"
         assert "persist" in w1, f"First connect: {w1}"
         w2 = _cli_check_window(WS_NAME + " persist", self._env)
+        assert re.fullmatch(r"\d+:\S+", w2), f"Second connect: {w2}"
         assert "persist" in w2, f"Second connect: {w2}"
         # Both should report the same window name
         name1 = w1.split(":", 1)[1] if ":" in w1 else w1

--- a/src/klangk/klangkc-tests/e2e-tests/test_terminal_windows_e2e.py
+++ b/src/klangk/klangkc-tests/e2e-tests/test_terminal_windows_e2e.py
@@ -116,9 +116,14 @@ def _expect_window_capture(ws_name, env, timeout=25):
     as an opaque ``TIMEOUT:ready`` after the full timeout (#3037) — it
     now fails fast with ``READY-NONZERO``, and a ready-stage
     timeout/eof appends a bounded tail of what the pane actually
-    printed, so a wrong-pane ping is identifiable in artifacts.
+    printed, so a wrong-pane ping is identifiable in artifacts. The
+    ping is resent every 2s until the marker executes: on a cold attach
+    the first send can race the client's input wiring and be dropped
+    entirely (observed in CI on #3044 — the typed ping was never even
+    echoed), so a late-wiring attach is polled instead of failed.
     """
     nonce = secrets.token_hex(4)
+    max_tries = max(1, timeout // 2)
     script = f"""
 set timeout {timeout}
 log_user 0
@@ -141,17 +146,28 @@ expect {{
     timeout {{ puts "TIMEOUT:prompt"; exit 1 }}
     eof {{ puts "EOF:prompt"; exit 1 }}
 }}
+set timeout 2
 send "echo KLANGK_READY_{nonce}_\\$?\\r"
-expect {{
-    -re {{KLANGK_READY_{nonce}_([0-9]+)}} {{
-        if {{$expect_out(1,string) != 0}} {{
-            puts "READY-NONZERO:$expect_out(1,string)"
-            exit 1
+set ready 0
+for {{set i 0}} {{$i < {max_tries}}} {{incr i}} {{
+    expect {{
+        -re {{KLANGK_READY_{nonce}_([0-9]+)}} {{
+            if {{$expect_out(1,string) != 0}} {{
+                puts "READY-NONZERO:$expect_out(1,string)"
+                exit 1
+            }}
+            set ready 1
         }}
+        timeout {{ send "echo KLANGK_READY_{nonce}_\\$?\\r" }}
+        eof {{ puts "EOF:ready tail=<<[string range $expect_out(buffer) end-399 end]>>"; exit 1 }}
     }}
-    timeout {{ puts "TIMEOUT:ready tail=<<[ready_tail]>>"; exit 1 }}
-    eof {{ puts "EOF:ready tail=<<[string range $expect_out(buffer) end-399 end]>>"; exit 1 }}
+    if {{$ready}} {{ break }}
 }}
+if {{!$ready}} {{
+    puts "TIMEOUT:ready tail=<<[ready_tail]>>"
+    exit 1
+}}
+set timeout {timeout}
 send "echo W_S; tmux display-message -p '#I:#W'; echo W_E\\r"
 expect {{
     -re {{W_S\\r?\\n(\\d+:\\S+)\\r?\\nW_E}} {{
@@ -206,10 +222,37 @@ def _cli_check_window(ws_name, env, timeout=25):
 def _cli_hold_and_check(ws_name, window_name, hold_seconds, env):
     """Start CLI shell, check window before and after a hold period.
 
-    Raises AssertionError carrying the expect diagnostic (stage tags and,
-    for the ready stage, a bounded pane-output tail, #3037) when either
-    capture stage fails — the tags used to be swallowed here, leaving
-    only an opaque ``CLI moved from None to None``.
+    Retried once (#3012 pattern): under CI load a cold attach can race
+    the expect handshake once (ping dropped before the client's input
+    path is wired, prompt never painted); a single retry absorbs the
+    transient while persistent breakage still fails. Raises
+    AssertionError carrying both attempts' expect diagnostics (stage
+    tags and, for the ready stage, a bounded pane-output tail, #3037) —
+    the tags used to be swallowed here, leaving only an opaque ``CLI
+    moved from None to None`` (a vacuous pass on ``None == None``).
+    """
+    diagnostics = []
+    for attempt in range(2):
+        before, after, failure = _cli_hold_and_check_once(
+            ws_name, window_name, hold_seconds, env
+        )
+        if failure is None:
+            return before, after
+        diagnostics.append(failure)
+        if attempt == 0:
+            time.sleep(3)
+    raise AssertionError(
+        "expect failed on both attempts:\n" + "\n---\n".join(diagnostics)
+    )
+
+
+def _cli_hold_and_check_once(ws_name, window_name, hold_seconds, env):
+    """One attempt of :func:`_cli_hold_and_check`.
+
+    Returns ``(before, after, None)`` on success or ``(None, None,
+    diagnostic)`` on failure. The readiness ping is nonced per attempt
+    and resent every 2s until it executes (see
+    :func:`_expect_window_capture` for the rationale).
     """
     if window_name:
         cmd = f"klangk shell {ws_name} {window_name} --no-consent-popup"
@@ -238,17 +281,28 @@ expect {{
     timeout {{ puts "TIMEOUT:prompt"; exit 1 }}
     eof {{ puts "EOF:prompt"; exit 1 }}
 }}
+set timeout 2
 send "echo KLANGK_READY_{nonce}_\\$?\\r"
-expect {{
-    -re {{KLANGK_READY_{nonce}_([0-9]+)}} {{
-        if {{$expect_out(1,string) != 0}} {{
-            puts "READY-NONZERO:$expect_out(1,string)"
-            exit 1
+set ready 0
+for {{set i 0}} {{$i < 15}} {{incr i}} {{
+    expect {{
+        -re {{KLANGK_READY_{nonce}_([0-9]+)}} {{
+            if {{$expect_out(1,string) != 0}} {{
+                puts "READY-NONZERO:$expect_out(1,string)"
+                exit 1
+            }}
+            set ready 1
         }}
+        timeout {{ send "echo KLANGK_READY_{nonce}_\\$?\\r" }}
+        eof {{ puts "EOF:ready tail=<<[string range $expect_out(buffer) end-399 end]>>"; exit 1 }}
     }}
-    timeout {{ puts "TIMEOUT:ready tail=<<[ready_tail]>>"; exit 1 }}
-    eof {{ puts "EOF:ready tail=<<[string range $expect_out(buffer) end-399 end]>>"; exit 1 }}
+    if {{$ready}} {{ break }}
 }}
+if {{!$ready}} {{
+    puts "TIMEOUT:ready tail=<<[ready_tail]>>"
+    exit 1
+}}
+set timeout 30
 send "echo BS; tmux display-message -p '#I:#W'; echo BE\\r"
 expect {{
     -re {{BS\\r?\\n(\\d+:\\S+)\\r?\\nBE}} {{
@@ -288,8 +342,8 @@ wait
         elif line.startswith("AFTER="):
             after = line.split("=", 1)[1]
     if before is None or after is None:
-        raise AssertionError(f"expect failed:\n{result.stdout}{result.stderr}")
-    return before, after
+        return None, None, f"{result.stdout}{result.stderr}"
+    return before, after, None
 
 
 class _WebSession:


### PR DESCRIPTION
Fixes #3037

## Summary

The e2e readiness ping (`echo KLANGK_READY_$?`) matched only
`KLANGK_READY_0`, so two failure modes presented as the same opaque
`TIMEOUT:ready` after burning the full 25s expect timeout on both
attempts:

1. **Nonzero `$?`** — the attached shell's last command exited nonzero,
   the marker echoes `KLANGK_READY_1`, which never matches.
2. **Wrong pane** — the ping goes to a pane that never executes it.

Changes in `_expect_window_capture` and `_cli_hold_and_check`
(`test_terminal_windows_e2e.py`):

- The ready pattern is now `KLANGK_READY_([0-9]+)`: a nonzero rc fails
  fast (<1s instead of 25s×2) with a distinct `READY-NONZERO:<rc>` stage
  tag instead of timing out.
- On `TIMEOUT:ready`, the expect script flushes Expect's retained
  internal buffer (an immediately-following `expect -re {(?s).*}`) and
  appends a bounded 400-char tail of what the pane actually printed, so
  a wrong-pane ping is identifiable in CI artifacts (the tail shows the
  echoed-but-never-executed ping). `EOF:ready` appends the same tail
  from `expect_out(buffer)` directly.
- `_cli_hold_and_check` now raises `AssertionError` carrying the expect
  diagnostic when either capture stage fails — the stage tags used to be
  swallowed there, leaving only "CLI moved from None to None".

The `$?` is kept in the marker on purpose: it is what makes the pattern
echo-resistant (the typed command echoes back as `KLANGK_READY_$?`,
which cannot match, so only executed output counts).

## Verification

Drove `_expect_window_capture`/`_cli_hold_and_check` against PATH shims
standing in for `klangk shell`:

- healthy shell (rc=0): ready stage passes, capture proceeds
- rc file ending `false`: `READY-NONZERO:1` in ~0.1s
- pane that prints a prompt but never executes input:
  `TIMEOUT:ready tail=<<echo KLANGK_READY_$?>>` — the tail names the
  failure mode directly

Full `test-cli-e2e` suite runs in CI on this PR.
