### PR TITLE
refactor(scripts,sidecar): bring every block under rank A (T26-T30)

### DIFF
--- a/scripts/check_deferred_imports.py
+++ b/scripts/check_deferred_imports.py
@@ -37,6 +37,14 @@ def _is_type_checking(node: ast.AST) -> bool:
     )
 
 
+def _catches_import_error(handler: ast.ExceptHandler) -> bool:
+    """Does an except clause catch ImportError/ModuleNotFoundError?"""
+    return isinstance(handler.type, ast.Name) and handler.type.id in (
+        "ImportError",
+        "ModuleNotFoundError",
+    )
+
+
 def _is_guarded_optional(node: ast.AST) -> bool:
     """Check if a node is a module-scope ``try: import`` over ``ImportError``.
 
@@ -48,9 +56,7 @@ def _is_guarded_optional(node: ast.AST) -> bool:
     if not (isinstance(parent, ast.Try) and _is_top_level(parent)):
         return False
     return any(
-        isinstance(h, ast.ExceptHandler)
-        and isinstance(h.type, ast.Name)
-        and h.type.id in ("ImportError", "ModuleNotFoundError")
+        isinstance(h, ast.ExceptHandler) and _catches_import_error(h)
         for h in parent.handlers
     )
 
@@ -90,6 +96,35 @@ def _is_marked(lines: list[str], lineno: int, comment: str) -> bool:
     return False
 
 
+def _is_exempt(node: ast.AST) -> bool:
+    """Is the import module-scope in one of the canonical patterns (plain
+    top-level, ``if TYPE_CHECKING:``, or a guarded optional dependency)?"""
+    return _is_top_level(node) or _is_type_checking(node) or _is_guarded_optional(node)
+
+
+def _is_flagged_import(node: ast.AST, source_lines: list[str]) -> bool:
+    """Is this import node a deferred import that carries no allow marker?"""
+    if not isinstance(node, (ast.Import, ast.ImportFrom)):
+        return False
+    if _is_exempt(node):
+        return False
+    return not _is_marked(source_lines, node.lineno, "allow-deferred-import")
+
+
+def _file_deferred_errors(root: Path, pyfile: Path) -> list[str]:
+    """The flagged deferred imports in one file (parse failures are
+    skipped)."""
+    parsed = _parse_file(pyfile)
+    if parsed is None:
+        return []
+    tree, source_lines = parsed
+    return [
+        _deferred_import_error(root, pyfile, node)
+        for node in ast.walk(tree)
+        if _is_flagged_import(node, source_lines)
+    ]
+
+
 def check_deferred_imports(package_dir: str) -> list[str]:
     """Flag imports that are not at module scope.
 
@@ -100,27 +135,9 @@ def check_deferred_imports(package_dir: str) -> list[str]:
     root = Path(package_dir).resolve()
     if not root.is_dir():
         return [f"ERROR: {package_dir} is not a directory"]
-
     errors: list[str] = []
     for pyfile in sorted(root.rglob("*.py")):
-        parsed = _parse_file(pyfile)
-        if parsed is None:
-            continue
-        tree, source_lines = parsed
-
-        for node in ast.walk(tree):
-            if not isinstance(node, (ast.Import, ast.ImportFrom)):
-                continue
-            if (
-                _is_top_level(node)
-                or _is_type_checking(node)
-                or _is_guarded_optional(node)
-            ):
-                continue
-            if _is_marked(source_lines, node.lineno, "allow-deferred-import"):
-                continue
-
-            errors.append(_deferred_import_error(root, pyfile, node))
+        errors.extend(_file_deferred_errors(root, pyfile))
     return errors
 
 
@@ -174,31 +191,35 @@ def _find_packages_in_dir(directory: Path) -> list[str]:
     return sorted(str(r) for r in roots)
 
 
-def main() -> int:
-    args = sys.argv[1:]
-
+def resolve_package_dirs(args: list[str]) -> list[str]:
+    """The package dirs to scan: discovered under cwd when no args, derived
+    from .py file paths when given files, else the args themselves."""
     if not args:
         # No arguments: discover packages under cwd
-        package_dirs = _find_packages_in_dir(Path.cwd())
-    elif any(a.endswith(".py") for a in args):
+        return _find_packages_in_dir(Path.cwd())
+    if any(a.endswith(".py") for a in args):
         # File paths: discover packages from them
-        package_dirs = _packages_from_files(args)
-    else:
-        # Package directories
-        package_dirs = args
+        return _packages_from_files(args)
+    return args
 
+
+def report_errors(all_errors: list[str]) -> int:
+    """Print the error lines; the exit code (1 on any deferred import)."""
+    if not all_errors:
+        return 0
+    for line in all_errors:
+        print(line, file=sys.stderr)
+    return 1
+
+
+def main() -> int:
+    package_dirs = resolve_package_dirs(sys.argv[1:])
     if not package_dirs:
         return 0
-
     all_errors: list[str] = []
     for pkg_dir in package_dirs:
         all_errors.extend(check_deferred_imports(pkg_dir))
-
-    if all_errors:
-        for line in all_errors:
-            print(line, file=sys.stderr)
-        return 1
-    return 0
+    return report_errors(all_errors)
 
 
 if __name__ == "__main__":

--- a/scripts/consent-decide.py
+++ b/scripts/consent-decide.py
@@ -72,6 +72,19 @@ def decide(
     )
 
 
+def allowed_spec(host: str, port) -> str:
+    """The allowed_domains entry for a destination: raw IPs must be CIDR
+    (ip/32) so the sidecar entrypoint's static allow loop applies them (a
+    bare IP is neither matched by that loop nor by the DNS proxy, which
+    matches query names); domains stay as host specs."""
+    try:
+        ipaddress.ip_address(host)
+        spec = f"{host}/32"
+    except ValueError:
+        spec = host
+    return f"{spec}:{port}" if port else spec
+
+
 def _allow_destination(conn: sqlite3.Connection, ws: str, row: sqlite3.Row) -> bool:
     """Add the request's destination to the workspace's allowed_domains.
 
@@ -85,17 +98,7 @@ def _allow_destination(conn: sqlite3.Connection, ws: str, row: sqlite3.Row) -> b
     if wrow is None:
         return False
     domains = json.loads(wrow["allowed_domains"] or "[]")
-    # Raw IPs must be CIDR (ip/32) so the sidecar entrypoint's static allow
-    # loop applies them; a bare IP is neither matched by that loop nor by the
-    # DNS proxy (which matches query names). Domains stay as host specs.
-    host = row["dest_host"]
-    port = row["dest_port"]
-    try:
-        ipaddress.ip_address(host)
-        spec = f"{host}/32"
-    except ValueError:
-        spec = host
-    entry = f"{spec}:{port}" if port else spec
+    entry = allowed_spec(row["dest_host"], row["dest_port"])
     if entry in domains:
         return False
     domains.append(entry)
@@ -148,6 +151,25 @@ def _prompt_and_decide(conn, ws: str, row, user_id: str, seen: set) -> None:
         console.print("skipped")
 
 
+def pending_rows(conn: sqlite3.Connection, ws: str, seen: set) -> list[sqlite3.Row]:
+    """The workspace's pending requests not yet decided/skipped."""
+    return [r for r in _fetch_pending(conn, ws) if r["id"] not in seen]
+
+
+def poll_pending(conn: sqlite3.Connection, ws: str, user_id: str, seen: set) -> None:
+    """Poll + prompt over pending requests until Ctrl-C."""
+    while True:
+        pending = pending_rows(conn, ws, seen)
+        if not pending:
+            sys.stdout.write("\rno pending requests; polling (Ctrl-C to quit)   ")
+            sys.stdout.flush()
+            time.sleep(2)
+            continue
+        sys.stdout.write("\r" + " " * 50 + "\r")
+        for row in pending:
+            _prompt_and_decide(conn, ws, row, user_id, seen)
+
+
 def main() -> None:
     ap = argparse.ArgumentParser(description=__doc__)
     ap.add_argument("workspace_id", help="workspace id (full or prefix)")
@@ -177,16 +199,7 @@ def main() -> None:
             f"[bold]egress consent decide[/bold] -- workspace {ws[:8]} "
             f"(decider: {args.as_user})"
         )
-        while True:
-            pending = [r for r in _fetch_pending(conn, ws) if r["id"] not in seen]
-            if not pending:
-                sys.stdout.write("\rno pending requests; polling (Ctrl-C to quit)   ")
-                sys.stdout.flush()
-                time.sleep(2)
-                continue
-            sys.stdout.write("\r" + " " * 50 + "\r")
-            for row in pending:
-                _prompt_and_decide(conn, ws, row, user_id, seen)
+        poll_pending(conn, ws, user_id, seen)
     except KeyboardInterrupt:
         console.print("\nbye.")
     finally:

--- a/scripts/consent-watch.py
+++ b/scripts/consent-watch.py
@@ -49,6 +49,20 @@ def _clock(ts: float | None) -> str:
     return time.strftime("%H:%M:%S", time.localtime(ts)) if ts else ""
 
 
+def consent_row(row: tuple) -> list:
+    """One table row from a consent record (decision styled by verdict)."""
+    host, port, decision, scope, req_at, dec_at, by = row
+    dest = f"{host}:{port}" if port else host
+    return [
+        dest,
+        Text(decision, style=_DECISION_STYLE.get(decision, "")),
+        _clock(req_at),
+        _clock(dec_at),
+        scope or "",
+        by or "",
+    ]
+
+
 def _render(rows: list[tuple], ws: str) -> Table:
     table = Table(
         title=f"egress consent -- workspace {ws[:8]}",
@@ -63,16 +77,8 @@ def _render(rows: list[tuple], ws: str) -> Table:
     if not rows:
         table.add_row(Text("no requests yet", style="dim"), "", "", "", "", "")
         return table
-    for host, port, decision, scope, req_at, dec_at, by in rows:
-        dest = f"{host}:{port}" if port else host
-        table.add_row(
-            dest,
-            Text(decision, style=_DECISION_STYLE.get(decision, "")),
-            _clock(req_at),
-            _clock(dec_at),
-            scope or "",
-            by or "",
-        )
+    for row in rows:
+        table.add_row(*consent_row(row))
     return table
 
 

--- a/scripts/fmtk-seed.py
+++ b/scripts/fmtk-seed.py
@@ -112,18 +112,23 @@ def ensure_users(base: str, token: str) -> dict[str, str]:
     return ids
 
 
+def group_id_by_name(base: str, token: str, name: str) -> str:
+    """The id of a group by name (from the paged listing)."""
+    _, listing = api(base, token, "GET", "/api/v1/groups?page_size=100")
+    return next(g["id"] for g in listing["groups"] if g["name"] == name)
+
+
 def ensure_admin_group_member(base: str, token: str, user_id: str) -> None:
     """Idempotently add fmtk-admin to the ``admins`` group."""
-    _, listing = api(base, token, "GET", "/api/v1/groups?page_size=100")
-    group = next(g for g in listing["groups"] if g["name"] == "admins")
-    _, members = api(base, token, "GET", f"/api/v1/groups/{group['id']}/members")
+    group_id = group_id_by_name(base, token, "admins")
+    _, members = api(base, token, "GET", f"/api/v1/groups/{group_id}/members")
     if any(m["id"] == user_id for m in members):
         return
     status, body = api(
         base,
         token,
         "POST",
-        f"/api/v1/groups/{group['id']}/members",
+        f"/api/v1/groups/{group_id}/members",
         {"user_id": user_id},
     )
     if status != 200:
@@ -150,12 +155,17 @@ def ensure_workspace(base: str, owner_token: str) -> str:
     return body["id"]
 
 
+def role_bucket(base: str, token: str, ws_id: str, role: str) -> dict:
+    """The workspace's ``role`` bucket from the roles listing."""
+    _, roles = api(base, token, "GET", f"/api/v1/workspaces/{ws_id}/roles")
+    return next(r for r in roles if r["role"] == role)
+
+
 def ensure_role_member(
     base: str, token: str, ws_id: str, role: str, email: str
 ) -> None:
     """Idempotently add ``email`` to the workspace's ``role`` bucket."""
-    _, roles = api(base, token, "GET", f"/api/v1/workspaces/{ws_id}/roles")
-    bucket = next(r for r in roles if r["role"] == role)
+    bucket = role_bucket(base, token, ws_id, role)
     if any(m["email"] == email for m in bucket["members"]):
         return
     status, body = api(

--- a/scripts/fuzz-api.py
+++ b/scripts/fuzz-api.py
@@ -672,6 +672,14 @@ def wait_for_server(uds_path: str, timeout: float = 30) -> None:
 # ---------------------------------------------------------------------------
 
 
+def truncated_body(body: dict) -> str:
+    """The body serialized for the report, truncated past 200 chars."""
+    body_str = json.dumps(body, default=str)
+    if len(body_str) > 200:
+        return body_str[:200] + "..."
+    return body_str
+
+
 class AnomalyTracker:
     def __init__(self):
         self.server_errors: list[dict] = []  # 5xx responses
@@ -699,14 +707,17 @@ class AnomalyTracker:
             "time": time.strftime("%H:%M:%S"),
         }
         if body is not None:
-            # Truncate large bodies for the report
-            body_str = json.dumps(body, default=str)
-            if len(body_str) > 200:
-                body_str = body_str[:200] + "..."
-            entry["body"] = body_str
+            entry["body"] = truncated_body(body)
+        self.classify_entry(entry, status, error)
+
+    def classify_entry(
+        self, entry: dict, status: int | None, error: str | None
+    ) -> None:
+        """Route one recorded entry to its bucket: 5xx -> server_errors,
+        timeout -> timeouts, connection -> connection_errors."""
         if status is not None and status >= 500:
             self.server_errors.append(entry)
-            logger.warning("5xx: %s %s → %d", method, path, status)
+            logger.warning("5xx: %s %s → %d", entry["method"], entry["path"], status)
         elif error == "timeout":
             self.timeouts.append(entry)
         elif error == "connection":
@@ -794,16 +805,25 @@ _STDERR_ANOMALY_KEYWORDS = [
 ]
 
 
+def stderr_line_is_anomaly(line: str) -> bool:
+    """Does a server-stderr line look like an unhandled exception?
+    Expected/normal log lines (INFO/WARNING/password noise) are filtered out."""
+    low = line.lower()
+    return (
+        any(kw in low for kw in _STDERR_ANOMALY_KEYWORDS)
+        and "INFO" not in line
+        and "WARNING" not in line
+        and "password" not in low
+    )
+
+
 def _stderr_anomaly_lines(stderr_output: str) -> list[str]:
     """Server-stderr lines that look like unhandled exceptions, with
     expected/normal log lines (INFO/WARNING/password noise) filtered out."""
     return [
         line
         for line in stderr_output.strip().splitlines()
-        if any(kw in line.lower() for kw in _STDERR_ANOMALY_KEYWORDS)
-        and "INFO" not in line
-        and "WARNING" not in line
-        and "password" not in line.lower()
+        if stderr_line_is_anomaly(line)
     ]
 
 
@@ -847,51 +867,50 @@ def create_fixture_id(
     return None
 
 
+def collect_fixture_ids(
+    uds_path: str,
+    headers: dict,
+    url: str,
+    payloads: list[dict],
+    ok_codes: tuple[int, ...] = (200,),
+) -> list[str]:
+    """POST each payload fixture; collect the ids that came back."""
+    ids = []
+    for payload in payloads:
+        fid = create_fixture_id(uds_path, headers, url, payload, ok_codes)
+        if fid:
+            ids.append(fid)
+    return ids
+
+
 def seed_fuzz_fixtures(
     uds_path: str, token: str
 ) -> tuple[list[str], list[str], list[str]]:
     """Pre-create workspaces / users / groups so fuzzed paths have real
     ids to target. Returns (workspace_ids, user_ids, group_ids)."""
     headers = {"Authorization": f"Bearer {token}"}
-    workspace_ids: list[str] = []
-    user_ids: list[str] = []
-    group_ids: list[str] = []
-
-    # Pre-create a couple of workspaces
-    for i in range(2):
-        wid = create_fixture_id(
-            uds_path,
-            headers,
-            "/api/v1/workspaces",
-            {"name": f"fuzz-ws-{i}"},
-        )
-        if wid:
-            workspace_ids.append(wid)
-
-    # Also create some users and groups to have IDs for fuzzing
-    for i in range(3):
-        uid = create_fixture_id(
-            uds_path,
-            headers,
-            "/api/v1/users",
-            {
-                "email": f"fuzzuser{i}@example.com",
-                "password": "fuzzpass",
-            },
-        )
-        if uid:
-            user_ids.append(uid)
-    for i in range(2):
-        gid = create_fixture_id(
-            uds_path,
-            headers,
-            "/api/v1/groups",
-            {"name": f"fuzz-group-{i}"},
-            ok_codes=(200, 201),
-        )
-        if gid:
-            group_ids.append(gid)
-
+    workspace_ids = collect_fixture_ids(
+        uds_path,
+        headers,
+        "/api/v1/workspaces",
+        [{"name": f"fuzz-ws-{i}"} for i in range(2)],
+    )
+    user_ids = collect_fixture_ids(
+        uds_path,
+        headers,
+        "/api/v1/users",
+        [
+            {"email": f"fuzzuser{i}@example.com", "password": "fuzzpass"}
+            for i in range(3)
+        ],
+    )
+    group_ids = collect_fixture_ids(
+        uds_path,
+        headers,
+        "/api/v1/groups",
+        [{"name": f"fuzz-group-{i}"} for i in range(2)],
+        ok_codes=(200, 201),
+    )
     return workspace_ids, user_ids, group_ids
 
 
@@ -906,6 +925,32 @@ def _fill_id_placeholder(
         placeholder,
         rng.choice(ids + [fuzz_uuid(rng)]) if ids else fuzz_uuid(rng),
     )
+
+
+_NAMED_PLACEHOLDER_DRAWS = {
+    "{role}": lambda rng: rng.choice(ROLES),
+    "{invitation_id}": fuzz_uuid,
+    "{name}": fuzz_string,
+    "{provider_id}": fuzz_string,
+}
+
+
+def fuzz_random_path(rng: random.Random) -> str:
+    """A synthetic random multi-segment path for the catch-all endpoints."""
+    segments = rng.randint(1, 4)
+    return "/" + "/".join(fuzz_string(rng) for _ in range(segments))
+
+
+def fill_named_placeholders(rng: random.Random, path: str) -> str:
+    """Substitute the non-id placeholders ({role} from the known role
+    list, {invitation_id}/{name}/{provider_id} as fuzzed values) and the
+    synthetic {random_path} catch-all."""
+    for placeholder, draw in _NAMED_PLACEHOLDER_DRAWS.items():
+        if placeholder in path:
+            path = path.replace(placeholder, draw(rng))
+    if "{random_path}" in path:
+        path = fuzz_random_path(rng)
+    return path
 
 
 def fill_path_params(
@@ -924,18 +969,7 @@ def fill_path_params(
         ("{group_id}", group_ids),
     ):
         path = _fill_id_placeholder(rng, path, placeholder, ids)
-    if "{role}" in path:
-        path = path.replace("{role}", rng.choice(ROLES))
-    if "{invitation_id}" in path:
-        path = path.replace("{invitation_id}", fuzz_uuid(rng))
-    if "{name}" in path:
-        path = path.replace("{name}", fuzz_string(rng))
-    if "{random_path}" in path:
-        segments = rng.randint(1, 4)
-        path = "/" + "/".join(fuzz_string(rng) for _ in range(segments))
-    if "{provider_id}" in path:
-        path = path.replace("{provider_id}", fuzz_string(rng))
-    return path
+    return fill_named_placeholders(rng, path)
 
 
 def fuzz_request_headers(rng: random.Random, headers: dict) -> dict:
@@ -962,6 +996,16 @@ def fuzz_request_headers(rng: random.Random, headers: dict) -> dict:
     return req_headers
 
 
+def fuzz_request_args(body, params, req_headers: dict) -> dict:
+    """The httpx request kwargs: the JSON body as ``json=``, or raw
+    ``content=`` when the fuzzed headers override the content-type."""
+    if not body:
+        return {"params": params}
+    if "Content-Type" in req_headers:
+        return {"content": json.dumps(body).encode(), "params": params}
+    return {"json": body, "params": params}
+
+
 async def send_fuzz_request(
     client: httpx.AsyncClient,
     tracker: AnomalyTracker,
@@ -972,17 +1016,9 @@ async def send_fuzz_request(
     req_headers: dict,
 ) -> None:
     """Fire one fuzzed request and record the outcome."""
+    args = fuzz_request_args(body, params, req_headers)
     try:
-        r = await client.request(
-            method,
-            path,
-            json=body if body and "Content-Type" not in req_headers else None,
-            content=json.dumps(body).encode()
-            if body and "Content-Type" in req_headers
-            else None,
-            params=params,
-            headers=req_headers,
-        )
+        r = await client.request(method, path, headers=req_headers, **args)
         tracker.record(method, path, r.status_code, body=body)
     except httpx.TimeoutException:
         tracker.record(method, path, None, error="timeout", body=body)
@@ -992,6 +1028,18 @@ async def send_fuzz_request(
         await asyncio.sleep(2)
     except Exception as exc:
         tracker.record(method, path, None, error=str(exc), body=body)
+
+
+def maybe_relogin(tracker: AnomalyTracker, headers: dict, uds_path: str) -> None:
+    """Periodically re-login in case the token was invalidated (checked
+    every 200 requests); on failure continue with the old/no token."""
+    if tracker.requests_sent % 200 != 0:
+        return
+    try:
+        new_token = uds_login(uds_path, "admin@example.com", "admin")
+        headers["Authorization"] = f"Bearer {new_token}"
+    except Exception:
+        pass  # will continue with old or no token
 
 
 async def run_fuzz(
@@ -1045,12 +1093,7 @@ async def run_fuzz(
             await asyncio.sleep(rng.uniform(0.01, 0.1))
 
             # Periodically re-login in case the token was invalidated
-            if tracker.requests_sent % 200 == 0:
-                try:
-                    new_token = uds_login(uds_path, "admin@example.com", "admin")
-                    headers["Authorization"] = f"Bearer {new_token}"
-                except Exception:
-                    pass  # will continue with old or no token
+            maybe_relogin(tracker, headers, uds_path)
 
 
 # ---------------------------------------------------------------------------
@@ -1094,6 +1137,18 @@ def _backend_routes() -> set[tuple[str, str]]:
     return routes
 
 
+def print_route_diff(missing: list, extra: list) -> None:
+    """Print the missing/extra route sets from the drift diff."""
+    if missing:
+        print("\nMISSING from fuzzer (real routes not fuzzed):")
+        for m, p in missing:
+            print(f"  {m:6} {p}")
+    if extra:
+        print("\nEXTRA in fuzzer (fuzzed, no matching route):")
+        for m, p in extra:
+            print(f"  {m:6} {p}")
+
+
 def check_endpoints() -> int:
     """Diff ENDPOINTS against the live router; fail on drift (#1536).
 
@@ -1107,14 +1162,7 @@ def check_endpoints() -> int:
     missing = sorted(backend - fuzzed, key=lambda x: x[1])
     extra = sorted(fuzzed - backend, key=lambda x: x[1])
     print(f"backend routes: {len(backend)}  fuzzer endpoints: {len(fuzzed)}")
-    if missing:
-        print("\nMISSING from fuzzer (real routes not fuzzed):")
-        for m, p in missing:
-            print(f"  {m:6} {p}")
-    if extra:
-        print("\nEXTRA in fuzzer (fuzzed, no matching route):")
-        for m, p in extra:
-            print(f"  {m:6} {p}")
+    print_route_diff(missing, extra)
     if not missing and not extra:
         print("No drift ✓")
         return 0
@@ -1124,6 +1172,58 @@ def check_endpoints() -> int:
 # ---------------------------------------------------------------------------
 # Main
 # ---------------------------------------------------------------------------
+
+
+def stop_server(proc: subprocess.Popen, tee: TeeReader) -> None:
+    """SIGTERM the server (SIGKILL after a 10s grace) + drain the tee."""
+    proc.send_signal(signal.SIGTERM)
+    try:
+        proc.wait(timeout=10)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        proc.wait()
+    tee.join()
+
+
+def fuzz_session(tracker: AnomalyTracker, args, seed: int, data_dir: str) -> str:
+    """Start the server, log in, run the fuzz loop, tear down. Returns the
+    captured server stderr."""
+    logger.info("Starting klangkd")
+    proc, tee, uds_path = start_server(data_dir)
+    try:
+        wait_for_server(uds_path)
+        logger.info("Server is up")
+
+        token = uds_login(uds_path, "admin@example.com", "admin")
+        logger.info("Logged in as admin")
+
+        logger.info(
+            "Starting fuzz run: duration=%g min, seed=%d",
+            args.duration,
+            seed,
+        )
+        asyncio.run(run_fuzz(uds_path, token, args.duration, seed, tracker))
+    except KeyboardInterrupt:
+        logger.info("Interrupted by user")
+    except Exception:
+        logger.exception("Fuzz runner error")
+    finally:
+        stop_server(proc, tee)
+    return tee.output
+
+
+def write_server_log(stderr_data: str) -> None:
+    """Write the full server log for later inspection."""
+    log_path = os.path.join(os.path.dirname(__file__), "..", "fuzz-server.log")
+    with open(log_path, "w") as f:
+        f.write(stderr_data)
+    logger.info("Server stderr saved to %s", log_path)
+
+
+def fuzz_exit(tracker: AnomalyTracker) -> int:
+    """Exit code: 1 on 5xx or connection errors (the anomalies that gate
+    CI), 0 otherwise."""
+    return 1 if bool(tracker.server_errors or tracker.connection_errors) else 0
 
 
 def main():
@@ -1160,49 +1260,11 @@ def main():
     tracker = AnomalyTracker()
 
     with tempfile.TemporaryDirectory(prefix="klangk-fuzz-") as data_dir:
-        logger.info("Starting klangkd")
-        proc, tee, uds_path = start_server(data_dir)
+        stderr_data = fuzz_session(tracker, args, seed, data_dir)
 
-        try:
-            wait_for_server(uds_path)
-            logger.info("Server is up")
-
-            token = uds_login(uds_path, "admin@example.com", "admin")
-            logger.info("Logged in as admin")
-
-            logger.info(
-                "Starting fuzz run: duration=%g min, seed=%d",
-                args.duration,
-                seed,
-            )
-            asyncio.run(run_fuzz(uds_path, token, args.duration, seed, tracker))
-        except KeyboardInterrupt:
-            logger.info("Interrupted by user")
-        except Exception:
-            logger.exception("Fuzz runner error")
-        finally:
-            # Stop server
-            proc.send_signal(signal.SIGTERM)
-            try:
-                proc.wait(timeout=10)
-            except subprocess.TimeoutExpired:
-                proc.kill()
-                proc.wait()
-            tee.join()
-
-        stderr_data = tee.output
-
-        report = tracker.report(stderr_data)
-        print(report)
-
-        # Write full server log for later inspection
-        log_path = os.path.join(os.path.dirname(__file__), "..", "fuzz-server.log")
-        with open(log_path, "w") as f:
-            f.write(stderr_data)
-        logger.info("Server stderr saved to %s", log_path)
-
-        has_anomalies = bool(tracker.server_errors or tracker.connection_errors)
-        sys.exit(1 if has_anomalies else 0)
+    print(tracker.report(stderr_data))
+    write_server_log(stderr_data)
+    sys.exit(fuzz_exit(tracker))
 
 
 if __name__ == "__main__":

--- a/scripts/fuzz-api.py
+++ b/scripts/fuzz-api.py
@@ -944,7 +944,9 @@ def fuzz_random_path(rng: random.Random) -> str:
 def fill_named_placeholders(rng: random.Random, path: str) -> str:
     """Substitute the non-id placeholders ({role} from the known role
     list, {invitation_id}/{name}/{provider_id} as fuzzed values) and the
-    synthetic {random_path} catch-all."""
+    synthetic {random_path} catch-all. The {random_path} replacement is
+    LAST and whole-path -- it must never share a template with the named
+    placeholders, or the extra fuzz draw would shift the seed sequence."""
     for placeholder, draw in _NAMED_PLACEHOLDER_DRAWS.items():
         if placeholder in path:
             path = path.replace(placeholder, draw(rng))

--- a/scripts/fuzz-idle.py
+++ b/scripts/fuzz-idle.py
@@ -210,6 +210,13 @@ class Server:
         self.proc._log_file = log_file  # type: ignore[attr-defined]
         self._wait_ready()
 
+    def _health_ok(self, client: httpx.Client) -> bool:
+        """One /health probe; False on a transport error."""
+        try:
+            return client.get("/health").status_code == 200
+        except httpx.HTTPError:
+            return False
+
     def _wait_ready(self, timeout: float = 90) -> None:
         deadline = time.monotonic() + timeout
         with httpx.Client(base_url=self.url, timeout=2) as client:
@@ -218,11 +225,8 @@ class Server:
                     raise RuntimeError(
                         f"klangkd exited early:\n{self._read_log()[-4000:]}"
                     )
-                try:
-                    if client.get("/health").status_code == 200:
-                        return
-                except httpx.HTTPError:
-                    pass
+                if self._health_ok(client):
+                    return
                 time.sleep(0.5)
         raise RuntimeError(
             f"klangkd not healthy within {timeout}s:\n{self._read_log()[-4000:]}"
@@ -244,18 +248,7 @@ class Server:
         text = self._read_log()
         new = text[self._log_scan_offset :]
         self._log_scan_offset = len(text)
-        hits = []
-        for line in new.splitlines():
-            low = line.lower()
-            if (
-                any(
-                    kw in low for kw in ("traceback", "unhandled", "exception", "fatal")
-                )
-                and "INFO" not in line
-                and "WARNING" not in line
-            ):
-                hits.append(line.strip())
-        return hits
+        return [line.strip() for line in new.splitlines() if log_line_is_anomaly(line)]
 
     def stop(self) -> None:
         proc = self.proc
@@ -271,14 +264,43 @@ class Server:
                     log_file.close()
         self._cleanup_containers()
 
+    def _instance_id(self) -> str:
+        """This instance's id from the data dir ("" when absent/unreadable)."""
+        try:
+            with open(os.path.join(self.data_dir, "instance-id")) as fh:
+                return fh.read().strip()
+        except OSError:
+            return ""
+
+    def _rm_role_containers(self, instance_id: str, role: str) -> None:
+        """Force-remove every podman container labelled with this
+        instance+role."""
+        result = subprocess.run(
+            [
+                PODMAN,
+                "ps",
+                "-a",
+                "-q",
+                "--filter",
+                f"label=klangk.instance={instance_id}",
+                "--filter",
+                f"label=klangk.role={role}",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        ids = result.stdout.split()
+        if ids:
+            subprocess.run(
+                [PODMAN, "rm", "-f", *ids],
+                capture_output=True,
+                timeout=60,
+            )
+
     def _cleanup_containers(self) -> None:
         """Remove any podman containers labelled with this instance's id."""
-        id_file = os.path.join(self.data_dir, "instance-id")
-        try:
-            with open(id_file) as fh:
-                instance_id = fh.read().strip()
-        except OSError:
-            return
+        instance_id = self._instance_id()
         if not instance_id:
             return
         try:
@@ -286,28 +308,7 @@ class Server:
             # sidecar's netns, so podman refuses to remove a sidecar with
             # a live dependent (#2476).
             for role in ("workspace", "network-sidecar"):
-                result = subprocess.run(
-                    [
-                        PODMAN,
-                        "ps",
-                        "-a",
-                        "-q",
-                        "--filter",
-                        f"label=klangk.instance={instance_id}",
-                        "--filter",
-                        f"label=klangk.role={role}",
-                    ],
-                    capture_output=True,
-                    text=True,
-                    timeout=30,
-                )
-                ids = result.stdout.split()
-                if ids:
-                    subprocess.run(
-                        [PODMAN, "rm", "-f", *ids],
-                        capture_output=True,
-                        timeout=60,
-                    )
+                self._rm_role_containers(instance_id, role)
         except (FileNotFoundError, subprocess.TimeoutExpired):
             pass
 
@@ -315,6 +316,15 @@ class Server:
 # ---------------------------------------------------------------------------
 # Anomalies
 # ---------------------------------------------------------------------------
+
+
+def log_line_is_anomaly(line: str) -> bool:
+    """Does a log line look like an unhandled exception? INFO/WARNING lines
+    are excluded -- an invalid KLANGKD_IDLE_TIMEOUT_SECONDS draw legitimately
+    warns at startup."""
+    low = line.lower()
+    has_kw = any(kw in low for kw in ("traceback", "unhandled", "exception", "fatal"))
+    return has_kw and "INFO" not in line and "WARNING" not in line
 
 
 class Anomalies:
@@ -588,6 +598,14 @@ def global_tick(global_timeout: int) -> int:
     return max(10, min(60, global_timeout // 3))
 
 
+def live_override_values(specs: list[WsSpec]) -> list[int]:
+    """Every override value that can ever be live in the wave: the initial
+    per-workspace overrides plus the runtime-change values."""
+    values = [s.override for s in specs if s.override is not None]
+    values += [s.runtime_change[1] for s in specs if s.runtime_change is not None]
+    return values
+
+
 def wave_tick_bound(specs: list[WsSpec], global_timeout: int) -> int:
     """A conservative upper bound on the cleanup loop's tick for the wave.
 
@@ -597,10 +615,8 @@ def wave_tick_bound(specs: list[WsSpec], global_timeout: int) -> int:
     any ``v in S``. So the max of ``v//2`` over every value that can ever
     be live (plus the no-override global tick) bounds every phase.
     """
-    values = [s.override for s in specs if s.override is not None]
-    values += [s.runtime_change[1] for s in specs if s.runtime_change is not None]
     bounds = [global_tick(global_timeout), 2]
-    bounds += [v // 2 for v in values]
+    bounds += [v // 2 for v in live_override_values(specs)]
     return max(bounds)
 
 
@@ -618,6 +634,17 @@ def draw_override(rng: random.Random, bogus_global: bool) -> int | None:
     return draw  # None or 0
 
 
+def runtime_change_tuple(kind: str | None) -> tuple[str, int] | None:
+    """The ``(kind, value)`` change for a drawn kind (None -> no change)."""
+    if kind == "shorten":
+        return ("shorten", 3)
+    if kind == "lengthen":
+        return ("lengthen", 30)
+    if kind == "zero":
+        return ("zero", 0)
+    return None
+
+
 def draw_runtime_change(rng: random.Random, pattern: str):
     """Draw the mid-flight change, only where the outcome stays
     deterministic: no-activity patterns may shorten (reap sooner must be
@@ -631,13 +658,7 @@ def draw_runtime_change(rng: random.Random, pattern: str):
         kind = rng.choices([None, "lengthen", "zero"], weights=[7, 1, 1])[0]
     else:
         kind = None
-    if kind == "shorten":
-        return ("shorten", 3)
-    if kind == "lengthen":
-        return ("lengthen", 30)
-    if kind == "zero":
-        return ("zero", 0)
-    return None
+    return runtime_change_tuple(kind)
 
 
 def apply_effective_timeout(
@@ -660,17 +681,26 @@ def apply_effective_timeout(
     return eff
 
 
+def spec_expects_alive(spec: WsSpec, pattern: str, eff: int) -> bool:
+    """Does the drawn spec expect to stay alive (vs be reaped)? A zero
+    override / a >=60s effective timeout never reaps in-window; an activity
+    pattern keeps it alive; a lengthen/zero runtime change must not be
+    reaped in-window."""
+    if spec.override == 0 or eff >= 60:
+        return True
+    if pattern in ("term_under", "egress", "mixed"):
+        return True
+    return spec.runtime_change is not None and spec.runtime_change[0] in (
+        "lengthen",
+        "zero",
+    )
+
+
 def expected_outcome(spec: WsSpec, pattern: str, eff: int) -> str:
     """The observable expectation for the drawn spec."""
     if spec.override == 0 or eff >= 60:
         spec.loose_alive = eff >= 60
-        return "alive"
-    if pattern in ("term_under", "egress", "mixed"):
-        return "alive"
-    if spec.runtime_change is not None and spec.runtime_change[0] in (
-        "lengthen",
-        "zero",
-    ):
+    if spec_expects_alive(spec, pattern, eff):
         return "alive"  # must not be reaped in-window
     return "reap"
 
@@ -727,6 +757,26 @@ async def wait_running(
     raise RuntimeError(f"container never became running; last={last!r}")
 
 
+def check_idle_reported(
+    ctx: Ctx, spec: WsSpec, reported, wall: float, tol: float, phase: str
+) -> None:
+    """Assert idle_seconds is numeric and tracks wall-clock idle."""
+    if not isinstance(reported, (int, float)):
+        ctx.anomalies.add(
+            "idle-secs",
+            f"{spec.name}: idle_seconds not numeric: {reported!r}",
+            scenario=spec.scenario_json(),
+        )
+        return
+    if abs(reported - wall) > tol:
+        ctx.anomalies.add(
+            "idle-secs",
+            f"{spec.name} ({phase}): idle_seconds={reported} but wall "
+            f"idle={wall:.1f}s (tolerance +/-{tol}s)",
+            scenario=spec.scenario_json(),
+        )
+
+
 async def check_idle_seconds(
     ctx: Ctx, spec: WsSpec, last_activity: float, tick: int, phase: str
 ) -> None:
@@ -737,80 +787,73 @@ async def check_idle_seconds(
     wall = time.monotonic() - last_activity
     if wall < tick + 2:
         return  # too close to the last bump to assert tightly
-    reported = st.get("idle_seconds")
-    if not isinstance(reported, (int, float)):
+    check_idle_reported(
+        ctx, spec, st.get("idle_seconds"), wall, tick + IDLE_SECS_TOL, phase
+    )
+
+
+async def probe_invalid_patches(ctx: Ctx, spec: WsSpec) -> None:
+    """PATCH values the settings coercion must reject (workspace_settings.py
+    _coerce_nonnegative_int): negative, non-numeric string, empty string,
+    non-integer float. Each must 400, never 5xx."""
+    for bad in (-5, "notanumber", "", 1.5):
+        resp = await ctx.api.patch_settings(spec.ws_id, {"idle_timeout": bad})
+        if not 400 <= resp.status_code < 500:
+            ctx.anomalies.add(
+                "invalid-patch",
+                f"{spec.name}: PATCH idle_timeout={bad!r} -> "
+                f"{resp.status_code} (expected 4xx)",
+                scenario=spec.scenario_json(),
+            )
+
+
+async def apply_idle_override(ctx: Ctx, spec: WsSpec) -> None:
+    """PATCH the per-workspace idle_timeout override."""
+    resp = await ctx.api.patch_settings(spec.ws_id, {"idle_timeout": spec.override})
+    if resp.status_code != 200:
         ctx.anomalies.add(
-            "idle-secs",
-            f"{spec.name}: idle_seconds not numeric: {reported!r}",
-            scenario=spec.scenario_json(),
-        )
-        return
-    tol = tick + IDLE_SECS_TOL
-    if abs(reported - wall) > tol:
-        ctx.anomalies.add(
-            "idle-secs",
-            f"{spec.name} ({phase}): idle_seconds={reported} but wall "
-            f"idle={wall:.1f}s (tolerance +/-{tol}s)",
+            "patch",
+            f"{spec.name}: PATCH override {spec.override} -> {resp.status_code}",
             scenario=spec.scenario_json(),
         )
 
 
 async def configure_workspace(ctx: Ctx, spec: WsSpec) -> None:
     """Apply the scenario's settings patches (invalid-probe + override)."""
-    api = ctx.api
     if spec.invalid_patch:
-        # Values the settings coercion must reject (workspace_settings.py
-        # _coerce_nonnegative_int): negative, non-numeric string, empty
-        # string, non-integer float. Each must 400, never 5xx.
-        for bad in (-5, "notanumber", "", 1.5):
-            resp = await api.patch_settings(spec.ws_id, {"idle_timeout": bad})
-            if not 400 <= resp.status_code < 500:
-                ctx.anomalies.add(
-                    "invalid-patch",
-                    f"{spec.name}: PATCH idle_timeout={bad!r} -> "
-                    f"{resp.status_code} (expected 4xx)",
-                    scenario=spec.scenario_json(),
-                )
+        await probe_invalid_patches(ctx, spec)
         spec.note("invalid-patches-sent")
     if spec.override is not None:
-        resp = await api.patch_settings(spec.ws_id, {"idle_timeout": spec.override})
-        if resp.status_code != 200:
-            ctx.anomalies.add(
-                "patch",
-                f"{spec.name}: PATCH override {spec.override} -> {resp.status_code}",
-                scenario=spec.scenario_json(),
-            )
+        await apply_idle_override(ctx, spec)
         spec.note(f"override={spec.override}")
 
 
-async def start_scenario_workspace(
-    ctx: Ctx, spec: WsSpec
-) -> tuple[WsTerminal | None, dict]:
-    """Start the workspace per its pattern; returns (terminal-or-None,
-    running-status)."""
-    api = ctx.api
-    term: WsTerminal | None = None
-    if spec.pattern in WS_PATTERNS:
-        term = WsTerminal(ctx.server, api.token, spec.ws_id)
-        spec.note("ws-connect")
-        await term.connect()
-        if spec.pattern != "quiet_ws":
-            await term.start_terminal()
-            await asyncio.sleep(1)
-            await term.send_input(" ")
-    else:
-        spec.note("api-start")
-        resp = await api.start(spec.ws_id)
-        if resp.status_code != 200:
-            ctx.anomalies.add(
-                "start",
-                f"{spec.name}: start -> {resp.status_code}",
-            )
-    st = await wait_running(ctx, spec)
-    cid = st.get("container_id") or ""
-    spec.note(f"running cid={cid[:12]}")
+async def start_ws_terminal(ctx: Ctx, spec: WsSpec) -> WsTerminal:
+    """Connect a WS session + open a terminal for a WS-driven pattern
+    (quiet_ws stops at the connect)."""
+    term = WsTerminal(ctx.server, ctx.api.token, spec.ws_id)
+    spec.note("ws-connect")
+    await term.connect()
+    if spec.pattern != "quiet_ws":
+        await term.start_terminal()
+        await asyncio.sleep(1)
+        await term.send_input(" ")
+    return term
 
-    # Sanity: the status endpoint reports the effective timeout.
+
+async def api_start(ctx: Ctx, spec: WsSpec) -> None:
+    """Start the workspace via the plain API (idle/egress patterns)."""
+    spec.note("api-start")
+    resp = await ctx.api.start(spec.ws_id)
+    if resp.status_code != 200:
+        ctx.anomalies.add(
+            "start",
+            f"{spec.name}: start -> {resp.status_code}",
+        )
+
+
+def check_status_timeout(ctx: Ctx, spec: WsSpec, st: dict) -> None:
+    """Sanity: the status endpoint reports the effective timeout."""
     if st.get("idle_timeout") != spec.eff_timeout:
         ctx.anomalies.add(
             "status-timeout",
@@ -819,6 +862,22 @@ async def start_scenario_workspace(
             f"{spec.eff_timeout}",
             scenario=spec.scenario_json(),
         )
+
+
+async def start_scenario_workspace(
+    ctx: Ctx, spec: WsSpec
+) -> tuple[WsTerminal | None, dict]:
+    """Start the workspace per its pattern; returns (terminal-or-None,
+    running-status)."""
+    term: WsTerminal | None = None
+    if spec.pattern in WS_PATTERNS:
+        term = await start_ws_terminal(ctx, spec)
+    else:
+        await api_start(ctx, spec)
+    st = await wait_running(ctx, spec)
+    cid = st.get("container_id") or ""
+    spec.note(f"running cid={cid[:12]}")
+    check_status_timeout(ctx, spec, st)
     return term, st
 
 
@@ -882,6 +941,40 @@ async def send_keepalive(
         state["last_activity"] = time.monotonic()
 
 
+def pattern_gaps(spec: WsSpec, tick: int) -> tuple[int, int, int]:
+    """``(gap_under, gap_over, cadence)`` for the spec's effective timeout."""
+    eff0 = spec.eff_timeout
+    gap_under = max(1, eff0 - 2) if eff0 > 3 else 1
+    gap_over = eff0 + tick + 6
+    cadence = max(1, min(2, eff0 // 3)) if eff0 > 0 else 2
+    return gap_under, gap_over, cadence
+
+
+async def sleep_term_over(term, state: dict, gap_over: int) -> None:
+    """term_over's burst: lands beyond timeout+tick, so the reaper must
+    reap between bursts (timer reset)."""
+    await asyncio.sleep(gap_over)
+    if term is not None:
+        await term.send_input(" ")
+    state["last_activity"] = time.monotonic()
+
+
+def stops_mid_gone_silent(spec: WsSpec, seq: int, gap_under: int) -> bool:
+    """stops_mid: silent after enough bursts to have been keep-alive."""
+    bursts = max(2, int(spec.eff_timeout * 1.5 / gap_under))
+    return seq >= bursts
+
+
+async def sleep_stops_mid(spec: WsSpec, seq: int, gap_under: int) -> bool:
+    """stops_mid's tick: silent (False) after enough bursts to have been
+    keep-alive."""
+    if stops_mid_gone_silent(spec, seq, gap_under):
+        spec.note("gone-silent")
+        return False  # silence -> reap expected
+    await asyncio.sleep(gap_under)
+    return True
+
+
 async def pattern_sleep(
     spec: WsSpec,
     state: dict,
@@ -897,18 +990,9 @@ async def pattern_sleep(
     elif spec.pattern == "term_under":
         await asyncio.sleep(gap_under)
     elif spec.pattern == "term_over":
-        # The next burst lands beyond timeout+tick: the
-        # reaper must reap between bursts (timer reset).
-        await asyncio.sleep(gap_over)
-        if term is not None:
-            await term.send_input(" ")
-        state["last_activity"] = time.monotonic()
+        await sleep_term_over(term, state, gap_over)
     elif spec.pattern == "stops_mid":
-        bursts = max(2, int(spec.eff_timeout * 1.5 / gap_under))
-        if seq >= bursts:
-            spec.note("gone-silent")
-            return False  # silence -> reap expected
-        await asyncio.sleep(gap_under)
+        return await sleep_stops_mid(spec, seq, gap_under)
     else:  # egress / mixed
         await asyncio.sleep(cadence)
     return True
@@ -926,40 +1010,76 @@ async def run_activity_pattern(
 ) -> None:
     """Drive the scenario's keep-alive / silence pattern until stopped,
     the container vanishes, or a podman-exec error lands."""
-    eff0 = spec.eff_timeout
-    gap_under = max(1, eff0 - 2) if eff0 > 3 else 1
-    gap_over = eff0 + tick + 6
-    cadence = max(1, min(2, eff0 // 3)) if eff0 > 0 else 2
+    gap_under, gap_over, cadence = pattern_gaps(spec, tick)
     seq = 0
-    try:
-        while not stop_pattern.is_set():
-            seq += 1
-            try:
-                await send_keepalive(ctx, spec, state, term, cid, seq)
-            except subprocess.CalledProcessError as exc:
-                if is_container_gone_error(exc):
-                    gone.set()
-                    return  # container vanished mid-pattern
-                ctx.anomalies.add(
-                    "pattern-error",
-                    f"{spec.name}: podman exec rc={exc.returncode}",
-                    scenario=spec.scenario_json(),
-                )
-                return
-            if not await pattern_sleep(
-                spec, state, term, seq, gap_under, gap_over, cadence
-            ):
-                return  # gone-silent (stops_mid)
-    except asyncio.CancelledError:
-        raise
+    while not stop_pattern.is_set():
+        seq += 1
+        try:
+            await send_keepalive(ctx, spec, state, term, cid, seq)
+        except subprocess.CalledProcessError as exc:
+            if is_container_gone_error(exc):
+                gone.set()
+                return  # container vanished mid-pattern
+            ctx.anomalies.add(
+                "pattern-error",
+                f"{spec.name}: podman exec rc={exc.returncode}",
+                scenario=spec.scenario_json(),
+            )
+            return
+        if not await pattern_sleep(
+            spec, state, term, seq, gap_under, gap_over, cadence
+        ):
+            return  # gone-silent (stops_mid)
+
+
+async def launch_scenario_tasks(
+    ctx: Ctx, spec: WsSpec, state: dict, term, cid: str, tick: int
+) -> tuple:
+    """Create the runtime-change + activity-pattern tasks. Returns
+    ``(pattern_task, change_task, gone, stop_pattern)``."""
+    change_task: asyncio.Task | None = None
+    if spec.runtime_change is not None:
+        change_task = asyncio.create_task(
+            apply_runtime_change(ctx, ctx.api, spec, state)
+        )
+    gone = asyncio.Event()
+    stop_pattern = asyncio.Event()
+    pattern_task = asyncio.create_task(
+        run_activity_pattern(ctx, spec, state, term, cid, gone, stop_pattern, tick)
+    )
+    return pattern_task, change_task, gone, stop_pattern
+
+
+async def observe_scenario(
+    ctx: Ctx, spec: WsSpec, state: dict, tick: int, gone: asyncio.Event, cid: str
+) -> None:
+    """Supervise the observers: a runtime change can flip the expected
+    outcome mid-flight (shorten -> reap, lengthen/zero -> alive), so the
+    observer is re-picked whenever ``expect`` changes; each observer returns
+    False on a flip (unfinished) and True when done."""
+    while True:
+        if state["expect"] == "reap":
+            done = await _observe_reap(ctx, spec, state, tick, gone, cid)
+        else:
+            done = await _observe_alive(ctx, spec, state, tick, gone)
+        if done:
+            return
+
+
+async def cleanup_scenario(api: Api, spec: WsSpec, term) -> None:
+    """Close the terminal + delete the workspace (row + container)."""
+    if term is not None:
+        await term.close()
+    if spec.ws_id:
+        await api.delete(spec.ws_id)
+        spec.note("deleted")
 
 
 async def run_ws_scenario(ctx: Ctx, spec: WsSpec, tick: int) -> None:
     """One workspace lifecycle: create -> configure -> start -> activity
     pattern -> invariants -> restart check -> cleanup."""
-    api = ctx.api
     spec.note("create")
-    spec.ws_id = await api.create_workspace(spec.name)
+    spec.ws_id = await ctx.api.create_workspace(spec.name)
     term: WsTerminal | None = None
     try:
         # -- configure ------------------------------------------------------
@@ -976,32 +1096,12 @@ async def run_ws_scenario(ctx: Ctx, spec: WsSpec, tick: int) -> None:
         }
 
         # -- optional runtime change, applied mid-flight ----------------------
-        change_task: asyncio.Task | None = None
-        if spec.runtime_change is not None:
-            change_task = asyncio.create_task(
-                apply_runtime_change(ctx, api, spec, state)
-            )
-
-        # -- activity pattern -------------------------------------------------
-        gone = asyncio.Event()
-        stop_pattern = asyncio.Event()
-        pattern_task = asyncio.create_task(
-            run_activity_pattern(ctx, spec, state, term, cid, gone, stop_pattern, tick)
+        # -- activity pattern + observation -----------------------------------
+        pattern_task, change_task, gone, stop_pattern = await launch_scenario_tasks(
+            ctx, spec, state, term, cid, tick
         )
-
-        # -- observation ------------------------------------------------------
-        # A runtime change can flip the expected outcome mid-flight
-        # (shorten -> reap, lengthen/zero -> alive), so a supervisor
-        # re-picks the observer whenever ``expect`` changes; each observer
-        # returns False on a flip (unfinished) and True when done.
         try:
-            while True:
-                if state["expect"] == "reap":
-                    done = await _observe_reap(ctx, spec, state, tick, gone, cid)
-                else:
-                    done = await _observe_alive(ctx, spec, state, tick, gone)
-                if done:
-                    break
+            await observe_scenario(ctx, spec, state, tick, gone, cid)
         finally:
             stop_pattern.set()
             await cancel_scenario_tasks(pattern_task, change_task)
@@ -1013,30 +1113,31 @@ async def run_ws_scenario(ctx: Ctx, spec: WsSpec, tick: int) -> None:
             timeline=spec.timeline[-20:],
         )
     finally:
-        if term is not None:
-            await term.close()
-        if spec.ws_id:
-            await api.delete(spec.ws_id)
-            spec.note("deleted")
+        await cleanup_scenario(ctx.api, spec, term)
+
+
+async def confirm_container_removed(ctx: Ctx, spec: WsSpec, cid: str) -> None:
+    """After the reap the container must be fully removed from podman (no
+    stopped-but-not-removed leaks)."""
+    if not cid:
+        return
+    removed_by = time.monotonic() + REMOVE_GRACE
+    while time.monotonic() < removed_by:
+        if not await container_exists(cid):
+            return
+        await asyncio.sleep(2)
+    ctx.anomalies.add(
+        "not-removed",
+        f"{spec.name}: container {cid[:12]} still in podman "
+        f"ps -a {REMOVE_GRACE}s after running=false "
+        "(stopped-but-not-removed leak)",
+        scenario=spec.scenario_json(),
+    )
 
 
 async def confirm_reap_cleanup(ctx: Ctx, spec: WsSpec, cid: str) -> None:
     """After the reap: the container is fully removed and the row survives."""
-    if cid:
-        removed_by = time.monotonic() + REMOVE_GRACE
-        while time.monotonic() < removed_by:
-            if not await container_exists(cid):
-                break
-            await asyncio.sleep(2)
-        else:
-            ctx.anomalies.add(
-                "not-removed",
-                f"{spec.name}: container {cid[:12]} still in podman "
-                f"ps -a {REMOVE_GRACE}s after running=false "
-                "(stopped-but-not-removed leak)",
-                scenario=spec.scenario_json(),
-            )
-    # The row must survive the reap...
+    await confirm_container_removed(ctx, spec, cid)
     if not await ctx.api.workspace_row_exists(spec.ws_id):
         ctx.anomalies.add(
             "row-gone",
@@ -1045,10 +1146,20 @@ async def confirm_reap_cleanup(ctx: Ctx, spec: WsSpec, cid: str) -> None:
         )
 
 
+async def await_restart_running(api: Api, ws_id: str) -> bool:
+    """True once the workspace is running again within RESTART_TIMEOUT."""
+    deadline = time.monotonic() + RESTART_TIMEOUT
+    while time.monotonic() < deadline:
+        st = await api.status(ws_id)
+        if st is not None and st.get("running"):
+            return True
+        await asyncio.sleep(2)
+    return False
+
+
 async def confirm_restart(ctx: Ctx, spec: WsSpec) -> None:
     """...and the workspace restarts cleanly after the reap."""
-    api = ctx.api
-    resp = await api.start(spec.ws_id)
+    resp = await ctx.api.start(spec.ws_id)
     if resp.status_code != 200:
         ctx.anomalies.add(
             "restart-failed",
@@ -1056,15 +1167,7 @@ async def confirm_restart(ctx: Ctx, spec: WsSpec) -> None:
             scenario=spec.scenario_json(),
         )
         return
-    deadline = time.monotonic() + RESTART_TIMEOUT
-    restarted = False
-    while time.monotonic() < deadline:
-        st = await api.status(spec.ws_id)
-        if st is not None and st.get("running"):
-            restarted = True
-            break
-        await asyncio.sleep(2)
-    if restarted:
+    if await await_restart_running(ctx.api, spec.ws_id):
         spec.note("restarted-ok")
     else:
         ctx.anomalies.add(
@@ -1072,6 +1175,35 @@ async def confirm_restart(ctx: Ctx, spec: WsSpec) -> None:
             f"{spec.name}: not running within {RESTART_TIMEOUT}s of restart after reap",
             scenario=spec.scenario_json(),
         )
+
+
+async def running_status(api: Api, ws_id: str) -> bool | None:
+    """The /status running flag, or None when the status call itself failed
+    (a non-200) -- callers treat that as "keep waiting", not as a verdict."""
+    st = await api.status(ws_id)
+    if st is None:
+        return None
+    return bool(st.get("running"))
+
+
+async def reap_wait_tick(
+    ctx: Ctx, spec: WsSpec, la: float, tick: int, checked: bool
+) -> bool:
+    """Still running inside the reap window: one idle_seconds check + a
+    sleep. Returns the updated checked flag."""
+    if not checked:
+        await check_idle_seconds(ctx, spec, la, tick, "reap-wait")
+        checked = True
+    await asyncio.sleep(2)
+    return checked
+
+
+async def finish_reap(ctx: Ctx, spec: WsSpec, cid: str) -> None:
+    """running=false (or gone): the reap happened -- confirm full removal
+    plus a clean restart."""
+    spec.note("reaped")
+    await confirm_reap_cleanup(ctx, spec, cid)
+    await confirm_restart(ctx, spec)
 
 
 async def _observe_reap(
@@ -1085,14 +1217,12 @@ async def _observe_reap(
     """Expect stopped+removed within timeout + tick + slack of the last
     activity; the row survives; a restart returns to running. Returns
     False (unfinished) when a runtime change flipped the expectation."""
-    api = ctx.api
     checked_idle = False
     while True:
         if state["expect"] != "reap":
             return False  # flipped (lengthen/zero) -> supervisor re-picks
         la, eff = state["last_activity"], state["eff"]
-        deadline = la + eff + tick + REAP_SLACK
-        if time.monotonic() > deadline:
+        if time.monotonic() > la + eff + tick + REAP_SLACK:
             ctx.anomalies.add(
                 "not-reaped",
                 f"{spec.name}: not reaped "
@@ -1102,18 +1232,62 @@ async def _observe_reap(
                 timeline=spec.timeline[-20:],
             )
             return True
-        st = await api.status(spec.ws_id)
-        if st is not None and st.get("running"):
-            if not checked_idle:
-                await check_idle_seconds(ctx, spec, la, tick, "reap-wait")
-                checked_idle = True
-            await asyncio.sleep(2)
+        if await running_status(ctx.api, spec.ws_id):
+            checked_idle = await reap_wait_tick(ctx, spec, la, tick, checked_idle)
             continue
-        # running=false (or gone): reaped. Confirm full removal.
-        spec.note("reaped")
-        await confirm_reap_cleanup(ctx, spec, cid)
-        await confirm_restart(ctx, spec)
+        await finish_reap(ctx, spec, cid)
         return True
+
+
+def alive_window(spec: WsSpec, eff0: int) -> float:
+    """The observation window for an alive expectation: a nominal 30s when
+    there is no meaningful deadline (loose/3600s fallback, or a zero
+    timeout), else factor x effective timeout (capped)."""
+    if spec.loose_alive or eff0 == 0:
+        return 30
+    return min(ALIVE_FACTOR * max(eff0, 1), ALIVE_CAP)
+
+
+def report_vanished_while_active(ctx: Ctx, spec: WsSpec, eff: int) -> None:
+    """Anomaly: the container vanished while the pattern was still driving
+    activity."""
+    ctx.anomalies.add(
+        "reaped-while-active",
+        f"{spec.name}: container vanished while the pattern was "
+        f"still driving activity (timeout={eff}s, "
+        f"pattern={spec.pattern})",
+        scenario=spec.scenario_json(),
+        timeline=spec.timeline[-20:],
+    )
+
+
+def report_stopped_while_active(ctx: Ctx, spec: WsSpec, la: float, eff: int) -> None:
+    """Anomaly: running=false while active (a stopped container can't be
+    un-stopped by later activity)."""
+    ctx.anomalies.add(
+        "reaped-while-active",
+        f"{spec.name}: running=false while active (timeout={eff}s, "
+        f"pattern={spec.pattern}, {time.monotonic() - la:.0f}s "
+        f"after last activity)",
+        scenario=spec.scenario_json(),
+        timeline=spec.timeline[-20:],
+    )
+
+
+async def alive_violation(
+    ctx: Ctx, spec: WsSpec, state: dict, gone: asyncio.Event
+) -> bool:
+    """True (reporting an anomaly) when the workspace was reaped while
+    active: the container vanished (podman exec rc 125), or running=false
+    (a stopped container can't be un-stopped by later activity)."""
+    la, eff = state["last_activity"], state["eff"]
+    if gone.is_set():
+        report_vanished_while_active(ctx, spec, eff)
+        return True
+    if await running_status(ctx.api, spec.ws_id) is False:
+        report_stopped_while_active(ctx, spec, la, eff)
+        return True
+    return False
 
 
 async def _observe_alive(
@@ -1129,41 +1303,15 @@ async def _observe_alive(
     pattern keeps refreshing that, so a last-activity anchor would never
     expire for a continuously-active workspace). Returns False (unfinished)
     when a runtime change flipped the expectation to reap."""
-    api = ctx.api
     started = time.monotonic()
-    eff0 = state["eff"]
-    if spec.loose_alive or eff0 == 0:
-        window = 30  # no meaningful deadline; just must keep running
-    else:
-        window = min(ALIVE_FACTOR * max(eff0, 1), ALIVE_CAP)
+    window = alive_window(spec, state["eff"])
     while True:
         if state["expect"] != "alive":
             return False  # flipped (shorten) -> supervisor re-picks
         if time.monotonic() > started + window:
             spec.note("alive-ok")
             return True
-        la, eff = state["last_activity"], state["eff"]
-        if gone.is_set():
-            ctx.anomalies.add(
-                "reaped-while-active",
-                f"{spec.name}: container vanished while the pattern was "
-                f"still driving activity (timeout={eff}s, "
-                f"pattern={spec.pattern})",
-                scenario=spec.scenario_json(),
-                timeline=spec.timeline[-20:],
-            )
-            return True
-        st = await api.status(spec.ws_id)
-        if st is not None and not st.get("running"):
-            # A stopped container can't be un-stopped by later activity.
-            ctx.anomalies.add(
-                "reaped-while-active",
-                f"{spec.name}: running=false while active (timeout={eff}s, "
-                f"pattern={spec.pattern}, {time.monotonic() - la:.0f}s "
-                f"after last activity)",
-                scenario=spec.scenario_json(),
-                timeline=spec.timeline[-20:],
-            )
+        if await alive_violation(ctx, spec, state, gone):
             return True
         await asyncio.sleep(2)
 
@@ -1173,24 +1321,30 @@ async def _observe_alive(
 # ---------------------------------------------------------------------------
 
 
+def lengthened_timeout(s: WsSpec) -> int:
+    """The effective timeout counting a lengthen runtime change."""
+    eff = s.eff_timeout
+    if s.runtime_change and s.runtime_change[0] == "lengthen":
+        eff += s.runtime_change[1]
+    return eff
+
+
+def spec_observe_cost(s: WsSpec, tick: int) -> float:
+    """Rough upper bound on one spec's observation window: the reap window
+    (timeout + tick + slack + removal grace) for a reap expectation, else
+    the alive window (a nominal 30s when there is no meaningful deadline)."""
+    if s.expect != "alive":
+        return s.eff_timeout + tick + REAP_SLACK + REMOVE_GRACE
+    if s.loose_alive or s.eff_timeout == 0:
+        return 30
+    eff = lengthened_timeout(s)
+    return min(ALIVE_FACTOR * max(eff, 1), ALIVE_CAP)
+
+
 def est_wave_cost(specs: list[WsSpec], tick: int) -> float:
     """Rough upper bound on one wave's wall time (for budget planning)."""
     bringup = 60
-    obs = 0.0
-    for s in specs:
-        if s.expect == "alive":
-            if s.loose_alive or s.eff_timeout == 0:
-                obs = max(obs, 30)
-            else:
-                eff = s.eff_timeout
-                if s.runtime_change and s.runtime_change[0] == "lengthen":
-                    eff += s.runtime_change[1]
-                obs = max(obs, min(ALIVE_FACTOR * max(eff, 1), ALIVE_CAP))
-        else:
-            obs = max(
-                obs,
-                s.eff_timeout + tick + REAP_SLACK + REMOVE_GRACE,
-            )
+    obs = max(spec_observe_cost(s, tick) for s in specs) if specs else 0.0
     return bringup + obs + 90  # + restart/delete headroom
 
 
@@ -1222,6 +1376,25 @@ def report_anomalies(anomalies: Anomalies) -> int:
     return 1
 
 
+def over_budget(args, cost: float, deadline: float) -> bool:
+    """Would the next wave exceed the duration budget? (--waves overrides
+    the budget check.)"""
+    if args.waves:
+        return False
+    return time.monotonic() + cost > deadline
+
+
+def log_wave_plan(waves_run: int, specs: list[WsSpec], tick: int) -> None:
+    """Print the wave's drawn plan."""
+    print(f"-- wave {waves_run} (tick bound {tick}s)")
+    for spec in specs:
+        print(
+            f"   {spec.name}: pattern={spec.pattern} "
+            f"override={spec.override} eff={spec.eff_timeout}s "
+            f"change={spec.runtime_change} -> {spec.expect}"
+        )
+
+
 async def run_wave(
     server: Server,
     anomalies: Anomalies,
@@ -1246,7 +1419,7 @@ async def run_wave(
     )
     tick = wave_tick_bound(specs, global_timeout)
     cost = est_wave_cost(specs, tick)
-    if not args.waves and time.monotonic() + cost > deadline:
+    if over_budget(args, cost, deadline):
         print(
             f"stopping: next wave (~{cost:.0f}s) would exceed the "
             f"{args.duration}m budget"
@@ -1259,18 +1432,100 @@ async def run_wave(
             "specs": [spec.scenario_json() for spec in specs],
         }
     )
-    print(f"-- wave {waves_run} (tick bound {tick}s)")
-    for spec in specs:
-        print(
-            f"   {spec.name}: pattern={spec.pattern} "
-            f"override={spec.override} eff={spec.eff_timeout}s "
-            f"change={spec.runtime_change} -> {spec.expect}"
-        )
+    log_wave_plan(waves_run, specs, tick)
     await asyncio.gather(*(run_ws_scenario(ctx, spec, tick) for spec in specs))
     for hit in server.scan_log_anomalies():
         anomalies.add("server-log", hit, wave=waves_run)
     await ctx.api.aclose()
     return Ctx(server, Api(server, anomalies), anomalies)
+
+
+def server_env_for(args, global_raw: str) -> dict[str, str]:
+    """The klangkd env for the run: the drawn global idle timeout. Image
+    default: the ambient KLANGKD_IMAGE_NAME (forwarded by clean_env for the
+    devenv-built image) or the plain settings default; --image overrides."""
+    env = {"KLANGKD_IDLE_TIMEOUT_SECONDS": global_raw}
+    if args.image:
+        env["KLANGKD_IMAGE_NAME"] = args.image
+    return env
+
+
+def waves_done(args, waves_run: int) -> bool:
+    """--waves count reached?"""
+    return bool(args.waves) and waves_run >= args.waves
+
+
+async def run_waves(
+    server: Server,
+    anomalies: Anomalies,
+    rng: random.Random,
+    args,
+    global_timeout: int,
+    bogus_global: bool,
+    deadline: float,
+    scenario_log: list[dict],
+) -> int:
+    """Draw + run waves until the --waves count or the time budget says
+    stop; returns the waves run."""
+    waves_run = 0
+    while True:
+        if waves_done(args, waves_run):
+            break
+        ctx = await run_wave(
+            server,
+            anomalies,
+            rng,
+            args,
+            global_timeout,
+            bogus_global,
+            waves_run,
+            deadline,
+            scenario_log,
+        )
+        if ctx is None:
+            break
+        waves_run += 1
+    for hit in server.scan_log_anomalies():
+        anomalies.add("server-log", hit, wave="final")
+    return waves_run
+
+
+def write_scenario_log(
+    log_dir: str, seed: int, global_raw: str, scenario_log: list[dict]
+) -> None:
+    """Persist the drawn scenario plan for post-run diagnosis."""
+    with open(os.path.join(log_dir, "scenarios.json"), "w") as fh:
+        json.dump(
+            {
+                "seed": seed,
+                "global_idle_env": global_raw,
+                "waves": scenario_log,
+            },
+            fh,
+            indent=2,
+        )
+
+
+def print_run_header(args, log_dir: str, global_raw: str, global_timeout: int) -> None:
+    print("== klangk idle-timeout fuzz ==")
+    print(f"seed={args.seed} duration={args.duration}m log_dir={log_dir}")
+    print(
+        f"global KLANGKD_IDLE_TIMEOUT_SECONDS={global_raw!r} "
+        f"(effective {global_timeout}s)"
+    )
+
+
+def print_run_report(
+    args, log_dir: str, global_raw: str, global_timeout: int, waves_run: int
+) -> None:
+    print()
+    print("=" * 60)
+    print("IDLE FUZZ REPORT")
+    print("=" * 60)
+    print(f"seed: {args.seed}")
+    print(f"global idle timeout env: {global_raw!r} ({global_timeout}s)")
+    print(f"waves run: {waves_run}")
+    print(f"scenario log: {os.path.join(log_dir, 'scenarios.json')}")
 
 
 async def run(args) -> int:
@@ -1288,76 +1543,34 @@ async def run(args) -> int:
     )
 
     bogus_global, global_raw, global_timeout = draw_global_timeout(rng)
-
-    server_env = {"KLANGKD_IDLE_TIMEOUT_SECONDS": global_raw}
-    # Image default: the ambient KLANGKD_IMAGE_NAME (forwarded by clean_env
-    # for the devenv-built image) or the plain settings default. --image
-    # overrides.
-    if args.image:
-        server_env["KLANGKD_IMAGE_NAME"] = args.image
-
-    waves_run = 0
+    server_env = server_env_for(args, global_raw)
     scenario_log: list[dict] = []
     deadline = time.monotonic() + args.duration * 60
 
-    print("== klangk idle-timeout fuzz ==")
-    print(f"seed={args.seed} duration={args.duration}m log_dir={log_dir}")
-    print(
-        f"global KLANGKD_IDLE_TIMEOUT_SECONDS={global_raw!r} "
-        f"(effective {global_timeout}s)"
-    )
+    print_run_header(args, log_dir, global_raw, global_timeout)
 
     try:
         server.start(**server_env)
         print("klangkd is up")
-
-        while True:
-            if args.waves and waves_run >= args.waves:
-                break
-            ctx = await run_wave(
-                server,
-                anomalies,
-                rng,
-                args,
-                global_timeout,
-                bogus_global,
-                waves_run,
-                deadline,
-                scenario_log,
-            )
-            if ctx is None:
-                break
-            waves_run += 1
-        for hit in server.scan_log_anomalies():
-            anomalies.add("server-log", hit, wave="final")
+        waves_run = await run_waves(
+            server,
+            anomalies,
+            rng,
+            args,
+            global_timeout,
+            bogus_global,
+            deadline,
+            scenario_log,
+        )
     finally:
-        with open(os.path.join(log_dir, "scenarios.json"), "w") as fh:
-            json.dump(
-                {
-                    "seed": args.seed,
-                    "global_idle_env": global_raw,
-                    "waves": scenario_log,
-                },
-                fh,
-                indent=2,
-            )
+        write_scenario_log(log_dir, args.seed, global_raw, scenario_log)
         server.stop()
         shutil.rmtree(data_dir, ignore_errors=True)
         shutil.rmtree(state_dir, ignore_errors=True)
 
-    print()
-    print("=" * 60)
-    print("IDLE FUZZ REPORT")
-    print("=" * 60)
-    print(f"seed: {args.seed}")
-    print(f"global idle timeout env: {global_raw!r} ({global_timeout}s)")
-    print(f"waves run: {waves_run}")
-    print(f"scenario log: {os.path.join(log_dir, 'scenarios.json')}")
+    print_run_report(args, log_dir, global_raw, global_timeout, waves_run)
     print(f"server log:   {server.log_path}")
     return report_anomalies(anomalies)
-    print("RESULT: CLEAN")
-    print("=" * 60)
-    return 0
 
 
 def main() -> None:

--- a/scripts/import_dart_features.py
+++ b/scripts/import_dart_features.py
@@ -61,6 +61,40 @@ FEATURE_API_DEP = {
 }
 
 
+def dart_package_classes(dart_dir: str) -> tuple[list[str], list[str]]:
+    """(tool_classes, tab_classes) from a feature's lib/feature.dart."""
+    with open(os.path.join(dart_dir, "lib", "feature.dart")) as f:
+        source = f.read()
+    tool_classes = re.findall(r"class\s+(\w+)\s+extends\s+ToolPlugin", source)
+    tab_classes = re.findall(r"class\s+(\w+)\s+extends\s+WorkspaceTabPlugin", source)
+    return tool_classes, tab_classes
+
+
+def scan_feature_dir(name: str, features_dir: str) -> dict | None:
+    """One features/<name> entry's metadata, or None when it has no Dart
+    package (missing pubspec/feature.dart) or declares no plugins (a
+    feature with neither a ToolPlugin nor a WorkspaceTabPlugin isn't a
+    klangk feature)."""
+    dart_dir = os.path.join(features_dir, name, "klangk")
+    pubspec_file = os.path.join(dart_dir, "pubspec.yaml")
+    feature_dart = os.path.join(dart_dir, "lib", "feature.dart")
+    if not os.path.isfile(pubspec_file) or not os.path.isfile(feature_dart):
+        return None
+    tool_classes, tab_classes = dart_package_classes(dart_dir)
+    if not tool_classes and not tab_classes:
+        return None
+    with open(pubspec_file) as f:
+        pubspec = yaml.safe_load(f)
+    package_name = pubspec.get("name", f"klangk_feature_{name}")
+    return {
+        "name": name,
+        "package_name": package_name,
+        "dart_dir": dart_dir,
+        "tool_classes": tool_classes,
+        "tab_classes": tab_classes,
+    }
+
+
 def find_features(features_dir):
     """Scan features/*/klangk/ for Dart packages, return metadata.
 
@@ -80,39 +114,9 @@ def find_features(features_dir):
         return features
 
     for name in sorted(os.listdir(features_dir)):
-        feature_dir = os.path.join(features_dir, name)
-        dart_dir = os.path.join(feature_dir, "klangk")
-        pubspec_file = os.path.join(dart_dir, "pubspec.yaml")
-        feature_dart = os.path.join(dart_dir, "lib", "feature.dart")
-
-        if not os.path.isfile(pubspec_file) or not os.path.isfile(feature_dart):
-            continue
-
-        with open(pubspec_file) as f:
-            pubspec = yaml.safe_load(f)
-
-        package_name = pubspec.get("name", f"klangk_feature_{name}")
-
-        with open(feature_dart) as f:
-            source = f.read()
-
-        tool_classes = re.findall(r"class\s+(\w+)\s+extends\s+ToolPlugin", source)
-        tab_classes = re.findall(
-            r"class\s+(\w+)\s+extends\s+WorkspaceTabPlugin", source
-        )
-        # A feature with neither component isn't a klangk feature — skip it.
-        if not tool_classes and not tab_classes:
-            continue
-
-        features.append(
-            {
-                "name": name,
-                "package_name": package_name,
-                "dart_dir": dart_dir,
-                "tool_classes": tool_classes,
-                "tab_classes": tab_classes,
-            }
-        )
+        meta = scan_feature_dir(name, features_dir)
+        if meta is not None:
+            features.append(meta)
 
     return features
 
@@ -170,6 +174,71 @@ def _validate_feature_config_key(key, feature_name):
         )
 
 
+def normalized_scope(spec: dict) -> str:
+    """The key's scope, defaulting unknown scopes to "container" (same
+    as the old server resolver)."""
+    scope = spec.get("scope", "container")
+    if scope not in {"container", "frontend", "both"}:
+        return "container"
+    return scope
+
+
+def manifest_config_entry(spec: dict) -> tuple[dict, bool]:
+    """The manifest config entry for one declared key + whether it is
+    container-scoped (eligible for container-env injection). Carries only
+    the JSON-serializable, runtime-relevant shape: {description, default,
+    scope}."""
+    scope = normalized_scope(spec)
+    entry = {
+        "description": spec.get("description", ""),
+        "default": spec.get("default", ""),
+        "scope": scope,
+    }
+    return entry, scope in _CONTAINER_SCOPES
+
+
+def feature_config(cfg: dict, name: str) -> tuple[dict, list[str]]:
+    """The normalized {key: entry} config + the container-scope keys for
+    one feature's package.json klangk.config block."""
+    config = {}
+    env_keys = []
+    for key, spec in cfg.items():
+        if not isinstance(spec, dict):
+            continue
+        # Every declared key must carry the KLANGKWS_FEATURE_ prefix,
+        # regardless of scope (#1662). Validate before emitting anything so
+        # a bad declaration aborts the build rather than shipping a manifest
+        # the runtime would silently skip.
+        _validate_feature_config_key(key, name)
+        config[key], container_scoped = manifest_config_entry(spec)
+        if container_scoped:
+            env_keys.append(key)
+    return config, env_keys
+
+
+def package_json_manifest(pkg_json: str, name: str) -> tuple[str, str, dict, list[str]]:
+    """(version, description, config, container_env_keys) from one
+    feature's package.json; empty metadata when absent/unreadable/malformed
+    (a malformed feature's parse errors don't abort the build)."""
+    version = ""
+    description = ""
+    config = {}
+    env_keys: list[str] = []
+    if not os.path.isfile(pkg_json):
+        return version, description, config, env_keys
+    try:
+        with open(pkg_json) as f:
+            manifest = json.load(f)
+        version = manifest.get("version", "")
+        description = manifest.get("description", "")
+        cfg = manifest.get("klangk", {}).get("config", {})
+        if isinstance(cfg, dict):
+            config, env_keys = feature_config(cfg, name)
+    except (json.JSONDecodeError, ValueError, OSError):
+        pass
+    return version, description, config, env_keys
+
+
 def collect_feature_metadata(dart_features, features_dir):
     """Build the per-feature metadata + container_env_keys from package.json.
 
@@ -188,41 +257,8 @@ def collect_feature_metadata(dart_features, features_dir):
     for p in dart_features:
         name = p["name"]
         pkg_json = os.path.join(features_dir, name, "package.json")
-        version = ""
-        description = ""
-        config = {}
-        if os.path.isfile(pkg_json):
-            try:
-                with open(pkg_json) as f:
-                    manifest = json.load(f)
-                version = manifest.get("version", "")
-                description = manifest.get("description", "")
-                cfg = manifest.get("klangk", {}).get("config", {})
-                if isinstance(cfg, dict):
-                    # Carry only the JSON-serializable, runtime-relevant shape
-                    # per key: {description, default, scope}. Unknown scopes
-                    # default to "container" (same as the old server resolver).
-                    for key, spec in cfg.items():
-                        if not isinstance(spec, dict):
-                            continue
-                        # Every declared key must carry the KLANGKWS_FEATURE_
-                        # prefix, regardless of scope (#1662). Validate before
-                        # emitting anything so a bad declaration aborts the
-                        # build rather than shipping a manifest the runtime
-                        # would silently skip.
-                        _validate_feature_config_key(key, name)
-                        scope = spec.get("scope", "container")
-                        if scope not in {"container", "frontend", "both"}:
-                            scope = "container"
-                        config[key] = {
-                            "description": spec.get("description", ""),
-                            "default": spec.get("default", ""),
-                            "scope": scope,
-                        }
-                        if scope in _CONTAINER_SCOPES:
-                            container_env_keys.append(key)
-            except (json.JSONDecodeError, ValueError, OSError):
-                pass
+        version, description, config, env_keys = package_json_manifest(pkg_json, name)
+        container_env_keys.extend(env_keys)
         features.append(
             {
                 "name": name,
@@ -282,6 +318,25 @@ def write_pubspec(features, dart_pkg_dir):
         yaml.dump(pubspec, f, default_flow_style=False, sort_keys=False)
 
 
+def constructor_lines(features: list, classes_key: str) -> list[str]:
+    """The ``    Cls(),`` lines for one aggregator's feature list."""
+    lines = []
+    for p in features:
+        for cls in p[classes_key]:
+            lines.append(f"    {cls}(),")
+    return lines
+
+
+def named_constructor_lines(features: list, classes_key: str, label: str) -> list[str]:
+    """The ``    (name: ..., label: Cls()),`` lines for one named-record
+    aggregator."""
+    lines = []
+    for p in features:
+        for cls in p[classes_key]:
+            lines.append(f"    (name: {p['name']!r}, {label}: {cls}()),")
+    return lines
+
+
 def generate_dart(features):
     """Generate klangk_features.dart source as a string."""
     lines = [
@@ -295,9 +350,7 @@ def generate_dart(features):
     lines.append("")
     lines.append("List<ToolPlugin> createAllFeatures() {")
     lines.append("  return [")
-    for p in features:
-        for cls in p["tool_classes"]:
-            lines.append(f"    {cls}(),")
+    lines.extend(constructor_lines(features, "tool_classes"))
     lines.append("  ];")
     lines.append("}")
     lines.append("")
@@ -307,9 +360,7 @@ def generate_dart(features):
     lines.append("// `name` matches features.json features[].name / defaults[].")
     lines.append("List<({String name, ToolPlugin feature})> createAllNamedFeatures() {")
     lines.append("  return [")
-    for p in features:
-        for cls in p["tool_classes"]:
-            lines.append(f"    (name: {p['name']!r}, feature: {cls}()),")
+    lines.extend(named_constructor_lines(features, "tool_classes", "feature"))
     lines.append("  ];")
     lines.append("}")
     lines.append("")
@@ -324,9 +375,7 @@ def generate_dart(features):
         "List<({String name, WorkspaceTabPlugin tab})> createAllNamedWorkspaceTabs() {"
     )
     lines.append("  return [")
-    for p in features:
-        for cls in p["tab_classes"]:
-            lines.append(f"    (name: {p['name']!r}, tab: {cls}()),")
+    lines.extend(named_constructor_lines(features, "tab_classes", "tab"))
     lines.append("  ];")
     lines.append("}")
     lines.append("")
@@ -349,6 +398,22 @@ def write_overrides_and_symlink(dart_pkg_dir):
     if os.path.islink(symlink_path) or os.path.exists(symlink_path):
         os.remove(symlink_path)
     os.symlink(overrides_path, symlink_path)
+
+
+def write_dart_aggregator(features: list, dart_pkg_dir: str) -> None:
+    """Generate klangk_features.dart + print the codegen summary."""
+    output = generate_dart(features)
+    output_path = os.path.join(dart_pkg_dir, "lib", "klangk_features.dart")
+    os.makedirs(os.path.dirname(output_path), exist_ok=True)
+    with open(output_path, "w") as f:
+        f.write(output)
+
+    names = [c for p in features for c in (p["tool_classes"] + p["tab_classes"])]
+    print(
+        f"Generated Dart pubspec at {os.path.join(dart_pkg_dir, 'pubspec.yaml')} "
+        f"with {len(features)} feature(s)"
+    )
+    print(f"Generated Dart {output_path}: {', '.join(names) or '(none)'}")
 
 
 def main(argv=None):
@@ -398,18 +463,7 @@ def main(argv=None):
         print(f"Regenerated feature manifest {FEATURES_JSON}")
         return
 
-    output = generate_dart(features)
-    output_path = os.path.join(dart_pkg_dir, "lib", "klangk_features.dart")
-    os.makedirs(os.path.dirname(output_path), exist_ok=True)
-    with open(output_path, "w") as f:
-        f.write(output)
-
-    names = [c for p in features for c in (p["tool_classes"] + p["tab_classes"])]
-    print(
-        f"Generated Dart pubspec at {os.path.join(dart_pkg_dir, 'pubspec.yaml')} "
-        f"with {len(features)} feature(s)"
-    )
-    print(f"Generated Dart {output_path}: {', '.join(names) or '(none)'}")
+    write_dart_aggregator(features, dart_pkg_dir)
     print(f"Generated feature manifest {FEATURES_JSON}")
 
 

--- a/scripts/import_dart_features.py
+++ b/scripts/import_dart_features.py
@@ -74,17 +74,19 @@ def scan_feature_dir(name: str, features_dir: str) -> dict | None:
     """One features/<name> entry's metadata, or None when it has no Dart
     package (missing pubspec/feature.dart) or declares no plugins (a
     feature with neither a ToolPlugin nor a WorkspaceTabPlugin isn't a
-    klangk feature)."""
+    klangk feature). The pubspec is parsed BEFORE the plugin scan so a
+    malformed pubspec aborts the build loudly (matching the original
+    read order), rather than being silently skipped."""
     dart_dir = os.path.join(features_dir, name, "klangk")
     pubspec_file = os.path.join(dart_dir, "pubspec.yaml")
     feature_dart = os.path.join(dart_dir, "lib", "feature.dart")
     if not os.path.isfile(pubspec_file) or not os.path.isfile(feature_dart):
         return None
+    with open(pubspec_file) as f:
+        pubspec = yaml.safe_load(f)
     tool_classes, tab_classes = dart_package_classes(dart_dir)
     if not tool_classes and not tab_classes:
         return None
-    with open(pubspec_file) as f:
-        pubspec = yaml.safe_load(f)
     package_name = pubspec.get("name", f"klangk_feature_{name}")
     return {
         "name": name,

--- a/scripts/inline_sources_in_map.py
+++ b/scripts/inline_sources_in_map.py
@@ -21,12 +21,11 @@ import sys
 from pathlib import Path
 
 
-def _resolve_against_bases(map_dir: Path, stripped: str) -> Path | None:
-    """Try every directory between map_dir and `/`, plus $HOME. dart2js
+def ancestor_bases(map_dir: Path) -> list[Path]:
+    """Every directory between map_dir and `/`, plus $HOME. dart2js
     emits paths with a `../` depth that doesn't quite match the map file's
     directory (app `lib/` paths are off by one, pub-cache paths by several),
-    so walk up and try each candidate base — the first one where stripped
-    resolves is the source."""
+    so each candidate base gets tried."""
     bases: list[Path] = []
     cur = map_dir
     while True:
@@ -36,7 +35,13 @@ def _resolve_against_bases(map_dir: Path, stripped: str) -> Path | None:
         cur = cur.parent
     if Path.home() not in bases:
         bases.append(Path.home())
-    for base in bases:
+    return bases
+
+
+def _resolve_against_bases(map_dir: Path, stripped: str) -> Path | None:
+    """Try every candidate base — the first one where stripped resolves is
+    the source."""
+    for base in ancestor_bases(map_dir):
         cand = (base / stripped).resolve()
         if cand.is_file():
             return cand
@@ -58,6 +63,19 @@ def resolve(uri: str, flutter_sdk: Path, map_dir: Path) -> Path | None:
     return None
 
 
+def find_bare_filename(map_dir: Path, stripped: str) -> Path | None:
+    """Bare filename fallback: dart2js emits `main.dart` and
+    `web_plugin_registrant.dart` without a directory prefix. Search the
+    Flutter project (map_dir's grandparent) for the first match."""
+    if "/" in stripped:
+        return None
+    project = map_dir.parent.parent
+    for candidate in project.rglob(stripped):
+        if candidate.is_file():
+            return candidate
+    return None
+
+
 def _resolve_relative_uri(uri: str, map_dir: Path) -> Path | None:
     """Resolve dart2js's relative emitted paths, which carry one too many
     `../` for the actual map-file directory (the relative form treats
@@ -75,15 +93,7 @@ def _resolve_relative_uri(uri: str, map_dir: Path) -> Path | None:
     cand = _resolve_against_bases(map_dir, stripped)
     if cand is not None:
         return cand
-    # Bare filename fallback: dart2js emits `main.dart` and
-    # `web_plugin_registrant.dart` without a directory prefix. Search the
-    # Flutter project (map_dir's grandparent) for the first match.
-    if "/" not in stripped:
-        project = map_dir.parent.parent
-        for candidate in project.rglob(stripped):
-            if candidate.is_file():
-                return candidate
-    return None
+    return find_bare_filename(map_dir, stripped)
 
 
 def inline_map(map_path: Path, flutter_sdk: Path) -> tuple[int, int]:

--- a/scripts/lcov-report.py
+++ b/scripts/lcov-report.py
@@ -4,6 +4,23 @@
 import sys
 
 
+def note_uncovered(line: str, uncovered_lines: dict, current) -> None:
+    """Record a ``DA:`` line whose execution count is 0 (uncovered)."""
+    parts = line[3:].split(",")
+    if len(parts) >= 2 and parts[1] == "0":
+        uncovered_lines.setdefault(current, []).append(int(parts[0]))
+
+
+def note_lcov_line(line: str, current, files: dict, uncovered_lines: dict) -> None:
+    """Apply one non-``SF:`` lcov record to the accumulators."""
+    if line.startswith("DA:"):
+        note_uncovered(line, uncovered_lines, current)
+    elif line.startswith("LH:"):
+        files.setdefault(current, {})["hit"] = int(line[3:])
+    elif line.startswith("LF:"):
+        files.setdefault(current, {})["total"] = int(line[3:])
+
+
 def parse_lcov(lines: list[str]) -> tuple[dict, dict]:
     """(per-file {hit, total}, per-file uncovered line numbers) from an lcov
     tracefile."""
@@ -14,14 +31,8 @@ def parse_lcov(lines: list[str]) -> tuple[dict, dict]:
         line = line.strip()
         if line.startswith("SF:"):
             current = line[3:]
-        elif line.startswith("DA:"):
-            parts = line[3:].split(",")
-            if len(parts) >= 2 and parts[1] == "0":
-                uncovered_lines.setdefault(current, []).append(int(parts[0]))
-        elif line.startswith("LH:"):
-            files.setdefault(current, {})["hit"] = int(line[3:])
-        elif line.startswith("LF:"):
-            files.setdefault(current, {})["total"] = int(line[3:])
+        else:
+            note_lcov_line(line, current, files, uncovered_lines)
     return files, uncovered_lines
 
 

--- a/scripts/tests/test_binary_integrity.py
+++ b/scripts/tests/test_binary_integrity.py
@@ -58,6 +58,24 @@ def test_clean_binary_edit_passes(repo):
     assert cbi.find_violations() == []
 
 
+def assert_single_violation(violations: list, path: str, is_bin: bool) -> tuple:
+    """find_violations flagged exactly one binary/text violation for the
+    path; returns (old, new)."""
+    assert len(violations) == 1
+    vpath, old, new, vbin = violations[0]
+    assert vpath == path
+    assert vbin is is_bin
+    return old, new
+
+
+def assert_integrity_report(err: str) -> None:
+    """main()'s stderr names the mechanism, the file, and the remediation."""
+    assert "EF BF BD" in err
+    assert "#1734" in err
+    assert "asset.wasm" in err
+    assert "checkout HEAD" in err  # remediation hint present
+
+
 def test_lossy_rewrite_of_binary_flagged(repo):
     """The #1734 mechanism: a text-mode round-trip injects thousands of
     replacement chars into a binary — flagged as binary, any increase."""
@@ -69,11 +87,7 @@ def test_lossy_rewrite_of_binary_flagged(repo):
     assert mangled.count(REPL) > 50  # sanity: the round-trip inflated REPLs
     p.write_bytes(mangled)
     _stage(repo, "asset.wasm")
-    v = cbi.find_violations()
-    assert len(v) == 1
-    path, old, new, is_bin = v[0]
-    assert path == "asset.wasm"
-    assert is_bin is True
+    old, new = assert_single_violation(cbi.find_violations(), "asset.wasm", True)
     assert old == 0  # clean HEAD baseline had no replacement chars
     assert new > 0  # the lossy rewrite injected them
 
@@ -85,11 +99,7 @@ def test_new_corrupt_binary_flagged(repo):
         raw.decode("utf-8", errors="replace").encode("utf-8")
     )
     _stage(repo, "new.wasm")
-    v = cbi.find_violations()
-    assert len(v) == 1
-    path, old, new, is_bin = v[0]
-    assert path == "new.wasm"
-    assert is_bin is True
+    old, new = assert_single_violation(cbi.find_violations(), "new.wasm", True)
     assert old == 0  # no prior version
     assert new > cbi.TEXT_THRESHOLD
 
@@ -138,8 +148,4 @@ def test_script_entrypoint(repo):
 def test_main_reports_and_fails(monkeypatch, capsys):
     monkeypatch.setattr(cbi, "find_violations", lambda: [("asset.wasm", 0, 1000, True)])
     assert cbi.main() == 1
-    err = capsys.readouterr().err
-    assert "EF BF BD" in err
-    assert "#1734" in err
-    assert "asset.wasm" in err
-    assert "checkout HEAD" in err  # remediation hint present
+    assert_integrity_report(capsys.readouterr().err)

--- a/scripts/tests/test_build_pipeline.py
+++ b/scripts/tests/test_build_pipeline.py
@@ -141,6 +141,60 @@ def _materialize(payload_dir):
 # ────────────────────────────────────────────────────────────────────────────
 
 
+def materialized_feature_names(payload) -> set:
+    """The feature dirs materialized in the payload (features.lock — a
+    file — and dot-dirs excluded)."""
+    return {
+        p
+        for p in os.listdir(payload)
+        if (payload / p).is_dir() and not p.startswith(".")
+    }
+
+
+def lock_feature_names(payload) -> set:
+    """The feature names listed in the payload's features.lock."""
+    import yaml
+
+    lock = yaml.safe_load((payload / "features.lock").read_text())
+    return {e["name"] for e in lock["features"]}
+
+
+def assert_tab_aggregator_present(source: str) -> None:
+    """The workspace-tab aggregator (#1975) is always emitted — its absence
+    would break main.dart's active-set filter at runtime."""
+    assert "createAllNamedWorkspaceTabs()" in source, (
+        "createAllNamedWorkspaceTabs() aggregator not emitted"
+    )
+
+
+def assert_feature_imported(source: str, name: str, cls: str) -> None:
+    """The feature's package is imported + its class instantiated in the
+    aggregators."""
+    pkg = f"klangk_feature_{name.replace('-', '_')}"
+    assert f"import 'package:{pkg}/feature.dart';" in source, (
+        f"{pkg} not imported by the aggregator"
+    )
+    assert f"{cls}()" in source, (
+        f"{cls}() not instantiated in createAllFeatures/createAllNamedFeatures"
+    )
+
+
+def assert_not_imported(source: str, name: str) -> None:
+    """A feature WITHOUT a klangk/ dir must not appear in the Dart
+    aggregator."""
+    pkg = f"klangk_feature_{name.replace('-', '_')}"
+    assert f"import 'package:{pkg}/" not in source, (
+        f"{name} has no klangk/ dir but leaked into the Dart aggregator"
+    )
+
+
+def assert_tab_emitted(source: str, name: str, cls: str) -> None:
+    """The feature's tab class is emitted into the tab aggregator."""
+    assert f"(name: '{name}', tab: {cls}())," in source, (
+        f"{cls}() not instantiated in createAllNamedWorkspaceTabs"
+    )
+
+
 class TestPipelineRuns:
     """update_features + import_dart_features succeed against the real repo."""
 
@@ -155,21 +209,14 @@ class TestPipelineRuns:
 
         # Every declared feature is symlinked into the payload dir. Filter to
         # directories — features.lock (a file) also lives there.
-        materialized = {
-            p
-            for p in os.listdir(payload)
-            if (payload / p).is_dir() and not p.startswith(".")
-        }
+        materialized = materialized_feature_names(payload)
         assert materialized == EXPECTED_FEATURE_NAMES, (
             f"materialized set != declared set — drift in features.yaml "
             f"or features/. materialized={sorted(materialized)}"
         )
 
         # features.lock lists EVERY declared feature.
-        import yaml
-
-        lock = yaml.safe_load((payload / "features.lock").read_text())
-        lock_names = {e["name"] for e in lock["features"]}
+        lock_names = lock_feature_names(payload)
         assert lock_names == EXPECTED_FEATURE_NAMES, (
             f"features.lock names != all declared: {sorted(lock_names)}"
         )
@@ -187,33 +234,17 @@ class TestPipelineRuns:
 
         # Every Dart-bearing feature's class is imported + instantiated.
         for name, cls in EXPECTED_DART_FEATURES.items():
-            pkg = f"klangk_feature_{name.replace('-', '_')}"
-            assert f"import 'package:{pkg}/feature.dart';" in source, (
-                f"{pkg} not imported by the aggregator"
-            )
-            assert f"{cls}()" in source, (
-                f"{cls}() not instantiated in createAllFeatures/createAllNamedFeatures"
-            )
+            assert_feature_imported(source, name, cls)
 
         # Features WITHOUT a klangk/ dir must not appear in the Dart aggregator.
-        non_dart = EXPECTED_FEATURE_NAMES - EXPECTED_DART_PACKAGE_FEATURES
-        for name in non_dart:
-            pkg = f"klangk_feature_{name.replace('-', '_')}"
-            assert f"import 'package:{pkg}/" not in source, (
-                f"{name} has no klangk/ dir but leaked into the Dart aggregator"
-            )
+        for name in EXPECTED_FEATURE_NAMES - EXPECTED_DART_PACKAGE_FEATURES:
+            assert_not_imported(source, name)
 
-        # The workspace-tab aggregator (#1975) is always emitted — its
-        # absence would break main.dart's active-set filter at runtime.
-        assert "createAllNamedWorkspaceTabs()" in source, (
-            "createAllNamedWorkspaceTabs() aggregator not emitted"
-        )
-        # Chat is the first checked-in tab-only feature (#1976): its ChatTab
-        # is emitted into the tab aggregator.
+        # The workspace-tab aggregator (#1975) is always emitted.
+        assert_tab_aggregator_present(source)
+        # Tab-only features (#1976) land in the tab aggregator.
         for name, cls in EXPECTED_DART_TAB_FEATURES.items():
-            assert f"(name: '{name}', tab: {cls}())," in source, (
-                f"{cls}() not instantiated in createAllNamedWorkspaceTabs"
-            )
+            assert_tab_emitted(source, name, cls)
 
     def test_named_aggregator_names_match_feature_names(self, tmp_path, monkeypatch):
         """createAllNamedFeatures() emits records whose `name` matches the
@@ -249,6 +280,25 @@ class TestPipelineRuns:
 # ────────────────────────────────────────────────────────────────────────────
 
 
+def assert_single_feature(
+    features: list, tool_classes: list, tab_classes: list
+) -> dict:
+    """find_features found exactly one feature with the given classes."""
+    assert len(features) == 1
+    feat = features[0]
+    assert feat["tool_classes"] == tool_classes
+    assert feat["tab_classes"] == tab_classes
+    return feat
+
+
+def assert_tab_only_dart(dart: str, name: str, cls: str) -> None:
+    """The tab-only feature's class appears in the tab aggregator exactly
+    once — never leaked into createAllFeatures / createAllNamedFeatures."""
+    assert "createAllNamedWorkspaceTabs()" in dart
+    assert f"(name: '{name}', tab: {cls}())," in dart
+    assert dart.count(f"{cls}()") == 1, "tab class leaked into a tool aggregator"
+
+
 class TestWorkspaceTabAggregator:
     """createAllNamedWorkspaceTabs() (#1975): a feature may contribute a
     workspace tab with or without a ToolPlugin."""
@@ -272,11 +322,7 @@ class TestWorkspaceTabAggregator:
         self._write_feature(tmp_path, "notes", src)
 
         features = import_dart_features.find_features(str(tmp_path))
-        assert len(features) == 1
-        feat = features[0]
-        assert feat["name"] == "notes"
-        assert feat["tool_classes"] == []
-        assert feat["tab_classes"] == ["NotesTab"]
+        assert_single_feature(features, [], ["NotesTab"])
 
         # A tab-only feature still appears in the features.json manifest
         # (collect_feature_metadata iterates features, not tool_classes).
@@ -286,11 +332,7 @@ class TestWorkspaceTabAggregator:
         assert [m["name"] for m in meta] == ["notes"]
 
         dart = import_dart_features.generate_dart(features)
-        assert "createAllNamedWorkspaceTabs()" in dart
-        assert "(name: 'notes', tab: NotesTab())," in dart
-        # The tab class appears exactly once — only in the tab aggregator,
-        # never leaked into createAllFeatures / createAllNamedFeatures.
-        assert dart.count("NotesTab()") == 1, "tab class leaked into a tool aggregator"
+        assert_tab_only_dart(dart, "notes", "NotesTab")
 
     def test_both_tool_and_tab_feature(self, tmp_path):
         """A feature declaring both a ToolPlugin and a WorkspaceTabPlugin
@@ -304,10 +346,7 @@ class TestWorkspaceTabAggregator:
         self._write_feature(tmp_path, "chat", src)
 
         features = import_dart_features.find_features(str(tmp_path))
-        assert len(features) == 1
-        feat = features[0]
-        assert feat["tool_classes"] == ["ChatFeature"]
-        assert feat["tab_classes"] == ["ChatTab"]
+        assert_single_feature(features, ["ChatFeature"], ["ChatTab"])
 
         dart = import_dart_features.generate_dart(features)
         assert "(name: 'chat', feature: ChatFeature())," in dart
@@ -326,6 +365,43 @@ class TestWorkspaceTabAggregator:
 # src/klangk/klangk/features.py; if the runtime's expectations change, both
 # this test (real manifest) and test_features.py (synthetic) must update.
 # ────────────────────────────────────────────────────────────────────────────
+
+
+def assert_manifest_feature_types(f: dict) -> None:
+    """The feature entry's string fields + the config dict."""
+    for field in ("name", "version", "description"):
+        assert isinstance(f[field], str)
+    assert bool(f["name"]), f"feature name empty: {f!r}"
+    assert isinstance(f["config"], dict)
+
+
+def assert_manifest_feature_shape(f: dict) -> None:
+    """One features[] entry carries the runtime-required keys/types."""
+    assert isinstance(f, dict)
+    for key in ("name", "version", "description", "config"):
+        assert key in f, f"feature {f.get('name')} missing {key}"
+    assert_manifest_feature_types(f)
+
+
+def assert_config_key_shape(f: dict, key: str, spec: dict) -> None:
+    """One config key's entry carries {description, default, scope} with a
+    valid scope."""
+    assert isinstance(spec, dict), f"feature {f['name']} config {key} is not a dict"
+    for subkey in ("description", "default", "scope"):
+        assert subkey in spec, f"feature {f['name']} config {key} missing {subkey}"
+    assert spec["scope"] in {"container", "frontend", "both"}, (
+        f"feature {f['name']} config {key} has invalid scope {spec['scope']!r}"
+    )
+
+
+def declared_container_keys(manifest: dict) -> set:
+    """Keys declared in some feature's config with container/both scope."""
+    return {
+        key
+        for f in manifest["features"]
+        for key, spec in f["config"].items()
+        if spec["scope"] in {"container", "both"}
+    }
 
 
 class TestManifestContract:
@@ -348,13 +424,7 @@ class TestManifestContract:
         manifest = self._build_manifest(tmp_path, monkeypatch)
         feature_names = set()
         for f in manifest["features"]:
-            assert isinstance(f, dict)
-            for key in ("name", "version", "description", "config"):
-                assert key in f, f"feature {f.get('name')} missing {key}"
-            assert isinstance(f["name"], str) and f["name"]
-            assert isinstance(f["version"], str)
-            assert isinstance(f["description"], str)
-            assert isinstance(f["config"], dict)
+            assert_manifest_feature_shape(f)
             feature_names.add(f["name"])
         # features[] carries only Dart features — TS-only features are absent
         # (wheel/workspace activation asymmetry, #1655).
@@ -365,21 +435,10 @@ class TestManifestContract:
 
     def test_every_config_key_has_valid_shape_and_scope(self, tmp_path, monkeypatch):
         manifest = self._build_manifest(tmp_path, monkeypatch)
-        valid_scopes = {"container", "frontend", "both"}
         all_keys = {}
         for f in manifest["features"]:
             for key, spec in f["config"].items():
-                assert isinstance(spec, dict), (
-                    f"feature {f['name']} config {key} is not a dict"
-                )
-                for subkey in ("description", "default", "scope"):
-                    assert subkey in spec, (
-                        f"feature {f['name']} config {key} missing {subkey}"
-                    )
-                assert spec["scope"] in valid_scopes, (
-                    f"feature {f['name']} config {key} has invalid scope "
-                    f"{spec['scope']!r}"
-                )
+                assert_config_key_shape(f, key, spec)
                 all_keys[key] = spec["scope"]
         # Spot-check the keys declared today (the chat feature's agent
         # on-switch was removed with the chat feature, #2716).
@@ -431,14 +490,11 @@ class TestManifestContract:
         """Every container_env_key is declared in some feature's config with
         scope container/both — the bridge Features.container_env() depends on."""
         manifest = self._build_manifest(tmp_path, monkeypatch)
-        declared_container_keys = set()
-        for f in manifest["features"]:
-            for key, spec in f["config"].items():
-                if spec["scope"] in {"container", "both"}:
-                    declared_container_keys.add(key)
-        assert set(manifest["container_env_keys"]) <= declared_container_keys, (
+        assert set(manifest["container_env_keys"]) <= declared_container_keys(
+            manifest
+        ), (
             f"container_env_keys names keys not declared with container/both scope: "
-            f"{set(manifest['container_env_keys']) - declared_container_keys}"
+            f"{set(manifest['container_env_keys']) - declared_container_keys(manifest)}"
         )
         # Spot-check the one key actually declared today.
         assert manifest["container_env_keys"] == EXPECTED_CONTAINER_ENV_KEYS

--- a/scripts/tests/test_build_script_remote_guard.py
+++ b/scripts/tests/test_build_script_remote_guard.py
@@ -47,8 +47,9 @@ _HELPER = _SCRIPTS_DIR / "_podman_common.sh"
 _HELPER_CONSUMER_SCRIPTS = [_SCRIPTS_DIR / "build-workspace-image.sh"]
 
 
-def _assert_guard_pattern(where: Path, text: str) -> None:
-    """The four-line remote-feature guard contract, wherever it lives."""
+def _assert_calls_update_features(where: Path, text: str) -> None:
+    """The script calls update_features.py behind the env guard, with
+    --local-only."""
     assert "update_features.py" in text, (
         f"{where.name} no longer calls update_features.py — "
         f"guard test is stale, investigate"
@@ -63,7 +64,10 @@ def _assert_guard_pattern(where: Path, text: str) -> None:
         f"{where.name} references the env var but doesn't pass "
         f"--local-only to update_features.py"
     )
-    # The polarity guard: the default (env var unset) must skip remote.
+
+
+def _assert_guard_polarity(where: Path, text: str) -> None:
+    """The polarity guard: the default (env var unset) must skip remote."""
     assert "KLANGKBUILD_BUILD_INCLUDE_REMOTE:-0" in text, (
         f"{where.name} doesn't default KLANGKBUILD_BUILD_INCLUDE_REMOTE to '0' "
         f"— the polarity may be flipped, making remote-fetch the default "
@@ -73,6 +77,12 @@ def _assert_guard_pattern(where: Path, text: str) -> None:
         f"{where.name} doesn't compare against '1' — polarity may be "
         f"flipped (re-exposes CI to upstream failures)"
     )
+
+
+def _assert_guard_pattern(where: Path, text: str) -> None:
+    """The four-line remote-feature guard contract, wherever it lives."""
+    _assert_calls_update_features(where, text)
+    _assert_guard_polarity(where, text)
 
 
 def test_build_scripts_check_env_var():

--- a/scripts/tests/test_deploy_docs.py
+++ b/scripts/tests/test_deploy_docs.py
@@ -45,9 +45,8 @@ def test_script_exists_and_is_executable():
     assert first.startswith("#!"), "scripts/deploy-docs.py needs a shebang"
 
 
-def test_script_uses_mike_python_api_with_redirect_aliases():
-    """The deploy must keep every prior version and alias safely."""
-    script = _SCRIPT.read_text()
+def assert_mike_alias_api(script: str) -> None:
+    """The mike deploy uses redirect aliases + refreshes the latest alias."""
     assert "AliasType.redirect" in script, (
         "deploy must use redirect alias pages — GitHub Pages does not serve symlinks"
     )
@@ -58,6 +57,10 @@ def test_script_uses_mike_python_api_with_redirect_aliases():
     assert "update_aliases=True" in script, (
         "deploy without update_aliases leaves the latest alias stale"
     )
+
+
+def assert_gh_pages_sync(script: str) -> None:
+    """The deploy syncs gh-pages from origin + tolerates empty redeploys."""
     assert "update_from_upstream" in script, (
         "deploy must sync the local gh-pages branch from origin first — "
         "otherwise every deploy clobbers all earlier versions"
@@ -66,6 +69,13 @@ def test_script_uses_mike_python_api_with_redirect_aliases():
         "re-deploying unchanged docs raises GitEmptyCommit; it must be "
         "treated as a no-op, not a failure"
     )
+
+
+def test_script_uses_mike_python_api_with_redirect_aliases():
+    """The deploy must keep every prior version and alias safely."""
+    script = _SCRIPT.read_text()
+    assert_mike_alias_api(script)
+    assert_gh_pages_sync(script)
 
 
 def test_script_versions_the_build_and_root_redirect():
@@ -84,13 +94,8 @@ def test_script_versions_the_build_and_root_redirect():
     )
 
 
-def test_workflow_deploys_via_gh_pages_branch():
-    """The workflow pushes a versioned gh-pages branch, not artifacts."""
-    workflow = _WORKFLOW.read_text()
-    assert "fetch-depth: 0" in workflow, (
-        "checkout must fetch all refs so mike sees origin/gh-pages"
-    )
-    assert "contents: write" in workflow, "pushing gh-pages needs contents: write"
+def assert_no_deploy_pages_flow(workflow: str) -> None:
+    """The removed actions/deploy-pages flow's permissions/steps are gone."""
     assert "pages: write" not in workflow, (
         "the pages: write permission belongs to the removed actions/deploy-pages flow"
     )
@@ -98,15 +103,19 @@ def test_workflow_deploys_via_gh_pages_branch():
         "the id-token: write permission belongs to the removed "
         "actions/deploy-pages flow"
     )
-    assert "squidfunk/mike.git" in workflow, (
-        "CI must install squidfunk's mike fork — the PyPI mike builds via "
-        "mkdocs and cannot parse zensical.toml"
-    )
     assert "deploy-pages" not in workflow, (
         "docs now deploy from the gh-pages branch, not a workflow artifact"
     )
     assert "upload-pages-artifact" not in workflow, (
         "docs now deploy from the gh-pages branch, not a workflow artifact"
+    )
+
+
+def assert_gh_pages_push(workflow: str) -> None:
+    """The workflow installs squidfunk's mike fork + pushes gh-pages."""
+    assert "squidfunk/mike.git" in workflow, (
+        "CI must install squidfunk's mike fork — the PyPI mike builds via "
+        "mkdocs and cannot parse zensical.toml"
     )
     assert "git push origin gh-pages" in workflow, (
         "the workflow must push the gh-pages branch mike committed to"
@@ -114,3 +123,14 @@ def test_workflow_deploys_via_gh_pages_branch():
     assert "MIKE_DOCS_VERSION:" in workflow, (
         "the workflow must pass the extracted version to deploy-docs.py"
     )
+
+
+def test_workflow_deploys_via_gh_pages_branch():
+    """The workflow pushes a versioned gh-pages branch, not artifacts."""
+    workflow = _WORKFLOW.read_text()
+    assert "fetch-depth: 0" in workflow, (
+        "checkout must fetch all refs so mike sees origin/gh-pages"
+    )
+    assert "contents: write" in workflow, "pushing gh-pages needs contents: write"
+    assert_no_deploy_pages_flow(workflow)
+    assert_gh_pages_push(workflow)

--- a/scripts/tests/test_fmtk_harness.py
+++ b/scripts/tests/test_fmtk_harness.py
@@ -54,6 +54,14 @@ def test_devenv_wires_the_scripts():
         assert f"scripts/{path}" in nix, f"{name} must delegate to the script"
 
 
+def assert_proxy_split(up: str) -> None:
+    """same-origin split: /api and /ws to the backend, rest to the dev
+    server."""
+    assert "handle /api/*" in up and "handle /ws" in up, (
+        "the proxy must route /api/* and /ws to the backend"
+    )
+
+
 def test_up_boots_all_pieces():
     """The harness must compose backend, proxy, seed, and flutter run."""
     up = _UP.read_text()
@@ -63,10 +71,7 @@ def test_up_boots_all_pieces():
     assert "flutter run --debug -d chrome" in up, (
         "fmtk-up must start the debug flutter run"
     )
-    # same-origin split: /api and /ws to the backend, rest to the dev server
-    assert "handle /api/*" in up and "handle /ws" in up, (
-        "the proxy must route /api/* and /ws to the backend"
-    )
+    assert_proxy_split(up)
 
 
 def test_up_reuses_kept_services_for_fast_relaunch():
@@ -82,6 +87,13 @@ def test_up_reuses_kept_services_for_fast_relaunch():
     assert "--no-pub" in up, "skip pub get when package_config is fresh"
 
 
+def assert_no_debug_port_flag(chrome: str) -> None:
+    """The wrapper must not add --remote-debugging-port (flutter's own flag
+    wins; the port is discovered from the process list instead)."""
+    active = [ln for ln in chrome.splitlines() if not ln.lstrip().startswith("#")]
+    assert not any("--remote-debugging-port" in ln for ln in active)
+
+
 def test_up_uses_the_chrome_wrapper():
     """The debug run must load the app through the proxy via the wrapper."""
     assert "fmtk-chrome.sh" in _UP.read_text(), (
@@ -89,11 +101,7 @@ def test_up_uses_the_chrome_wrapper():
     )
     chrome = _CHROME.read_text()
     assert "8124" in chrome, "the wrapper must rewrite to the proxy origin"
-    active = [ln for ln in chrome.splitlines() if not ln.lstrip().startswith("#")]
-    assert not any("--remote-debugging-port" in ln for ln in active), (
-        "the wrapper must not add --remote-debugging-port (flutter's own "
-        "flag wins; the port is discovered from the process list instead)"
-    )
+    assert_no_debug_port_flag(chrome)
 
 
 def test_down_stops_the_right_processes():
@@ -110,6 +118,18 @@ def test_down_stops_the_right_processes():
         assert pattern in down, f"fmtk-down must handle: {pattern}"
 
 
+def assert_removed_fixtures_absent(seed: str) -> None:
+    """The pre-#2881 fixture names are gone."""
+    for removed in ("fmtk-sharer", "fmtk-acler", "fmtk-viewer"):
+        assert removed not in seed, f"the {removed} fixture was removed"
+
+
+def assert_role_buckets_seeded(seed: str) -> None:
+    """One fixture member per role bucket."""
+    for role in ("collaborators", "coders", "spectators"):
+        assert f'"{role}"' in seed, f"a fixture must sit in {role}"
+
+
 def test_seed_matrix_wiring():
     """Fixture wiring: admin-group owner plus one member per role bucket.
 
@@ -122,10 +142,8 @@ def test_seed_matrix_wiring():
     assert "fmtk-admin" in seed and '"admins"' in seed, (
         "fmtk-admin must exist and join the admins group"
     )
-    for removed in ("fmtk-sharer", "fmtk-acler", "fmtk-viewer"):
-        assert removed not in seed, f"the {removed} fixture was removed"
-    for role in ("collaborators", "coders", "spectators"):
-        assert f'"{role}"' in seed, f"a fixture must sit in {role}"
+    assert_removed_fixtures_absent(seed)
+    assert_role_buckets_seeded(seed)
     assert "owner_token" in seed, (
         "the workspace must be created with fmtk-admin's token (ownership)"
     )

--- a/scripts/tests/test_pip_audit.py
+++ b/scripts/tests/test_pip_audit.py
@@ -50,11 +50,16 @@ def review_dates(comment_lines):
     return [m.group(1) for m in map(REVIEW_RE.match, comment_lines) if m]
 
 
+def assert_ids_well_formed(ids: list) -> None:
+    """Every advisory ID matches the ID grammar."""
+    for vuln_id in ids:
+        assert ID_RE.match(vuln_id), f"malformed advisory ID: {vuln_id}"
+
+
 def test_ids_are_well_formed_and_unique():
     ids = [vuln_id for vuln_id, _ in entries()]
     assert ids, "allowlist is empty — drop the file and its wiring instead"
-    for vuln_id in ids:
-        assert ID_RE.match(vuln_id), f"malformed advisory ID: {vuln_id}"
+    assert_ids_well_formed(ids)
     assert len(ids) == len(set(ids)), "duplicate advisory ID in allowlist"
 
 

--- a/scripts/tests/test_supply_chain_pins.py
+++ b/scripts/tests/test_supply_chain_pins.py
@@ -71,27 +71,51 @@ def _arg(df: Path, name: str) -> str:
 # ── Base/host images: immutable digest references ───────────────────────────
 
 
+def assert_hex64_arg(df: Path, name: str) -> None:
+    """A Dockerfile ARG is a 64-hex-char sha256."""
+    assert _HEX64.match(_arg(df, name)), f"{name} must be a 64-hex-char sha256"
+
+
+def assert_sha256_verified(text: str, path: str) -> None:
+    """``$sha <path>`` is piped into sha256sum -c before the tarball is used."""
+    assert re.search(rf"\$\{{sha\}}\s+{re.escape(path)}.*\| sha256sum -c -", text), (
+        f"{path} must be verified (sha256sum -c) before use"
+    )
+
+
+def assert_from_ref_pinned(df: Path, ref: str, stage_names: set) -> None:
+    """One FROM target is digest-pinned (ARG refs + local stage aliases
+    exempt)."""
+    if ref.startswith("$"):
+        return  # ARG reference (value pinned elsewhere)
+    if ref.lower() in stage_names:
+        return  # local build-stage alias
+    assert "@sha256:" in ref, (
+        f"{df}: FROM {ref} is not pinned by digest (#2063) — "
+        f"mutable-tag base images let the registry serve "
+        f"different content for the same reference"
+    )
+
+
+def assert_from_lines_pinned(df: Path) -> None:
+    """Every FROM in one Dockerfile is a digest ref, ARG reference, or a
+    local build-stage alias — never a mutable registry tag."""
+    text = df.read_text()
+    froms = re.findall(r"(?im)^FROM\s+(\S+)", text)
+    assert froms, f"{df} has no FROM lines — test is stale"
+    # Stage names defined in this file (``FROM … AS name``) may be used as
+    # later FROM targets without a digest.
+    stage_names = {
+        m.lower() for m in re.findall(r"(?im)^FROM\s+\S+\s+AS\s+(\S+)", text)
+    }
+    for ref in froms:
+        assert_from_ref_pinned(df, ref, stage_names)
+
+
 class TestFromLinesPinnedByDigest:
     def test_every_image_dockerfile_from_line_is_digest_arg_or_alias(self):
         for df in _IMAGE_DOCKERFILES:
-            text = df.read_text()
-            froms = re.findall(r"(?im)^FROM\s+(\S+)", text)
-            assert froms, f"{df} has no FROM lines — test is stale"
-            # Stage names defined in this file (``FROM … AS name``) may be
-            # used as later FROM targets without a digest.
-            stage_names = {
-                m.lower() for m in re.findall(r"(?im)^FROM\s+\S+\s+AS\s+(\S+)", text)
-            }
-            for ref in froms:
-                if ref.startswith("$"):
-                    continue  # ARG reference (value pinned elsewhere)
-                if ref.lower() in stage_names:
-                    continue  # local build-stage alias
-                assert "@sha256:" in ref, (
-                    f"{df}: FROM {ref} is not pinned by digest (#2063) — "
-                    f"mutable-tag base images let the registry serve "
-                    f"different content for the same reference"
-                )
+            assert_from_lines_pinned(df)
 
     def test_workspace_base_image_arg_is_digest(self):
         ref = _arg(_WORKSPACE_DF, "WORKSPACE_BASE_IMAGE")
@@ -154,6 +178,13 @@ class TestFromLinesPinnedByDigest:
 # ── Workspace image: verified tarballs (pi agent, uv, process-compose) ───────
 
 
+def assert_no_piped_curl(df: Path, line: str) -> None:
+    """One Dockerfile line is not a piped curl (unverified network input)."""
+    assert not re.search(r"curl[^|]*\|", line), (
+        f"piped curl in {df.name} (unverified network input, #2063): {line.strip()}"
+    )
+
+
 class TestWorkspaceTarballPins:
     def test_pi_agent_tarball_is_sha512_verified(self):
         text = _WORKSPACE_DF.read_text()
@@ -178,25 +209,17 @@ class TestWorkspaceTarballPins:
         assert "astral.sh" not in text, (
             "uv must not be installed via the astral.sh piped installer (#2063)"
         )
-        assert re.search(r"\$\{sha\}\s+/tmp/uv\.tar\.gz.*\| sha256sum -c -", text), (
-            "uv tarball must be verified (sha256sum -c) before extraction"
-        )
+        assert_sha256_verified(text, "/tmp/uv.tar.gz")
         for arch in ("AMD64", "ARM64"):
-            assert _HEX64.match(_arg(_WORKSPACE_DF, f"UV_SHA256_{arch}")), (
-                f"UV_SHA256_{arch} must be a 64-hex-char sha256"
-            )
+            assert_hex64_arg(_WORKSPACE_DF, f"UV_SHA256_{arch}")
         # Both arches must map to their own pin inside the build.
         assert 'sha="$UV_SHA256_AMD64"' in text and 'sha="$UV_SHA256_ARM64"' in text
 
     def test_process_compose_is_per_arch_sha256_verified(self):
         text = _WORKSPACE_DF.read_text()
-        assert re.search(
-            r"\$\{sha\}\s+/tmp/process-compose\.tar\.gz.*\| sha256sum -c -", text
-        ), "process-compose tarball must be verified (sha256sum -c) before tar"
+        assert_sha256_verified(text, "/tmp/process-compose.tar.gz")
         for arch in ("AMD64", "ARM64"):
-            assert _HEX64.match(
-                _arg(_WORKSPACE_DF, f"PROCESS_COMPOSE_SHA256_{arch}")
-            ), f"PROCESS_COMPOSE_SHA256_{arch} must be a 64-hex-char sha256"
+            assert_hex64_arg(_WORKSPACE_DF, f"PROCESS_COMPOSE_SHA256_{arch}")
 
     def test_no_unverified_curl_pipes(self):
         r"""No `curl ... | sh` / `curl ... | tar` piping in the image
@@ -213,13 +236,23 @@ class TestWorkspaceTarballPins:
                 ln for ln in text.splitlines() if not ln.lstrip().startswith("#")
             ]
             for line in code_lines:
-                assert not re.search(r"curl[^|]*\|", line), (
-                    f"piped curl in {df.name} (unverified network input, "
-                    f"#2063): {line.strip()}"
-                )
+                assert_no_piped_curl(df, line)
 
 
 # ── Apt repo keys: verified before entering a keyring ───────────────────────
+
+
+def assert_caddy_sources_inline(text: str) -> None:
+    """The Caddy sources list is written inline, not fetched over the
+    network."""
+    assert (
+        "echo 'deb [signed-by=/usr/share/keyrings/caddy-stable-archive-keyring.gpg]"
+        " https://dl.cloudsmith.io/public/caddy/stable/deb/debian any-version main'"
+        in text
+    ), "Caddy apt sources list must be written inline (#2063)"
+    assert "debian.deb.txt" not in text, (
+        "Caddy sources list must not be fetched from the network (#2063)"
+    )
 
 
 class TestAptRepoKeyPins:
@@ -233,15 +266,7 @@ class TestAptRepoKeyPins:
         assert _HEX64.match(_arg(_HOST_DF, "CADDY_REPO_KEY_SHA256")), (
             "CADDY_REPO_KEY_SHA256 must be a 64-hex-char sha256"
         )
-        # The sources list is written inline, not fetched over the network.
-        assert (
-            "echo 'deb [signed-by=/usr/share/keyrings/caddy-stable-archive-keyring.gpg]"
-            " https://dl.cloudsmith.io/public/caddy/stable/deb/debian any-version main'"
-            in text
-        ), "Caddy apt sources list must be written inline (#2063)"
-        assert "debian.deb.txt" not in text, (
-            "Caddy sources list must not be fetched from the network (#2063)"
-        )
+        assert_caddy_sources_inline(text)
 
     def test_nodesource_and_githubcli_keys_are_verified(self):
         text = _WORKSPACE_BASE_DF.read_text()

--- a/scripts/tests/test_update_features.py
+++ b/scripts/tests/test_update_features.py
@@ -263,6 +263,14 @@ class TestMainPayloadDir:
         shutil.rmtree(payload_path, ignore_errors=True)
 
 
+def assert_skipped_entry(entry: dict) -> None:
+    """A --local-only git entry carries sha='skipped' + its source for
+    traceability."""
+    assert entry["sha"] == "skipped", f"expected sha='skipped'; got {entry!r}"
+    assert entry["git"].endswith("/repo.git")
+    assert entry["ref"] == "v1.0"
+
+
 class TestLocalOnlyFlag:
     """--local-only skips git-sourced features without hitting the network (#1664).
 
@@ -327,12 +335,7 @@ class TestLocalOnlyFlag:
         assert set(entries) == {"local-one", "remote-one"}, (
             f"lock should list both features; got {sorted(entries)}"
         )
-        assert entries["remote-one"]["sha"] == "skipped", (
-            f"remote-one should be sha='skipped'; got {entries['remote-one']!r}"
-        )
-        # The git URL + ref are preserved in the lock for traceability.
-        assert entries["remote-one"]["git"].endswith("/repo.git")
-        assert entries["remote-one"]["ref"] == "v1.0"
+        assert_skipped_entry(entries["remote-one"])
 
     def test_local_only_off_by_default(self, tmp_path, monkeypatch):
         """Without --local-only, a git entry with an unresolvable ref fails

--- a/scripts/trivy-report-nofix.py
+++ b/scripts/trivy-report-nofix.py
@@ -46,8 +46,9 @@ def _md_escape(text: str) -> str:
     return (text or "").replace("|", "\\|").replace("\n", " ").strip()
 
 
-def load_results(path: str | None) -> list[dict]:
-    raw = sys.stdin.read() if not path or path == "-" else open(path).read()
+def parse_scan(raw: str) -> list[dict]:
+    """Parse the Trivy scan JSON; exit(2) on invalid JSON/shape. Returns
+    the Results array (empty when absent)."""
     try:
         data = json.loads(raw)
     except json.JSONDecodeError as exc:
@@ -59,23 +60,49 @@ def load_results(path: str | None) -> list[dict]:
     return data.get("Results", []) or []
 
 
+def load_results(path: str | None) -> list[dict]:
+    raw = sys.stdin.read() if not path or path == "-" else open(path).read()
+    return parse_scan(raw)
+
+
+def is_fixable(v: dict) -> bool:
+    """A HIGH/CRITICAL vuln is fixable when a fixed version exists;
+    anything else (a known no-fix status -- ``affected``, ``fix_deferred``,
+    ``will_not_fix``, ``end_of_life`` -- or no fixed version at all) can't
+    be acted on now."""
+    return bool(v.get("FixedVersion"))
+
+
+def high_critical_vulns(results: list[dict]) -> list[dict]:
+    """Every HIGH/CRITICAL vulnerability across the scan results."""
+    out = []
+    for res in results:
+        for v in res.get("Vulnerabilities") or []:
+            if v.get("Severity") in ("CRITICAL", "HIGH"):
+                out.append(v)
+    return out
+
+
 def collect(results: list[dict]) -> tuple[list[dict], list[dict]]:
     """Return (no_fix_vulns, fixable_vulns) restricted to HIGH/CRITICAL."""
     no_fix: list[dict] = []
     fixable: list[dict] = []
-    for res in results:
-        for v in res.get("Vulnerabilities") or []:
-            if v.get("Severity") not in ("CRITICAL", "HIGH"):
-                continue
-            if v.get("FixedVersion"):
-                fixable.append(v)
-            elif v.get("Status") in NO_FIX_STATUSES:
-                no_fix.append(v)
-            else:
-                # Severity HIGH/CRITICAL with neither a fixed version nor a
-                # known no-fix status — treat as no-fix (can't act on it).
-                no_fix.append(v)
+    for v in high_critical_vulns(results):
+        (fixable if is_fixable(v) else no_fix).append(v)
     return no_fix, fixable
+
+
+def merge_vuln_entry(entry: dict, v: dict) -> None:
+    """Merge one vuln into its CVE entry: keep the most severe severity
+    observed + record the package's (installed, fixed) pair."""
+    if SEVERITY_RANK.get(v.get("Severity"), 99) < SEVERITY_RANK.get(
+        entry["severity"], 99
+    ):
+        entry["severity"] = v.get("Severity")
+    pkg = v.get("PkgName") or "?"
+    entry["packages"].setdefault(
+        pkg, (v.get("InstalledVersion") or "", v.get("FixedVersion") or "")
+    )
 
 
 def group_by_cve(vulns: list[dict]) -> list[dict]:
@@ -96,20 +123,39 @@ def group_by_cve(vulns: list[dict]) -> list[dict]:
                 "packages": {},  # pkg -> (installed, fixed)
             },
         )
-        # Keep the most severe severity observed.
-        if SEVERITY_RANK.get(v.get("Severity"), 99) < SEVERITY_RANK.get(
-            entry["severity"], 99
-        ):
-            entry["severity"] = v.get("Severity")
-        pkg = v.get("PkgName") or "?"
-        entry["packages"].setdefault(
-            pkg, (v.get("InstalledVersion") or "", v.get("FixedVersion") or "")
-        )
+        merge_vuln_entry(entry, v)
     # Sort: CRITICAL first, then HIGH, then alphabetical.
     return sorted(
         by_cve.values(),
         key=lambda e: (SEVERITY_RANK.get(e["severity"], 99), e["cve"]),
     )
+
+
+def fixable_table_lines(fixable_cves: list[dict]) -> list[str]:
+    """The fix-available markdown table rows (one row per CVE+package)."""
+    lines = []
+    for e in fixable_cves:
+        for pkg, (inst, fixed) in sorted(e["packages"].items()):
+            lines.append(
+                f"| {e['cve']} | {e['severity']} | "
+                f"{_md_escape(pkg)} | {_md_escape(inst)} | "
+                f"{_md_escape(fixed)} |"
+            )
+    return lines
+
+
+def no_fix_table_lines(no_fix_cves: list[dict]) -> list[str]:
+    """The no-upstream-fix markdown table rows (one row per CVE)."""
+    lines = []
+    for e in no_fix_cves:
+        pkgs = ", ".join(sorted(e["packages"]))
+        if len(pkgs) > 60:
+            pkgs = pkgs[:59] + "…"
+        lines.append(
+            f"| {e['cve']} | {e['severity']} | `{e['status']}` | "
+            f"{_md_escape(pkgs)} | {_md_escape(_short(e['title']))} |"
+        )
+    return lines
 
 
 def render(no_fix: list[dict], fixable: list[dict]) -> str:
@@ -149,13 +195,7 @@ def render(no_fix: list[dict], fixable: list[dict]) -> str:
         lines.append("")
         lines.append("| CVE | Severity | Package | Installed | Fixed |")
         lines.append("| --- | --- | --- | --- | --- |")
-        for e in fixable_cves:
-            for pkg, (inst, fixed) in sorted(e["packages"].items()):
-                lines.append(
-                    f"| {e['cve']} | {e['severity']} | "
-                    f"{_md_escape(pkg)} | {_md_escape(inst)} | "
-                    f"{_md_escape(fixed)} |"
-                )
+        lines.extend(fixable_table_lines(fixable_cves))
         lines.append("")
 
     lines.append(
@@ -173,14 +213,7 @@ def render(no_fix: list[dict], fixable: list[dict]) -> str:
         lines.append("")
         lines.append("| CVE | Severity | Status | Packages | Title |")
         lines.append("| --- | --- | --- | --- | --- |")
-        for e in no_fix_cves:
-            pkgs = ", ".join(sorted(e["packages"]))
-            if len(pkgs) > 60:
-                pkgs = pkgs[:59] + "…"
-            lines.append(
-                f"| {e['cve']} | {e['severity']} | `{e['status']}` | "
-                f"{_md_escape(pkgs)} | {_md_escape(_short(e['title']))} |"
-            )
+        lines.extend(no_fix_table_lines(no_fix_cves))
         lines.append("")
 
     lines.append("<details><summary>Status legend</summary>")

--- a/scripts/update_features.py
+++ b/scripts/update_features.py
@@ -103,17 +103,37 @@ def _repo_origin_url():
         return ""
 
 
+def clear_dest(dest: str) -> None:
+    """Remove an old materialized feature at dest (dir, symlink, or broken
+    symlink) so it can be replaced."""
+    if not (os.path.islink(dest) or os.path.exists(dest)):
+        return
+    if os.path.islink(dest):
+        os.unlink(dest)
+    else:
+        shutil.rmtree(dest)
+
+
 def _copy_feature_tree(source, dest):
     """Copy a feature directory tree into dest, dropping any .git inside."""
-    if os.path.islink(dest) or os.path.exists(dest):
-        if os.path.islink(dest):
-            os.unlink(dest)
-        else:
-            shutil.rmtree(dest)
+    clear_dest(dest)
     shutil.copytree(source, dest)
     git_dir = os.path.join(dest, ".git")
     if os.path.exists(git_dir):
         shutil.rmtree(git_dir)
+
+
+def is_local_repo_feature(git_url: str, subpath: str, local_origin: str) -> bool:
+    """Is the feature's git source this repo AND the local path present?
+    The unresolvable-ref fallback applies only then (GitHub PR builds check
+    out a synthesized merge commit whose SHA exists only on the runner, so
+    `git ls-remote` can never resolve it)."""
+    local_path = os.path.join(ROOT, subpath) if subpath else ROOT
+    return (
+        bool(local_origin)
+        and _normalize_git_url(git_url) == local_origin
+        and os.path.isdir(local_path)
+    )
 
 
 def _feature_from_local_tree(
@@ -131,15 +151,11 @@ def _feature_from_local_tree(
     already-checked-out working tree (which has the exact content being
     built) instead of cloning; never silently degrade to the remote's default
     branch."""
-    dest = os.path.join(features_dir, name)
-    local_path = os.path.join(ROOT, subpath) if subpath else ROOT
-    if not (
-        local_origin
-        and _normalize_git_url(git_url) == local_origin
-        and os.path.isdir(local_path)
-    ):
+    if not is_local_repo_feature(git_url, subpath, local_origin):
         print(f"  ERROR: Could not resolve ref '{ref}' for {git_url}", file=sys.stderr)
         return None
+    dest = os.path.join(features_dir, name)
+    local_path = os.path.join(ROOT, subpath) if subpath else ROOT
     print(
         f"  {name}: ref '{ref}' not on remote; "
         f"using local working tree {subpath or '.'}/"
@@ -152,6 +168,80 @@ def _feature_from_local_tree(
         "ref": ref,
         "sha": "local",
     }
+
+
+def clone_at_ref(git_url: str, ref: str, clone_dir: str) -> bool:
+    """Clone git_url into clone_dir at ref: a shallow branch clone first,
+    falling back to a full clone + checkout when ref is a SHA. False (with
+    an ERROR print) when the clone/checkout fails."""
+    result = subprocess.run(
+        ["git", "clone", "--depth=1", "--branch", ref, git_url, clone_dir],
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    if result.returncode == 0:
+        return True
+    # ref might be a SHA (not a branch name); full clone + checkout.
+    result = subprocess.run(
+        ["git", "clone", git_url, clone_dir],
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    if result.returncode != 0:
+        print(
+            f"  ERROR: git clone failed: {result.stderr.strip()}",
+            file=sys.stderr,
+        )
+        return False
+    checkout = subprocess.run(
+        ["git", "checkout", ref],
+        cwd=clone_dir,
+        capture_output=True,
+        text=True,
+    )
+    if checkout.returncode != 0:
+        print(
+            f"  ERROR: git checkout '{ref}' failed: {checkout.stderr.strip()}",
+            file=sys.stderr,
+        )
+        return False
+    return True
+
+
+def clone_head(clone_dir: str) -> str:
+    """The checked-out HEAD SHA."""
+    return subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=clone_dir,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+
+
+def head_matches_ref(clone_dir: str, sha: str, ref: str) -> bool:
+    """Guard against silently landing on the default branch: the checked-out
+    HEAD must match the ref we resolved on the remote."""
+    head = clone_head(clone_dir)
+    if head != sha:
+        print(
+            f"  ERROR: checked-out HEAD {head[:12]} != resolved {sha[:12]} "
+            f"for '{ref}'; refusing to use default-branch content",
+            file=sys.stderr,
+        )
+        return False
+    return True
+
+
+def feature_source(clone_dir: str, subpath: str, git_url: str) -> str | None:
+    """The feature tree inside the clone (subpath or the clone root); None
+    (with an ERROR print) when the subpath doesn't exist."""
+    source = os.path.join(clone_dir, subpath) if subpath else clone_dir
+    if not os.path.isdir(source):
+        print(f"  ERROR: path '{subpath}' not found in {git_url}", file=sys.stderr)
+        return None
+    return source
 
 
 def fetch_feature(feature, features_dir):
@@ -188,61 +278,13 @@ def fetch_feature(feature, features_dir):
     # Clone into temp dir, then check out the resolved ref.
     with tempfile.TemporaryDirectory() as tmpdir:
         clone_dir = os.path.join(tmpdir, "repo")
-        result = subprocess.run(
-            ["git", "clone", "--depth=1", "--branch", ref, git_url, clone_dir],
-            capture_output=True,
-            text=True,
-            timeout=120,
-        )
-        if result.returncode != 0:
-            # ref might be a SHA (not a branch name); full clone + checkout.
-            result = subprocess.run(
-                ["git", "clone", git_url, clone_dir],
-                capture_output=True,
-                text=True,
-                timeout=120,
-            )
-            if result.returncode != 0:
-                print(
-                    f"  ERROR: git clone failed: {result.stderr.strip()}",
-                    file=sys.stderr,
-                )
-                return None
-            checkout = subprocess.run(
-                ["git", "checkout", ref],
-                cwd=clone_dir,
-                capture_output=True,
-                text=True,
-            )
-            if checkout.returncode != 0:
-                print(
-                    f"  ERROR: git checkout '{ref}' failed: {checkout.stderr.strip()}",
-                    file=sys.stderr,
-                )
-                return None
-
-        # Guard against silently landing on the default branch: the checked-out
-        # HEAD must match the ref we resolved on the remote.
-        head = subprocess.run(
-            ["git", "rev-parse", "HEAD"],
-            cwd=clone_dir,
-            capture_output=True,
-            text=True,
-        ).stdout.strip()
-        if head != sha:
-            print(
-                f"  ERROR: checked-out HEAD {head[:12]} != resolved {sha[:12]} "
-                f"for '{ref}'; refusing to use default-branch content",
-                file=sys.stderr,
-            )
+        if not clone_at_ref(git_url, ref, clone_dir):
             return None
-
-        source = os.path.join(clone_dir, subpath) if subpath else clone_dir
-
-        if not os.path.isdir(source):
-            print(f"  ERROR: path '{subpath}' not found in {git_url}", file=sys.stderr)
+        if not head_matches_ref(clone_dir, sha, ref):
             return None
-
+        source = feature_source(clone_dir, subpath, git_url)
+        if source is None:
+            return None
         _copy_feature_tree(source, dest)
 
     return {"name": name, "git": git_url, "path": subpath, "ref": ref, "sha": sha}
@@ -263,14 +305,7 @@ def link_feature(feature, features_dir):
         return None
 
     dest = os.path.join(features_dir, name)
-
-    # Remove old version (dir, symlink, or broken symlink)
-    if os.path.islink(dest) or os.path.exists(dest):
-        if os.path.islink(dest):
-            os.unlink(dest)
-        else:
-            shutil.rmtree(dest)
-
+    clear_dest(dest)
     os.symlink(source, dest)
     print(f"  {name}: {source} (local symlink)")
     return {"name": name, "path": source}
@@ -333,6 +368,15 @@ def parse_args(argv=None):
     return parser.parse_args(argv)
 
 
+def filter_to_only(features: list, only: str) -> list:
+    """The entries matching the ``only`` feature name; exit(1) when absent."""
+    matched = [p for p in features if feature_name(p) == only]
+    if not matched:
+        print(f"Feature '{only}' not found in features.yaml", file=sys.stderr)
+        sys.exit(1)
+    return matched
+
+
 def select_features(config: dict, only: str | None) -> list:
     """The declared features, filtered to ``only`` when one is named."""
     features = config.get("features", [])
@@ -340,12 +384,26 @@ def select_features(config: dict, only: str | None) -> list:
         print("No features listed in features.yaml")
         return []
     if only:
-        matched = [p for p in features if feature_name(p) == only]
-        if not matched:
-            print(f"Feature '{only}' not found in features.yaml", file=sys.stderr)
-            sys.exit(1)
-        return matched
+        return filter_to_only(features, only)
     return features
+
+
+def skipped_lock_entry(feature: dict, lock_map: dict) -> dict:
+    """The lock entry for a git feature skipped under --local-only: every
+    declared feature appears in the lock (shape consistency) without
+    fetching. Preserve a real SHA from the prior lock if one exists (an
+    interleaved `update_features <name>` may have already resolved it) —
+    only write sha='skipped' when there's nothing better to keep."""
+    prior = lock_map.get(feature["name"])
+    prior_sha = prior.get("sha") if prior else None
+    sha = prior_sha if prior_sha and prior_sha != "skipped" else "skipped"
+    return {
+        "name": feature["name"],
+        "git": feature["git"],
+        "path": feature.get("path", ""),
+        "ref": feature.get("ref", "main"),
+        "sha": sha,
+    }
 
 
 def materialize_feature(feature: dict, args, lock_map: dict, payload_dir: str):
@@ -356,20 +414,7 @@ def materialize_feature(feature: dict, args, lock_map: dict, payload_dir: str):
                 f"  SKIP: {feature['name']} (git entry, --local-only)",
                 file=sys.stderr,
             )
-            # Record the skip in the lock so its shape stays consistent
-            # (every declared feature appears) without fetching. Preserve
-            # a real SHA from the prior lock if one exists (an interleaved
-            # `update_features <name>` may have already resolved it) — only
-            # write sha='skipped' when there's nothing better to keep.
-            prior = lock_map.get(feature["name"])
-            prior_sha = prior.get("sha") if prior else None
-            lock_map[feature["name"]] = {
-                "name": feature["name"],
-                "git": feature["git"],
-                "path": feature.get("path", ""),
-                "ref": feature.get("ref", "main"),
-                "sha": prior_sha if prior_sha and prior_sha != "skipped" else "skipped",
-            }
+            lock_map[feature["name"]] = skipped_lock_entry(feature, lock_map)
             return None
         return fetch_feature(feature, payload_dir)
     if "path" in feature:
@@ -381,58 +426,84 @@ def materialize_feature(feature: dict, args, lock_map: dict, payload_dir: str):
     return None
 
 
+def declared_feature_names(config: dict) -> set:
+    """Names of features.yaml entries that declare a source (git or path)."""
+    return {
+        feature_name(p) for p in config.get("features", []) if "git" in p or "path" in p
+    }
+
+
+def remove_feature_dir(payload_dir: str, name: str) -> None:
+    """Remove a materialized feature (symlink or tree)."""
+    feature_dir = os.path.join(payload_dir, name)
+    if os.path.islink(feature_dir):
+        os.unlink(feature_dir)
+    elif os.path.isdir(feature_dir):
+        shutil.rmtree(feature_dir)
+    else:
+        return
+    print(f"  Removed {name} (no longer in features.yaml)")
+
+
 def prune_dropped_features(config: dict, lock_map: dict, payload_dir: str) -> None:
     """Remove features that were in the old lockfile but dropped from
     features.yaml."""
-    yaml_names = {
-        feature_name(p) for p in config.get("features", []) if "git" in p or "path" in p
-    }
+    yaml_names = declared_feature_names(config)
     for name in list(lock_map):
         if name not in yaml_names:
-            feature_dir = os.path.join(payload_dir, name)
-            if os.path.islink(feature_dir):
-                os.unlink(feature_dir)
-                print(f"  Removed {name} (no longer in features.yaml)")
-            elif os.path.isdir(feature_dir):
-                shutil.rmtree(feature_dir)
-                print(f"  Removed {name} (no longer in features.yaml)")
+            remove_feature_dir(payload_dir, name)
             del lock_map[name]
 
 
-def main(argv=None):
-    args = parse_args(argv)
-
+def load_config() -> dict | None:
+    """Parse features.yaml; None (with an ERROR print) when it's missing."""
     if not os.path.isfile(YAML_PATH):
         print(
             f"ERROR: {YAML_PATH} not found — the feature declaration list is "
             "checked into the repo at its root. Run from a klangk checkout.",
             file=sys.stderr,
         )
+        return None
+    with open(YAML_PATH) as f:
+        return yaml.safe_load(f)
+
+
+def print_fetch_plan(features: list, payload_dir: str, args) -> None:
+    """Announce the fetch + remind about --payload-dir when defaulted."""
+    print(f"Fetching {len(features)} feature{'s' if len(features) != 1 else ''}...")
+    if not args.payload_dir:
+        print(f"  (payload dir: {payload_dir} — pass --payload-dir to pin it)")
+
+
+def materialize_all(features: list, args, lock_map: dict, payload_dir: str) -> None:
+    """Fetch/link every selected feature, merging lock entries."""
+    for feature in features:
+        entry = materialize_feature(feature, args, lock_map, payload_dir)
+        if entry:
+            lock_map[entry["name"]] = entry
+
+
+def main(argv=None):
+    args = parse_args(argv)
+
+    config = load_config()
+    if config is None:
         return 1
 
     payload_dir = args.payload_dir or _make_temp_payload_dir()
     os.makedirs(payload_dir, exist_ok=True)
     lock_path = os.path.join(payload_dir, "features.lock")
 
-    with open(YAML_PATH) as f:
-        config = yaml.safe_load(f)
-
     features = select_features(config, args.only)
     if not features:
         return 0
 
-    print(f"Fetching {len(features)} feature{'s' if len(features) != 1 else ''}...")
-    if not args.payload_dir:
-        print(f"  (payload dir: {payload_dir} — pass --payload-dir to pin it)")
+    print_fetch_plan(features, payload_dir, args)
 
     # Preserve existing lock entries when updating a single feature
-    old_lock = read_lock(lock_path)
-    lock_map = dict(old_lock)
+    lock_map = dict(read_lock(lock_path))
 
-    for feature in features:
-        entry = materialize_feature(feature, args, lock_map, payload_dir)
-        if entry:
-            lock_map[entry["name"]] = entry
+    materialize_all(features, args, lock_map, payload_dir)
 
     if not args.only:
         prune_dropped_features(config, lock_map, payload_dir)

--- a/src/klangksidecar/klangksidecar/allowlist.py
+++ b/src/klangksidecar/klangksidecar/allowlist.py
@@ -29,6 +29,41 @@ INCLUSIVE = "inclusive"
 SUBDOMAINS = "subdomains"
 
 
+def _split_spec_port(spec: str) -> tuple[str, int | None]:
+    """Split a trailing ``:port`` off a spec -> ``(host_part, port)``; the
+    port is None when absent or not numeric (then the whole spec is the host,
+    e.g. a bare IPv6 literal fragment)."""
+    if ":" not in spec:
+        return spec, None
+    host_part, port_part = spec.rsplit(":", 1)
+    if port_part.isdigit():
+        return host_part, int(port_part)
+    return spec, None
+
+
+def _spec_scope(s: str) -> tuple[str, str]:
+    """The nginx-style host-scope strip (#2377) -> ``(host, mode)``: a leading
+    ``*.`` is SUBDOMAINS, a leading ``.`` is INCLUSIVE, bare is EXACT."""
+    if s.startswith("*."):
+        return s[2:], SUBDOMAINS
+    if s.startswith("."):
+        return s[1:], INCLUSIVE
+    return s, EXACT
+
+
+def _parse_one_spec(spec: str) -> tuple[str, int | None, str] | None:
+    """One comma-separated entry -> ``(host, port, mode)``, or None when it
+    is empty/a CIDR (CIDR specs are applied statically by the entrypoint)."""
+    spec = spec.strip()
+    if not spec or "/" in spec:
+        return None
+    spec, port = _split_spec_port(spec)
+    s, mode = _spec_scope(spec.lower())
+    if not s:
+        return None
+    return s, port, mode
+
+
 def parse_specs(
     env_var: str = "KLANGKNETWORK_EGRESS_ALLOW",
 ) -> list[tuple[str, int | None, str]]:
@@ -42,25 +77,9 @@ def parse_specs(
     """
     out: list[tuple[str, int | None, str]] = []
     for spec in os.environ.get(env_var, "").split(","):
-        spec = spec.strip()
-        if not spec or "/" in spec:
-            continue
-        port: int | None = None
-        if ":" in spec:
-            host_part, port_part = spec.rsplit(":", 1)
-            if port_part.isdigit():
-                port = int(port_part)
-                spec = host_part
-        s = spec.lower()
-        mode = EXACT
-        if s.startswith("*."):
-            mode = SUBDOMAINS
-            s = s[2:]
-        elif s.startswith("."):
-            mode = INCLUSIVE
-            s = s[1:]
-        if s:
-            out.append((s, port, mode))
+        parsed = _parse_one_spec(spec)
+        if parsed is not None:
+            out.append(parsed)
     return out
 
 
@@ -155,6 +174,21 @@ def _add_session_entry(lst: list, host: str, port: int, ttl: float) -> None:
     lst.append((host, port, EXACT, expire))
 
 
+def _entry_remaining(entry: tuple, host: str, port: int, now: float) -> float | None:
+    """Remaining TTL an *lst* entry covers ``host:port``, or None (expired,
+    no match, or port mismatch). Matches via :func:`host_matches`; the entry's
+    port must match or be all-ports (``None``)."""
+    h, p, mode, exp = entry
+    if exp <= now:
+        return None  # belt-and-suspenders: _prune ran above, but a just-expired
+        # entry can survive the microseconds between its `now` and this one.
+    if not host_matches(host, h, mode):
+        return None
+    if p != port and p is not None:
+        return None
+    return exp - now
+
+
 def session_entry_ttl(lst: list, host: str, port: int) -> float | None:
     """Max remaining TTL of an entry in *lst* covering ``host:port``, or None.
 
@@ -167,16 +201,10 @@ def session_entry_ttl(lst: list, host: str, port: int) -> float | None:
     if not host:
         return None
     now = time.time()
-    best: float | None = None
-    for h, p, mode, exp in lst:
-        if exp <= now:
-            continue  # belt-and-suspenders: _prune ran above, but a just-expired
-            # entry can survive the microseconds between its `now` and this one.
-        if host_matches(host, h, mode) and (p == port or p is None):
-            remaining = exp - now
-            if best is None or remaining > best:
-                best = remaining
-    return best
+    remainings = [
+        r for e in lst if (r := _entry_remaining(e, host, port, now)) is not None
+    ]
+    return max(remainings, default=None)
 
 
 def add_session_host(host: str, port: int, ttl: float) -> None:
@@ -219,6 +247,22 @@ def session_host_allows_ttl(host: str, port: int) -> float | None:
     return session_entry_ttl(state.SESSION_HOST_ALLOWS, host, port)
 
 
+def _matches_static_spec(qname: str) -> bool:
+    """Does any static :data:`SPECS` entry match ``qname`` (any port)?"""
+    return any(host_matches(qname, host, mode) for host, _port, mode in SPECS)
+
+
+def _min_session_allow_ttl(qname: str, now: float) -> float | None:
+    """Min remaining TTL across unexpired session allows matching ``qname``,
+    or None when none matches."""
+    remainings = [
+        exp - now
+        for host, _port, mode, exp in state.SESSION_HOST_ALLOWS
+        if exp > now and host_matches(qname, host, mode)
+    ]
+    return min(remainings, default=None)
+
+
 def session_allow_rule_cap(qname: str) -> float | None:
     """Min remaining TTL bounding a DNS-path learned rule for ``qname``, or
     ``None`` (#2465).
@@ -255,19 +299,10 @@ def session_allow_rule_cap(qname: str) -> float | None:
     NOT covered by the NFQUEUE gate. All real consent flows hit this for a
     single host:port, where the cap is exact.
     """
-    if any(host_matches(qname, host, mode) for host, _port, mode in SPECS):
+    if _matches_static_spec(qname):
         return None  # a static spec matches -> forever -> DNS TTL is correct
     _prune_session_allows()
-    now = time.time()
-    best: float | None = None
-    for host, _port, mode, exp in state.SESSION_HOST_ALLOWS:
-        if exp <= now:
-            continue
-        if host_matches(qname, host, mode):
-            remaining = exp - now
-            if best is None or remaining < best:
-                best = remaining
-    return best
+    return _min_session_allow_ttl(qname, time.time())
 
 
 def _prune_session_denies() -> None:

--- a/src/klangksidecar/klangksidecar/app.py
+++ b/src/klangksidecar/klangksidecar/app.py
@@ -126,6 +126,67 @@ def resolve_ws_host(consent_url: str) -> str | None:
     return ip
 
 
+async def start_consent_client() -> SidecarConsentClient | None:
+    """Start the WS consent client when consent is configured (a
+    :data:`config.CONSENT_URL`), else None (static mode)."""
+    if not config.CONSENT_URL:
+        return None
+    client = consent.SidecarConsentClient(
+        config.CONSENT_URL, WORKSPACE_TOKEN_PATH, HOLD_TIMEOUT
+    )
+    await client.start()
+    return client
+
+
+def bind_dns_socket() -> socket.socket:
+    """Bind the non-blocking UDP DNS socket the per-query loop serves on."""
+    s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    s.bind(("127.0.0.1", LISTEN_PORT))
+    s.setblocking(False)
+    print(
+        f"dns-proxy listening on 127.0.0.1:{LISTEN_PORT} "
+        f"(upstream={UPSTREAM[0]}, allowed={allowlist.SPECS})",
+        flush=True,
+    )
+    return s
+
+
+async def start_consent_services(loop, client: SidecarConsentClient) -> tuple:
+    """Start the NFQUEUE consumer + the egress sampler (interactive mode).
+
+    #2485: the egress byte-accounting rule + the sampler that bumps the idle
+    timer on real workspace traffic (long-lived / UDP flows the #2481 DNS+SYN
+    hooks miss). Best-effort; a missing rule -> flat zero counter -> sampler
+    never bumps (falls back to #2481). resolve_ws_host scopes the rule to
+    exclude the sidecar's own WS so its keepalives can't self-sustain the
+    timer. Resolve + install run off-loop (gethostbyname + 2 iptables forks
+    are blocking), matching the rest of startup. Returns ``(nfq, sampler)``.
+    """
+    packets.check_rst_socket()  # eager-deny RST forge (#2345); best-effort (NET_RAW)
+    nfq = nfqueue.setup_nfq_consumer(client)  # bound NFQUEUE, for shutdown (#2400)
+    ws_ip = await loop.run_in_executor(None, resolve_ws_host, config.CONSENT_URL)
+    await loop.run_in_executor(None, rules.install_acct, ws_ip)
+    sampler = asyncio.create_task(
+        consent.activity_sampler(client, rules.acct_bytes, config.ACTIVITY_GATE_S)
+    )
+    BG_TASKS.add(sampler)
+    sampler.add_done_callback(BG_TASKS.discard)
+    return nfq, sampler
+
+
+async def serve_dns(s: socket.socket, client: SidecarConsentClient | None) -> None:
+    """The per-query recv loop; exits only via the SIGTERM CancelledError,
+    never by falling through the condition -- the arc to loop exit is
+    unreachable."""
+    loop = asyncio.get_running_loop()
+    while True:  # pragma: no branch
+        try:
+            data, addr = await loop.sock_recvfrom(s, 65535)
+        except Exception:
+            continue
+        await resolve.handle_packet(s, data, addr, client)
+
+
 async def async_main() -> None:
     """The asyncio DNS loop (#2311 half B, #2324): allow-listed + denied names
     resolve inline; a denied name in interactive mode records IP->host so its
@@ -136,45 +197,18 @@ async def async_main() -> None:
     PID 1, and the kernel suppresses default terminate dispositions for init).
     """
     loop = asyncio.get_running_loop()
-    client: SidecarConsentClient | None = None
-    if config.CONSENT_URL:
-        client = consent.SidecarConsentClient(
-            config.CONSENT_URL, WORKSPACE_TOKEN_PATH, HOLD_TIMEOUT
-        )
-        await client.start()
-    s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-    s.bind(("127.0.0.1", LISTEN_PORT))
-    s.setblocking(False)
-    print(
-        f"dns-proxy listening on 127.0.0.1:{LISTEN_PORT} "
-        f"(upstream={UPSTREAM[0]}, allowed={allowlist.SPECS})",
-        flush=True,
-    )
+    client = await start_consent_client()
+    s = bind_dns_socket()
     rules.check_mark()
     _sweep = asyncio.create_task(rules.async_sweeper())
     BG_TASKS.add(_sweep)  # strong ref for the loop's lifetime
     _sweep.add_done_callback(BG_TASKS.discard)
-    nfq = None
-    _sampler: asyncio.Task | None = None
     # NFQUEUE consumer is driven by this event loop (get_fd + add_reader) so a
     # slow verdict on one SYN doesn't serialize others (#2324, #2329).
-    if config.CONSENT_URL:
-        packets.check_rst_socket()  # eager-deny RST forge (#2345); best-effort (NET_RAW)
-        nfq = nfqueue.setup_nfq_consumer(client)  # bound NFQUEUE, for shutdown (#2400)
-        # #2485: egress byte-accounting rule + the sampler that bumps the idle
-        # timer on real workspace traffic (long-lived / UDP flows the #2481
-        # DNS+SYN hooks miss). Best-effort; a missing rule -> flat zero counter
-        # -> sampler never bumps (falls back to #2481). resolve_ws_host scopes
-        # the rule to exclude the sidecar's own WS so its keepalives can't
-        # self-sustain the timer. Resolve + install run off-loop (gethostbyname
-        # + 2 iptables forks are blocking), matching the rest of startup.
-        ws_ip = await loop.run_in_executor(None, resolve_ws_host, config.CONSENT_URL)
-        await loop.run_in_executor(None, rules.install_acct, ws_ip)
-        _sampler = asyncio.create_task(
-            consent.activity_sampler(client, rules.acct_bytes, config.ACTIVITY_GATE_S)
-        )
-        BG_TASKS.add(_sampler)
-        _sampler.add_done_callback(BG_TASKS.discard)
+    nfq = None
+    _sampler: asyncio.Task | None = None
+    if client is not None:
+        nfq, _sampler = await start_consent_services(loop, client)
     # The sidecar is PID 1 (entrypoint.sh execs python). The kernel suppresses
     # default terminate/stop dispositions for a PID-namespace init: a SIGTERM
     # with no handler installed is effectively ignored, so podman's `stop -t 5`
@@ -208,14 +242,7 @@ async def async_main() -> None:
     except (NotImplementedError, RuntimeError):
         pass  # signal handlers need the main thread + a supported loop backend
     try:
-        # Exits only via the SIGTERM CancelledError above, never by falling
-        # through the condition -- the arc to loop exit is unreachable.
-        while True:  # pragma: no branch
-            try:
-                data, addr = await loop.sock_recvfrom(s, 65535)
-            except Exception:
-                continue
-            await resolve.handle_packet(s, data, addr, client)
+        await serve_dns(s, client)
     except asyncio.CancelledError:
         if DEBUG:
             print("dns-proxy: stop signal received, shutting down", flush=True)

--- a/src/klangksidecar/klangksidecar/consent.py
+++ b/src/klangksidecar/klangksidecar/consent.py
@@ -50,6 +50,14 @@ def ws_url(consent_url: str) -> str:
     return consent_url  # already ws(s)://, or an exotic scheme used verbatim
 
 
+def verdict_result(msg: dict) -> tuple[str, str]:
+    """The ``(decision, duration)`` a verdict frame resolves a pending hold
+    to: any non-"allow" verdict (deny, expired, malformed) -> deny."""
+    decision = msg.get("decision")
+    token = decision if decision == "allow" else "deny"
+    return token, msg.get("duration") or "once"
+
+
 class SidecarConsentClient:
     """Persistent WS client to klangkd's ``/ws/egress-sidecar`` (#2311 half B).
 
@@ -112,6 +120,56 @@ class SidecarConsentClient:
                 pass
         self._fail_close_pending()
 
+    def _warn_token_missing(self) -> None:
+        """One-shot DEBUG note while the workspace JWT has not been written
+        (expected at startup; retried without escalating backoff)."""
+        if DEBUG and not self._no_token_warned:
+            print(
+                "consent: workspace token not yet present; retrying",
+                flush=True,
+            )
+            self._no_token_warned = True
+
+    async def _try_connect(self, token: str) -> bool:
+        """One connect/serve/disconnect cycle. Returns True when the connection
+        was established (the caller resets its backoff)."""
+        connected = False
+        try:
+            async with websockets.connect(
+                self._url,
+                ping_interval=20,
+                ping_timeout=10,
+                close_timeout=5,
+                additional_headers={"Authorization": "Bearer " + token},
+            ) as ws:
+                self._ws = ws
+                self._connected.set()
+                self._no_token_warned = False
+                connected = True
+                if DEBUG:
+                    print(f"consent: connected to {self._url}", flush=True)
+                async for raw in ws:
+                    await self._dispatch(raw)
+        except Exception as exc:
+            # Log the exception TYPE only -- the connection carries the
+            # workspace JWT (Authorization header), and a websockets
+            # exception could embed request details (#2309). The websockets
+            # package logger is capped at WARNING on import so its DEBUG
+            # request-line can't leak either.
+            if DEBUG:
+                print(
+                    f"consent: connection error: {type(exc).__name__}",
+                    flush=True,
+                )
+        finally:
+            # Disconnected (clean close, error, or crash): the sidecar's
+            # held connections die with it (fail-close). Any in-flight
+            # request resolves to deny so its caller NXDOMAIN/DROPs.
+            self._ws = None
+            self._connected.clear()
+            self._fail_close_pending()
+        return connected
+
     async def run(self) -> None:
         backoff = 1.0
         while not self._stop:
@@ -119,48 +177,11 @@ class SidecarConsentClient:
             if not token:
                 # Token file not present yet (workspace JWT not written). Retry
                 # without escalating backoff (expected at startup).
-                if DEBUG and not self._no_token_warned:
-                    print(
-                        "consent: workspace token not yet present; retrying",
-                        flush=True,
-                    )
-                    self._no_token_warned = True
+                self._warn_token_missing()
                 await asyncio.sleep(1.0)
                 continue
-            try:
-                async with websockets.connect(
-                    self._url,
-                    ping_interval=20,
-                    ping_timeout=10,
-                    close_timeout=5,
-                    additional_headers={"Authorization": "Bearer " + token},
-                ) as ws:
-                    self._ws = ws
-                    self._connected.set()
-                    self._no_token_warned = False
-                    backoff = 1.0
-                    if DEBUG:
-                        print(f"consent: connected to {self._url}", flush=True)
-                    async for raw in ws:
-                        await self._dispatch(raw)
-            except Exception as exc:
-                # Log the exception TYPE only -- the connection carries the
-                # workspace JWT (Authorization header), and a websockets
-                # exception could embed request details (#2309). The websockets
-                # package logger is capped at WARNING on import so its DEBUG
-                # request-line can't leak either.
-                if DEBUG:
-                    print(
-                        f"consent: connection error: {type(exc).__name__}",
-                        flush=True,
-                    )
-            finally:
-                # Disconnected (clean close, error, or crash): the sidecar's
-                # held connections die with it (fail-close). Any in-flight
-                # request resolves to deny so its caller NXDOMAIN/DROPs.
-                self._ws = None
-                self._connected.clear()
-                self._fail_close_pending()
+            if await self._try_connect(token):
+                backoff = 1.0
             if self._stop:
                 break
             await asyncio.sleep(backoff)
@@ -181,15 +202,60 @@ class SidecarConsentClient:
 
     def apply_verdict(self, msg: dict) -> None:
         vid = msg.get("id")
-        decision = msg.get("decision")
         if not isinstance(vid, str):
             return
         fut = self._pending.pop(vid, None)
         if fut is not None and not fut.done():
-            # Any non-"allow" verdict (deny, expired, malformed) -> deny.
-            token = decision if decision == "allow" else "deny"
-            duration = msg.get("duration") or "once"
-            fut.set_result((token, duration))
+            fut.set_result(verdict_result(msg))
+
+    def _drop_session_rules(self, host: str, decision: str) -> None:
+        """Close the session gates BEFORE the executor window (#2370, #2446).
+
+        While :func:`klangksidecar.rules.drop_for_host` forks iptables
+        off-loop (~tens of ms), a racing SYN/DNS could read the loop-only
+        session lists and re-install a fresh ACCEPT (an allow revoke) or keep
+        auto-denying (a deny revoke) that the revoke never clears; clearing
+        them first on the loop makes both gates deny during the window. (A
+        deny never adds to SESSION_HOST_ALLOWS, so skip it there.)"""
+        if decision == "allowed":
+            allowlist.drop_session_hosts(host)
+        # The caller already restricted decision to allowed/denied, so exactly
+        # one of these branches runs -- the elif's false arc (neither) is
+        # unreachable.
+        elif decision == "denied":  # pragma: no branch
+            allowlist.drop_session_denies(host)
+
+    async def _drop_host_rules(self, host, decision) -> bool:
+        """Run the revoke off the loop; True once the rule is gone and the
+        cached verdicts cleared."""
+        if not (isinstance(host, str) and decision in ("allowed", "denied")):
+            return False
+        self._drop_session_rules(host, decision)
+        try:
+            ips = await asyncio.get_running_loop().run_in_executor(
+                None, rules.drop_for_host, host, decision
+            )
+            # Drop the host's cached verdicts on the loop AFTER the rule
+            # removal (loop-only dict). A cache hit only pkt.accept()s a
+            # retransmit -- it does not re-install an ACCEPT -- so this is
+            # safe after the drop and needs no window protection.
+            clear_verdict_cache(ips)
+            # The ack means "the rule is dropped" (#2339); the loop-state
+            # clears are pure dict ops and don't affect it.
+            return True
+        except Exception:
+            return False
+
+    async def _send_drop_ack(self, ack_id, ok: bool) -> None:
+        """Best-effort drop_ack frame back to klangkd."""
+        if not (isinstance(ack_id, str) and self._ws is not None):
+            return
+        try:
+            await self._ws.send(
+                json.dumps({"type": "drop_ack", "id": ack_id, "ok": ok})
+            )
+        except Exception:
+            pass
 
     async def handle_drop_rule(self, msg: dict) -> None:
         """klangkd asked us to drop a host's rules (revocation, #2339).
@@ -197,50 +263,8 @@ class SidecarConsentClient:
         Runs :func:`drop_for_host` off the loop (it forks iptables) and acks
         back so klangkd marks the verdict revoked only once the rule is gone.
         """
-        ack_id = msg.get("id")
-        host = msg.get("host")
-        decision = msg.get("decision")
-        ok = False
-        if isinstance(host, str) and decision in ("allowed", "denied"):
-            # #2370: close the session-allow gates BEFORE the executor window.
-            # While drop_for_host forks iptables off-loop (~tens of ms), a racing
-            # SYN/DNS could read SESSION_HOST_ALLOWS and re-install a fresh
-            # ACCEPT (the host's remaining allow TTL) the revoke never clears.
-            # drop_session_hosts runs on the loop (loop-only structure) and
-            # makes cb's session_host_allows_ttl + ports_for deny during the
-            # window. (A deny never adds to SESSION_HOST_ALLOWS, so skip it
-            # there.)
-            if decision == "allowed":
-                allowlist.drop_session_hosts(host)
-            # The outer guard already restricted decision to allowed/denied,
-            # so exactly one of these branches runs -- the elif's false arc
-            # (neither) is unreachable.
-            elif decision == "denied":  # pragma: no branch
-                # Clear the host-scoped deny memory (#2446) BEFORE drop_for_host
-                # forks iptables, so a SYN arriving during that window re-prompts
-                # instead of staying auto-denied (mirror of the allow revoke).
-                allowlist.drop_session_denies(host)
-            try:
-                ips = await asyncio.get_running_loop().run_in_executor(
-                    None, rules.drop_for_host, host, decision
-                )
-                # Drop the host's cached verdicts on the loop AFTER the rule
-                # removal (loop-only dict). A cache hit only pkt.accept()s a
-                # retransmit -- it does not re-install an ACCEPT -- so this is
-                # safe after the drop and needs no window protection.
-                clear_verdict_cache(ips)
-                # The ack means "the rule is dropped" (#2339); the loop-state
-                # clears above are pure dict ops and don't affect it.
-                ok = True
-            except Exception:
-                ok = False
-        if isinstance(ack_id, str) and self._ws is not None:
-            try:
-                await self._ws.send(
-                    json.dumps({"type": "drop_ack", "id": ack_id, "ok": ok})
-                )
-            except Exception:
-                pass
+        ok = await self._drop_host_rules(msg.get("host"), msg.get("decision"))
+        await self._send_drop_ack(msg.get("id"), ok)
 
     async def request(self, dst: str, dport: int | None) -> tuple[str, str]:
         """Send an egress frame + await the verdict. Fail-close -> ``("deny",

--- a/src/klangksidecar/klangksidecar/nfqueue.py
+++ b/src/klangksidecar/klangksidecar/nfqueue.py
@@ -96,25 +96,71 @@ def classify_packet(payload: bytes) -> tuple[str, int, str, int] | None:
     return src_ip, src_port, dst, port
 
 
-def cb(pkt, client: SidecarConsentClient | None) -> None:
-    """Classify + route one queued SYN -- non-blocking (#2324, #2329).
-
-    A retransmit of an already-decided connection reuses the cached verdict
-    inline (fast path). A new connection is retained + handed to
-    :func:`decide_and_verdict` so the verdict wait doesn't block the queue's
-    drain (distinct connections are held concurrently, not serialized behind
-    the first).
-    """
-    # Every queued SYN is outbound egress activity -- bump klangkd's idle timer
-    # (flood-gated inside the client) so an egress-only workload is not reaped
-    # (#2479). First, before any classification: even a SYN we drop (cached
-    # deny / retransmit) is real network activity.
+def _bump_activity(client: SidecarConsentClient | None) -> None:
+    """Every queued SYN is outbound egress activity -- bump klangkd's idle
+    timer (flood-gated inside the client) so an egress-only workload is not
+    reaped (#2479). First, before any classification: even a SYN we drop
+    (cached deny / retransmit) is real network activity."""
     if client is not None:
         client.bump_activity()
+
+
+def _drop_unroutable(pkt, key, client: SidecarConsentClient | None) -> bool:
+    """Unparseable or pure-static (no consent configured): drop the SYN.
+    Returns True when handled."""
+    if key is None or client is None:
+        pkt.drop()
+        return True
+    return False
+
+
+def _cached_verdict_for(flow: tuple, now: float) -> tuple | None:
+    """The still-valid cached verdict for ``flow``, if any."""
+    cached = VERDICT_CACHE.get(flow)
+    if cached is not None and cached[1] > now:
+        return cached
+    return None
+
+
+def _verdict_fast_path(pkt, payload, flow: tuple, port: int, now: float) -> bool:
+    """SYN-retransmit handling before prompting. A retransmit of an
+    already-decided connection reuses the cached verdict inline so the
+    kernel's retransmits (tcp_syn_retries) don't each re-prompt. A SYN that
+    arrives WHILE this connection is still held (no verdict yet) must not
+    spawn a second consent request: the in-flight task resolves it, and a
+    request per retransmit piles up duplicates that linger past the first's
+    resolution (#2345 e2e flake) -- drop it; the kernel sends another
+    retransmit once the verdict lands, and that one hits the cache.
+    Returns True when the SYN was handled."""
+    cached = _cached_verdict_for(flow, now)
+    if cached is not None:
+        apply_cached_verdict(pkt, cached, payload, port)
+        return True
+    if flow in INFLIGHT:
+        pkt.drop()
+        return True
+    return False
+
+
+def _dispatch_verdict(
+    pkt, flow: tuple, dst: str, port: int, host: str, client: SidecarConsentClient
+) -> None:
+    """Retain the SYN + hand the verdict wait to a task so the verdict wait
+    doesn't block the queue's drain (distinct connections are held
+    concurrently, not serialized behind the first)."""
+    pkt.retain()  # keep the payload valid past this callback (deferred verdict)
+    INFLIGHT.add(flow)
+    t = asyncio.create_task(decide_and_verdict(pkt, flow, dst, port, host, client))
+    BG_TASKS.add(t)  # strong ref so the verdict task isn't GC'd
+    t.add_done_callback(BG_TASKS.discard)
+
+
+def cb(pkt, client: SidecarConsentClient | None) -> None:
+    """Classify + route one queued SYN -- non-blocking (#2324, #2329)."""
+    _bump_activity(client)
     payload = pkt.get_payload()
     key = classify_packet(payload)
-    if key is None or client is None:
-        pkt.drop()  # unparseable / pure-static (no consent configured) -> drop
+    if _drop_unroutable(pkt, key, client):
         return
     src_ip, src_port, dst, port = key
     if not client.connected:
@@ -122,28 +168,12 @@ def cb(pkt, client: SidecarConsentClient | None) -> None:
         return
     flow = (src_ip, src_port, dst, port)
     now = time.time()
-    # SYN retransmit of an already-decided connection -> reuse the verdict so
-    # the kernel's retransmits (tcp_syn_retries) don't each re-prompt.
-    cached = VERDICT_CACHE.get(flow)
-    if cached is not None and cached[1] > now:
-        apply_cached_verdict(pkt, cached, payload, port)
-        return
-    # A SYN retransmit that arrives WHILE this connection is still held (no
-    # verdict yet) must not spawn a second consent request: the in-flight task
-    # resolves it, and a request per retransmit piles up duplicates that linger
-    # past the first's resolution (#2345 e2e flake). Drop it -- the kernel sends
-    # another retransmit once the verdict lands, and that one hits the cache.
-    if flow in INFLIGHT:
-        pkt.drop()
+    if _verdict_fast_path(pkt, payload, flow, port, now):
         return
     host = host_for(dst)  # DNS name if resolved here, else the IP
     if _session_gate_holds(pkt, flow, payload, dst, port, host, now):
         return
-    pkt.retain()  # keep the payload valid past this callback (deferred verdict)
-    INFLIGHT.add(flow)
-    t = asyncio.create_task(decide_and_verdict(pkt, flow, dst, port, host, client))
-    BG_TASKS.add(t)  # strong ref so the verdict task isn't GC'd
-    t.add_done_callback(BG_TASKS.discard)
+    _dispatch_verdict(pkt, flow, dst, port, host, client)
 
 
 def _session_gate_holds(
@@ -335,6 +365,68 @@ def remember_session_verdict(
         add_session_deny(host, port, ttl)
 
 
+async def _apply_allow_verdict(pkt, dst: str, ttl: float | None, loop) -> None:
+    """Allow: learn the IP all-ports (reconnects + this connection's SYN
+    retransmits pass without re-prompting) + ``pkt.accept()`` (conntrack
+    ESTABLISHED,RELATED carries the in-flight connection). ``once`` (ttl
+    None) -> no learn, just this connection (reconnect re-prompts)."""
+    if ttl is not None:
+        try:
+            await loop.run_in_executor(None, rules.allow, dst, None, ttl, False)
+        except Exception:
+            pass
+    pkt.accept()
+
+
+def _deny_reject_args(flow: tuple, ttl: float | None) -> tuple[float, int]:
+    """``(reject_ttl, sport)`` for a deny verdict. ``once`` is
+    per-connection: scope the REJECT to THIS connection's source port so a
+    NEW connection (different sport) to the same host:port re-prompts instead
+    of being rejected above NFQUEUE for the fail-close window (#2463). A
+    timed/forever deny stays destination-scoped (sport 0) -- its over-deny is
+    correct (the DB rule + SESSION_HOST_DENIES govern re-prompting). The
+    source port is guarded: a real TCP SYN never has src port 0 (RFC 793),
+    so a truthy flow[1] is the normal case; if it is ever 0 (a
+    non-TCP/unparseable flow), sport 0 falls back to destination-scoped so a
+    future parse change can't silently re-introduce the over-deny."""
+    reject_ttl = ttl if ttl is not None else CONSENT_REJECT_TTL
+    sport = flow[1] if ttl is None else 0
+    return reject_ttl, sport
+
+
+def _forge_deny_rst(pkt, port: int) -> None:
+    """Forge the RST directly so connect() fails fast (ECONNREFUSED) at once,
+    independent of the conntrack/retransmit race that made the REJECT rule
+    flaky (#2345). TCP only (port 0 is non-TCP)."""
+    if not port:
+        return
+    try:
+        packets.send_rst(pkt.get_payload())
+    except Exception:
+        pass
+
+
+async def _apply_deny_verdict(
+    pkt, flow: tuple, dst: str, port: int, ttl: float | None, loop
+) -> None:
+    """Deny: the forged RST plus the REJECT (tcp-reset) backstop for any
+    retransmit the RST missed -- the short fail-close window for ``once``, or
+    the verdict's window for a timed duration -- then drop."""
+    _forge_deny_rst(pkt, port)
+    if port:
+        reject_ttl, sport = _deny_reject_args(flow, ttl)
+        try:
+            if sport:
+                await loop.run_in_executor(
+                    None, rules.reject, dst, port, reject_ttl, sport
+                )
+            else:
+                await loop.run_in_executor(None, rules.reject, dst, port, reject_ttl)
+        except Exception:
+            pass
+    pkt.drop()
+
+
 async def apply_verdict(
     pkt,
     flow,
@@ -349,43 +441,6 @@ async def apply_verdict(
     matches the DNS path's learn_all; the packet is retained, so verdicting
     after the await is safe)."""
     if decision == "allow":
-        # `once` (ttl None) -> no learn, just this connection (reconnect
-        # re-prompts); a timed duration -> learn all-ports for it.
-        if ttl is not None:
-            try:
-                await loop.run_in_executor(None, rules.allow, dst, None, ttl, False)
-            except Exception:
-                pass
-        pkt.accept()
+        await _apply_allow_verdict(pkt, dst, ttl, loop)
         return
-    # Forge a RST directly so connect() fails fast (ECONNREFUSED) at once,
-    # independent of the conntrack/retransmit race that made the REJECT
-    # rule flaky (#2345). The REJECT rule stays as a belt-and-suspenders
-    # backstop for any retransmit the RST missed. `once` -> the short
-    # fail-close reject window; a timed duration -> that long.
-    # ``once`` is per-connection: scope the REJECT to THIS connection's
-    # source port so a NEW connection (different sport) to the same
-    # host:port re-prompts instead of being rejected above NFQUEUE for
-    # the fail-close window (#2463). A timed/forever deny stays
-    # destination-scoped -- its over-deny is correct (the DB rule +
-    # SESSION_HOST_DENIES govern re-prompting). The source port is
-    # guarded: a real TCP SYN never has src port 0 (RFC 793), so a
-    # truthy flow[1] is the normal case; if it is ever 0 (a
-    # non-TCP/unparseable flow), fall back to destination-scoped so a
-    # future parse change can't silently re-introduce the over-deny.
-    if port:
-        try:
-            packets.send_rst(pkt.get_payload())
-        except Exception:
-            pass
-        reject_ttl = ttl if ttl is not None else CONSENT_REJECT_TTL
-        try:
-            if ttl is None and flow[1]:
-                await loop.run_in_executor(
-                    None, rules.reject, dst, port, reject_ttl, flow[1]
-                )
-            else:
-                await loop.run_in_executor(None, rules.reject, dst, port, reject_ttl)
-        except Exception:
-            pass
-    pkt.drop()
+    await _apply_deny_verdict(pkt, flow, dst, port, ttl, loop)

--- a/src/klangksidecar/klangksidecar/packets.py
+++ b/src/klangksidecar/klangksidecar/packets.py
@@ -27,12 +27,18 @@ def rst_debug(msg: str) -> None:
         print(msg, flush=True)
 
 
+def _ethernet_offset(payload: bytes) -> int:
+    """14 when the payload carries a 14-byte Ethernet header before the IPv4
+    packet (bare L3 payloads start at 0)."""
+    if len(payload) > 14 and (payload[0] >> 4) != 4 and (payload[14] >> 4) == 4:
+        return 14  # Ethernet header
+    return 0
+
+
 def ipv4_offsets(payload: bytes) -> tuple[int, int] | None:
     """(header_offset, ihl) for the IPv4 header, or None when the payload is
     not IPv4 (bare L3 or with a 14-byte Ethernet prefix) or too short."""
-    off = 0
-    if len(payload) > 14 and (payload[0] >> 4) != 4 and (payload[14] >> 4) == 4:
-        off = 14  # Ethernet header
+    off = _ethernet_offset(payload)
     if off + 20 > len(payload) or (payload[off] >> 4) != 4:
         return None
     ihl = (payload[off] & 0x0F) * 4
@@ -62,12 +68,24 @@ def parse_dest(payload: bytes) -> tuple[str, int]:
     return dst, port
 
 
+def _syn_tuple_at(payload: bytes, off: int, ihl: int) -> tuple[str, int, str, int, int]:
+    """``(src_ip, src_port, dst_ip, dst_port, seq)`` read at a validated
+    (off, ihl): the SYN's source end (IP:port) is the workspace's local end
+    and becomes the forged RST's *destination*; its sequence number drives
+    the RST's ack (#2345)."""
+    l4 = off + ihl
+    src_ip = ".".join(str(b) for b in payload[off + 12 : off + 16])
+    dst_ip = ".".join(str(b) for b in payload[off + 16 : off + 20])
+    src_port = int.from_bytes(payload[l4 : l4 + 2], "big")
+    dst_port = int.from_bytes(payload[l4 + 2 : l4 + 4], "big")
+    seq = int.from_bytes(payload[l4 + 4 : l4 + 8], "big")
+    return src_ip, src_port, dst_ip, dst_port, seq
+
+
 def parse_syn_tuple(payload: bytes) -> tuple[str, int, str, int, int]:
     """``(src_ip, src_port, dst_ip, dst_port, seq)`` from an IPv4 TCP SYN, or an
     all-zero tuple if unparseable.
 
-    The SYN's source end (IP:port) is the workspace's local end and becomes the
-    forged RST's *destination*; its sequence number drives the RST's ack (#2345).
     Pure (mirrors :func:`parse_dest`'s L3/L4 offset logic) so it can be
     unit-tested with synthetic bytes.
     """
@@ -80,12 +98,7 @@ def parse_syn_tuple(payload: bytes) -> tuple[str, int, str, int, int]:
     l4 = off + ihl
     if l4 + 12 > len(payload):  # sport + dport + seq
         return "", 0, "", 0, 0
-    src_ip = ".".join(str(b) for b in payload[off + 12 : off + 16])
-    dst_ip = ".".join(str(b) for b in payload[off + 16 : off + 20])
-    src_port = int.from_bytes(payload[l4 : l4 + 2], "big")
-    dst_port = int.from_bytes(payload[l4 + 2 : l4 + 4], "big")
-    seq = int.from_bytes(payload[l4 + 4 : l4 + 8], "big")
-    return src_ip, src_port, dst_ip, dst_port, seq
+    return _syn_tuple_at(payload, off, ihl)
 
 
 def ones_checksum(data: bytes) -> int:

--- a/src/klangksidecar/klangksidecar/resolve.py
+++ b/src/klangksidecar/klangksidecar/resolve.py
@@ -58,6 +58,15 @@ def nxdomain_for(wire: bytes) -> bytes:
     return resp.to_wire()
 
 
+def a_records_or_none(resp: bytes) -> list[tuple[str, int]]:
+    """``a_records_with_ttl`` with a parse failure swallowed (``[]``) so a
+    malformed upstream response drops only this one response, not the proxy."""
+    try:
+        return a_records_with_ttl(resp)
+    except Exception:
+        return []
+
+
 async def respond_allowed(
     s: socket.socket,
     resp: bytes,
@@ -77,10 +86,7 @@ async def respond_allowed(
     persist (a partial fail-open).
     """
     loop = asyncio.get_running_loop()
-    try:
-        recs = a_records_with_ttl(resp)
-    except Exception:
-        recs = []
+    recs = a_records_or_none(resp)
     try:
         if recs:
             # Bound a timed session-allow's learned rule at its verdict's
@@ -176,10 +182,7 @@ async def respond_recorded(
     :func:`respond_allowed` minus the ACCEPT install.
     """
     loop = asyncio.get_running_loop()
-    try:
-        recs = a_records_with_ttl(resp)
-    except Exception:
-        recs = []
+    recs = a_records_or_none(resp)
     try:
         if recs:
             await loop.run_in_executor(None, rules.record_hosts, recs, qname)
@@ -221,6 +224,39 @@ def send_nxdomain(s: socket.socket, data: bytes, addr: tuple[str, int]) -> None:
         pass
 
 
+async def send_denied(
+    s: socket.socket,
+    data: bytes,
+    addr: tuple[str, int],
+    qname: str,
+    client: SidecarConsentClient | None,
+) -> None:
+    """The deny path: interactive mode resolves + responds + records IP->host
+    (the SYN is consent-gated at NFQUEUE, not held here at the DNS query);
+    static mode (no client) NXDOMAINs."""
+    if DEBUG:
+        print(f"deny  {qname}", flush=True)
+    if client is not None:
+        await forward_and_record(s, data, addr, qname)
+    else:
+        send_nxdomain(s, data, addr)
+
+
+def _handle_rejected(
+    s: socket.socket, data: bytes, addr: tuple[str, int], qname: str
+) -> bool:
+    """Static deny-list (#2367): a rejected name is NXDOMAIN'd unconditionally,
+    in BOTH static and interactive modes, and takes precedence over the
+    allow-list + consent (a name in both allowed + rejected is rejected).
+    Returns True when handled."""
+    if not rejected_for(qname):
+        return False
+    if DEBUG:
+        print(f"reject {qname}", flush=True)
+    send_nxdomain(s, data, addr)
+    return True
+
+
 async def handle_packet(
     s: socket.socket,
     data: bytes,
@@ -246,24 +282,11 @@ async def handle_packet(
     # bypass NFQUEUE entirely.
     if client is not None:
         client.bump_activity()
-    # Static deny-list (#2367): a rejected name is NXDOMAIN'd unconditionally,
-    # in BOTH static and interactive modes, and takes precedence over the
-    # allow-list + consent (a name in both allowed + rejected is rejected).
-    if rejected_for(qname):
-        if DEBUG:
-            print(f"reject {qname}", flush=True)
-        send_nxdomain(s, data, addr)
+    if _handle_rejected(s, data, addr, qname):
         return
     ports = ports_for(qname)
     deny, port_set = decision(qname, ports)
     if deny:
-        if DEBUG:
-            print(f"deny  {qname}", flush=True)
-        if client is not None:
-            # Interactive: resolve + respond + record IP->host; the SYN is
-            # consent-gated at NFQUEUE (not held here at the DNS query).
-            await forward_and_record(s, data, addr, qname)
-        else:
-            send_nxdomain(s, data, addr)
+        await send_denied(s, data, addr, qname, client)
         return
     await forward_and_learn(s, data, addr, qname, port_set)

--- a/src/klangksidecar/klangksidecar/resolve.py
+++ b/src/klangksidecar/klangksidecar/resolve.py
@@ -242,7 +242,7 @@ async def send_denied(
         send_nxdomain(s, data, addr)
 
 
-def _handle_rejected(
+def handle_rejected(
     s: socket.socket, data: bytes, addr: tuple[str, int], qname: str
 ) -> bool:
     """Static deny-list (#2367): a rejected name is NXDOMAIN'd unconditionally,
@@ -282,7 +282,7 @@ async def handle_packet(
     # bypass NFQUEUE entirely.
     if client is not None:
         client.bump_activity()
-    if _handle_rejected(s, data, addr, qname):
+    if handle_rejected(s, data, addr, qname):
         return
     ports = ports_for(qname)
     deny, port_set = decision(qname, ports)

--- a/src/klangksidecar/klangksidecar/rules.py
+++ b/src/klangksidecar/klangksidecar/rules.py
@@ -55,6 +55,53 @@ def remove(ip: str, port: int | None) -> None:
     )
 
 
+def _floored_expire(ttl: int | float, floor: bool) -> float:
+    """The rule/record expiry for a TTL of ``ttl``: floored at
+    :data:`MIN_TTL` when ``floor`` (the static-spec DNS learn), verbatim when
+    not (a consent-verdict TTL -- see :func:`allow`)."""
+    return time.time() + (max(ttl, MIN_TTL) if floor else ttl)
+
+
+def _record_allow(ip: str, port: int | None, expire: float) -> None:
+    """Create/refresh the learned IP's ``LEARNED`` record for an allow
+    (caller holds :data:`LOCK`)."""
+    rec = LEARNED.get(ip)
+    if rec is None:
+        LEARNED[ip] = {
+            "expire": expire,
+            "rule_expire": expire,
+            "ports": {port},
+            "host": None,
+        }
+        return
+    rec["expire"] = max(rec["expire"], expire)
+    # rule_expire is the ACCEPT rule's lifetime, kept SEPARATE from the
+    # host-mapping expire so a re-resolve's longer DNS TTL can't extend
+    # a consent allow's rule past its verdict (#2408). max() preserves
+    # the longest across static re-learns (#2256); for a consent allow
+    # it is just the verdict's TTL (the pre-existing rule_expire is
+    # absent -- only record_hosts has touched the record -- and `or
+    # 0.0` coerces the None).
+    rec["rule_expire"] = max(rec.get("rule_expire") or 0.0, expire)
+    rec["ports"].add(port)
+    # ``host`` (set by record_hosts) is preserved across re-learn.
+
+
+def _supersede_port_denies(ip: str) -> None:
+    """Remove any lingering per-port REJECTs for ``ip`` (caller holds LOCK).
+
+    An all-ports allow (the consent path) supersedes any prior per-port
+    denies for this IP -- otherwise the all-ports ACCEPT at the top of
+    OUTPUT would silently shadow a lingering REJECT (the decider allowed
+    the host, so a prior port-specific deny no longer applies)."""
+    for key in [k for k in REJECTED if k[0] == ip]:
+        try:
+            remove_reject(*key)
+        except Exception:
+            pass
+        del REJECTED[key]
+
+
 def allow(ip: str, port: int | None, ttl: int | float, floor: bool = True) -> None:
     """Install (if new) the ACCEPT for ``ip[:port]`` and refresh its TTL.
 
@@ -65,7 +112,7 @@ def allow(ip: str, port: int | None, ttl: int | float, floor: bool = True) -> No
     0-TTL-DNS-response safety net (a resolver may hand back a 0-TTL A record,
     and that must not yank the rule the workspace needs to reach the IP it
     just resolved). A *consent-verdict* TTL is the user's intent, not a DNS
-    TTL, so the consent paths (:func:`decide_and_verdict`, the ``cb``
+    TTL, so the consent paths (:func:`nfqueue.decide_and_verdict`, the ``cb``
     in-session auto-allow, and a capped :func:`learn_all`) pass
     ``floor=False`` -- a timed verdict's rule lapses at the verdict, not at
     MIN_TTL (#2465: otherwise a ``5s`` verdict's rule lived 30s under the
@@ -81,40 +128,12 @@ def allow(ip: str, port: int | None, ttl: int | float, floor: bool = True) -> No
     executor (see :func:`learn_all` / :func:`async_sweeper`), so the lock
     genuinely serializes them; contention is negligible.
     """
-    expire = time.time() + (max(ttl, MIN_TTL) if floor else ttl)
+    expire = _floored_expire(ttl, floor)
     with LOCK:
         install(ip, port)
-        rec = LEARNED.get(ip)
-        if rec is None:
-            LEARNED[ip] = {
-                "expire": expire,
-                "rule_expire": expire,
-                "ports": {port},
-                "host": None,
-            }
-        else:
-            rec["expire"] = max(rec["expire"], expire)
-            # rule_expire is the ACCEPT rule's lifetime, kept SEPARATE from the
-            # host-mapping expire so a re-resolve's longer DNS TTL can't extend
-            # a consent allow's rule past its verdict (#2408). max() preserves
-            # the longest across static re-learns (#2256); for a consent allow
-            # it is just the verdict's TTL (the pre-existing rule_expire is
-            # absent -- only record_hosts has touched the record -- and `or
-            # 0.0` coerces the None).
-            rec["rule_expire"] = max(rec.get("rule_expire") or 0.0, expire)
-            rec["ports"].add(port)
-            # ``host`` (set by record_hosts) is preserved across re-learn.
-        # An all-ports allow (the consent path) supersedes any prior per-port
-        # denies for this IP -- otherwise the all-ports ACCEPT at the top of
-        # OUTPUT would silently shadow a lingering REJECT (the decider allowed
-        # the host, so a prior port-specific deny no longer applies).
+        _record_allow(ip, port, expire)
         if port is None:
-            for key in [k for k in REJECTED if k[0] == ip]:
-                try:
-                    remove_reject(*key)
-                except Exception:
-                    pass
-                del REJECTED[key]
+            _supersede_port_denies(ip)
 
 
 def _reject_rule_args(ip: str, port: int, sport: int = 0) -> list[str]:
@@ -182,6 +201,19 @@ def reject(ip: str, port: int, ttl: float, sport: int = 0) -> None:
         REJECTED[(ip, port, sport)] = max(REJECTED.get((ip, port, sport), 0.0), expire)
 
 
+def _drop_targets(host: str) -> set[str]:
+    """The candidate IPs a host revoke must touch (caller holds LOCK):
+    every learned IP that resolved to ``host`` (via ``LEARNED[ip]["host"]``,
+    set by ``record_hosts`` for every resolved name, allow-listed or not),
+    plus the host string itself (a direct-IP connect that never went through
+    DNS, and a direct-IP allow whose ``host`` is ``None``)."""
+    host_l = host.lower()
+    ips = [
+        ip for ip, rec in LEARNED.items() if (rec.get("host") or "").lower() == host_l
+    ]
+    return {ip for ip in ips} | {host_l, host}
+
+
 def drop_for_host(host: str, decision: str) -> set[str]:
     """Drop the sidecar's rules for a host (revocation, #2339).
 
@@ -190,8 +222,7 @@ def drop_for_host(host: str, decision: str) -> set[str]:
     ``denied``: remove the temporary REJECT rules for the host's IPs (stop
     force-rejecting; the host is again subject to the allow-list).
 
-    Returns the set of candidate IPs (the host's resolved IPs + the host
-    string itself, for a direct-IP connect) so the caller --
+    Returns the set of candidate IPs so the caller --
     :meth:`SidecarConsentClient.handle_drop_rule`, on the event loop -- can
     clear the loop-only ``SESSION_HOST_ALLOWS``/``VERDICT_CACHE`` state
     (via :func:`drop_session_hosts` / :func:`clear_verdict_cache`). Those
@@ -212,19 +243,8 @@ def drop_for_host(host: str, decision: str) -> set[str]:
     other too. A correct per-host revoke for co-resident hosts (CDN/S3/Cloudflare
     fronted sites) needs L7/SNI filtering, which is a separate feature (#2352).
     """
-    host_l = host.lower()
     with LOCK:
-        ips = [
-            ip
-            for ip, rec in LEARNED.items()
-            if (rec.get("host") or "").lower() == host_l
-        ]
-        # IPs that resolved to this host, plus the host itself if it's a
-        # direct-IP connect/allow (the scan above misses a direct-IP allow,
-        # whose host record is None).
-        targets = {ip for ip in ips}
-        targets.add(host_l)
-        targets.add(host)
+        targets = _drop_targets(host)
         if decision == "allowed":
             _drop_learned_rules(targets)
         elif decision == "denied":
@@ -232,16 +252,22 @@ def drop_for_host(host: str, decision: str) -> set[str]:
     return targets
 
 
+def _remove_learned_ports(ip: str) -> None:
+    """Remove every learned ACCEPT rule for ``ip``'s recorded ports
+    (best-effort: a failed delete drops one rule, not the whole revoke)."""
+    for port in list(LEARNED[ip]["ports"]):
+        try:
+            remove(ip, port)
+        except Exception:
+            pass
+
+
 def _drop_learned_rules(targets: set[str]) -> None:
     """Remove the learned ACCEPT rules (+ ``LEARNED`` records) for the
     target IPs (best-effort: a failed delete drops one rule, not the whole
     revoke). Caller holds ``LOCK``."""
     for ip in [i for i in targets if i in LEARNED]:
-        for port in list(LEARNED[ip]["ports"]):
-            try:
-                remove(ip, port)
-            except Exception:
-                pass
+        _remove_learned_ports(ip)
         del LEARNED[ip]
 
 
@@ -256,30 +282,49 @@ def _drop_reject_rules(targets: set[str]) -> None:
         del REJECTED[key]
 
 
+def _sweep_learned_rules(ip: str, rec: dict, now: float) -> set | None:
+    """Rule sweep for one learned IP: delete the ACCEPT rules whose lifetime
+    elapsed, returning the swept ports (or None when nothing swept). The
+    lifetime is ``rule_expire`` when set (a consent allow, whose verdict must
+    outlive the host-mapping's DNS TTL, #2408), else ``expire`` (static
+    re-learn / backward compat)."""
+    rule_expire = rec.get("rule_expire", rec["expire"])
+    if not (rec["ports"] and rule_expire <= now):
+        return None
+    ports = set(rec["ports"])
+    for port in ports:
+        try:
+            remove(ip, port)
+        except Exception:
+            pass  # a transient failure drops one rule, not the sweep
+    return ports
+
+
 def _sweep_learned_record(
     ip: str, rec: dict, now: float, expired: list[tuple[str, set]]
 ) -> None:
     """Sweep one learned-IP record in place (caller holds ``LOCK``):
-
-    rule sweep -- the ACCEPT rule's lifetime is rule_expire when set (a
-    consent allow, whose verdict must outlive the host-mapping's DNS TTL,
-    #2408), else expire (static re-learn / backward compat); record sweep --
-    drop the host mapping once its own expire elapses and no ACCEPT rule
-    remains."""
-    rule_expire = rec.get("rule_expire", rec["expire"])
-    if rec["ports"] and rule_expire <= now:
-        ports = set(rec["ports"])
-        for port in ports:
-            try:
-                remove(ip, port)
-            except Exception:
-                pass  # a transient failure drops one rule, not the sweep
+    rule sweep via :func:`_sweep_learned_rules`; record sweep -- drop the
+    host mapping once its own expire elapses and no ACCEPT rule remains."""
+    ports = _sweep_learned_rules(ip, rec, now)
+    if ports:
         expired.append((ip, ports))
         rec["ports"] = set()  # rule gone; keep record for naming
     # Record sweep: drop the host mapping once its own expire elapses
     # and no ACCEPT rule remains.
     if rec["expire"] <= now and not rec["ports"]:
         del LEARNED[ip]
+
+
+def _sweep_rejected(now: float) -> None:
+    """Remove temporary REJECT (tcp-reset) rules whose TTL elapsed
+    (best-effort; caller holds ``LOCK``)."""
+    for key in [k for k, exp in REJECTED.items() if exp <= now]:
+        try:
+            remove_reject(*key)
+        except Exception:
+            pass
+        del REJECTED[key]
 
 
 def sweep_once(now: float | None = None) -> list[tuple[str, set]]:
@@ -309,13 +354,7 @@ def sweep_once(now: float | None = None) -> list[tuple[str, set]]:
     with LOCK:
         for ip, rec in list(LEARNED.items()):
             _sweep_learned_record(ip, rec, now, expired)
-        # also sweep temporary REJECT (tcp-reset) rules for denied connections
-        for key in [k for k, exp in REJECTED.items() if exp <= now]:
-            try:
-                remove_reject(*key)
-            except Exception:
-                pass
-            del REJECTED[key]
+        _sweep_rejected(now)
     return expired
 
 
@@ -410,13 +449,26 @@ def install_acct(exclude_ip: str | None = None) -> None:
         pass
 
 
+def _acct_bytes_from_output(out: str) -> int:
+    """The byte count on the ``--comment``-tagged accounting rule line, or 0
+    when the rule is absent or the columns don't parse. With ``-v`` the first
+    two columns are pkts/bytes; ``-x`` makes bytes exact (no K/M suffix)."""
+    for line in out.splitlines():
+        if ACCT_COMMENT in line:
+            parts = line.split()  # parts[0]=pkts, parts[1]=bytes (the -v cols)
+            try:
+                return int(parts[1])
+            except (IndexError, ValueError):
+                return 0
+    return 0
+
+
 def acct_bytes() -> int:
     """Current byte count on the accounting rule, or 0 if absent/unreadable.
 
-    Parsed from ``iptables -t mangle -L OUTPUT -v -x -n``: with ``-v`` the first
-    two columns are pkts/bytes, ``-x`` makes bytes exact (no K/M suffix), and
-    the ``--comment`` tag uniquely identifies the rule line. 0 on any parse /
-    subprocess failure so the sampler treats a missing rule as a flat baseline
+    Parsed from ``iptables -t mangle -L OUTPUT -v -x -n``; the ``--comment``
+    tag uniquely identifies the rule line. 0 on any parse / subprocess
+    failure so the sampler treats a missing rule as a flat baseline
     (never as a burst of activity).
     """
     try:
@@ -428,16 +480,7 @@ def acct_bytes() -> int:
         ).stdout
     except Exception:
         return 0
-    for line in out.splitlines():
-        if ACCT_COMMENT in line:
-            parts = line.split()  # parts[0]=pkts, parts[1]=bytes (the -v cols)
-            if len(parts) >= 2:
-                try:
-                    return int(parts[1])
-                except ValueError:
-                    return 0
-            return 0
-    return 0
+    return _acct_bytes_from_output(out)
 
 
 def learn_all(


### PR DESCRIPTION
## Summary

Tranches 26–30 of the #2845 A-ratchet (issue #3043): all **98 rank-B blocks** across `scripts/` and the `klangksidecar` package brought to rank A (cyclomatic complexity ≤ 5), measured at `ceec1147` post-rebase. Pure extract-function / dispatch-table refactors, no behavior change.

- **T26 — `scripts/fuzz-idle.py` (19)**: `Server` wait/health/cleanup split; the scenario runners (`run_ws_scenario`, observers, pattern driver) decomposed into single-purpose helpers; wave planning and the run loop extracted; drops unreachable post-`return` lines in `run()`.
- **T27 — `scripts/fuzz-api.py` (9)**: request-arg building, record classification, the stderr-anomaly predicate, fixture seeding, and session teardown each extracted; placeholder filling via a dispatch table.
- **T28 — scripts tools (26)**: `update_features` (clone/checkout guard, lock-entry helpers), `import_dart_features` (per-file scan, manifest config normalization, aggregator line emitters), `trivy-report-nofix`, `check_deferred_imports`, `inline_sources_in_map`, `fmtk-seed`, `consent-decide`, `consent-watch`, `lcov-report`. Also dedups the dest-clearing logic shared by `_copy_feature_tree`/`link_feature`.
- **T29 — scripts/tests (24)**: assertion groups extracted into shared helpers (radon counts `assert` as a decision point, so the long flat contract tests were the B blocks).
- **T30 — klangksidecar (20)**: `rules` (allow/record bookkeeping, sweep phases, acct parsing), `allowlist` (spec parsing, TTL scans), `consent` (connect cycle, drop-rule handling), `resolve` (deny/recorded paths), `packets` (offset/tuple parsing), `nfqueue` (cb fast paths, verdict application), `app` (startup + serve loop).

## Verification

- `radon cc -n B scripts/ src/klangksidecar/klangksidecar/` → empty; `xenon --max-absolute A` passes on every touched file.
- Repo-wide B gate green: `xenon --max-absolute B --max-modules B --max-average B` over the full gate file set.
- Full Python suite `klangkd-tests` + `klangkc-tests`: 6575 passed, **100% branch coverage**; sidecar suite: 290 passed, 100%; scripts/tests: 102 passed. No warnings.
- `pre-commit` ruff-format/ruff-lint/deferred-imports/xenon all pass.

Closes #3043 (ticks the T26–T30 boxes of #2845's plan).
