### PR TITLE
refactor(cli): bring the CLI campaign (T19-T25, 142 blocks) under xenon rank A

### DIFF
--- a/src/klangk/klangk/cli/account.py
+++ b/src/klangk/klangk/cli/account.py
@@ -26,6 +26,39 @@ EMAIL_RE = re.compile(r"^[^@\s]+@[^@\s]+\.[^@\s]+$")
 _DEFAULT_MIN_PASSWORD = 8
 
 
+# Ordered (fails, error) checks — the same order as the server's
+# ``validate_handle`` so the error message for any input matches.
+HANDLE_CHECKS = [
+    (
+        lambda h: not h,
+        lambda h: "Handle cannot be empty",
+    ),
+    (
+        lambda h: len(h) > MAX_HANDLE_LEN,
+        lambda h: f"Handle must be {MAX_HANDLE_LEN} characters or fewer",
+    ),
+    (
+        lambda h: h.startswith("."),
+        lambda h: "Handle cannot start with a dot",
+    ),
+    (
+        lambda h: h in RESERVED_HANDLES,
+        lambda h: f"'{h}' is reserved",
+    ),
+    (
+        lambda h: h != h.lower(),
+        lambda h: "Handle must be lowercase",
+    ),
+    (
+        lambda h: not HANDLE_RE.match(h),
+        lambda h: (
+            "Handle may only contain lowercase letters, digits,"
+            " dots, dashes, and underscores"
+        ),
+    ),
+]
+
+
 def validate_handle(handle: str) -> str | None:
     """Return an error message if *handle* is invalid, else ``None``.
 
@@ -36,21 +69,9 @@ def validate_handle(handle: str) -> str | None:
     given input matches.
     """
     handle = (handle or "").strip()
-    if not handle:
-        return "Handle cannot be empty"
-    if len(handle) > MAX_HANDLE_LEN:
-        return f"Handle must be {MAX_HANDLE_LEN} characters or fewer"
-    if handle.startswith("."):
-        return "Handle cannot start with a dot"
-    if handle in RESERVED_HANDLES:
-        return f"'{handle}' is reserved"
-    if handle != handle.lower():
-        return "Handle must be lowercase"
-    if not HANDLE_RE.match(handle):
-        return (
-            "Handle may only contain lowercase letters, digits,"
-            " dots, dashes, and underscores"
-        )
+    for fails, error in HANDLE_CHECKS:
+        if fails(handle):
+            return error(handle)
     return None
 
 
@@ -81,22 +102,32 @@ class PasswordPolicy(NamedTuple):
         server and the web UI.
         """
         counts = _class_requirements_met(password, self.requirements)
-        unmet = [
-            f"at least {need} {name}{'s' if need != 1 else ''}"
-            for name, (have, need) in counts.items()
-            if need > 0 and have < need
-        ]
+        unmet = unmet_class_messages(counts)
         if unmet:
             return f"Password must contain {', '.join(unmet)}"
         return None
 
 
+def unmet_class_messages(counts: dict) -> list[str]:
+    """Human-readable messages for each unmet character-class requirement."""
+    return [
+        f"at least {need} {name}{'s' if need != 1 else ''}"
+        for name, (have, need) in counts.items()
+        if need > 0 and have < need
+    ]
+
+
+def class_count(password: str, low: str, high: str) -> int:
+    """How many characters fall in the ``[low, high]`` ASCII range."""
+    return sum(1 for c in password if low <= c <= high)
+
+
 def _class_requirements_met(password: str, requirements: dict) -> dict:
     """name -> (have, need) for each ASCII character class (A-Z, a-z, 0-9,
     everything else special) — matching the server's classes."""
-    upper = sum(1 for c in password if "A" <= c <= "Z")
-    lower = sum(1 for c in password if "a" <= c <= "z")
-    digit = sum(1 for c in password if "0" <= c <= "9")
+    upper = class_count(password, "A", "Z")
+    lower = class_count(password, "a", "z")
+    digit = class_count(password, "0", "9")
     special = len(password) - upper - lower - digit
     return {
         "uppercase letter": (upper, requirements.get("upper", 0)),
@@ -104,6 +135,36 @@ def _class_requirements_met(password: str, requirements: dict) -> dict:
         "digit": (digit, requirements.get("digit", 0)),
         "special character": (special, requirements.get("special", 0)),
     }
+
+
+_DEFAULT_REQUIREMENTS = {"upper": 0, "lower": 0, "digit": 0, "special": 0}
+
+
+def default_policy() -> PasswordPolicy:
+    """The permissive fallback policy (length 8, no class requirements)."""
+    return PasswordPolicy(_DEFAULT_MIN_PASSWORD, dict(_DEFAULT_REQUIREMENTS))
+
+
+def parsed_min_length(config: dict) -> int:
+    """The advertised min password length, or the default when unparseable."""
+    try:
+        return int(config.get("min_password_length") or _DEFAULT_MIN_PASSWORD)
+    except (TypeError, ValueError):
+        return _DEFAULT_MIN_PASSWORD
+
+
+def parsed_requirements(config: dict) -> dict:
+    """The advertised class requirements (0s when absent or unparseable)."""
+    requirements = dict(_DEFAULT_REQUIREMENTS)
+    reqs = config.get("password_requirements")
+    if not isinstance(reqs, dict):
+        return requirements
+    for key in requirements:
+        try:
+            requirements[key] = int(reqs.get(key) or 0)
+        except (TypeError, ValueError):
+            pass
+    return requirements
 
 
 def password_policy(server_url: str) -> PasswordPolicy:
@@ -115,20 +176,8 @@ def password_policy(server_url: str) -> PasswordPolicy:
     server enforces its own policy authoritatively either way.
     """
     config = fetch_config(server_url)
-    min_length = _DEFAULT_MIN_PASSWORD
-    requirements = {"upper": 0, "lower": 0, "digit": 0, "special": 0}
-    if isinstance(config, dict):
-        try:
-            min_length = int(
-                config.get("min_password_length") or _DEFAULT_MIN_PASSWORD
-            )
-        except (TypeError, ValueError):
-            pass
-        reqs = config.get("password_requirements")
-        if isinstance(reqs, dict):
-            for key in requirements:
-                try:
-                    requirements[key] = int(reqs.get(key) or 0)
-                except (TypeError, ValueError):
-                    pass
-    return PasswordPolicy(min_length, requirements)
+    if not isinstance(config, dict):
+        return default_policy()
+    return PasswordPolicy(
+        parsed_min_length(config), parsed_requirements(config)
+    )

--- a/src/klangk/klangk/cli/admin.py
+++ b/src/klangk/klangk/cli/admin.py
@@ -60,6 +60,18 @@ def admin_error(resp) -> None:
     raise typer.Exit(code=1)
 
 
+def user_row(u: dict) -> tuple[str, ...]:
+    """One table row for ``admin users ls``."""
+    return (
+        u["id"],
+        u["email"],
+        u.get("handle") or "",
+        "yes" if u.get("verified") else "no",
+        u.get("provider") or "password",
+        (u.get("created_at") or "")[:10],
+    )
+
+
 @admin_users_app.command("ls")
 def admin_users_ls(
     page: int = typer.Option(1, "--page", help="Page number"),
@@ -91,14 +103,7 @@ def admin_users_ls(
     table.add_column("Provider")
     table.add_column("Created")
     for u in users:
-        table.add_row(
-            u["id"],
-            u["email"],
-            u.get("handle") or "",
-            "yes" if u.get("verified") else "no",
-            u.get("provider") or "password",
-            (u.get("created_at") or "")[:10],
-        )
+        table.add_row(*user_row(u))
     total = body.get("total", len(users))
     console.print(table)
     if total > len(users):
@@ -106,6 +111,25 @@ def admin_users_ls(
             f"\n[dim]Showing {len(users)} of {total} "
             f"(use --page to see more)[/dim]"
         )
+
+
+def search_user_matches(search_json: list[dict], email: str) -> list[dict]:
+    """Exact email-or-handle matches from the prefix-match search."""
+    return [
+        u
+        for u in search_json
+        if u.get("email") == email or u.get("handle") == email
+    ]
+
+
+def prompt_new_password() -> str:
+    """Prompt for a new password twice, exiting on mismatch."""
+    password = Prompt.ask("[bold]New password[/bold]", password=True)
+    confirm = Prompt.ask("[bold]Confirm password[/bold]", password=True)
+    if password != confirm:
+        context.err.print("[red]Passwords do not match[/red]")
+        raise typer.Exit(code=1)
+    return password
 
 
 @admin_users_app.command("set-password")
@@ -137,11 +161,7 @@ def admin_users_set_password(
     client.check_auth(search)
     if search.status_code != 200:
         admin_error(search)
-    matches = [
-        u
-        for u in search.json()
-        if u.get("email") == email or u.get("handle") == email
-    ]
+    matches = search_user_matches(search.json(), email)
     if not matches:
         context.err.print(
             f"[red]No user found with email or handle {email}[/red]"
@@ -150,11 +170,7 @@ def admin_users_set_password(
     user_id = matches[0]["id"]
 
     if password is None:
-        password = Prompt.ask("[bold]New password[/bold]", password=True)
-        confirm = Prompt.ask("[bold]Confirm password[/bold]", password=True)
-        if password != confirm:
-            context.err.print("[red]Passwords do not match[/red]")
-            raise typer.Exit(code=1)
+        password = prompt_new_password()
 
     resp = client.patch(
         f"/api/v1/users/{user_id}",

--- a/src/klangk/klangk/cli/auth.py
+++ b/src/klangk/klangk/cli/auth.py
@@ -44,6 +44,14 @@ def fetch_config(server_url: str) -> dict | str | None:
         return UNREACHABLE
 
 
+def login_failure_detail(resp) -> str:
+    """The server's error detail, or the HTTP status when not JSON."""
+    try:
+        return resp.json().get("detail", f"HTTP {resp.status_code}")
+    except Exception:
+        return f"HTTP {resp.status_code}"
+
+
 def local_login(server_url: str) -> tuple[str, str]:
     """No-auth single-user mode: fetch a free token for the seeded default
     user via POST /api/v1/auth/local (#1374).
@@ -63,11 +71,7 @@ def local_login(server_url: str) -> tuple[str, str]:
         )
         raise SystemExit(1)
     if resp.status_code != 200:
-        try:
-            detail = resp.json().get("detail", f"HTTP {resp.status_code}")
-        except Exception:
-            detail = f"HTTP {resp.status_code}"
-        _err.print(f"[red]Login failed:[/red] {detail}")
+        _err.print(f"[red]Login failed:[/red] {login_failure_detail(resp)}")
         raise SystemExit(1)
     data = resp.json()
     token = data.get("access_token")
@@ -184,22 +188,30 @@ margin:0;background:#1a1a2e;color:#e0e0e0">
         raise SystemExit(1)
 
 
-def already_logged_in(state, server_url: str, email: str) -> bool:
-    """True (and prints) when a cached token for *email* still works."""
+def cached_user_token(state, server_url: str, email: str) -> str | None:
+    """The cached token for *email* on the server, if any."""
     ss = state.servers.get(server_url)
     cached = ss.users.get(email) if ss else None
-    if not (cached and cached.token):
+    if cached and cached.token:
+        return cached.token
+    return None
+
+
+def already_logged_in(state, server_url: str, email: str) -> bool:
+    """True (and prints) when a cached token for *email* still works."""
+    token = cached_user_token(state, server_url, email)
+    if not token:
         return False
     try:
         resp = http_request(
             server_url,
             "GET",
             "/api/v1/workspaces",
-            headers={"Authorization": f"Bearer {cached.token}"},
+            headers={"Authorization": f"Bearer {token}"},
             timeout=5.0,
         )
         if resp.status_code == 200:
-            state.set_credentials(server_url, email, cached.token)
+            state.set_credentials(server_url, email, token)
             state.save()
             _out.print(f"Already logged in as [bold]{email}[/bold]")
             return True
@@ -247,6 +259,11 @@ def select_oidc_provider(providers: list) -> dict:
         raise SystemExit(1)
 
 
+def should_use_oidc(auth_modes: str, email, password) -> bool:
+    """OIDC when password login is off, or no credentials were given."""
+    return auth_modes == "oidc" or (email is None and password is None)
+
+
 def try_oidc_login(server_url, email, password, config, state) -> bool:
     """Run the OIDC browser flow when the server config calls for it.
 
@@ -257,8 +274,7 @@ def try_oidc_login(server_url, email, password, config, state) -> bool:
     auth_modes = config.get("auth_modes", "password")
     if not (providers and auth_modes in ("oidc", "both")):
         return False
-    use_oidc = auth_modes == "oidc" or (email is None and password is None)
-    if not use_oidc:
+    if not should_use_oidc(auth_modes, email, password):
         return False
     provider = select_oidc_provider(providers)
     oidc_browser_login(server_url, provider["id"], state)
@@ -305,6 +321,28 @@ def password_login(server_url, email, password, state) -> None:
     _out.print(f"Logged in as [bold]{email}[/bold]")
 
 
+def none_mode_login(server_url, state) -> None:
+    """Log in via the no-auth free-token arm and persist it."""
+    email, token = local_login(server_url)
+    state.set_credentials(server_url, email, token)
+    state.save()
+    seed_config(server_url, email)
+    _out.print(f"Logged in as [bold]{email}[/bold] (no-auth mode)")
+
+
+def login_with_config(
+    server_url, email, password, config: dict, state
+) -> None:
+    """The config-routed login arms: no-auth, OIDC, or password."""
+    auth_modes = config.get("auth_modes", "password")
+    if auth_modes == "none":
+        none_mode_login(server_url, state)
+        return
+    if try_oidc_login(server_url, email, password, config, state):
+        return
+    password_login(server_url, email, password, state)
+
+
 def login(
     server_url: str,
     email: str | None = None,
@@ -320,22 +358,11 @@ def login(
     # Probe the server to verify it's a klangk instance
     config = fetch_config_or_exit(server_url)
 
-    # Default-safe per #1374: a missing/unparseable auth_modes field falls
-    # back to password so an old server never routes to the /auth/local arm.
-    auth_modes = "password"
+    # Default-safe per #1374: a missing config (old server) routes to
+    # the password arm rather than the /auth/local arm.
     if config:
-        auth_modes = config.get("auth_modes", "password")
-
-        if auth_modes == "none":
-            email, token = local_login(server_url)
-            state.set_credentials(server_url, email, token)
-            state.save()
-            seed_config(server_url, email)
-            _out.print(f"Logged in as [bold]{email}[/bold] (no-auth mode)")
-            return
-
-        if try_oidc_login(server_url, email, password, config, state):
-            return
+        login_with_config(server_url, email, password, config, state)
+        return
 
     password_login(server_url, email, password, state)
 
@@ -375,37 +402,59 @@ def refresh_token(server_url: str, token: str) -> str | None:
         return None
 
 
+def proc_cmdline(pid: int) -> str | None:
+    """One /proc pid's cmdline, or None when unreadable."""
+    try:
+        return (
+            open(f"/proc/{pid}/cmdline", "rb")
+            .read()
+            .replace(b"\0", b" ")
+            .decode("utf-8", "replace")
+            .strip()
+        )
+    except OSError:
+        return None
+
+
+def proc_ppid(pid: int) -> int | None:
+    """One /proc pid's parent pid, or None when unreadable."""
+    try:
+        return int(open(f"/proc/{pid}/stat", "rb").read().decode().split()[3])
+    except (OSError, ValueError):
+        return None
+
+
+def next_chain_pid(cur: int) -> int | None:
+    """The next pid up the chain, or None when the walk should stop."""
+    ppid = proc_ppid(cur)
+    if ppid is None or ppid <= 1 or ppid == cur:
+        return None
+    return ppid
+
+
+def logout_process_chain() -> list[str]:
+    """The parent-process chain entries (``pid=[cmd]``) up to init."""
+    chain: list[str] = []
+    cur = os.getppid()
+    for _ in range(8):
+        cmd = proc_cmdline(cur)
+        if cmd is None:
+            break
+        chain.append(f"{cur}=[{cmd}]")
+        cur = next_chain_pid(cur)
+        if cur is None:
+            break
+    return chain
+
+
 def _log_logout_caller() -> None:
     """Diagnostic: log the parent-process chain that invoked logout.
 
     Walks /proc upward so the next spurious logout reveals its spawner
     (shell, script, cron, the TUI, ...). Best-effort; never raises.
     """
-    chain: list[str] = []
-    cur = os.getppid()
-    for _ in range(8):
-        try:
-            cmd = (
-                open(f"/proc/{cur}/cmdline", "rb")
-                .read()
-                .replace(b"\0", b" ")
-                .decode("utf-8", "replace")
-                .strip()
-            )
-        except OSError:
-            break
-        chain.append(f"{cur}=[{cmd}]")
-        try:
-            ppid = int(
-                open(f"/proc/{cur}/stat", "rb").read().decode().split()[3]
-            )
-        except (OSError, ValueError):
-            break
-        if ppid <= 1 or ppid == cur:
-            break
-        cur = ppid
     msg = "auth.logout() invoked; process chain: " + (
-        " <- ".join(chain) or "(unknown)"
+        " <- ".join(logout_process_chain()) or "(unknown)"
     )
     logging.getLogger(__name__).warning(msg)
 

--- a/src/klangk/klangk/cli/authcmds.py
+++ b/src/klangk/klangk/cli/authcmds.py
@@ -85,16 +85,43 @@ def admin_status(token: str | None) -> bool | None:
     return is_admin
 
 
+def identity_lines(email, user_id) -> list[str]:
+    """The user= / user_id= plain-status lines."""
+    return [f"user={email or 'unknown'}", f"user_id={user_id or 'unknown'}"]
+
+
+def admin_field(is_admin) -> str | None:
+    """The admin= plain-status line, or None when unknown."""
+    if is_admin is None:
+        return None
+    return f"admin={'yes' if is_admin else 'no'}"
+
+
 def print_status_plain(url, token, email, user_id, is_admin) -> None:
     print(f"server={url or '(none)'}")
     if token:
-        print(f"user={email or 'unknown'}")
-        print(f"user_id={user_id or 'unknown'}")
+        for line in identity_lines(email, user_id):
+            print(line)
         print("status=logged_in")
-        if is_admin is not None:
-            print(f"admin={'yes' if is_admin else 'no'}")
+        admin = admin_field(is_admin)
+        if admin:
+            print(admin)
     else:
         print("status=not_logged_in")
+
+
+def identity_rows(email, user_id) -> list[tuple[str, str]]:
+    """The User / User ID table rows."""
+    return [("User", email or "unknown"), ("User ID", user_id or "unknown")]
+
+
+def admin_row(is_admin) -> tuple[str, str] | None:
+    """The Admin table row, or None when unknown."""
+    if is_admin:
+        return "Admin", "[green]yes[/green]"
+    if is_admin is False:
+        return "Admin", "no"
+    return None
 
 
 def print_status_table(url, token, email, user_id, is_admin) -> None:
@@ -104,16 +131,31 @@ def print_status_table(url, token, email, user_id, is_admin) -> None:
     table.add_column()
     table.add_row("Server", url or "(none)")
     if token:
-        table.add_row("User", email or "unknown")
-        table.add_row("User ID", user_id or "unknown")
+        for label, value in identity_rows(email, user_id):
+            table.add_row(label, value)
         table.add_row("Status", "[green]logged in[/green]")
-        if is_admin:
-            table.add_row("Admin", "[green]yes[/green]")
-        elif is_admin is False:
-            table.add_row("Admin", "no")
+        admin = admin_row(is_admin)
+        if admin:
+            table.add_row(*admin)
     else:
         table.add_row("Status", "[yellow]not logged in[/yellow]")
     console.print(table)
+
+
+def current_session_info() -> tuple[
+    str | None, str | None, str | None, str | None
+]:
+    """(url, token, email, user_id) for the active session.
+
+    status works even with no active server (unlike other commands), so
+    url — and everything derived from it — may be None.
+    """
+    url = context.server_override or context.state().active_server
+    state = context.state()
+    token = state.get_token(url) if url else None
+    email = state.get_email(url) if url else None
+    user_id = decode_token_claims(token).get("sub") if token else None
+    return url, token, email, user_id
 
 
 @context.app.command()
@@ -121,12 +163,7 @@ def status(
     plain: bool = typer.Option(False, "--plain", help="Plain text output"),
 ) -> None:
     """Show connection info (server, user, admin status)."""
-    # status works even with no active server (unlike other commands).
-    url = context.server_override or context.state().active_server
-    state = context.state()
-    token = state.get_token(url) if url else None
-    email = state.get_email(url) if url else None
-    user_id = decode_token_claims(token).get("sub") if token else None
+    url, token, email, user_id = current_session_info()
     is_admin = admin_status(token)
     if plain:
         print_status_plain(url, token, email, user_id, is_admin)

--- a/src/klangk/klangk/cli/client.py
+++ b/src/klangk/klangk/cli/client.py
@@ -1817,17 +1817,19 @@ class TerminalSession(_ShellSession):
             disposition, payload = await self._handle_byte(data, st, fd)
             if disposition == "exit":
                 return False
-            if disposition == "send":
-                await self.ws.send(
-                    json.dumps(
-                        {
-                            "cmd": "terminal_input",
-                            "data": payload.decode("utf-8", errors="replace"),
-                        }
-                    )
-                )
         except (OSError, io.UnsupportedOperation):
             return False
+        # The send sits outside the except scope, as in the original loop:
+        # a send failure must propagate and tear down the other pumps.
+        if disposition == "send":
+            await self.ws.send(
+                json.dumps(
+                    {
+                        "cmd": "terminal_input",
+                        "data": payload.decode("utf-8", errors="replace"),
+                    }
+                )
+            )
         return True
 
     async def stdin_loop(self) -> None:

--- a/src/klangk/klangk/cli/client.py
+++ b/src/klangk/klangk/cli/client.py
@@ -57,6 +57,17 @@ _HEARTBEAT_INTERVAL = 60  # seconds between terminal heartbeats
 _STDIN_DRAIN_TIMEOUT = 2  # seconds to let exec stdin forwarder finish
 
 
+def recv_exact(agent, target: int) -> bytes:
+    """Read exactly *target* bytes (short when the agent closes early)."""
+    buf = b""
+    while len(buf) < target:
+        chunk = agent.recv(target - len(buf))
+        if not chunk:
+            break
+        buf += chunk
+    return buf
+
+
 def query_local_ssh_agent(sock_path: str, data: bytes) -> bytes | None:
     """Send *data* to the local SSH agent and return its response.
 
@@ -69,21 +80,11 @@ def query_local_ssh_agent(sock_path: str, data: bytes) -> bytes | None:
     try:
         agent.connect(sock_path)
         agent.sendall(data)
-        header = b""
-        while len(header) < 4:
-            chunk = agent.recv(4 - len(header))
-            if not chunk:
-                break
-            header += chunk
+        header = recv_exact(agent, 4)
         if len(header) < 4:
             return None
         msg_len = struct.unpack(">I", header)[0]
-        body = b""
-        while len(body) < msg_len:
-            chunk = agent.recv(msg_len - len(body))
-            if not chunk:
-                break
-            body += chunk
+        body = recv_exact(agent, msg_len)
         return header + body
     finally:
         agent.close()
@@ -118,6 +119,19 @@ async def wait_container_ready(
             raise ConnectionError(f"Connection failed: {resp}")
 
 
+def transient_status(resp, attempt: int) -> bool:
+    """True when a 502/503/504 response should be retried."""
+    return (
+        resp.status_code in (502, 503, 504) and attempt < _RETRY_ATTEMPTS - 1
+    )
+
+
+def sleep_backoff(backoff: float) -> float:
+    """Sleep the backoff and return the next (doubled) one."""
+    _time.sleep(backoff)
+    return backoff * 2
+
+
 def request_with_retry(
     server_spec: str,
     method: str,
@@ -140,10 +154,7 @@ def request_with_retry(
             resp = http_request(
                 server_spec, method, path, timeout=timeout, **kwargs
             )
-            if (
-                resp.status_code in (502, 503, 504)
-                and attempt < _RETRY_ATTEMPTS - 1
-            ):
+            if transient_status(resp, attempt):
                 logger.debug(
                     "HTTP %s %s returned %d, retrying in %.1fs",
                     method,
@@ -151,8 +162,7 @@ def request_with_retry(
                     resp.status_code,
                     backoff,
                 )
-                _time.sleep(backoff)
-                backoff *= 2
+                backoff = sleep_backoff(backoff)
                 continue
             return resp
         except (httpx.TimeoutException, httpx.ConnectError) as exc:
@@ -164,10 +174,29 @@ def request_with_retry(
                     exc,
                     backoff,
                 )
-                _time.sleep(backoff)
-                backoff *= 2
+                backoff = sleep_backoff(backoff)
             else:
                 raise
+
+
+def download_total(resp) -> int | None:
+    """Content-Length when present, else the server's size estimate."""
+    if "content-length" in resp.headers:
+        return int(resp.headers["content-length"])
+    if "x-estimated-size" in resp.headers:
+        return int(resp.headers["x-estimated-size"])
+    return None
+
+
+def write_chunks(resp, output: Path, on_progress, total: int | None) -> None:
+    """Stream the response body to *output*, reporting progress."""
+    downloaded = 0
+    with open(output, "wb") as f:
+        for chunk in resp.iter_bytes():
+            f.write(chunk)
+            downloaded += len(chunk)
+            if on_progress:
+                on_progress(downloaded, total)
 
 
 @dataclass
@@ -449,6 +478,26 @@ class KlangkClient:
             q=q,
         )
 
+    def _fetch_page(self, path: str, params: dict) -> dict:
+        """One authenticated page of the paginated list endpoint."""
+        resp = self.get(path, params=params)
+        self.check_auth(resp)
+        self._raise_for_status(resp)
+        return resp.json()
+
+    def _accumulate_pages(
+        self, path: str, params: dict, all_pages: bool, shared: bool
+    ) -> list[Workspace]:
+        """Fetch one page (or follow pagination to the end)."""
+        workspaces: list[Workspace] = []
+        while True:
+            body = self._fetch_page(path, params)
+            for w in body["items"]:
+                workspaces.append(self._workspace_from_json(w, shared=shared))
+            if not all_pages or not body.get("has_more"):
+                return workspaces
+            params["offset"] = body["next_offset"]
+
     def _list_paginated(
         self,
         path: str,
@@ -461,7 +510,6 @@ class KlangkClient:
         order: str = "desc",
         q: str | None = None,
     ) -> list[Workspace]:
-        workspaces: list[Workspace] = []
         params: dict = {
             "limit": limit,
             "offset": offset,
@@ -470,17 +518,7 @@ class KlangkClient:
         }
         if q:
             params["q"] = q
-        while True:
-            resp = self.get(path, params=params)
-            self.check_auth(resp)
-            self._raise_for_status(resp)
-            body = resp.json()
-            for w in body["items"]:
-                workspaces.append(self._workspace_from_json(w, shared=shared))
-            if not all_pages or not body.get("has_more"):
-                break
-            params["offset"] = body["next_offset"]
-        return workspaces
+        return self._accumulate_pages(path, params, all_pages, shared)
 
     @staticmethod
     def _workspace_from_json(w: dict, *, shared: bool) -> Workspace:
@@ -757,6 +795,53 @@ class KlangkClient:
         """Rename terminal window at *index* in workspace *name*; return list."""
         return await self.terminals(name, rename=(index, new_name))
 
+    async def _maybe_close_window(
+        self, conn, windows: list[dict], close_window_id
+    ) -> list[dict]:
+        """Close the requested window; the refreshed window list."""
+        if close_window_id is not None and windows:
+            await conn.send(
+                json.dumps(
+                    {
+                        "cmd": "terminal_close_window",
+                        "window_id": close_window_id,
+                    }
+                )
+            )
+            return await self._recv_windows(conn)
+        return windows
+
+    async def _maybe_create_window(
+        self, conn, windows: list[dict], create_window: bool, window_name
+    ) -> list[dict]:
+        """Create a named window; the refreshed window list."""
+        if create_window:
+            cmd = {"cmd": "terminal_new_window"}
+            # No name → server names the window "bash" (#2192).
+            if window_name:
+                cmd["name"] = window_name
+            await conn.send(json.dumps(cmd))
+            return await self._recv_windows(conn)
+        return windows
+
+    async def _maybe_rename_window(
+        self, conn, windows: list[dict], rename
+    ) -> list[dict]:
+        """Rename the requested window; the refreshed window list."""
+        if rename is not None and windows:
+            idx, new_name = rename
+            await conn.send(
+                json.dumps(
+                    {
+                        "cmd": "terminal_rename_window",
+                        "index": idx,
+                        "name": new_name,
+                    }
+                )
+            )
+            return await self._recv_windows(conn)
+        return windows
+
     async def terminals(
         self,
         name: str,
@@ -785,35 +870,15 @@ class KlangkClient:
                     )
                 )
                 windows = await self._recv_windows(conn)
-                if close_window_id is not None and windows:
-                    await conn.send(
-                        json.dumps(
-                            {
-                                "cmd": "terminal_close_window",
-                                "window_id": close_window_id,
-                            }
-                        )
-                    )
-                    windows = await self._recv_windows(conn)
-                if create_window:
-                    cmd = {"cmd": "terminal_new_window"}
-                    # No name → server names the window "bash" (#2192).
-                    if window_name:
-                        cmd["name"] = window_name
-                    await conn.send(json.dumps(cmd))
-                    windows = await self._recv_windows(conn)
-                if rename is not None and windows:
-                    idx, new_name = rename
-                    await conn.send(
-                        json.dumps(
-                            {
-                                "cmd": "terminal_rename_window",
-                                "index": idx,
-                                "name": new_name,
-                            }
-                        )
-                    )
-                    windows = await self._recv_windows(conn)
+                windows = await self._maybe_close_window(
+                    conn, windows, close_window_id
+                )
+                windows = await self._maybe_create_window(
+                    conn, windows, create_window, window_name
+                )
+                windows = await self._maybe_rename_window(
+                    conn, windows, rename
+                )
                 await send_ignore_closed(
                     conn, json.dumps({"cmd": "terminal_stop"})
                 )
@@ -878,19 +943,8 @@ class KlangkClient:
                 self._raise_for_status(resp)
             # Use Content-Length if available, otherwise fall back to
             # the server's compressed size estimate.
-            if "content-length" in resp.headers:
-                total = int(resp.headers["content-length"])
-            elif "x-estimated-size" in resp.headers:
-                total = int(resp.headers["x-estimated-size"])
-            else:
-                total = None
-            downloaded = 0
-            with open(output, "wb") as f:
-                for chunk in resp.iter_bytes():
-                    f.write(chunk)
-                    downloaded += len(chunk)
-                    if on_progress:
-                        on_progress(downloaded, total)
+            total = download_total(resp)
+            write_chunks(resp, output, on_progress, total)
 
     def import_workspace(
         self, archive: Path, name: str | None = None, on_progress=None
@@ -1047,6 +1101,16 @@ _TERMINAL_RESPONSE_RE = re.compile(
 )
 
 
+def osc_or_dcs(data: bytes) -> bool:
+    """OSC (\\e]) and DCS (\\eP) are always responses, never user input."""
+    return data[1:2] in (b"]", b"P")
+
+
+def csi_response(data: bytes) -> bool:
+    """CSI responses: \\e[> (DA2), \\e[? (DA1/DECRPM)."""
+    return data[1:2] == b"[" and len(data) > 2 and data[2:3] in (b">", b"?")
+
+
 def is_terminal_response(data: bytes) -> bool:
     """True if *data* looks like a terminal query response, not user input.
 
@@ -1059,12 +1123,33 @@ def is_terminal_response(data: bytes) -> bool:
         return False
     # Fast path: OSC (\e]) and DCS (\eP) are always responses, never
     # user input.
-    if data[1:2] in (b"]", b"P"):
+    if osc_or_dcs(data):
         return True
-    # CSI responses: \e[> (DA2), \e[? (DA1/DECRPM)
-    if data[1:2] == b"[" and len(data) > 2 and data[2:3] in (b">", b"?"):
-        return True
-    return False
+    return csi_response(data)
+
+
+def raw_stdin_mode() -> tuple[int, object | None]:
+    """(fd, old_attrs) with stdin set raw; old_attrs None when not a tty."""
+    fd = sys.stdin.fileno()
+    try:
+        old = termios.tcgetattr(fd)
+        tty.setraw(fd)
+        return fd, old
+    except termios.error:
+        return fd, None
+
+
+def drain_rounds(fd: int) -> None:
+    """Drain stdin for up to 500ms, checking every 50ms."""
+    for _ in range(10):
+        if select.select([fd], [], [], 0.05)[0]:
+            os.read(fd, 4096)
+            continue
+        # No data for 50ms — but responses may still be in
+        # flight. Wait one more round to be sure.
+        if not select.select([fd], [], [], 0.1)[0]:
+            break
+        os.read(fd, 4096)
 
 
 def drain_stdin() -> None:
@@ -1076,28 +1161,11 @@ def drain_stdin() -> None:
     the host shell as garbage commands.
     """
     try:
-        fd = sys.stdin.fileno()
-        # Put stdin in raw mode temporarily so responses don't echo
-        # and aren't line-buffered.
+        fd, old = raw_stdin_mode()
         try:
-            old = termios.tcgetattr(fd)
-            tty.setraw(fd)
-            restore = True
-        except termios.error:
-            restore = False
-        try:
-            # Drain for up to 500ms total, checking every 50ms.
-            for _ in range(10):
-                if select.select([fd], [], [], 0.05)[0]:
-                    os.read(fd, 4096)
-                else:
-                    # No data for 50ms — but responses may still be in
-                    # flight. Wait one more round to be sure.
-                    if not select.select([fd], [], [], 0.1)[0]:
-                        break
-                    os.read(fd, 4096)
+            drain_rounds(fd)
         finally:
-            if restore:
+            if old is not None:
                 termios.tcsetattr(fd, termios.TCSADRAIN, old)
     except (OSError, io.UnsupportedOperation):
         pass
@@ -1130,6 +1198,24 @@ def reset_terminal() -> None:
     sys.stdout.flush()
 
 
+def agent_forward_available(forward_agent: bool, sock: str | None) -> bool:
+    """True when forwarding was requested and the local agent socket exists."""
+    return bool(forward_agent and sock and os.path.exists(sock))
+
+
+async def wait_agent_started(ws) -> bool:
+    """Wait for the ssh_agent_started ack (False on error/timeout)."""
+    try:
+        async for msg in recv_json_messages(ws, 10):
+            if msg.get("type") == "ssh_agent_started":
+                return True
+            if msg.get("type") == "error":
+                return False
+    except asyncio.TimeoutError:
+        pass  # proceed without agent forwarding
+    return False
+
+
 async def start_ssh_agent_forward(
     ws, forward_agent: bool
 ) -> tuple[bool, str | None]:
@@ -1140,18 +1226,32 @@ async def start_ssh_agent_forward(
     """
     ssh_agent_active = False
     local_agent_sock = os.environ.get("SSH_AUTH_SOCK")
-    if forward_agent and local_agent_sock and os.path.exists(local_agent_sock):
+    if agent_forward_available(forward_agent, local_agent_sock):
         await ws.send(json.dumps({"cmd": "ssh_agent_start"}))
-        try:
-            async for msg in recv_json_messages(ws, 10):
-                if msg.get("type") == "ssh_agent_started":
-                    ssh_agent_active = True
-                    break
-                if msg.get("type") == "error":
-                    break
-        except asyncio.TimeoutError:
-            pass  # proceed without agent forwarding
+        ssh_agent_active = await wait_agent_started(ws)
     return ssh_agent_active, local_agent_sock
+
+
+def absorb_output_frame(msg: dict, state: dict) -> None:
+    """Buffer one terminal_output frame; raise on a server error frame."""
+    if msg.get("type") == "error":
+        raise ConnectionError(f"Server error: {msg.get('message', 'unknown')}")
+    state["buffered_output"].append(msg.get("data", ""))
+
+
+def startup_frame_result(msg: dict, state: dict, needs_shared: bool) -> bool:
+    """One startup frame's effect on the drain state; True when done."""
+    mtype = msg.get("type")
+    if mtype in ("terminal_output", "error"):
+        absorb_output_frame(msg, state)
+        return False
+    if mtype == "terminal_windows":
+        state["own_windows"] = msg.get("windows", [])
+        return not needs_shared
+    if mtype == "shared_terminals":
+        state["shared_terminals"] = msg.get("terminals", [])
+        return needs_shared
+    return False
 
 
 async def drain_terminal_startup(
@@ -1167,9 +1267,11 @@ async def drain_terminal_startup(
     breaking on terminal_windows alone leaves shared_terminals empty
     and the join fails with "Shared terminal not found".
     """
-    own_windows: list[dict] = []
-    shared_terminals: list[dict] = []
-    buffered_output: list[str] = []
+    state: dict = {
+        "own_windows": [],
+        "shared_terminals": [],
+        "buffered_output": [],
+    }
     try:
         # recv_json_messages only ends by raising (deadline), so the
         # async-for can never complete normally — break/raise are the
@@ -1177,25 +1279,17 @@ async def drain_terminal_startup(
         async for msg in recv_json_messages(  # pragma: no branch
             ws, 30
         ):
-            if msg.get("type") == "terminal_windows":
-                own_windows = msg.get("windows", [])
-                if not needs_shared:
-                    break
-            elif msg.get("type") == "shared_terminals":
-                shared_terminals = msg.get("terminals", [])
-                if needs_shared:
-                    break
-            elif msg.get("type") == "terminal_output":
-                buffered_output.append(msg.get("data", ""))
-            elif msg.get("type") == "error":
-                raise ConnectionError(
-                    f"Server error: {msg.get('message', 'unknown')}"
-                )
+            if startup_frame_result(msg, state, needs_shared):
+                break
     except asyncio.TimeoutError:
         raise ConnectionError(
             "Terminal did not start within 30 seconds"
         ) from None
-    return own_windows, shared_terminals, buffered_output
+    return (
+        state["own_windows"],
+        state["shared_terminals"],
+        state["buffered_output"],
+    )
 
 
 async def join_shared_terminal(
@@ -1260,6 +1354,23 @@ def starts_disconnect_sequence(data: bytes, after_newline: bool) -> bool:
     return data == b"~" and after_newline
 
 
+def first_or_none(matches: list):
+    """The first match, or None when empty."""
+    return matches[0] if matches else None
+
+
+def shared_name_match(
+    shared_terminals: list[dict], owner_handle: str, win_ref: str
+):
+    """The single name match, raising when ambiguous (#2192)."""
+    by_name = _shared_matches(
+        shared_terminals, owner_handle, "window_name", win_ref
+    )
+    if len(by_name) > 1:
+        _raise_ambiguous_shared(owner_handle, win_ref, by_name)
+    return first_or_none(by_name)
+
+
 def match_shared_terminal(window: str, shared_terminals: list[dict]) -> dict:
     """Resolve "handle:window_name" (or "handle:@N") to one shared
     terminal; ConnectionError when absent or ambiguous."""
@@ -1268,14 +1379,9 @@ def match_shared_terminal(window: str, shared_terminals: list[dict]) -> dict:
         by_id = _shared_matches(
             shared_terminals, owner_handle, "window_id", win_ref
         )
-        match = by_id[0] if by_id else None
+        match = first_or_none(by_id)
     else:
-        by_name = _shared_matches(
-            shared_terminals, owner_handle, "window_name", win_ref
-        )
-        if len(by_name) > 1:
-            _raise_ambiguous_shared(owner_handle, win_ref, by_name)
-        match = by_name[0] if by_name else None
+        match = shared_name_match(shared_terminals, owner_handle, win_ref)
     if match is None:
         raise ConnectionError(f"Shared terminal '{window}' not found")
     return match
@@ -1288,17 +1394,58 @@ def _raise_ambiguous_own(window: str, name_matches: list[dict]) -> None:
     )
 
 
+def window_by_id(own_windows: list[dict], window: str) -> list[dict]:
+    """Own windows matching an @N id."""
+    return [w for w in own_windows if w.get("id") == window]
+
+
+def windows_by_name(own_windows: list[dict], window: str) -> list[dict]:
+    """Own windows matching a name."""
+    return [w for w in own_windows if w.get("name") == window]
+
+
+def own_id_match(window: str, by_id: list[dict]) -> dict:
+    """The exact @N match; ConnectionError when the window is gone."""
+    if not by_id:
+        raise ConnectionError(f"Window '{window}' no longer exists")
+    return by_id[0]
+
+
+def own_name_match(window: str, name_matches: list[dict]):
+    """The single name match (None when absent), raising when ambiguous."""
+    if len(name_matches) > 1:
+        _raise_ambiguous_own(window, name_matches)
+    return first_or_none(name_matches)
+
+
 def match_own_window(window: str, own_windows: list[dict]) -> dict | None:
     """Resolve a @N id or name to an existing own window (None = absent)."""
     if window.startswith("@"):
-        by_id = [w for w in own_windows if w.get("id") == window]
-        if not by_id:
-            raise ConnectionError(f"Window '{window}' no longer exists")
-        return by_id[0]
-    name_matches = [w for w in own_windows if w.get("name") == window]
-    if len(name_matches) > 1:
-        _raise_ambiguous_own(window, name_matches)
-    return name_matches[0] if name_matches else None
+        return own_id_match(window, window_by_id(own_windows, window))
+    return own_name_match(window, windows_by_name(own_windows, window))
+
+
+def own_window_frame(
+    msg: dict, buffered_output: list[str], state: dict
+) -> bool:
+    """Absorb one create-window frame; True when the window list arrived."""
+    mtype = msg.get("type")
+    if mtype == "terminal_windows":
+        state["windows"] = msg.get("windows", [])
+        return True
+    if mtype == "terminal_output":
+        buffered_output.append(msg.get("data", ""))
+    if mtype == "error":
+        raise ConnectionError(f"Failed to create window: {msg.get('message')}")
+    return False
+
+
+def named_window(windows: list[dict], window: str):
+    """The first window named *window* from a refreshed list."""
+    return next(
+        (w for w in windows if w.get("name") == window),
+        None,
+    )
 
 
 async def create_own_window(
@@ -1313,7 +1460,7 @@ async def create_own_window(
             }
         )
     )
-    match: dict | None = None
+    state: dict = {}
     # recv_json_messages only ends by raising (deadline), so the
     # async-for can never complete normally — break/raise are the only
     # exits (the arc to ``if match is None`` without a break is
@@ -1321,19 +1468,9 @@ async def create_own_window(
     async for msg in recv_json_messages(  # pragma: no branch
         ws, 10
     ):
-        if msg.get("type") == "terminal_windows":
-            new_windows = msg.get("windows", [])
-            match = next(
-                (w for w in new_windows if w.get("name") == window),
-                None,
-            )
+        if own_window_frame(msg, buffered_output, state):
             break
-        if msg.get("type") == "terminal_output":
-            buffered_output.append(msg.get("data", ""))
-        if msg.get("type") == "error":
-            raise ConnectionError(
-                f"Failed to create window: {msg.get('message')}"
-            )
+    match = named_window(state.get("windows", []), window)
     if match is None:
         raise ConnectionError(f"Window '{window}' not created")
     return match
@@ -1405,6 +1542,21 @@ async def run_terminal_session(
         await send_ignore_closed(ws, json.dumps({"cmd": "terminal_stop"}))
 
 
+def needs_shared_window(window: str | None) -> bool:
+    """True when the window target is a shared handle:name reference."""
+    return window is not None and ":" in window
+
+
+async def select_window(
+    ws, window, own_windows, shared_terminals, buffered_output
+) -> None:
+    """3b. Join a shared terminal or select/create an own window."""
+    if ":" in window:
+        await join_shared_terminal(ws, window, shared_terminals)
+    else:
+        await select_own_window(ws, window, own_windows, buffered_output)
+
+
 async def ws_shell(
     server_spec: str,
     token: str,
@@ -1458,17 +1610,14 @@ async def ws_shell(
             shared_terminals,
             buffered_output,
         ) = await drain_terminal_startup(
-            ws, needs_shared=window is not None and ":" in window
+            ws, needs_shared=needs_shared_window(window)
         )
 
         # 3b. Select window if requested.
         if window is not None:
-            if ":" in window:
-                await join_shared_terminal(ws, window, shared_terminals)
-            else:
-                await select_own_window(
-                    ws, window, own_windows, buffered_output
-                )
+            await select_window(
+                ws, window, own_windows, shared_terminals, buffered_output
+            )
 
         # Flush buffered terminal output from the startup drain.
         for text in buffered_output:
@@ -1521,6 +1670,25 @@ class _ShellSession:
         if raw:
             self.agent_queue.put_nowait(raw)
 
+    async def relay_one(self, data: bytes) -> None:
+        """Forward one agent request and send back its reply."""
+        try:
+            loop = asyncio.get_event_loop()
+            response = await loop.run_in_executor(
+                None, query_local_ssh_agent, self.ssh_agent_sock, data
+            )
+            if response is not None:
+                await self.ws.send(
+                    json.dumps(
+                        {
+                            "cmd": "ssh_agent_data",
+                            "data": base64.b64encode(response).decode("ascii"),
+                        }
+                    )
+                )
+        except (OSError, ConnectionError) as e:
+            logger.warning("SSH agent relay: %s", e)
+
     async def ssh_agent_relay_loop(self) -> None:
         """Relay SSH agent protocol between container and local agent.
 
@@ -1537,27 +1705,35 @@ class _ShellSession:
                 )
             except asyncio.TimeoutError:
                 continue
-            try:
-                loop = asyncio.get_event_loop()
-                response = await loop.run_in_executor(
-                    None, query_local_ssh_agent, self.ssh_agent_sock, data
-                )
-                if response is not None:
-                    await self.ws.send(
-                        json.dumps(
-                            {
-                                "cmd": "ssh_agent_data",
-                                "data": base64.b64encode(response).decode(
-                                    "ascii"
-                                ),
-                            }
-                        )
-                    )
-            except (OSError, ConnectionError) as e:
-                logger.warning("SSH agent relay: %s", e)
+            await self.relay_one(data)
 
     async def run(self) -> None:
         raise NotImplementedError
+
+
+def refreshed_token(server_url: str, token: str) -> str | None:
+    """A fresh token after a 4002 close (none-mode re-login included)."""
+    new = refresh_token(server_url, token)
+    if not new and server_mode_is_none(server_url):
+        try:
+            _email, new = _local_login(server_url)
+        except SystemExit:
+            new = None
+    return new
+
+
+def close_code(exc) -> int | None:
+    """The close code from a ConnectionClosed (None when absent)."""
+    return exc.rcvd.code if exc.rcvd else None
+
+
+def container_stopped_event(data: dict) -> bool:
+    """True for the container_stopped CUSTOM event."""
+    event = data.get("event", {})
+    return (
+        event.get("type") == "CUSTOM"
+        and event.get("name") == "container_stopped"
+    )
 
 
 class TerminalSession(_ShellSession):
@@ -1594,43 +1770,74 @@ class TerminalSession(_ShellSession):
             )
         )
 
+    async def _stdin_ready(self, fd) -> bool:
+        """True when stdin has data (200ms poll)."""
+        ready, _, _ = await self._loop.run_in_executor(
+            None, lambda: select.select([fd], [], [], 0.2)
+        )
+        return bool(ready)
+
+    async def _tilde_pending(self, data: bytes, st: dict) -> str | None:
+        """Handle a pending ~; "exit" when the ~. disconnect fired."""
+        if st["saw_tilde"]:
+            st["saw_tilde"] = False
+            if await self._tilde_key(data):
+                return "exit"
+        return None
+
+    async def _handle_byte(
+        self, data: bytes, st: dict, fd
+    ) -> tuple[str, bytes | None]:
+        """One byte through the ~. state machine -> (disposition, payload).
+
+        disposition: "exit" (disconnect fired — end the loop), "skip"
+        (consumed locally — read the next byte), or "send" (payload
+        carries the bytes to forward).
+        """
+        outcome = await self._tilde_pending(data, st)
+        if outcome == "exit":
+            return "exit", None
+        if starts_disconnect_sequence(data, st["after_newline"]):
+            st["saw_tilde"] = True
+            st["after_newline"] = False
+            return "skip", None
+        st["after_newline"] = data in (b"\r", b"\n")
+        if data == b"\x1b":
+            data = await self._extend_escape_sequence(fd, data)
+            if data is None:
+                return "skip", None
+        return "send", data
+
+    async def _forward_input(self, fd, st: dict) -> bool:
+        """Read and handle one stdin byte; False when the loop should exit."""
+        try:
+            data = await self._loop.run_in_executor(None, os.read, fd, 1)
+            if not data:
+                return False
+            disposition, payload = await self._handle_byte(data, st, fd)
+            if disposition == "exit":
+                return False
+            if disposition == "send":
+                await self.ws.send(
+                    json.dumps(
+                        {
+                            "cmd": "terminal_input",
+                            "data": payload.decode("utf-8", errors="replace"),
+                        }
+                    )
+                )
+        except (OSError, io.UnsupportedOperation):
+            return False
+        return True
+
     async def stdin_loop(self) -> None:
         fd = self.stdin.fileno()
-        after_newline = True
-        saw_tilde = False
+        st = {"after_newline": True, "saw_tilde": False}
         while not self.stop.is_set():
-            ready, _, _ = await self._loop.run_in_executor(
-                None, lambda: select.select([fd], [], [], 0.2)
-            )
-            if not ready:
+            if not await self._stdin_ready(fd):
                 continue
-            try:
-                data = await self._loop.run_in_executor(None, os.read, fd, 1)
-                if not data:
-                    return
-                if saw_tilde:
-                    saw_tilde = False
-                    if await self._tilde_key(data):
-                        return
-                if starts_disconnect_sequence(data, after_newline):
-                    saw_tilde = True
-                    after_newline = False
-                    continue
-                after_newline = data in (b"\r", b"\n")
-                if data == b"\x1b":
-                    data = await self._extend_escape_sequence(fd, data)
-                    if data is None:
-                        continue
-            except (OSError, io.UnsupportedOperation):
+            if not await self._forward_input(fd, st):
                 return
-            await self.ws.send(
-                json.dumps(
-                    {
-                        "cmd": "terminal_input",
-                        "data": data.decode("utf-8", errors="replace"),
-                    }
-                )
-            )
 
     async def _tilde_key(self, data: bytes) -> bool:
         """Consume the pending ``~`` after a newline; True when the ~.
@@ -1644,23 +1851,52 @@ class TerminalSession(_ShellSession):
         await self.ws.send(json.dumps({"cmd": "terminal_input", "data": "~"}))
         return False
 
-    async def _extend_escape_sequence(self, fd, data: bytes) -> bytes | None:
-        """Extend a pending ESC into its full sequence; None when it is a
-        terminal query response that gets drained locally instead of sent."""
-        if select.select([fd], [], [], 0.05)[0]:
-            more = await self._loop.run_in_executor(None, os.read, fd, 32)
-            if more:
-                data += more
-        if not is_terminal_response(data):
-            return data
+    async def _read_more(self, fd, size: int) -> bytes:
+        """Read up to *size* more bytes from stdin."""
+        return await self._loop.run_in_executor(None, os.read, fd, size)
+
+    async def _drain_query_response(self, fd) -> None:
+        """Drain the remaining bytes of a terminal query response."""
         for _ in range(10):
             if not select.select([fd], [], [], 0.02)[0]:
                 break
             try:
-                await self._loop.run_in_executor(None, os.read, fd, 256)
+                await self._read_more(fd, 256)
             except OSError:
                 break
+
+    async def _extend_escape_sequence(self, fd, data: bytes) -> bytes | None:
+        """Extend a pending ESC into its full sequence; None when it is a
+        terminal query response that gets drained locally instead of sent."""
+        if select.select([fd], [], [], 0.05)[0]:
+            more = await self._read_more(fd, 32)
+            if more:
+                data += more
+        if not is_terminal_response(data):
+            return data
+        await self._drain_query_response(fd)
         return None
+
+    def _write_terminal_output(self, text: str) -> None:
+        """Write output; an [exited] marker gets the disconnect hint."""
+        self.stdout.write(text)
+        self.stdout.flush()
+        if "[exited]" in text:
+            self.stdout.write("\r\nPress Enter, then ~. to disconnect.\r\n")
+            self.stdout.flush()
+
+    async def _apply_shell_frame(self, msg: str) -> bool:
+        """Handle one shell frame; True when the loop should stop."""
+        data = json.loads(msg)
+        if data.get("type") == "terminal_output":
+            self._write_terminal_output(data["data"])
+        elif data.get("type") == "ssh_agent_response":
+            self.dispatch_agent_response(data)
+        elif data.get("type") == "event":
+            if container_stopped_event(data):
+                logging.info("[container stopped]")
+                return True
+        return False
 
     async def stdout_loop(self) -> None:
         try:
@@ -1668,58 +1904,42 @@ class TerminalSession(_ShellSession):
                 msg = await self.ws.recv()
                 if isinstance(msg, bytes):
                     msg = msg.decode("utf-8", errors="replace")
-                data = json.loads(msg)
-                if data.get("type") == "terminal_output":
-                    text = data["data"]
-                    self.stdout.write(text)
-                    self.stdout.flush()
-                    if "[exited]" in text:
-                        self.stdout.write(
-                            "\r\nPress Enter, then ~. to disconnect.\r\n"
-                        )
-                        self.stdout.flush()
-                elif data.get("type") == "ssh_agent_response":
-                    self.dispatch_agent_response(data)
-                elif data.get("type") == "event":
-                    event = data.get("event", {})
-                    if (
-                        event.get("type") == "CUSTOM"
-                        and event.get("name") == "container_stopped"
-                    ):
-                        logging.info("[container stopped]")
-                        self.stop.set()
-                        break
+                if await self._apply_shell_frame(msg):
+                    break
         except websockets.ConnectionClosed as exc:
             self._handle_disconnect(exc)
         self.stop.set()
+
+    def _report_session_state(self, new: str | None) -> None:
+        """Tell the user whether the session self-healed or expired."""
+        if new:
+            self.stdout.write(
+                "\r\nSession refreshed."
+                " Run your command again to reconnect.\r\n"
+            )
+        else:
+            self.stdout.write(
+                "\r\nSession expired. Run `klangk login`"
+                " to re-authenticate.\r\n"
+            )
+
+    def _session_expired_line(self) -> None:
+        """The session-expired hint (dead token, refresh not possible)."""
+        self.stdout.write(
+            "\r\nSession expired. Run `klangk login` to re-authenticate.\r\n"
+        )
 
     def _handle_disconnect(self, exc) -> None:
         """Explain an unexpected close (and try a token refresh on 4002)."""
         if self.stop.is_set():
             return
-        _code = exc.rcvd.code if exc.rcvd else None
+        _code = close_code(exc)
         if _code == 4002 and self.token:
-            new = refresh_token(self.server_url, self.token)
-            if not new and server_mode_is_none(self.server_url):
-                try:
-                    _email, new = _local_login(self.server_url)
-                except SystemExit:
-                    new = None
-            if new:
-                self.stdout.write(
-                    "\r\nSession refreshed."
-                    " Run your command again to reconnect.\r\n"
-                )
-            else:
-                self.stdout.write(
-                    "\r\nSession expired. Run `klangk login`"
-                    " to re-authenticate.\r\n"
-                )
-        elif _code in (4001, 4002):
-            self.stdout.write(
-                "\r\nSession expired. Run `klangk login` to"
-                " re-authenticate.\r\n"
+            self._report_session_state(
+                refreshed_token(self.server_url, self.token)
             )
+        elif _code in (4001, 4002):
+            self._session_expired_line()
         else:
             self.stdout.write("\r\nServer disconnected.\r\n")
         self.stdout.flush()
@@ -1755,6 +1975,15 @@ class TerminalSession(_ShellSession):
             for t in tasks:
                 t.cancel()
             await asyncio.gather(*tasks, return_exceptions=True)
+
+
+async def cancel_task(task) -> None:
+    """Cancel a task and await its end, ignoring cancellation."""
+    task.cancel()
+    try:
+        await task
+    except asyncio.CancelledError:
+        pass
 
 
 class ExecSession(_ShellSession):
@@ -1793,82 +2022,116 @@ class ExecSession(_ShellSession):
             pass
         self._has_stdout_fd = self._stdout_fd >= 0
 
+    def _stdin_fd(self) -> int | None:
+        """stdin's fileno, or None when it has none (BytesIO etc.)."""
+        try:
+            return self.stdin.fileno()
+        except (io.UnsupportedOperation, AttributeError):
+            return None
+
+    async def send_exec_input(self, data: bytes) -> None:
+        """Send one exec_input chunk (base64)."""
+        await self.ws.send(
+            json.dumps(
+                {
+                    "cmd": "exec_input",
+                    "data": base64.b64encode(data).decode("ascii"),
+                }
+            )
+        )
+
+    async def _forward_fd_stdin(self, fd: int) -> None:
+        """Forward stdin by fd (select loop)."""
+        while not self.stop.is_set():
+            ready = await self._loop.run_in_executor(
+                None,
+                lambda: select.select([fd], [], [], 0.2)[0],
+            )
+            if not ready:
+                continue
+            data = await self._loop.run_in_executor(None, os.read, fd, 65536)
+            if not data:
+                break
+            await self.send_exec_input(data)
+
+    async def _forward_buffered_stdin(self) -> None:
+        """Forward a non-fd stdin in one read."""
+        data = self.stdin.read()
+        if data:
+            await self.send_exec_input(data)
+
     async def stdin_forward(self) -> None:
         if self.stdin is None:
             await self.ws.send(json.dumps({"cmd": "exec_close_stdin"}))
             return
-        try:
-            fd = self.stdin.fileno()
-            has_fd = True
-        except (io.UnsupportedOperation, AttributeError):
-            has_fd = False
-
-        if has_fd:
-            while not self.stop.is_set():
-                ready = await self._loop.run_in_executor(
-                    None,
-                    lambda: select.select([fd], [], [], 0.2)[0],
-                )
-                if not ready:
-                    continue
-                data = await self._loop.run_in_executor(
-                    None, os.read, fd, 65536
-                )
-                if not data:
-                    break
-                await self.ws.send(
-                    json.dumps(
-                        {
-                            "cmd": "exec_input",
-                            "data": base64.b64encode(data).decode("ascii"),
-                        }
-                    )
-                )
+        fd = self._stdin_fd()
+        if fd is not None:
+            await self._forward_fd_stdin(fd)
         else:
-            data = self.stdin.read()
-            if data:
-                await self.ws.send(
-                    json.dumps(
-                        {
-                            "cmd": "exec_input",
-                            "data": base64.b64encode(data).decode("ascii"),
-                        }
-                    )
-                )
+            await self._forward_buffered_stdin()
         await self.ws.send(json.dumps({"cmd": "exec_close_stdin"}))
+
+    async def _write_exec_output(self, raw: bytes) -> None:
+        """Write exec output to the fd-backed or plain stdout."""
+        if self.stdout is None:
+            return
+        if self._has_stdout_fd:
+            await self._loop.run_in_executor(
+                None, os.write, self._stdout_fd, raw
+            )
+        else:
+            self.stdout.write(raw)
+
+    async def _apply_exec_frame(self, msg: str) -> bool:
+        """Handle one exec frame; True when the session should stop."""
+        data = json.loads(msg)
+        mtype = data.get("type")
+        if mtype == "exec_output":
+            await self._write_exec_output(base64.b64decode(data["data"]))
+        elif mtype == "ssh_agent_response":
+            self.dispatch_agent_response(data)
+        elif mtype == "exec_exit":
+            self.exit_code = data.get("code", 0)
+            return True
+        elif mtype == "error":
+            # Server-side nack (e.g. the #2706/#2712 exec-and-sync permission
+            # gate on exec_start). stderr, never stdout: stdout
+            # carries rsync's binary protocol when this session is
+            # the sync transport, and rsync relays transport stderr
+            # to the user's rsync output.
+            print(
+                f"klangk: {data.get('message', 'unknown error')}",
+                file=sys.stderr,
+            )
+            self.exit_code = 1
+            return True
+        return False
 
     async def stdout_forward(self) -> None:
         while True:
             msg = await self.ws.recv()
             if isinstance(msg, bytes):
                 msg = msg.decode("utf-8", errors="replace")
-            data = json.loads(msg)
-            if data.get("type") == "exec_output":
-                raw = base64.b64decode(data["data"])
-                if self.stdout is not None:
-                    if self._has_stdout_fd:
-                        await self._loop.run_in_executor(
-                            None, os.write, self._stdout_fd, raw
-                        )
-                    else:
-                        self.stdout.write(raw)
-            elif data.get("type") == "ssh_agent_response":
-                self.dispatch_agent_response(data)
-            elif data.get("type") == "exec_exit":
-                self.exit_code = data.get("code", 0)
+            if await self._apply_exec_frame(msg):
                 break
-            elif data.get("type") == "error":
-                # Server-side nack (e.g. the #2706/#2712 exec-and-sync permission
-                # gate on exec_start). stderr, never stdout: stdout
-                # carries rsync's binary protocol when this session is
-                # the sync transport, and rsync relays transport stderr
-                # to the user's rsync output.
-                print(
-                    f"klangk: {data.get('message', 'unknown error')}",
-                    file=sys.stderr,
-                )
-                self.exit_code = 1
-                break
+
+    async def _await_output(self, stdout_task) -> None:
+        """Await stdout (with the optional timeout); 124 on timeout."""
+        try:
+            if self.timeout is not None:
+                await asyncio.wait_for(stdout_task, timeout=self.timeout)
+            else:
+                await stdout_task
+        except asyncio.TimeoutError:
+            self.exit_code = 124  # same as coreutils timeout(1)
+            await cancel_task(stdout_task)
+
+    async def _drain_stdin_forward(self, stdin_task) -> None:
+        """Let the stdin forwarder finish (bounded), then cancel it."""
+        try:
+            await asyncio.wait_for(stdin_task, timeout=_STDIN_DRAIN_TIMEOUT)
+        except asyncio.TimeoutError:
+            await cancel_task(stdin_task)
 
     async def run(self) -> int:
         await self.ws.send(
@@ -1885,37 +2148,11 @@ class ExecSession(_ShellSession):
         stdin_task = asyncio.create_task(self.stdin_forward())
         heartbeat_task = asyncio.create_task(self.heartbeat_loop())
         agent_task = asyncio.create_task(self.ssh_agent_relay_loop())
-        try:
-            if self.timeout is not None:
-                await asyncio.wait_for(stdout_task, timeout=self.timeout)
-            else:
-                await stdout_task
-        except asyncio.TimeoutError:
-            self.exit_code = 124  # same as coreutils timeout(1)
-            stdout_task.cancel()
-            try:
-                await stdout_task
-            except asyncio.CancelledError:
-                pass
+        await self._await_output(stdout_task)
         self.stop.set()
-        try:
-            await asyncio.wait_for(stdin_task, timeout=_STDIN_DRAIN_TIMEOUT)
-        except asyncio.TimeoutError:
-            stdin_task.cancel()
-            try:
-                await stdin_task
-            except asyncio.CancelledError:
-                pass
-        heartbeat_task.cancel()
-        try:
-            await heartbeat_task
-        except asyncio.CancelledError:
-            pass
-        agent_task.cancel()
-        try:
-            await agent_task
-        except asyncio.CancelledError:
-            pass
+        await self._drain_stdin_forward(stdin_task)
+        await cancel_task(heartbeat_task)
+        await cancel_task(agent_task)
 
         await send_ignore_closed(self.ws, json.dumps({"cmd": "exec_stop"}))
         return self.exit_code

--- a/src/klangk/klangk/cli/config.py
+++ b/src/klangk/klangk/cli/config.py
@@ -116,6 +116,19 @@ def _split_terminal_cmd(text: str) -> list[str] | None:
         return None
 
 
+def terminal_cmd_from_str(value: str) -> list[str] | None:
+    """A shell-string terminal-open-cmd, shlex-split."""
+    value = value.strip()
+    return _split_terminal_cmd(value) if value else None
+
+
+def terminal_cmd_from_list(value: list) -> list[str] | None:
+    """A list-of-strings terminal-open-cmd, copied (None when mistyped)."""
+    if not all(isinstance(v, str) for v in value):
+        return None
+    return list(value) if value else None
+
+
 def parse_terminal_open_cmd(value) -> list[str] | None:
     """Normalize a ``terminal-open-cmd`` yaml value to an argv list.
 
@@ -125,10 +138,9 @@ def parse_terminal_open_cmd(value) -> list[str] | None:
     inline shell instead of crashing the CLI/TUI (#2685).
     """
     if isinstance(value, str):
-        value = value.strip()
-        return _split_terminal_cmd(value) if value else None
-    if isinstance(value, list) and all(isinstance(v, str) for v in value):
-        return list(value) if value else None
+        return terminal_cmd_from_str(value)
+    if isinstance(value, list):
+        return terminal_cmd_from_list(value)
     return None
 
 
@@ -140,6 +152,21 @@ class ServerEntry:
     user: str | None = None
     forward_agent: bool | None = None
     ws_max_size: int | None = None
+
+
+def parse_server_entries(data: dict) -> dict[str, ServerEntry]:
+    """ServerEntry map from the klangk.yaml ``servers`` section."""
+    servers: dict[str, ServerEntry] = {}
+    for name, entry in (data.get("servers") or {}).items():
+        if not isinstance(entry, dict) or "url" not in entry:
+            continue
+        servers[name] = ServerEntry(
+            url=entry["url"],
+            user=entry.get("user"),
+            forward_agent=entry.get("forward-agent"),
+            ws_max_size=entry.get("ws-max-size"),
+        )
+    return servers
 
 
 @dataclass
@@ -157,23 +184,13 @@ class CLIConfig:
             return cls()
         text = CONFIG_PATH.read_text()
         data = yaml.safe_load(text) or {}
-        servers: dict[str, ServerEntry] = {}
-        for name, entry in (data.get("servers") or {}).items():
-            if not isinstance(entry, dict) or "url" not in entry:
-                continue
-            servers[name] = ServerEntry(
-                url=entry["url"],
-                user=entry.get("user"),
-                forward_agent=entry.get("forward-agent"),
-                ws_max_size=entry.get("ws-max-size"),
-            )
         return cls(
             forward_agent=data.get("forward-agent"),
             ws_max_size=data.get("ws-max-size"),
             terminal_open_cmd=parse_terminal_open_cmd(
                 data.get("terminal-open-cmd")
             ),
-            servers=servers,
+            servers=parse_server_entries(data),
         )
 
     def resolve_server(self, name_or_url: str) -> str:
@@ -267,6 +284,13 @@ def seed_config(server_url: str, user: str | None = None) -> None:
     CONFIG_PATH.write_text(header + servers_yaml)
 
 
+def load_yaml_config() -> dict:
+    """The parsed klangk.yaml (empty when the file is absent)."""
+    if not CONFIG_PATH.exists():
+        return {}
+    return yaml.safe_load(CONFIG_PATH.read_text()) or {}
+
+
 def add_server_to_config(
     alias: str, server_url: str, user: str | None = None
 ) -> None:
@@ -282,10 +306,7 @@ def add_server_to_config(
     must catch the error and surface it to the user (#1763).
     """
     CONFIG_PATH.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
-    if CONFIG_PATH.exists():
-        data = yaml.safe_load(CONFIG_PATH.read_text()) or {}
-    else:
-        data = {}
+    data = load_yaml_config()
     servers = data.get("servers") or {}
     if alias in servers:
         raise AliasConflictError(f"Alias '{alias}' already exists.")
@@ -299,6 +320,24 @@ def add_server_to_config(
 
 class AliasConflictError(Exception):
     """Raised when renaming a server alias to one that already exists."""
+
+
+def check_alias_renaming(
+    old_alias: str, new_alias: str, servers: dict
+) -> None:
+    """Reject a rename onto an existing alias (same-alias updates pass)."""
+    if old_alias != new_alias and new_alias in servers:
+        raise AliasConflictError(f"Alias '{new_alias}' already exists.")
+
+
+def replaced_server_entry(existing, server_url: str, user) -> dict:
+    """The updated server entry, preserving fields the edit form omits
+    (forward-agent, ws-max-size)."""
+    entry = dict(existing) if isinstance(existing, dict) else {}
+    entry["url"] = server_url
+    if user:
+        entry["user"] = user
+    return entry
 
 
 def update_server_in_config(
@@ -316,21 +355,12 @@ def update_server_in_config(
     """
     if not CONFIG_PATH.exists():
         return False
-    data = yaml.safe_load(CONFIG_PATH.read_text()) or {}
+    data = load_yaml_config()
     servers = data.get("servers") or {}
     if old_alias not in servers:
         return False
-    if old_alias != new_alias and new_alias in servers:
-        raise AliasConflictError(f"Alias '{new_alias}' already exists.")
-    # Preserve fields not shown in the edit form (forward_agent, ws_max_size).
-    existing = servers[old_alias]
-    if isinstance(existing, dict):
-        entry = dict(existing)
-    else:
-        entry = {}
-    entry["url"] = server_url
-    if user:
-        entry["user"] = user
+    check_alias_renaming(old_alias, new_alias, servers)
+    entry = replaced_server_entry(servers[old_alias], server_url, user)
     if old_alias != new_alias:
         del servers[old_alias]
     servers[new_alias] = entry
@@ -372,6 +402,45 @@ class ServerState:
     users: dict[str, UserEntry] = field(default_factory=dict)
 
 
+def parse_user_entries(val: dict) -> dict[str, UserEntry]:
+    """UserEntry map from one state server section."""
+    users: dict[str, UserEntry] = {}
+    for uname, uval in (val.get("users") or {}).items():
+        if isinstance(uval, dict):
+            users[uname] = UserEntry(token=uval.get("token"))
+    return users
+
+
+def parse_server_states(data: dict) -> dict[str, ServerState]:
+    """ServerState map from the klangk-state.yaml data."""
+    servers: dict[str, ServerState] = {}
+    for key, val in data.items():
+        if key == "active-server":
+            continue
+        if not isinstance(val, dict):
+            continue
+        servers[key] = ServerState(
+            active_user=val.get("active-user"),
+            users=parse_user_entries(val),
+        )
+    return servers
+
+
+def server_state_data(ss: ServerState) -> dict:
+    """One ServerState as its klangk-state.yaml section ({} when empty)."""
+    server_data: dict = {}
+    if ss.active_user is not None:
+        server_data["active-user"] = ss.active_user
+    users_data = {
+        uname: {"token": ue.token}
+        for uname, ue in ss.users.items()
+        if ue.token is not None
+    }
+    if users_data:
+        server_data["users"] = users_data
+    return server_data
+
+
 @dataclass
 class CLIState:
     """Parsed klangk-state.yaml — auto-managed by the CLI."""
@@ -385,22 +454,10 @@ class CLIState:
             return cls()
         text = STATE_PATH.read_text()
         data = yaml.safe_load(text) or {}
-        active = data.get("active-server")
-        servers: dict[str, ServerState] = {}
-        for key, val in data.items():
-            if key == "active-server":
-                continue
-            if not isinstance(val, dict):
-                continue
-            users: dict[str, UserEntry] = {}
-            for uname, uval in (val.get("users") or {}).items():
-                if isinstance(uval, dict):
-                    users[uname] = UserEntry(token=uval.get("token"))
-            servers[key] = ServerState(
-                active_user=val.get("active-user"),
-                users=users,
-            )
-        return cls(active_server=active, servers=servers)
+        return cls(
+            active_server=data.get("active-server"),
+            servers=parse_server_states(data),
+        )
 
     def save(self) -> None:
         STATE_PATH.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
@@ -408,15 +465,7 @@ class CLIState:
         if self.active_server is not None:
             data["active-server"] = self.active_server
         for url, ss in self.servers.items():
-            server_data: dict = {}
-            if ss.active_user is not None:
-                server_data["active-user"] = ss.active_user
-            users_data: dict = {}
-            for uname, ue in ss.users.items():
-                if ue.token is not None:
-                    users_data[uname] = {"token": ue.token}
-            if users_data:
-                server_data["users"] = users_data
+            server_data = server_state_data(ss)
             if server_data:
                 data[url] = server_data
         content = yaml.dump(data, default_flow_style=False)

--- a/src/klangk/klangk/cli/context.py
+++ b/src/klangk/klangk/cli/context.py
@@ -40,6 +40,22 @@ app = typer.Typer(
 err = Console(stderr=True)
 
 
+def timeout_detail(e: BaseException) -> str:
+    """A timeout error's message, or the generic wait wording if empty."""
+    return str(e) or "Timed out waiting for the server to respond"
+
+
+def print_ws_rejection(e: websockets.InvalidStatus) -> None:
+    """Report a handshake rejection; 4001/4002 mean the session expired."""
+    if e.response.status_code in (4001, 4002):
+        err.print(
+            "[red]Session expired. Run `klangk login`"
+            " to re-authenticate.[/red]"
+        )
+    else:
+        err.print(f"[red]Connection rejected: {e}[/red]")
+
+
 def run_ws_command(body):
     """Run an async ws command body, surfacing failures as a clean exit.
 
@@ -59,17 +75,10 @@ def run_ws_command(body):
         err.print(f"[red]{e}[/red]")
         raise typer.Exit(code=1) from None
     except asyncio.TimeoutError as e:
-        detail = str(e) or "Timed out waiting for the server to respond"
-        err.print(f"[red]{detail}[/red]")
+        err.print(f"[red]{timeout_detail(e)}[/red]")
         raise typer.Exit(code=1) from None
     except websockets.InvalidStatus as e:
-        if e.response.status_code in (4001, 4002):
-            err.print(
-                "[red]Session expired. Run `klangk login`"
-                " to re-authenticate.[/red]"
-            )
-        else:
-            err.print(f"[red]Connection rejected: {e}[/red]")
+        print_ws_rejection(e)
         raise typer.Exit(code=1) from None
 
 

--- a/src/klangk/klangk/cli/edit.py
+++ b/src/klangk/klangk/cli/edit.py
@@ -42,6 +42,54 @@ CREATE_TIME_KEYS = {
 CREATE_TIME_SETTINGS_DEFAULTS = {"nix": False, "allow_sudo": True}
 
 
+def print_list_editor_state(items, header, empty_note) -> None:
+    """Show the numbered current list (or the empty note)."""
+    if items:
+        typer.echo(f"\n{header}:")
+        for i, item in enumerate(items, 1):
+            typer.echo(f"  {i}. {item}")
+    else:
+        typer.echo(f"\n{empty_note}")
+
+
+def prompt_list_add(items, add_prompt, validate) -> bool | None:
+    """One add prompt: True added / False invalid (retry) / None skipped."""
+    add = input(add_prompt).strip()
+    if not add:
+        return None
+    err = validate(add)
+    if err:
+        typer.echo(err)
+        return False
+    items.append(add)
+    return True
+
+
+def prompt_list_remove(items, remove_what) -> bool | None:
+    """One remove prompt: True removed / False invalid (retry) / None skipped."""
+    rm = input(f"Remove {remove_what} number (or Enter to skip): ").strip()
+    if not rm:
+        return None
+    try:
+        idx = int(rm) - 1
+    except ValueError:
+        typer.echo("Invalid number.")
+        return False
+    if not 0 <= idx < len(items):
+        typer.echo("Invalid number.")
+        return False
+    typer.echo(f"Removed: {items.pop(idx)}")
+    return True
+
+
+def next_list_outcome(items, *, add_prompt, remove_what, validate):
+    """One add/remove interaction: True/False (changed / retry) or None (done)."""
+    outcome = prompt_list_add(items, add_prompt, validate)
+    if outcome is None and items:
+        outcome = prompt_list_remove(items, remove_what)
+    return outcome
+
+
 def edit_list_interactively(
     items: list[str],
     *,
@@ -54,91 +102,81 @@ def edit_list_interactively(
     """Add/remove loop for a repeatable string list; True if changed."""
     changed = False
     while True:
-        if items:
-            typer.echo(f"\n{header}:")
-            for i, item in enumerate(items, 1):
-                typer.echo(f"  {i}. {item}")
-        else:
-            typer.echo(f"\n{empty_note}")
-
-        add = input(add_prompt).strip()
-        if add:
-            err = validate(add)
-            if err:
-                typer.echo(err)
-                continue
-            items.append(add)
+        print_list_editor_state(items, header, empty_note)
+        outcome = next_list_outcome(
+            items,
+            add_prompt=add_prompt,
+            remove_what=remove_what,
+            validate=validate,
+        )
+        if outcome is None:
+            return changed
+        if outcome:
             changed = True
-            continue
 
-        if items:
-            rm = input(
-                f"Remove {remove_what} number (or Enter to skip): "
-            ).strip()
-            if rm:
-                try:
-                    idx = int(rm) - 1
-                    if 0 <= idx < len(items):
-                        removed = items.pop(idx)
-                        typer.echo(f"Removed: {removed}")
-                        changed = True
-                        continue
-                    else:
-                        typer.echo("Invalid number.")
-                        continue
-                except ValueError:
-                    typer.echo("Invalid number.")
-                    continue
 
-        break  # both add and remove were skipped
-    return changed
+def print_env_state(env) -> None:
+    """Show the numbered current env vars (or the empty note)."""
+    if env:
+        typer.echo("\nCurrent environment variables:")
+        env_items = list(env.items())
+        for i, (k, v) in enumerate(env_items, 1):
+            typer.echo(f"  {i}. {k}={v}")
+    else:
+        typer.echo("\nNo environment variables configured.")
+
+
+def prompt_env_add(env) -> bool | None:
+    """One add prompt: True added / False invalid (retry) / None skipped."""
+    add = input("\nAdd env var (e.g. KEY=VALUE, or Enter to skip): ").strip()
+    if not add:
+        return None
+    if "=" not in add:
+        typer.echo("Invalid format, expected KEY=VALUE.")
+        return False
+    key, _, value = add.partition("=")
+    env[key] = value
+    return True
+
+
+def prompt_env_remove(env) -> bool | None:
+    """One remove prompt: True removed / False invalid (retry) / None skipped."""
+    rm = input("Remove env var number (or Enter to skip): ").strip()
+    if not rm:
+        return None
+    try:
+        idx = int(rm) - 1
+    except ValueError:
+        typer.echo("Invalid number.")
+        return False
+    env_items = list(env.items())
+    if not 0 <= idx < len(env_items):
+        typer.echo("Invalid number.")
+        return False
+    removed_key = env_items[idx][0]
+    del env[removed_key]
+    typer.echo(f"Removed: {removed_key}")
+    return True
+
+
+def next_env_outcome(env):
+    """One add/remove interaction: True/False (changed / retry) or None (done)."""
+    outcome = prompt_env_add(env)
+    if outcome is None and env:
+        outcome = prompt_env_remove(env)
+    return outcome
 
 
 def edit_env_interactively(env: dict) -> bool:
     """Add/remove loop for the env-var map; True if changed."""
     changed = False
     while True:
-        if env:
-            typer.echo("\nCurrent environment variables:")
-            env_items = list(env.items())
-            for i, (k, v) in enumerate(env_items, 1):
-                typer.echo(f"  {i}. {k}={v}")
-        else:
-            typer.echo("\nNo environment variables configured.")
-
-        add = input(
-            "\nAdd env var (e.g. KEY=VALUE, or Enter to skip): "
-        ).strip()
-        if add:
-            if "=" not in add:
-                typer.echo("Invalid format, expected KEY=VALUE.")
-                continue
-            key, _, value = add.partition("=")
-            env[key] = value
+        print_env_state(env)
+        outcome = next_env_outcome(env)
+        if outcome is None:
+            return changed
+        if outcome:
             changed = True
-            continue
-
-        if env:
-            rm = input("Remove env var number (or Enter to skip): ").strip()
-            if rm:
-                try:
-                    idx = int(rm) - 1
-                    env_items = list(env.items())
-                    if 0 <= idx < len(env_items):
-                        removed_key = env_items[idx][0]
-                        del env[removed_key]
-                        typer.echo(f"Removed: {removed_key}")
-                        changed = True
-                        continue
-                    else:
-                        typer.echo("Invalid number.")
-                        continue
-                except ValueError:
-                    typer.echo("Invalid number.")
-                    continue
-
-        break  # both add and remove were skipped
-    return changed
 
 
 def has_any_flags(
@@ -295,6 +333,18 @@ def interactive_edit_body(ws) -> dict:
     return body
 
 
+def clearable_body(clearable: dict, skip) -> dict:
+    """Body fields for clearable overrides; a falsy value maps to None
+    on the wire ('' clears back to the deploy default, #2768). *skip* is
+    the not-given marker filtered out (``SENTINEL`` for prompts, ``None``
+    for flags)."""
+    return {
+        key: value or None
+        for key, value in clearable.items()
+        if value is not skip
+    }
+
+
 def prompted_body_fields(
     ws, new_name, new_image, new_command, new_health_check, new_banner
 ) -> dict:
@@ -303,16 +353,25 @@ def prompted_body_fields(
     if new_name is not SENTINEL:
         body["name"] = new_name or ws.name  # don't allow empty name
     # A cleared (whitespace) answer maps to None on the wire (#2768).
-    clearable = {
-        "image": new_image,
-        "service_command": new_command,
-        "health_check": new_health_check,
-        "classification_banner": new_banner,
-    }
-    for key, value in clearable.items():
-        if value is not SENTINEL:
-            body[key] = value or None
+    body.update(
+        clearable_body(
+            {
+                "image": new_image,
+                "service_command": new_command,
+                "health_check": new_health_check,
+                "classification_banner": new_banner,
+            },
+            skip=SENTINEL,
+        )
+    )
     return body
+
+
+def changed_list_body(changed: bool, key: str, current) -> dict:
+    """Body field for one interactively edited list (only when changed)."""
+    if not changed:
+        return {}
+    return {key: current or None}
 
 
 def edited_list_body(
@@ -327,14 +386,16 @@ def edited_list_body(
 ) -> dict:
     """Body fields from the interactive list editors (changed lists only)."""
     body: dict = {}
-    if mounts_changed:
-        body["mounts"] = current_mounts or None
-    if env_changed:
-        body["env"] = current_env or None
-    if domains_changed:
-        body["allowed_domains"] = current_domains or None
-    if rejected_changed:
-        body["rejected_domains"] = current_rejected or None
+    body.update(changed_list_body(mounts_changed, "mounts", current_mounts))
+    body.update(changed_list_body(env_changed, "env", current_env))
+    body.update(
+        changed_list_body(domains_changed, "allowed_domains", current_domains)
+    )
+    body.update(
+        changed_list_body(
+            rejected_changed, "rejected_domains", current_rejected
+        )
+    )
     return body
 
 
@@ -348,6 +409,13 @@ def validated_specs_or_exit(values: list[str], validate) -> list[str]:
     return values
 
 
+def override_body(overrides: dict) -> dict:
+    """Body fields for the non-None overrides."""
+    return {
+        key: value for key, value in overrides.items() if value is not None
+    }
+
+
 def flag_scalar_body(
     *,
     name: str | None,
@@ -359,27 +427,38 @@ def flag_scalar_body(
     classification_banner: str | None,
 ) -> dict:
     """Body fields for the scalar (non-repeatable) flags."""
-    body: dict = {}
-    if name is not None:
-        body["name"] = name
+    body: dict = override_body(
+        {
+            "name": name,
+            # Mutable (#2719); takes effect on the next connect/start —
+            # never a restart-prompt field (existing sessions keep their
+            # layout until they end).
+            "per_handle_home": per_handle_home,
+            "auto_start": auto_start,
+        }
+    )
     # '' clears these back to the deploy default (None on the wire).
-    clearable = {
-        "image": image,
-        "service_command": command,
-        "health_check": health_check,
-        "classification_banner": classification_banner,
-    }
-    for key, value in clearable.items():
-        if value is not None:
-            body[key] = value or None
-    if auto_start is not None:
-        body["auto_start"] = auto_start
-    if per_handle_home is not None:
-        # Mutable (#2719); takes effect on the next connect/start —
-        # never a restart-prompt field (existing sessions keep their
-        # layout until they end).
-        body["per_handle_home"] = per_handle_home
+    body.update(
+        clearable_body(
+            {
+                "image": image,
+                "service_command": command,
+                "health_check": health_check,
+                "classification_banner": classification_banner,
+            },
+            skip=None,
+        )
+    )
     return body
+
+
+def list_flag_body(value, key: str, validate) -> dict:
+    """Body for one repeatable list flag; {} when the flag was not given."""
+    if not isinstance(value, list):
+        return {}
+    if validate:
+        validated_specs_or_exit(value, validate)
+    return {key: value or None}
 
 
 def flag_list_body(
@@ -397,21 +476,20 @@ def flag_list_body(
 ) -> dict:
     """Body fields for the repeatable list flags and the settings bag."""
     body: dict = {}
-    if isinstance(mount, list):
-        validated_specs_or_exit(mount, validate_mount_spec)
-        body["mounts"] = mount or None
+    body.update(list_flag_body(mount, "mounts", validate_mount_spec))
     if isinstance(env, list):
         body["env"] = parse_env_list(env) or None
-    if isinstance(allow, list):
-        validated_specs_or_exit(allow, validate_allowed_domain_spec)
-        body["allowed_domains"] = allow or None
-    if isinstance(reject, list):
-        # CIDR is meaningless for a name-level NXDOMAIN deny-list (#2367).
-        validated_specs_or_exit(
+    body.update(
+        list_flag_body(allow, "allowed_domains", validate_allowed_domain_spec)
+    )
+    # CIDR is meaningless for a name-level NXDOMAIN deny-list (#2367).
+    body.update(
+        list_flag_body(
             reject,
+            "rejected_domains",
             lambda spec: validate_allowed_domain_spec(spec, allow_cidr=False),
         )
-        body["rejected_domains"] = reject or None
+    )
     merged = merged_flag_settings(
         ws, idle_timeout, cpu_limit, memory_limit, pids_limit, allow_sudo
     )
@@ -441,17 +519,32 @@ def merged_flag_settings(
     return merged
 
 
+def create_time_setting_changed(
+    bag: dict, old: dict, key: str, default
+) -> bool:
+    """True when a create-time settings key differs from its old value."""
+    return bag.get(key, default) != old.get(key, default)
+
+
+def settings_changed(ws, body: dict) -> bool:
+    """True when a create-time settings key (nix / allow_sudo) changed."""
+    if "settings" not in body:
+        return False
+    bag = body["settings"] or {}
+    old = ws.settings or {}
+    return any(
+        create_time_setting_changed(bag, old, key, default)
+        for key, default in CREATE_TIME_SETTINGS_DEFAULTS.items()
+    )
+
+
 def restart_needed(ws, body: dict) -> bool:
     """True if any create-time field changed on a running workspace."""
-    if ws.running and bool(body.keys() & CREATE_TIME_KEYS):
+    if not ws.running:
+        return False
+    if body.keys() & CREATE_TIME_KEYS:
         return True
-    if ws.running and "settings" in body:
-        bag = body["settings"] or {}
-        old = ws.settings or {}
-        for key, default in CREATE_TIME_SETTINGS_DEFAULTS.items():
-            if bag.get(key, default) != old.get(key, default):
-                return True
-    return False
+    return settings_changed(ws, body)
 
 
 def apply_edit(client, ws, body: dict, restart: bool) -> None:

--- a/src/klangk/klangk/cli/edit.py
+++ b/src/klangk/klangk/cli/edit.py
@@ -456,8 +456,7 @@ def list_flag_body(value, key: str, validate) -> dict:
     """Body for one repeatable list flag; {} when the flag was not given."""
     if not isinstance(value, list):
         return {}
-    if validate:
-        validated_specs_or_exit(value, validate)
+    validated_specs_or_exit(value, validate)
     return {key: value or None}
 
 

--- a/src/klangk/klangk/cli/execsync.py
+++ b/src/klangk/klangk/cli/execsync.py
@@ -132,6 +132,31 @@ def exec_cmd(
     raise typer.Exit(code=exit_code)
 
 
+def require_binary(name: str) -> str:
+    """Resolve *name* on PATH or exit with the standard error."""
+    path = shutil.which(name)
+    if not path:
+        context.err.print(f"[red]Cannot find {name} in PATH[/red]")
+        raise typer.Exit(code=1)
+    return path
+
+
+def ensure_sync_allowed(client, host: str | None, direction: str) -> None:
+    """Exit with a clear error if syncing via *host* is not permitted.
+
+    #2706/#2712: ``klangk sync`` rides the one-shot exec channel, gated
+    on the ``exec-and-sync`` permission. Fail fast with a clear
+    permission error; the server still enforces when rsync gets that
+    far. No-op when *host* is None (local side) or allowed.
+    """
+    if host and sync_denied(client, host):
+        context.err.print(
+            f"[red]Permission denied:[/red] syncing {direction} workspace"
+            f" '{host}' requires the exec-and-sync permission"
+        )
+        raise typer.Exit(code=1)
+
+
 @context.app.command(
     "sync",
     context_settings={
@@ -162,36 +187,12 @@ def sync(
     """
     context.require_auth()
 
-    klangk_bin = shutil.which("klangk")
-    if not klangk_bin:
-        context.err.print("[red]Cannot find klangk in PATH[/red]")
-        raise typer.Exit(code=1)
+    klangk_bin = require_binary("klangk")
+    rsync_bin = require_binary("rsync")
 
-    rsync_bin = shutil.which("rsync")
-    if not rsync_bin:
-        context.err.print("[red]Cannot find rsync in PATH[/red]")
-        raise typer.Exit(code=1)
-
-    # #2706/#2712: sync rides the one-shot exec channel, gated on the
-    # ``exec-and-sync`` permission — a remote source or destination
-    # means the user needs it on that workspace (either direction).
-    # Fail fast with a clear permission error; the server still enforces
-    # when rsync gets that far.
     client = context.client()
-    pull_host = remote_host(src)
-    if pull_host and sync_denied(client, pull_host):
-        context.err.print(
-            f"[red]Permission denied:[/red] syncing out of workspace"
-            f" '{pull_host}' requires the exec-and-sync permission"
-        )
-        raise typer.Exit(code=1)
-    push_host = remote_host(dest)
-    if push_host and sync_denied(client, push_host):
-        context.err.print(
-            f"[red]Permission denied:[/red] syncing into workspace"
-            f" '{push_host}' requires the exec-and-sync permission"
-        )
-        raise typer.Exit(code=1)
+    ensure_sync_allowed(client, remote_host(src), "out of")
+    ensure_sync_allowed(client, remote_host(dest), "into")
 
     cmd = [
         rsync_bin,

--- a/src/klangk/klangk/cli/monitor.py
+++ b/src/klangk/klangk/cli/monitor.py
@@ -24,6 +24,36 @@ from . import context
 from .transport import ws_connect
 
 
+def truthy_env(msg: dict, key: str, env_name: str) -> dict[str, str]:
+    """{env_name: value} when *key* is present and truthy."""
+    value = msg.get(key)
+    return {env_name: str(value)} if value else {}
+
+
+def present_env(msg: dict, key: str, env_name: str) -> dict[str, str]:
+    """{env_name: value} when *key* is present (even falsy, e.g. seq 0)."""
+    value = msg.get(key)
+    return {env_name: str(value)} if value is not None else {}
+
+
+def health_event_env(msg: dict) -> dict[str, str]:
+    """Env vars for a ``service_health`` event."""
+    env = {
+        "KLANGK_HEALTHY": "true" if msg.get("healthy") else "false",
+        # ``running`` distinguishes "unhealthy check" from "container
+        # stopped" -- both have healthy=false, but a death frame carries
+        # running=false (#1175 item 2).  Defaults to true for older
+        # servers that don't send the field.
+        "KLANGK_RUNNING": "true" if msg.get("running", True) else "false",
+    }
+    env.update(truthy_env(msg, "health_message", "KLANGK_HEALTH_MESSAGE"))
+    env.update(
+        truthy_env(msg, "health_checked_at", "KLANGK_HEALTH_CHECKED_AT")
+    )
+    env.update(present_env(msg, "seq", "KLANGK_HEALTH_SEQ"))
+    return env
+
+
 def dispatch_monitor_event(msg: dict, command: list[str]) -> None:
     """Act on one server event.
 
@@ -47,21 +77,7 @@ def dispatch_monitor_event(msg: dict, command: list[str]) -> None:
     if wid is not None:
         env["KLANGK_WORKSPACE_ID"] = str(wid)
     if msg.get("type") == "service_health":
-        env["KLANGK_HEALTHY"] = "true" if msg.get("healthy") else "false"
-        # ``running`` distinguishes "unhealthy check" from "container
-        # stopped" -- both have healthy=false, but a death frame carries
-        # running=false (#1175 item 2).  Defaults to true for older
-        # servers that don't send the field.
-        env["KLANGK_RUNNING"] = "true" if msg.get("running", True) else "false"
-        health_msg = msg.get("health_message")
-        if health_msg:
-            env["KLANGK_HEALTH_MESSAGE"] = str(health_msg)
-        checked_at = msg.get("health_checked_at")
-        if checked_at:
-            env["KLANGK_HEALTH_CHECKED_AT"] = str(checked_at)
-        seq = msg.get("seq")
-        if seq is not None:
-            env["KLANGK_HEALTH_SEQ"] = str(seq)
+        env.update(health_event_env(msg))
     # FileNotFoundError (missing binary) propagates to the caller.
     subprocess.run(command, input=payload.encode(), env=env, check=False)
 
@@ -89,6 +105,18 @@ async def monitor_connection(
                 dispatch_monitor_event(msg, command)
 
 
+def type_allowed(etype, type_filter: set) -> bool:
+    """True when *etype* passes the --type filter."""
+    return not type_filter or etype in type_filter
+
+
+def workspace_allowed(wid, ws_filter: set) -> bool:
+    """True when *wid* passes the --workspace filter."""
+    if not ws_filter:
+        return True
+    return wid is not None and wid in ws_filter
+
+
 def parse_monitor_event(
     raw: str, type_filter: set, ws_filter: set
 ) -> dict | None:
@@ -101,10 +129,9 @@ def parse_monitor_event(
     etype = msg.get("type")
     if etype is None:
         return None  # control/ack messages aren't events
-    if type_filter and etype not in type_filter:
+    if not type_allowed(etype, type_filter):
         return None
-    wid = msg.get("workspace_id")
-    if ws_filter and (wid is None or wid not in ws_filter):
+    if not workspace_allowed(msg.get("workspace_id"), ws_filter):
         return None
     return msg
 
@@ -135,6 +162,39 @@ async def refresh_token_threaded(server_url: str, token: str) -> str | None:
     return None
 
 
+def classify_monitor_failure(exc: BaseException) -> tuple[bool, str]:
+    """``(auth_close, reason)`` for a monitor connection failure."""
+    if isinstance(exc, websockets.ConnectionClosed):
+        code = exc.rcvd.code if exc.rcvd else None
+        return code in (4001, 4002), f"closed (code {code})"
+    if isinstance(exc, websockets.InvalidStatus):
+        code = exc.response.status_code
+        return code in (4001, 4002), f"rejected (HTTP {code})"
+    return False, f"network error: {exc}"
+
+
+async def refresh_on_auth_close(server_spec: str, current_token: str) -> str:
+    """A fresh token after an auth close, or the current one.
+
+    A failed refresh still returns the current token so the monitor
+    keeps retrying — the server/token may recover.
+    """
+    new = await refresh_token_threaded(server_spec, current_token)
+    if new:
+        context.err.print("[green]Token refreshed.[/green]")
+    else:
+        context.err.print(
+            "[yellow]Token refresh failed; retrying with the"
+            " current token.[/yellow]"
+        )
+    return new or current_token
+
+
+def reconnects_exhausted(max_reconnects: int | None, attempt: int) -> bool:
+    """True when the reconnect budget is spent."""
+    return max_reconnects is not None and attempt >= max_reconnects
+
+
 async def monitor_run(
     server_spec: str,
     token: str,
@@ -161,7 +221,6 @@ async def monitor_run(
     )
     attempt = 0
     while True:
-        auth_close = False
         try:
             await monitor_connection(
                 server_spec,
@@ -171,33 +230,25 @@ async def monitor_run(
                 types,
                 workspaces,
             )
+            auth_close = False
             reason = "connection closed"
-        except websockets.ConnectionClosed as exc:
-            code = exc.rcvd.code if exc.rcvd else None
-            auth_close = code in (4001, 4002)
-            reason = f"closed (code {code})"
-        except websockets.InvalidStatus as exc:
-            code = exc.response.status_code
-            auth_close = code in (4001, 4002)
-            reason = f"rejected (HTTP {code})"
-        except (OSError, asyncio.TimeoutError) as exc:
-            reason = f"network error: {exc}"
+        except (
+            websockets.ConnectionClosed,
+            websockets.InvalidStatus,
+            OSError,
+            asyncio.TimeoutError,
+        ) as exc:
+            auth_close, reason = classify_monitor_failure(exc)
 
         # On an auth-related close, try to refresh the JWT. A successful
         # refresh lets the next attempt authenticate cleanly; a failed
         # one still reconnects (the server/token may recover).
         if auth_close:
-            new = await refresh_token_threaded(server_spec, current_token)
-            if new:
-                current_token = new
-                context.err.print("[green]Token refreshed.[/green]")
-            else:
-                context.err.print(
-                    "[yellow]Token refresh failed; retrying with the"
-                    " current token.[/yellow]"
-                )
+            current_token = await refresh_on_auth_close(
+                server_spec, current_token
+            )
 
-        if max_reconnects is not None and attempt >= max_reconnects:
+        if reconnects_exhausted(max_reconnects, attempt):
             context.err.print(
                 f"[red]{reason}; max reconnects ({max_reconnects})"
                 " reached, giving up.[/red]"
@@ -210,6 +261,16 @@ async def monitor_run(
             f" (attempt {attempt})...[/yellow]"
         )
         await asyncio.sleep(delay)
+
+
+def monitor_options(
+    command: list[str] | None, no_reconnect: bool, max_reconnects: int | None
+) -> tuple[list[str], int | None]:
+    """Resolve the command list and reconnect bound from the CLI flags."""
+    return (
+        list(command) if command else [],
+        0 if no_reconnect else max_reconnects,
+    )
 
 
 @context.app.command()
@@ -304,14 +365,16 @@ def monitor(
             "[red]Not logged in. Run `klangk login` first.[/red]"
         )
         raise typer.Exit(code=1)
-    effective_max = 0 if no_reconnect else max_reconnects
+    command, effective_max = monitor_options(
+        command, no_reconnect, max_reconnects
+    )
     try:
         asyncio.run(
             monitor_run(
                 surl,
                 token,
                 max_size=context.ws_max_size(),
-                command=list(command) if command else [],
+                command=command,
                 types=event_type,
                 workspaces=workspace,
                 max_reconnects=effective_max,

--- a/src/klangk/klangk/cli/mount.py
+++ b/src/klangk/klangk/cli/mount.py
@@ -20,14 +20,8 @@ _VALID_MOUNT_OPTIONS = {
 }
 
 
-def validate_mount_spec(spec: str) -> str | None:
-    """Validate a container mount spec string.
-
-    Returns None if valid, or an error message string if invalid.
-    Valid forms: source:dest or source:dest:options
-    The container path (dest) must be absolute.
-    """
-    parts = spec.split(":")
+def mount_format_error(spec: str, parts: list[str]) -> str | None:
+    """Shape / source / destination format errors for a mount spec."""
     if len(parts) < 2 or len(parts) > 3:
         return (
             f"Invalid mount {spec!r}: "
@@ -41,11 +35,30 @@ def validate_mount_spec(spec: str) -> str | None:
             f"Invalid mount {spec!r}: "
             "container path must be absolute (start with /)"
         )
+    return None
+
+
+def mount_options_error(spec: str, options: str) -> str | None:
+    """An unknown-option error for a mount spec's options segment."""
+    for opt in options.split(","):
+        if opt and opt not in _VALID_MOUNT_OPTIONS:
+            return f"Invalid mount {spec!r}: unknown option {opt!r}"
+    return None
+
+
+def validate_mount_spec(spec: str) -> str | None:
+    """Validate a container mount spec string.
+
+    Returns None if valid, or an error message string if invalid.
+    Valid forms: source:dest or source:dest:options
+    The container path (dest) must be absolute.
+    """
+    parts = spec.split(":")
+    err = mount_format_error(spec, parts)
+    if err:
+        return err
     if len(parts) == 3:
-        options = parts[2]
-        for opt in options.split(","):
-            if opt and opt not in _VALID_MOUNT_OPTIONS:
-                return f"Invalid mount {spec!r}: unknown option {opt!r}"
+        return mount_options_error(spec, parts[2])
     return None
 
 
@@ -100,6 +113,13 @@ def validate_allowed_domain_spec(
     return None
 
 
+def cidr_port_error(spec: str, port: str) -> str | None:
+    """The CIDR-port range error, if *port* is not 1–65535 digits."""
+    if not port or not port.isdigit() or int(port) > 65535:
+        return f"Invalid allowed-domain {spec!r}: CIDR port must be 1–65535"
+    return None
+
+
 def _validate_cidr_domain_spec(spec: str, s: str) -> str | None:
     """Client-side IPv4 CIDR pre-check, mirroring the server's
     :func:`klangk.netfilter.valid_cidr_spec` (#1935).
@@ -113,10 +133,9 @@ def _validate_cidr_domain_spec(spec: str, s: str) -> str | None:
     port: str | None = None
     if ":" in s:
         cidr, port = s.rsplit(":", 1)
-        if not port or not port.isdigit() or int(port) > 65535:
-            return (
-                f"Invalid allowed-domain {spec!r}: CIDR port must be 1–65535"
-            )
+        err = cidr_port_error(spec, port)
+        if err:
+            return err
     try:
         ipaddress.IPv4Network(cidr, strict=False)
     except ValueError:

--- a/src/klangk/klangk/cli/sandbox.py
+++ b/src/klangk/klangk/cli/sandbox.py
@@ -28,6 +28,24 @@ class SandboxConfig:
     volumes: list[str] = field(default_factory=list)
 
 
+def parse_setup_timeout(sandbox: dict) -> int:
+    """The sandbox section's setup-timeout, or 300 when absent."""
+    setup_timeout = sandbox.get(
+        "setup-timeout", sandbox.get("setup_timeout", 300)
+    )
+    try:
+        return int(setup_timeout)
+    except (TypeError, ValueError):
+        raise ValueError(
+            f"setup-timeout must be an integer, got {setup_timeout!r}"
+        )
+
+
+def list_field(raw: dict, name: str) -> list[str]:
+    """A top-level config list, defaulting to empty."""
+    return raw.get(name) or []
+
+
 def load_sandbox_config(sandbox_root: Path) -> SandboxConfig:
     """Parse ``.klangk-sandbox.yaml`` under *sandbox_root*.
 
@@ -45,16 +63,6 @@ def load_sandbox_config(sandbox_root: Path) -> SandboxConfig:
     workspace = raw.get("workspace") or {}
     sandbox = raw.get("sandbox") or {}
 
-    setup_timeout = sandbox.get(
-        "setup-timeout", sandbox.get("setup_timeout", 300)
-    )
-    try:
-        setup_timeout = int(setup_timeout)
-    except (TypeError, ValueError):
-        raise ValueError(
-            f"setup-timeout must be an integer, got {setup_timeout!r}"
-        )
-
     return SandboxConfig(
         image=workspace.get("image"),
         service_command=workspace.get(
@@ -68,10 +76,10 @@ def load_sandbox_config(sandbox_root: Path) -> SandboxConfig:
         ),
         mount_at=sandbox.get("mount-at", sandbox.get("mount_at", "~/work")),
         setup=sandbox.get("setup"),
-        setup_timeout=setup_timeout,
-        copy=raw.get("copy") or [],
-        mounts=raw.get("mounts") or [],
-        volumes=raw.get("volumes") or [],
+        setup_timeout=parse_setup_timeout(sandbox),
+        copy=list_field(raw, "copy"),
+        mounts=list_field(raw, "mounts"),
+        volumes=list_field(raw, "volumes"),
     )
 
 

--- a/src/klangk/klangk/cli/sandboxcmd.py
+++ b/src/klangk/klangk/cli/sandboxcmd.py
@@ -38,16 +38,8 @@ def resolve_workspace_and_url(
     return (ws, context.server_url(), context.session_token())
 
 
-async def sandbox_setup(ws, config, sandbox_root, handle):
-    """Copy files and run setup script on an open WebSocket.
-
-    Called once after workspace creation, before the shell starts.
-    The caller has already connected and called wait_container_ready.
-
-    Returns the setup script's exit code, or ``None`` if no setup
-    command was configured (in which case there is nothing to fail).
-    """
-    # Copy files into container home.
+async def copy_sandbox_files(ws, config, sandbox_root, handle) -> None:
+    """Copy the configured files into the container home (cat via exec)."""
     for host_path, container_dest in build_copy_pairs(
         config, sandbox_root, handle
     ):
@@ -73,6 +65,28 @@ async def sandbox_setup(ws, config, sandbox_root, handle):
                 f" failed (exit {exit_code})[/yellow]"
             )
 
+
+def setup_warning(exit_code: int, timeout) -> None:
+    """Warn on a failed or timed-out setup script."""
+    if exit_code == 124:
+        context.err.print(f"[yellow]Setup timed out after {timeout}s[/yellow]")
+    elif exit_code != 0:
+        context.err.print(
+            f"[yellow]Setup exited with code {exit_code}[/yellow]"
+        )
+
+
+async def sandbox_setup(ws, config, sandbox_root, handle):
+    """Copy files and run setup script on an open WebSocket.
+
+    Called once after workspace creation, before the shell starts.
+    The caller has already connected and called wait_container_ready.
+
+    Returns the setup script's exit code, or ``None`` if no setup
+    command was configured (in which case there is nothing to fail).
+    """
+    await copy_sandbox_files(ws, config, sandbox_root, handle)
+
     # Run setup script — stream output to stderr in real time.
     setup_cmd = resolve_setup_command(config, handle)
     if setup_cmd:
@@ -94,14 +108,7 @@ async def sandbox_setup(ws, config, sandbox_root, handle):
             stdout=sys.stderr.buffer,
             timeout=timeout,
         )
-        if exit_code == 124:
-            context.err.print(
-                f"[yellow]Setup timed out after {timeout}s[/yellow]"
-            )
-        elif exit_code != 0:
-            context.err.print(
-                f"[yellow]Setup exited with code {exit_code}[/yellow]"
-            )
+        setup_warning(exit_code, timeout)
         return exit_code
     return None
 
@@ -202,6 +209,29 @@ def run_sandbox_setup(
         raise typer.Exit(code=1) from None
 
 
+def load_config_or_exit(sandbox_root: Path):
+    """Load .klangk-sandbox.yaml or exit with the standard error."""
+    try:
+        return load_sandbox_config(sandbox_root)
+    except FileNotFoundError as e:
+        context.err.print(f"[red]{e}[/red]")
+        raise typer.Exit(code=1) from None
+    except ValueError as e:
+        context.err.print(f"[red]Invalid sandbox config:[/red] {e}")
+        raise typer.Exit(code=1) from None
+
+
+def needs_setup(created: bool, force: bool) -> bool:
+    """A fresh create or a --force re-run both require the setup pass."""
+    return created or force
+
+
+def maybe_reallow(force: bool, created: bool, client, ws_id: str) -> None:
+    """On a --force re-setup, flip back to allow and restart (#2404)."""
+    if force and not created:
+        reallow_workspace_for_setup(client, ws_id)
+
+
 @context.app.command()
 def sandbox(
     workspace: str = typer.Argument(help="Workspace name"),
@@ -229,14 +259,7 @@ def sandbox(
         raise typer.Exit(code=1)
 
     sandbox_root = Path(path).resolve()
-    try:
-        config = load_sandbox_config(sandbox_root)
-    except FileNotFoundError as e:
-        context.err.print(f"[red]{e}[/red]")
-        raise typer.Exit(code=1) from None
-    except ValueError as e:
-        context.err.print(f"[red]Invalid sandbox config:[/red] {e}")
-        raise typer.Exit(code=1) from None
+    config = load_config_or_exit(sandbox_root)
 
     client = context.client()
     handle = client.get_handle()
@@ -252,11 +275,8 @@ def sandbox(
         )
         created = True
 
-    need_setup = created or force
-
-    if need_setup:
-        if force and not created:
-            reallow_workspace_for_setup(client, ws.id)
+    if needs_setup(created, force):
+        maybe_reallow(force, created, client, ws.id)
         run_sandbox_setup(
             surl, token, workspace, ws.id, config, sandbox_root, handle, client
         )
@@ -353,6 +373,22 @@ async def reset_egress_and_stop(client, workspace_id: str) -> None:
     )
 
 
+async def wait_for_terminal_start(ws, timeout: float) -> None:
+    """Wait (bounded) for the terminal to start so the command actually
+    runs before we disconnect. Other messages are ignored."""
+    deadline = asyncio.get_event_loop().time() + timeout
+    while True:
+        remaining = deadline - asyncio.get_event_loop().time()
+        if remaining <= 0:
+            break
+        try:
+            raw = await asyncio.wait_for(ws.recv(), timeout=remaining)
+        except (asyncio.TimeoutError, websockets.ConnectionClosed):
+            break
+        if json.loads(raw).get("type") == "terminal_started":
+            break
+
+
 async def fire_service_command(
     ws, config, setup_ok: bool, timeout: float = 30
 ) -> None:
@@ -366,19 +402,35 @@ async def fire_service_command(
     await ws.send(
         json.dumps({"cmd": "terminal_start", "cols": 80, "rows": 24})
     )
-    # Wait (bounded) for the terminal to start so the command actually
-    # runs before we disconnect. Other messages are ignored.
-    deadline = asyncio.get_event_loop().time() + timeout
-    while True:
-        remaining = deadline - asyncio.get_event_loop().time()
-        if remaining <= 0:
-            break
-        try:
-            raw = await asyncio.wait_for(ws.recv(), timeout=remaining)
-        except (asyncio.TimeoutError, websockets.ConnectionClosed):
-            break
-        if json.loads(raw).get("type") == "terminal_started":
-            break
+    await wait_for_terminal_start(ws, timeout)
+
+
+def setup_succeeded(exit_code) -> bool:
+    """No setup command (None) or a zero exit — both count as success."""
+    return exit_code is None or exit_code == 0
+
+
+async def post_setup_actions(
+    ws,
+    config,
+    setup_ok: bool,
+    client,
+    workspace_id: str,
+    reset_to_interactive: bool,
+    skipped_reason,
+) -> None:
+    """Stop-and-reset or keep-allow-and-fire, per the posture decision."""
+    if reset_to_interactive and client is not None:
+        await reset_egress_and_stop(client, workspace_id)
+    else:
+        # Stay in allow (auto-start, no sidecar, or no client to
+        # decide). The container keeps running, so fire the service
+        # command now so it's up.
+        await fire_service_command(ws, config, setup_ok)
+        if client is not None:
+            context.err.print(
+                f"[dim]Workspace left in allow mode ({skipped_reason}).[/dim]"
+            )
 
 
 async def sandbox_setup_only(
@@ -426,7 +478,7 @@ async def sandbox_setup_only(
         # Mark setup_state before anything else (#1033). 'complete'
         # when setup ran and returned 0, or when there was no setup
         # command at all (nothing to fail); 'failed' otherwise.
-        setup_ok = exit_code is None or exit_code == 0
+        setup_ok = setup_succeeded(exit_code)
         await mark_setup_state(
             client, workspace_id, "complete" if setup_ok else "failed"
         )
@@ -434,15 +486,12 @@ async def sandbox_setup_only(
         reset_to_interactive, skipped_reason = await decide_egress_reset(
             config, client
         )
-        if reset_to_interactive and client is not None:
-            await reset_egress_and_stop(client, workspace_id)
-        else:
-            # Stay in allow (auto-start, no sidecar, or no client to
-            # decide). The container keeps running, so fire the service
-            # command now so it's up.
-            await fire_service_command(ws, config, setup_ok)
-            if client is not None:
-                context.err.print(
-                    "[dim]Workspace left in allow mode"
-                    f" ({skipped_reason}).[/dim]"
-                )
+        await post_setup_actions(
+            ws,
+            config,
+            setup_ok,
+            client,
+            workspace_id,
+            reset_to_interactive,
+            skipped_reason,
+        )

--- a/src/klangk/klangk/cli/shell_popup.py
+++ b/src/klangk/klangk/cli/shell_popup.py
@@ -162,6 +162,38 @@ def popup_session_names(workspace_id: str) -> tuple[str, str]:
     )
 
 
+def list_session_names(socket: str) -> list[str] | None:
+    """Session names on the socket, or None when no server is running."""
+    try:
+        proc = subprocess.run(
+            _tmux(socket, "list-sessions", "-F", "#{session_name}"),
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if proc.returncode != 0:
+        return None
+    return proc.stdout.splitlines()
+
+
+def session_pid_is_dead(name: str, alive=os.path.exists) -> int | None:
+    """The pid embedded in *name* when its process is dead, else None.
+
+    No pid in the name (old sessions, foreign sessions) → None (left
+    alone). This wrapper's own pid and live pids are left alone too.
+    """
+    m = re.search(r"-p(\d+)-[0-9a-f]+$", name)
+    if not m:
+        return None
+    pid = int(m.group(1))
+    if pid == os.getpid() or alive(f"/proc/{pid}"):
+        return None
+    return pid
+
+
 def sweep_dead_sessions(
     workspace_id: str, run=None, alive=os.path.exists
 ) -> int:
@@ -178,29 +210,14 @@ def sweep_dead_sessions(
     """
     socket = socket_path(workspace_id)
     runner = run or default_run
-    try:
-        proc = subprocess.run(
-            _tmux(socket, "list-sessions", "-F", "#{session_name}"),
-            check=False,
-            capture_output=True,
-            text=True,
-            timeout=5,
-        )
-    except (OSError, subprocess.SubprocessError):
-        return 0
-    if proc.returncode != 0:
-        # No server running on the socket — nothing to sweep.
+    names = list_session_names(socket)
+    if names is None:
         return 0
     reaped = 0
-    for name in proc.stdout.splitlines():
-        m = re.search(r"-p(\d+)-[0-9a-f]+$", name)
-        if not m:
-            continue
-        pid = int(m.group(1))
-        if pid == os.getpid() or alive(f"/proc/{pid}"):
-            continue
-        runner(kill_session_cmd(socket, name), quiet=True)
-        reaped += 1
+    for name in names:
+        if session_pid_is_dead(name, alive) is not None:
+            runner(kill_session_cmd(socket, name), quiet=True)
+            reaped += 1
     return reaped
 
 
@@ -463,6 +480,12 @@ def default_attach(argv: list[str]) -> int:
     return subprocess.call(argv)
 
 
+def run_all(run, cmds) -> None:
+    """Run each tmux command built by a configure/binding helper."""
+    for cmd in cmds:
+        run(cmd)
+
+
 def run_consent_shell(
     *,
     workspace_id: str,
@@ -507,19 +530,16 @@ def run_consent_shell(
     # 1. outer session running the inner (normal) shell.
     run(new_detached_session(socket, outer, inner_argv, x=cols, y=rows))
     # 2. make the outer nearly invisible + inner-friendly.
-    for cmd in configure_outer_session(socket, outer):
-        run(cmd)
+    run_all(run, configure_outer_session(socket, outer))
     # 3. hidden decider session (sized to the popup so it doesn't reflow).
     run(new_detached_session(socket, hidden, decider_argv, x=pw, y=ph))
     # 3b. hide the hidden session's status bar so the popup shows only the
     #     decider (no tmux status bar across the popup's bottom).
-    for cmd in configure_hidden_session(socket, hidden):
-        run(cmd)
+    run_all(run, configure_hidden_session(socket, hidden))
     # 4. the C-a p reopen binding (no auto-show — the decider shows the popup
     #    itself when a held request arrives, so the shell isn't bothered at
     #    startup when there's nothing to decide).
-    for cmd in popup_binding_cmds(socket, hidden, w=pw, h=ph):
-        run(cmd)
+    run_all(run, popup_binding_cmds(socket, hidden, w=pw, h=ph))
     # 5. attach the user's terminal to the outer session (blocks). Cleanup
     #    runs even when the attach dies abnormally — the terminal window
     #    being closed delivers SIGHUP mid-attach, and an unhandled

--- a/src/klangk/klangk/cli/shellcmd.py
+++ b/src/klangk/klangk/cli/shellcmd.py
@@ -170,17 +170,8 @@ def run_consent_popup(ws, terminal: str | None, forward_agent: bool) -> int:
     return rc
 
 
-def resolve_shell_workspace(client, workspace: str | None):
-    """Resolve the shell target: the named workspace, or an interactive
-    pick (auto-select when exactly one exists)."""
-    if workspace:
-        return context.resolve_or_exit(client, workspace)
-    workspaces = client.list_workspaces(all_pages=True)
-    if not workspaces:
-        typer.echo("No workspaces found — create one with klangk create.")
-        raise typer.Exit(code=1)
-    if len(workspaces) == 1:
-        return workspaces[0]
+def pick_workspace_interactively(workspaces):
+    """Prompt for a workspace pick from a numbered list."""
     typer.echo("Select a workspace:")
     for i, w in enumerate(workspaces, 1):
         typer.echo(f"  {i}. {w.name}")
@@ -192,6 +183,60 @@ def resolve_shell_workspace(client, workspace: str | None):
     except ValueError:
         raise typer.Exit(code=1)
     return workspaces[idx]
+
+
+def resolve_shell_workspace(client, workspace: str | None):
+    """Resolve the shell target: the named workspace, or an interactive
+    pick (auto-select when exactly one exists)."""
+    if workspace:
+        return context.resolve_or_exit(client, workspace)
+    workspaces = client.list_workspaces(all_pages=True)
+    if not workspaces:
+        typer.echo("No workspaces found — create one with klangk create.")
+        raise typer.Exit(code=1)
+    if len(workspaces) == 1:
+        return workspaces[0]
+    return pick_workspace_interactively(workspaces)
+
+
+def normalize_shell_flags(
+    forward_agent: bool | None, no_consent_popup: bool
+) -> tuple[bool | None, bool]:
+    """Normalize flags called directly (not via typer) to their defaults.
+
+    When called directly, ``forward_agent`` may be a
+    ``typer.models.OptionInfo`` instead of bool/None; normalize to None
+    (and ``no_consent_popup`` to False).
+    """
+    if not isinstance(forward_agent, bool):
+        forward_agent = None
+    if not isinstance(no_consent_popup, bool):
+        no_consent_popup = False
+    return forward_agent, no_consent_popup
+
+
+def resolved_forward_agent(forward_agent: bool | None) -> bool:
+    """The forward-agent decision: CLI flag wins, then the config default."""
+    return resolve_forward_agent(
+        forward_agent,
+        config_default=context.cfg().get_forward_agent(context.server_url())
+        or False,
+    )
+
+
+def popup_shell_applicable(ws, no_consent_popup: bool, client) -> bool:
+    """True when the shell should wrap in the consent-popup russian-doll."""
+    return consent_popup_enabled(ws, no_consent_popup) and member_may_decide(
+        client, ws.id
+    )
+
+
+def shell_rejected(e: websockets.InvalidStatus) -> None:
+    """Report a rejected shell handshake after restoring the terminal."""
+    reset_terminal()
+    drain_stdin()
+    context.print_ws_rejection(e)
+    raise typer.Exit(code=1) from None
 
 
 @context.app.command()
@@ -225,12 +270,9 @@ def shell(
     ),
 ) -> None:
     """Connect to a workspace shell."""
-    # When called directly (not via typer CLI), forward_agent may be a
-    # typer.models.OptionInfo instead of bool/None.  Normalize to None.
-    if not isinstance(forward_agent, bool):
-        forward_agent = None
-    if not isinstance(no_consent_popup, bool):
-        no_consent_popup = False
+    forward_agent, no_consent_popup = normalize_shell_flags(
+        forward_agent, no_consent_popup
+    )
     token = context.session_token()
     if not token:
         context.err.print(
@@ -247,14 +289,8 @@ def shell(
     context.err.print(
         "[dim]Exit this shell: press Enter, then ~. (like ssh).[/dim]"
     )
-    forward_agent = resolve_forward_agent(
-        forward_agent,
-        config_default=context.cfg().get_forward_agent(context.server_url())
-        or False,
-    )
-    if consent_popup_enabled(ws, no_consent_popup) and member_may_decide(
-        client, ws.id
-    ):
+    forward_agent = resolved_forward_agent(forward_agent)
+    if popup_shell_applicable(ws, no_consent_popup, client):
         # Wrap the normal shell in the consent-popup russian-doll (#2383).
         # Falls back to the plain attach below when tmux is prevented, opted
         # out (--no-consent-popup / the inner re-invocation), the workspace
@@ -274,16 +310,7 @@ def shell(
         )
         context.err.print(f"Disconnected from [bold]{ws.name}[/bold].")
     except websockets.InvalidStatus as e:
-        reset_terminal()
-        drain_stdin()
-        if e.response.status_code in (4001, 4002):
-            context.err.print(
-                "[red]Session expired. Run `klangk login`"
-                " to re-authenticate.[/red]"
-            )
-        else:
-            context.err.print(f"[red]Connection rejected: {e}[/red]")
-        raise typer.Exit(code=1) from None
+        shell_rejected(e)
     except ConnectionError as e:
         reset_terminal()
         drain_stdin()

--- a/src/klangk/klangk/cli/terminals.py
+++ b/src/klangk/klangk/cli/terminals.py
@@ -216,6 +216,16 @@ def resolve_own_window(
     return _resolve_window_by_name(own_windows, terminal)
 
 
+def ambiguous_name_error(
+    name_matches: list[dict], terminal: str
+) -> tuple[dict | None, str | None]:
+    """The error payload for a name matching several windows (#2192)."""
+    ids = ", ".join(w["id"] for w in name_matches if w.get("id"))
+    return None, (
+        f"Multiple terminals named '{terminal}'; specify one by id: {ids}"
+    )
+
+
 def _resolve_window_by_name(
     own_windows: list[dict], terminal: str
 ) -> tuple[dict | None, str | None]:
@@ -223,10 +233,7 @@ def _resolve_window_by_name(
     are an error rather than a silent first match."""
     name_matches = [w for w in own_windows if w.get("name") == terminal]
     if len(name_matches) > 1:
-        ids = ", ".join(w["id"] for w in name_matches if w.get("id"))
-        return None, (
-            f"Multiple terminals named '{terminal}'; specify one by id: {ids}"
-        )
+        return ambiguous_name_error(name_matches, terminal)
     if not name_matches:
         return None, f"Terminal '{terminal}' not found"
     return name_matches[0], None

--- a/src/klangk/klangk/cli/transport.py
+++ b/src/klangk/klangk/cli/transport.py
@@ -34,6 +34,33 @@ class ServerTransport:
     server_spec: str  # original spec for back-reference
 
 
+def is_http_url(server_spec: str) -> bool:
+    """True for an ``http://`` / ``https://`` URL (TCP server spec)."""
+    return server_spec.startswith("http://") or server_spec.startswith(
+        "https://"
+    )
+
+
+def ws_scheme_base(server_spec: str) -> str:
+    """Derive the WS scheme://host[:port] base from an http(s) URL."""
+    if server_spec.startswith("http://"):
+        return server_spec.replace("http://", "ws://", 1)
+    return server_spec.replace("https://", "wss://", 1)
+
+
+def tcp_transport(server_spec: str) -> ServerTransport:
+    """TCP transport for an http(s) server spec."""
+    ws_base = ws_scheme_base(server_spec)
+    return ServerTransport(
+        is_uds=False,
+        uds_path=None,
+        base_url=server_spec,
+        ws_uri=ws_base + "/ws",
+        ws_base=ws_base,
+        server_spec=server_spec,
+    )
+
+
 def resolve_transport(server_spec: str) -> ServerTransport:
     """Classify *server_spec* as TCP (URL) or UDS (socket path).
 
@@ -45,20 +72,8 @@ def resolve_transport(server_spec: str) -> ServerTransport:
         raise ValueError(
             "no server configured — run `klangk login` or pass --server."
         )
-    if server_spec.startswith("http://") or server_spec.startswith("https://"):
-        # TCP — derive WS URI from the URL.
-        if server_spec.startswith("http://"):
-            ws_base = server_spec.replace("http://", "ws://", 1)
-        else:
-            ws_base = server_spec.replace("https://", "wss://", 1)
-        return ServerTransport(
-            is_uds=False,
-            uds_path=None,
-            base_url=server_spec,
-            ws_uri=ws_base + "/ws",
-            ws_base=ws_base,
-            server_spec=server_spec,
-        )
+    if is_http_url(server_spec):
+        return tcp_transport(server_spec)
 
     # Not a URL — must be an absolute socket path.
     if not server_spec.startswith("/"):

--- a/src/klangk/klangk/cli/tui/app.py
+++ b/src/klangk/klangk/cli/tui/app.py
@@ -60,6 +60,19 @@ KLANGK_THEME = Theme(
 )
 
 
+def screens_above(stack: list, target: Screen) -> list[Screen]:
+    """The screens above *target* (top-down order); target itself excluded."""
+    to_remove: list[Screen] = []
+    # A prior membership guard means the reversed walk always hits target
+    # (identity compare), so the loop can never exhaust: the arc to the
+    # pop loop without a break is unreachable.
+    for screen in reversed(stack):  # pragma: no branch
+        if screen is target:
+            break
+        to_remove.append(screen)
+    return to_remove
+
+
 class KlangkApp(App):
     """Interactive TUI over the existing klangk client."""
 
@@ -334,6 +347,21 @@ class KlangkApp(App):
 
         self.run_worker(_logout, exit_on_error=False)
 
+    def pop_planned_screens(self, to_remove: list[Screen]) -> None:
+        """Pop each planned screen, stopping if the stack diverges.
+
+        Defensive: ``pop_screen`` is synchronous, so today the live top
+        always equals the next planned screen and the loop ends by
+        exhausting ``to_remove``. The check keeps it correct if the
+        stack is ever changed between iterations (e.g. a re-entrant
+        pop) — stop rather than pop a screen we didn't plan to, and
+        never index an empty stack.
+        """
+        for screen in to_remove:
+            if not self.screen_stack or self.screen_stack[-1] is not screen:
+                break
+            self.pop_screen()
+
     def pop_above(self, target: Screen) -> bool:
         """Pop every screen above ``target`` (leaving it on top), safely.
 
@@ -355,24 +383,7 @@ class KlangkApp(App):
         """
         if target not in self.screen_stack:
             return False
-        to_remove: list[Screen] = []
-        # The membership guard above means the reversed walk always hits
-        # target (identity compare), so the loop can never exhaust: the
-        # arc to the pop loop without a break is unreachable.
-        for screen in reversed(self.screen_stack):  # pragma: no branch
-            if screen is target:
-                break
-            to_remove.append(screen)
-        for screen in to_remove:
-            # Defensive: ``pop_screen`` is synchronous, so today the live top
-            # always equals the next planned screen and the loop ends by
-            # exhausting ``to_remove``. The check keeps it correct if the
-            # stack is ever changed between iterations (e.g. a re-entrant
-            # pop) — stop rather than pop a screen we didn't plan to, and
-            # never index an empty stack.
-            if not self.screen_stack or self.screen_stack[-1] is not screen:
-                break
-            self.pop_screen()
+        self.pop_planned_screens(screens_above(self.screen_stack, target))
         return bool(self.screen_stack) and self.screen_stack[-1] is target
 
     def server_changed(self) -> None:

--- a/src/klangk/klangk/cli/tui/consent.py
+++ b/src/klangk/klangk/cli/tui/consent.py
@@ -303,6 +303,15 @@ def build_detach_command(socket_path: str, session: str) -> list[str]:
     return ["tmux", "-S", socket_path, "detach-client", "-s", session]
 
 
+FRAME_APPLY = {
+    "egress_request": "_apply_request",
+    "egress_resolved": "_apply_resolved",
+    "egress_rules": "_apply_rules",
+    "revoke_ack": "_apply_revoke_ack",
+    "pause_ack": "_apply_pause_ack",
+}
+
+
 class ConsentDeciderController:
     """Pure state machine over the consent-decider WS protocol (#2310).
 
@@ -359,11 +368,10 @@ class ConsentDeciderController:
         rid = msg.get("request_id")
         ok = bool(msg.get("ok"))
         if ok and isinstance(rid, str) and self.rules is not None:
-            self.rules = replace(
-                self.rules,
-                allowed=tuple(r for r in self.rules.allowed if r.id != rid),
-                denied=tuple(r for r in self.rules.denied if r.id != rid),
+            allowed, denied = rules_without(
+                self.rules.allowed, self.rules.denied, rid
             )
+            self.rules = replace(self.rules, allowed=allowed, denied=denied)
         return REVOKE_ACK, (
             rid if isinstance(rid, str) else None,
             ok,
@@ -398,21 +406,12 @@ class ConsentDeciderController:
             return IGNORED, None
         if not isinstance(msg, dict):
             return IGNORED, None
-        mtype = msg.get("type")
-        if mtype == "egress_request":
-            return self._apply_request(msg)
-        if mtype == "egress_resolved":
-            return self._apply_resolved(msg)
-        if mtype == "egress_rules":
-            return self._apply_rules(msg)
-        if mtype == "revoke_ack":
-            return self._apply_revoke_ack(msg)
-        if mtype == "pause_ack":
-            return self._apply_pause_ack(msg)
-        if mtype == "pong":
-            return PONG, None
-        if mtype == "error":
-            return ERROR, str(msg.get("message", ""))
+        handler = FRAME_APPLY.get(msg.get("type"))
+        if handler is not None:
+            return getattr(self, handler)(msg)
+        outcome = static_frame_outcome(msg)
+        if outcome is not None:
+            return outcome
         return IGNORED, None
 
     def ordered(self) -> list[ConsentRequest]:
@@ -489,20 +488,79 @@ def _parse_request(obj: object) -> ConsentRequest | None:
     requested_at = obj.get("requested_at")
     if not isinstance(requested_at, (int, float)):
         requested_at = 0
-    port = obj.get("dest_port")
-    pid = obj.get("pid")
     return ConsentRequest(
         id=rid,
         workspace_id=wid,
-        dest_host=str(obj.get("dest_host") or ""),
-        dest_port=int(port) if isinstance(port, (int, float)) else None,
+        dest_host=text_field(obj, "dest_host"),
+        dest_port=request_port_or_none(obj.get("dest_port")),
         process_name=obj.get("process_name"),
-        # bool is an int subclass -- exclude it so pid=True doesn't yield 1.
-        pid=pid
-        if isinstance(pid, int) and not isinstance(pid, bool)
-        else None,
+        pid=pid_or_none(obj.get("pid")),
         requested_at=float(requested_at),
     )
+
+
+def rules_without(allowed, denied, rid: str) -> tuple:
+    """(allowed, denied) with rule *rid* dropped from each."""
+    return (
+        tuple(r for r in allowed if r.id != rid),
+        tuple(r for r in denied if r.id != rid),
+    )
+
+
+def static_frame_outcome(msg: dict) -> tuple[str, object] | None:
+    """The outcome for a type with no state to apply (pong/error), or None."""
+    mtype = msg.get("type")
+    if mtype == "pong":
+        return PONG, None
+    if mtype == "error":
+        return ERROR, str(msg.get("message", ""))
+    return None
+
+
+def text_field(obj: dict, key: str, default: str = "") -> str:
+    """A frame field as text (a falsy value maps to *default*)."""
+    return str(obj.get(key) or default)
+
+
+def numeric_excluding_bool(value):
+    """*value* when numeric with bools excluded, else None."""
+    return (
+        value
+        if isinstance(value, (int, float)) and not isinstance(value, bool)
+        else None
+    )
+
+
+def request_port_or_none(value):
+    """A request frame's dest_port as int (bools pass, as before), or None."""
+    return int(value) if isinstance(value, (int, float)) else None
+
+
+def rule_port_or_none(value):
+    """A rule row's dest_port as int (bools excluded), or None."""
+    port = numeric_excluding_bool(value)
+    return int(port) if port is not None else None
+
+
+def rule_decided_at_or_none(value):
+    """A rule row's decided_at as float (bools excluded), or None."""
+    decided = numeric_excluding_bool(value)
+    return float(decided) if decided is not None else None
+
+
+def pid_or_none(value):
+    """A request frame's pid as int; bool excluded (bool is an int subclass)."""
+    return (
+        value
+        if isinstance(value, int) and not isinstance(value, bool)
+        else None
+    )
+
+
+def paused_until_or_none(value):
+    """A pause frame's until as float (bools excluded), or None."""
+    until = numeric_excluding_bool(value)
+    return float(until) if until is not None else None
 
 
 def _parse_rule_rows(raw) -> list[ConsentRule]:
@@ -543,22 +601,15 @@ def _parse_rule(obj: object) -> ConsentRule | None:
     """Build a :class:`ConsentRule` from one row of an ``egress_rules`` frame."""
     if not isinstance(obj, dict):
         return None
-    decided_at = obj.get("decided_at")
-    port = obj.get("dest_port")
     duration = obj.get("duration")
     return ConsentRule(
-        id=str(obj.get("id") or ""),
-        dest_host=str(obj.get("dest_host") or ""),
-        dest_port=int(port)
-        if isinstance(port, (int, float)) and not isinstance(port, bool)
-        else None,
+        id=text_field(obj, "id"),
+        dest_host=text_field(obj, "dest_host"),
+        dest_port=rule_port_or_none(obj.get("dest_port")),
         process_name=obj.get("process_name"),
-        decision=str(obj.get("decision") or ""),
+        decision=text_field(obj, "decision"),
         duration=duration if isinstance(duration, str) else None,
-        decided_at=float(decided_at)
-        if isinstance(decided_at, (int, float))
-        and not isinstance(decided_at, bool)
-        else None,
+        decided_at=rule_decided_at_or_none(obj.get("decided_at")),
         decided_by=obj.get("decided_by"),
     )
 
@@ -573,12 +624,7 @@ def _parse_pause(obj: object) -> PauseState | None:
     """
     if not isinstance(obj, dict) or obj.get("paused") is not True:
         return None
-    until = obj.get("until")
-    return PauseState(
-        until=float(until)
-        if isinstance(until, (int, float)) and not isinstance(until, bool)
-        else None
-    )
+    return PauseState(until=paused_until_or_none(obj.get("until")))
 
 
 def _rule_sort_key(rule: ConsentRule) -> tuple[int, float]:
@@ -586,6 +632,92 @@ def _rule_sort_key(rule: ConsentRule) -> tuple[int, float]:
     if rule.decided_at is None:
         return (1, 0.0)
     return (0, -rule.decided_at)
+
+
+def ws_refused(exc: BaseException) -> bool:
+    """True when a ws loop failure was a refused handshake (403, #2490)."""
+    if isinstance(exc, websockets.InvalidStatus):
+        if exc.response.status_code == 403:
+            return True
+        # A proxy/gateway error (502/503...) is transient -- retry.
+        logger.debug("consent-decide ws handshake failed: %s", exc)
+    else:
+        logger.debug("consent-decide ws dropped: %s", exc)
+    return False
+
+
+def closed_code(exc: websockets.ConnectionClosed) -> int | None:
+    """The close code from a ConnectionClosed (None when absent)."""
+    return exc.rcvd.code if exc.rcvd else None
+
+
+async def cancel_and_await(task) -> None:
+    """Cancel a task and swallow its result/exception."""
+    task.cancel()
+    try:
+        await task
+    except (asyncio.CancelledError, Exception):
+        pass
+
+
+def remove_stale_rows(lv, current_ids: set) -> None:
+    """Drop resolved/expired rows (leave survivors untouched -> no flicker)."""
+    for child in list(lv.children):
+        rid = getattr(child, "request_id", None)
+        if rid is not None and rid not in current_ids:
+            child.remove()
+
+
+def active_pause(rules, controller) -> PauseState | None:
+    """The live (unexpired) pause state, if any (#2498)."""
+    if rules is None or controller.pause_expired(rules):
+        return None
+    return rules.paused
+
+
+def pause_expired_flag(rules, controller) -> bool:
+    """True when a finite pause window has elapsed (#2498)."""
+    return rules is not None and controller.pause_expired(rules)
+
+
+def show_popup_to_clients(clients, sock: str, sess: str) -> None:
+    """display-popup on each shell client; subprocess errors swallowed."""
+    w, h = DEFAULT_POPUP_SIZE
+    for client in clients:
+        try:
+            subprocess.run(
+                show_popup_argv(sock, sess, client, w=w, h=h),
+                capture_output=True,
+                timeout=3,
+            )
+        except Exception:  # noqa: BLE001
+            logger.debug("consent-decide popup show failed")
+
+
+def revocable_rule_ids(rules) -> list[str]:
+    """The revocable rule ids (allowed then denied), for change detection."""
+    if rules is None:
+        return []
+    return [r.id for r in rules.allowed] + [r.id for r in rules.denied]
+
+
+def verdict_label(rule, controller, *, deny: bool) -> str:
+    """The duration label for an active verdict row."""
+    if rule.duration == DURATION_FOREVER:
+        return "forever"
+    if rule.duration == DURATION_TILRESTART:
+        return "until restart"
+    rem = controller.rule_remaining(rule)
+    # Guard None before formatting: a timed verdict with a null
+    # decided_at or an unknown duration has no countdown. Both allow
+    # and deny must degrade the same way (else fmt_duration(None)
+    # raises TypeError on a deny) -- the parser permits these rows, so
+    # rendering must too.
+    if rem is None:
+        return ""
+    if deny:
+        return f"{fmt_duration(rem)} left"
+    return f"expires in {fmt_duration(rem)}"
 
 
 class ConsentDeciderApp(App):
@@ -816,6 +948,21 @@ class ConsentDeciderApp(App):
         self._refresh()
         return refusals
 
+    def _mark_connected(self, ws) -> None:
+        """Record the fresh connection and clear any refusal flag."""
+        self._ws = ws
+        self._connected = True
+        # Healed: the refusal cause went away -- back to normal
+        # connected/reconnect reporting.
+        self._refused = False
+
+    async def _reconnect_wait(self, auth_close: bool, attempt: int) -> None:
+        """Rotate the token after an auth close, then backoff-sleep."""
+        if auth_close:
+            await self._rotate_token()
+        await asyncio.sleep(self._backoff(attempt))
+        self._refresh()
+
     async def _ws_loop(self) -> None:
         """Connect -> pump -> reconnect loop, until :attr:`_stop` is set.
 
@@ -852,24 +999,13 @@ class ConsentDeciderApp(App):
                     query={"workspace": self.workspace_id},
                     user_agent_header=USER_AGENT,
                 ) as ws:
-                    self._ws = ws
-                    self._connected = True
+                    self._mark_connected(ws)
                     attempt = 0
                     refusals = 0
-                    if self._refused:
-                        # Healed: the refusal cause went away -- back to
-                        # normal connected/reconnect reporting.
-                        self._refused = False
                     self._refresh()
                     auth_close = await self._pump(ws)
-            except websockets.InvalidStatus as e:
-                if e.response.status_code == 403:
-                    refused = True
-                else:
-                    # A proxy/gateway error (502/503...) is transient -- retry.
-                    logger.debug("consent-decide ws handshake failed: %s", e)
             except Exception as e:  # noqa: BLE001
-                logger.debug("consent-decide ws dropped: %s", e)
+                refused = ws_refused(e)
             finally:
                 self._ws = None
                 self._connected = False
@@ -878,11 +1014,8 @@ class ConsentDeciderApp(App):
                 continue
             if self._stop:
                 break
-            if auth_close:
-                await self._rotate_token()
             attempt += 1
-            await asyncio.sleep(self._backoff(attempt))
-            self._refresh()
+            await self._reconnect_wait(auth_close, attempt)
 
     async def refresh_token(self) -> str | None:
         """Refresh the JWT off the event loop (the HTTP call is blocking)."""
@@ -926,18 +1059,34 @@ class ConsentDeciderApp(App):
                 try:
                     raw = await ws.recv()
                 except websockets.ConnectionClosed as exc:
-                    code = exc.rcvd.code if exc.rcvd else None
-                    auth_close = code in (4001, 4002)
+                    auth_close = closed_code(exc) in (4001, 4002)
                     break
                 action, payload = self.controller.apply_frame(raw)
                 self._react(action, payload)
         finally:
-            ping.cancel()
-            try:
-                await ping
-            except (asyncio.CancelledError, Exception):
-                pass
+            await cancel_and_await(ping)
         return auth_close
+
+    def _react_ack(self, action: str, payload) -> None:
+        """React to a revoke/pause ack payload; flash on failure."""
+        if action == REVOKE_ACK:
+            # payload = (request_id, ok). A failed revoke (not an
+            # active verdict, wrong workspace, or the sidecar never
+            # acked the drop) leaves the row enforced -- flash so
+            # the decider knows it is still in effect, never silent.
+            # Success needs no flash; the controller already dropped
+            # the row and the refresh re-renders the list without it.
+            _rid, ok = payload  # type: ignore[misc]
+            if not ok:
+                self.flash("revoke failed — still in effect")
+        else:
+            # payload = (ok, until). A failed pause/unpause flashes;
+            # success is reflected by the refreshed egress_rules
+            # frame the server broadcasts (no flash needed).
+            ok, _until = payload  # type: ignore[misc]
+            if not ok:
+                self.flash("pause failed")
+        self._refresh()
 
     def _react(self, action: str, payload) -> None:
         """React to one parsed frame outcome (isolated render; see _pump)."""
@@ -957,25 +1106,8 @@ class ConsentDeciderApp(App):
         try:
             if action == ERROR:
                 self.flash(str(payload))
-            elif action == REVOKE_ACK:
-                # payload = (request_id, ok). A failed revoke (not an
-                # active verdict, wrong workspace, or the sidecar never
-                # acked the drop) leaves the row enforced -- flash so
-                # the decider knows it is still in effect, never silent.
-                # Success needs no flash; the controller already dropped
-                # the row and the refresh re-renders the list without it.
-                _rid, ok = payload  # type: ignore[misc]
-                if not ok:
-                    self.flash("revoke failed — still in effect")
-                self._refresh()
-            elif action == PAUSE_ACK:
-                # payload = (ok, until). A failed pause/unpause flashes;
-                # success is reflected by the refreshed egress_rules
-                # frame the server broadcasts (no flash needed).
-                ok, _until = payload  # type: ignore[misc]
-                if not ok:
-                    self.flash("pause failed")
-                self._refresh()
+            elif action in (REVOKE_ACK, PAUSE_ACK):
+                self._react_ack(action, payload)
             else:
                 self._refresh()
         except Exception:
@@ -1017,11 +1149,7 @@ class ConsentDeciderApp(App):
         """Drop resolved/expired rows, repaint survivors in place, append
         new ones (stable order). Returns the ids of the appended rows."""
         current_ids = {req.id for req in ordered}
-        # Drop resolved/expired rows (leave survivors untouched -> no flicker).
-        for child in list(lv.children):
-            rid = getattr(child, "request_id", None)
-            if rid is not None and rid not in current_ids:
-                child.remove()
+        remove_stale_rows(lv, current_ids)
         # Repaint survivors' countdown in place; append only new rows.
         existing = {getattr(c, "request_id", None): c for c in lv.children}
         new_ids: list[str] = []
@@ -1034,6 +1162,13 @@ class ConsentDeciderApp(App):
                 self._update_item(item, req)
         return new_ids
 
+    def _focus_survivor(self, focused_id, current_ids) -> bool:
+        """Refocus the previously-focused survivor, if it still exists."""
+        if focused_id is not None and focused_id in current_ids:
+            self._select_by_id(focused_id)
+            return True
+        return False
+
     def _apply_focus_policy(
         self, new_ids, current_ids, focused_id, focused_index
     ) -> None:
@@ -1043,8 +1178,8 @@ class ConsentDeciderApp(App):
         deciding doesn't strand the user on an unfocused list."""
         if new_ids:
             self._select_by_id(new_ids[0])
-        elif focused_id is not None and focused_id in current_ids:
-            self._select_by_id(focused_id)
+        elif self._focus_survivor(focused_id, current_ids):
+            pass
         elif focused_id is not None:
             self._select_index((focused_index or 0) - 1)
 
@@ -1229,7 +1364,7 @@ class ConsentDeciderApp(App):
         finite window that has elapsed is treated as not paused (#2498).
         """
         rules = self.controller.rules
-        expired = rules is not None and self.controller.pause_expired(rules)
+        expired = pause_expired_flag(rules, self.controller)
         if expired:
             # #2498: the finite window elapsed locally -- the workspace is
             # effectively unpaused, so clear the stale countdown and fall
@@ -1244,7 +1379,8 @@ class ConsentDeciderApp(App):
                 getattr(b, "pause_duration", None) == target, "pause-active"
             )
         countdown = self.query_one("#pause-countdown", Static)
-        if rules is not None and rules.paused is not None and not expired:
+        pause = active_pause(rules, self.controller)
+        if pause is not None:
             rem = self.controller.pause_remaining(rules)
             countdown.update(
                 "paused until restart"
@@ -1437,17 +1573,8 @@ class ConsentDeciderApp(App):
             return False
         if hidden_has_client(sock, sess):
             return True  # popup already open
-        w, h = DEFAULT_POPUP_SIZE
         clients = outer_clients(sock, sess)
-        for client in clients:
-            try:
-                subprocess.run(
-                    show_popup_argv(sock, sess, client, w=w, h=h),
-                    capture_output=True,
-                    timeout=3,
-                )
-            except Exception:  # noqa: BLE001
-                logger.debug("consent-decide popup show failed")
+        show_popup_to_clients(clients, sock, sess)
         return bool(clients)
 
     def decide(self, decision: str) -> None:
@@ -1697,6 +1824,32 @@ class RulesScreen(Screen):
             focused = self._last_focused_rule_id
         return focused
 
+    def _append_rule_rows(self, lv, rules) -> None:
+        """Append one row per active verdict (allows then denies)."""
+        for r in rules.allowed:
+            lv.append(self._rule_item(r, DECISION_ALLOWED))
+        for r in rules.denied:
+            lv.append(self._rule_item(r, DECISION_DENIED))
+
+    def _restore_rule_focus(self, lv, focused) -> None:
+        """Restore focus to the surviving rule after the refresh pass."""
+
+        def _restore_focus(_lv=lv, _focused=focused) -> None:
+            for index, child in enumerate(_lv.children):
+                if getattr(child, "rule_id", None) == _focused:
+                    _lv.index = index
+                    return
+            # The focused rule left the snapshot (revoke ack elsewhere /
+            # expiry): fall to a deterministic neighbor -- the old focus
+            # position clamped to the new list -- never silently index 0
+            # of a reordered list.
+            if _lv.children:
+                _lv.index = min(
+                    self._last_focused_rule_index, len(_lv.children) - 1
+                )
+
+        lv.call_after_refresh(_restore_focus)
+
     def _rebuild_rule_list(self, rules: EgressRules | None) -> None:
         """Rebuild the revoke selector from the controller's rules (#2341).
 
@@ -1719,39 +1872,16 @@ class RulesScreen(Screen):
         revokes the intended row.
         """
         lv = self.query_one("#rules-list", ListView)
-        desired: list[str] = []
-        if rules is not None:
-            desired += [r.id for r in rules.allowed]
-            desired += [r.id for r in rules.denied]
+        desired = revocable_rule_ids(rules)
         current = [getattr(c, "rule_id", None) for c in lv.children]
         if current == desired:
             return  # unchanged -> no flicker
         focused = self._capture_focused_rule_id(lv)
         lv.clear()
         if rules is not None:
-            for r in rules.allowed:
-                lv.append(self._rule_item(r, DECISION_ALLOWED))
-            for r in rules.denied:
-                lv.append(self._rule_item(r, DECISION_DENIED))
+            self._append_rule_rows(lv, rules)
         if focused is not None:
-            # Restore focus to the surviving rule. ``lv.clear()`` schedules an
-            # index reset that would clobber a synchronous set, so defer the
-            # restore to after the refresh pass lands it.
-            def _restore_focus(_lv=lv, _focused=focused) -> None:
-                for index, child in enumerate(_lv.children):
-                    if getattr(child, "rule_id", None) == _focused:
-                        _lv.index = index
-                        return
-                # The focused rule left the snapshot (revoke ack elsewhere /
-                # expiry): fall to a deterministic neighbor -- the old focus
-                # position clamped to the new list -- never silently index 0
-                # of a reordered list.
-                if _lv.children:
-                    _lv.index = min(
-                        self._last_focused_rule_index, len(_lv.children) - 1
-                    )
-
-            lv.call_after_refresh(_restore_focus)
+            self._restore_rule_focus(lv, focused)
 
     @staticmethod
     def _rule_item(rule: ConsentRule, decision: str) -> ListItem:
@@ -1836,21 +1966,5 @@ class RulesScreen(Screen):
         if rule.dest_port is not None:
             host = f"{host}:{rule.dest_port}"
         proc = f"  ({rule.process_name})" if rule.process_name else ""
-        if rule.duration == DURATION_FOREVER:
-            label = "forever"
-        elif rule.duration == DURATION_TILRESTART:
-            label = "until restart"
-        else:
-            rem = controller.rule_remaining(rule)
-            # Guard None before formatting: a timed verdict with a null
-            # decided_at or an unknown duration has no countdown. Both allow
-            # and deny must degrade the same way (else fmt_duration(None)
-            # raises TypeError on a deny) -- the parser permits these rows, so
-            # rendering must too.
-            if rem is None:
-                label = ""
-            elif deny:
-                label = f"{fmt_duration(rem)} left"
-            else:
-                label = f"expires in {fmt_duration(rem)}"
+        label = verdict_label(rule, controller, deny=deny)
         return f"{escape(host)}{escape(proc)}  [dim]{escape(label)}[/dim]"

--- a/src/klangk/klangk/cli/tui/screens/base.py
+++ b/src/klangk/klangk/cli/tui/screens/base.py
@@ -28,6 +28,37 @@ from textual.widgets import (
 _ScreenResult = TypeVar("_ScreenResult")
 
 
+def status_core_segment(server: str | None, user: str | None) -> str:
+    """The server/user segment of the status line."""
+    return (
+        f"server: {server or '(none)'}   |   user: {user or '(not logged in)'}"
+    )
+
+
+def status_bar_text(
+    *,
+    server: str | None,
+    user: str | None,
+    extra: str = "",
+    last_login: str | None = None,
+) -> str:
+    """The full status-line text for the bar's state.
+
+    The live `extra` segment (host notices, the #2661 schedule countdown)
+    renders FIRST when set: it is the time-sensitive bit, and appending it
+    last let it fall off the right edge of a typical terminal once
+    server/user/last-login (~76 cols) had claimed the row — an invisible
+    countdown on the very screens that need it.
+    """
+    parts = []
+    if extra:
+        parts.append(extra)
+    parts.append(status_core_segment(server, user))
+    if last_login:
+        parts.append(f"last login: {last_login}")
+    return "   |   ".join(parts)
+
+
 class StatusBar(Static):
     """One-line bottom bar: current server, user, and live-state flag."""
 
@@ -49,24 +80,18 @@ class StatusBar(Static):
         extra: str = "",
         last_login: str | None = None,
     ) -> None:
-        # The live `extra` segment (host notices, the #2661 schedule
-        # countdown) renders FIRST when set: it is the time-sensitive
-        # bit, and appending it last let it fall off the right edge of
-        # a typical terminal once server/user/last-login (~76 cols)
-        # had claimed the row — an invisible countdown on the very
-        # screens that need it.
-        text = ""
-        if extra:
-            text += f"{extra}"
-        text += (
-            f"{'   |   ' if text else ''}server: {server or '(none)'}"
-            f"   |   user: {user or '(not logged in)'}"
-        )
-        if last_login:
-            text += f"   |   last login: {last_login}"
         # Render literally — server URL / user / live `extra` may contain
         # bracket characters that would otherwise be parsed as markup.
-        self.update(Text(text))
+        self.update(
+            Text(
+                status_bar_text(
+                    server=server,
+                    user=user,
+                    extra=extra,
+                    last_login=last_login,
+                )
+            )
+        )
 
 
 class ButtonRowModalScreen(ModalScreen[_ScreenResult]):
@@ -426,6 +451,14 @@ class ServerListView(SpatialListView):
     SPATIAL_DOWN_TARGET = "#server_input"
 
 
+def chain_position(chain: list[str], focused) -> int | None:
+    """The focused widget's index in *chain*, or None when outside it."""
+    fid = getattr(focused, "id", None) if focused else None
+    if not fid or fid not in chain:
+        return None
+    return chain.index(fid)
+
+
 class SpatialNavScreen(Screen):
     """Screen mixin for spatial Up/Down navigation between a chain of
     widgets (inputs, buttons) in reading order (#1781).
@@ -445,20 +478,18 @@ class SpatialNavScreen(Screen):
     ]
 
     def action_spatial_up(self) -> None:
-        fid = getattr(self.focused, "id", None) if self.focused else None
-        if not fid or fid not in self.SPATIAL_CHAIN:
+        pos = chain_position(self.SPATIAL_CHAIN, self.focused)
+        if pos is None:
             return
-        pos = self.SPATIAL_CHAIN.index(fid)
         if pos > 0:
             self.query_one(f"#{self.SPATIAL_CHAIN[pos - 1]}").focus()
         elif self.SPATIAL_UP_EXIT:
             self.query_one(f"#{self.SPATIAL_UP_EXIT}").focus()
 
     def action_spatial_down(self) -> None:
-        fid = getattr(self.focused, "id", None) if self.focused else None
-        if not fid or fid not in self.SPATIAL_CHAIN:
+        pos = chain_position(self.SPATIAL_CHAIN, self.focused)
+        if pos is None:
             return
-        pos = self.SPATIAL_CHAIN.index(fid)
         if pos < len(self.SPATIAL_CHAIN) - 1:
             self.query_one(f"#{self.SPATIAL_CHAIN[pos + 1]}").focus()
 
@@ -474,6 +505,19 @@ class NonFocusableVerticalScroll(VerticalScroll):
     can_focus = False
 
 
+def focused_id(focused) -> str | None:
+    """The focused widget's id, or None."""
+    return getattr(focused, "id", None) if focused else None
+
+
+def next_tab_ids(tab_order: list[str], base: str, step: int):
+    """The tab-cycle ids after *base*, stepping by *step* (wrapping)."""
+    idx = tab_order.index(base)
+    n = len(tab_order)
+    for i in range(1, n):
+        yield tab_order[(idx + step * i) % n]
+
+
 class TabSkipMixin:
     """Cycle Tab through a primary field set, skipping editor buttons/lists.
 
@@ -485,23 +529,33 @@ class TabSkipMixin:
     _TAB_ORDER: list[str] = []
     _LIST_TO_INPUT: dict[str, str] = {}
 
-    def on_key(self, event) -> None:
-        if event.key not in ("tab", "shift+tab"):
-            return
-        fid = getattr(self.focused, "id", None) if self.focused else None
+    def tab_base(self, fid: str | None) -> str | None:
+        """The tab-cycle base id for a focused widget, or None when outside.
+
+        A mapped editor list (``_LIST_TO_INPUT``) tabs from its entry
+        input's position (#1783).
+        """
         base = self._LIST_TO_INPUT.get(fid, fid)
         if base not in self._TAB_ORDER:
-            return
-        event.stop()
-        idx = self._TAB_ORDER.index(base)
-        step = 1 if event.key == "tab" else -1
-        n = len(self._TAB_ORDER)
-        for i in range(1, n):
-            nxt = (idx + step * i) % n
-            target = self.query_one(f"#{self._TAB_ORDER[nxt]}")
+            return None
+        return base
+
+    def focus_next_tab_target(self, base: str, step: int) -> None:
+        """Focus the next visible, enabled widget in the tab cycle."""
+        for nxt in next_tab_ids(self._TAB_ORDER, base, step):
+            target = self.query_one(f"#{nxt}")
             if target.display and not target.disabled:
                 target.focus()
                 return
+
+    def on_key(self, event) -> None:
+        if event.key not in ("tab", "shift+tab"):
+            return
+        base = self.tab_base(focused_id(self.focused))
+        if base is None:
+            return
+        event.stop()
+        self.focus_next_tab_target(base, 1 if event.key == "tab" else -1)
 
 
 class WorkspaceListView(SpatialListView):

--- a/src/klangk/klangk/cli/tui/screens/login.py
+++ b/src/klangk/klangk/cli/tui/screens/login.py
@@ -32,6 +32,53 @@ from .base import (
 )
 
 
+def append_known_servers(lv, known, current) -> None:
+    """Append one row per known server alias."""
+    for s in known:
+        lv.append(ListItem(Label(server_row_label(s, current)), name=s.url))
+
+
+def first_provider_id(providers) -> str | None:
+    """The first well-formed provider entry's id, or None.
+
+    A malformed payload (non-dict entry, missing/non-string/empty id)
+    degrades to None instead of a KeyError crash (#2029 audit). An
+    empty string would dial /auth/oidc//login -> 404 (#2029 review).
+    """
+    return next(
+        (
+            p["id"]
+            for p in providers
+            if isinstance(p, dict) and isinstance(p.get("id"), str) and p["id"]
+        ),
+        None,
+    )
+
+
+def server_row_label(s, current) -> Text:
+    """One known-server row (the active server marked with *)."""
+    mark = "*" if s.url == current else " "
+    return Text(
+        f"{mark} {s.alias}  ({s.url})",
+        overflow="ellipsis",
+        no_wrap=True,
+    )
+
+
+def uds_row_label(uds: str) -> Text:
+    """The auto-detected local-klangkd UDS row."""
+    return Text(
+        f"  Local klangkd (UDS)  ({uds})",
+        overflow="ellipsis",
+        no_wrap=True,
+    )
+
+
+def should_offer_uds(uds, current, known_urls) -> bool:
+    """Offer the default UDS only when no alias already covers it."""
+    return bool(uds and uds != current and uds not in known_urls)
+
+
 class LoginScreen(SpatialNavScreen, StatusScreen):
     """Credential screen that also picks the server to log into.
 
@@ -129,24 +176,12 @@ class LoginScreen(SpatialNavScreen, StatusScreen):
         current = self.app.tui_state.current_url()
         known = self.app.tui_state.known_servers()
         known_urls = {s.url for s in known}
-        for s in known:
-            mark = "*" if s.url == current else " "
-            label = Text(
-                f"{mark} {s.alias}  ({s.url})",
-                overflow="ellipsis",
-                no_wrap=True,
-            )
-            lv.append(ListItem(Label(label), name=s.url))
+        append_known_servers(lv, known, current)
         uds = self.app.tui_state.default_uds()
         # Only offer the auto-detected default UDS if no alias already covers
         # it (otherwise it would duplicate the persisted alias row).
-        if uds and uds != current and uds not in known_urls:
-            label = Text(
-                f"  Local klangkd (UDS)  ({uds})",
-                overflow="ellipsis",
-                no_wrap=True,
-            )
-            lv.append(ListItem(Label(label), name=uds))
+        if should_offer_uds(uds, current, known_urls):
+            lv.append(ListItem(Label(uds_row_label(uds)), name=uds))
         # Autofocus the first server entry (#1826).
         if lv.query(ListItem):
             lv.focus()
@@ -344,20 +379,7 @@ class LoginScreen(SpatialNavScreen, StatusScreen):
 
     async def _do_login_oidc(self) -> None:
         providers = await asyncio.to_thread(self.app.tui_state.oidc_providers)
-        # Pick the first well-formed provider entry; a malformed payload
-        # (non-dict entry, missing/non-string/empty id) degrades to the "no
-        # provider" message instead of a KeyError crash (#2029 audit). An
-        # empty string would dial /auth/oidc//login -> 404 (#2029 review).
-        provider_id = next(
-            (
-                p["id"]
-                for p in providers
-                if isinstance(p, dict)
-                and isinstance(p.get("id"), str)
-                and p["id"]
-            ),
-            None,
-        )
+        provider_id = first_provider_id(providers)
         if provider_id is None:
             self._set_message("No SSO provider configured.", error=True)
             return

--- a/src/klangk/klangk/cli/tui/screens/main.py
+++ b/src/klangk/klangk/cli/tui/screens/main.py
@@ -90,6 +90,15 @@ def is_unreachable(exc: BaseException) -> bool:
     return isinstance(exc, (httpx.TransportError, OSError))
 
 
+def remaining_text(total: int) -> str:
+    """Coarse remaining duration, e.g. ``1h 12m`` / ``12m`` / ``30s``."""
+    if total >= 3600:
+        return f"{total // 3600}h {(total % 3600) // 60}m"
+    if total >= 60:
+        return f"{total // 60}m"
+    return f"{total}s"
+
+
 def server_schedule_line(schedule: dict) -> str:
     """Status-line text for the next pending server action (#2661).
 
@@ -110,13 +119,7 @@ def server_schedule_line(schedule: dict) -> str:
     fire_at = fire_at.astimezone()
     remaining = fire_at - datetime.datetime.now().astimezone()
     total = max(0, int(remaining.total_seconds()))
-    if total >= 3600:
-        left = f"{total // 3600}h {(total % 3600) // 60}m"
-    elif total >= 60:
-        left = f"{total // 60}m"
-    else:
-        left = f"{total}s"
-    return f"server: {action} at {fire_at:%H:%M} (in {left})"
+    return f"server: {action} at {fire_at:%H:%M} (in {remaining_text(total)})"
 
 
 def reconnect_backoff(attempt: int) -> float:
@@ -131,6 +134,41 @@ def reconnect_backoff(attempt: int) -> float:
     return (base + jitter) / 2.0
 
 
+def missing_credentials(url, token) -> bool:
+    """True when either the server url or the token is gone."""
+    return not url or not token
+
+
+def token_refresh_remaining(token: str) -> float | None:
+    """Seconds until expiry when within the refresh margin, else None."""
+    exp = decode_token_claims(token).get("exp")
+    if exp is None:
+        return None
+    remaining = exp - time.time()
+    if remaining > TOKEN_REFRESH_MARGIN:
+        return None
+    return remaining
+
+
+async def refresh_or_expire(state, url: str, token: str) -> str | None:
+    """Refresh the token; None to continue, "expired" to log out.
+
+    A refresh failure may just mean a concurrent refresher (e.g. the
+    CLI's background thread) already rotated the token and got this one
+    blocklisted; re-read state: if the token changed, keep running
+    instead of forcing a logout (#1882 review).
+    """
+    new = await asyncio.to_thread(refresh_token, url, token)
+    if new:
+        logger.debug("Token refreshed proactively")
+        return None
+    if state.token() != token:
+        logger.debug("Token rotated concurrently; not expiring")
+        return None
+    logger.warning("Proactive token refresh failed")
+    return "expired"
+
+
 async def run_token_refresh_loop(state) -> str:
     """Proactively refresh the access token before it expires.
 
@@ -142,28 +180,110 @@ async def run_token_refresh_loop(state) -> str:
         await asyncio.sleep(TOKEN_REFRESH_POLL)
         url = state.current_url()
         token = state.token()
-        if not url or not token:
+        if missing_credentials(url, token):
             return "no_token"
-        exp = decode_token_claims(token).get("exp")
-        if exp is None:
-            continue
-        remaining = exp - time.time()
-        if remaining > TOKEN_REFRESH_MARGIN:
+        remaining = token_refresh_remaining(token)
+        if remaining is None:
             continue
         logger.debug("Token expires in %.0fs, refreshing", remaining)
-        new = await asyncio.to_thread(refresh_token, url, token)
-        if new:
-            logger.debug("Token refreshed proactively")
-        else:
-            # Refresh failed — but a concurrent refresher (e.g. the CLI's
-            # background thread) may already have rotated the token and got
-            # this one blocklisted. Re-read state: if the token changed,
-            # keep running instead of forcing a logout (#1882 review).
-            if state.token() != token:
-                logger.debug("Token rotated concurrently; not expiring")
-                continue
-            logger.warning("Proactive token refresh failed")
-            return "expired"
+        outcome = await refresh_or_expire(state, url, token)
+        if outcome is not None:
+            return outcome
+
+
+def filtered_workspaces(workspaces, matches, q: str) -> list:
+    """The workspaces matching the filter query (a copy when empty)."""
+    if not q:
+        return list(workspaces)
+    return [ws for ws in workspaces if matches(ws, q)]
+
+
+async def fetch_image_defaults(state) -> tuple[str, list[str]] | None:
+    """The deploy's default image + allowed list; None on auth failure.
+
+    Transport failures degrade to empty values (empty default, no list).
+    """
+    try:
+        data = await asyncio.to_thread(state.list_images)
+    except AuthError:
+        return None
+    except (httpx.HTTPError, OSError, ValueError) as exc:
+        logger.debug("Could not fetch image list: %s", exc)
+        return "", []
+    return data.get("default", "") or "", list(data.get("allowed") or [])
+
+
+async def fetch_deploy_toggles(state) -> tuple[bool, bool] | None:
+    """The deploy nix/sudo toggles; None on auth failure."""
+    try:
+        return await asyncio.to_thread(state.deploy_toggles)
+    except AuthError:
+        return None
+    except (httpx.HTTPError, OSError, ValueError) as exc:
+        logger.debug("Could not fetch deploy toggles: %s", exc)
+        return False, False
+
+
+async def fetch_or_default(state_method, fallback, label: str):
+    """Await a state fetch off-loop, falling back on transport errors."""
+    try:
+        return await asyncio.to_thread(state_method)
+    except (httpx.HTTPError, OSError, ValueError) as exc:
+        logger.debug("Could not fetch %s: %s", label, exc)
+        return fallback
+
+
+def has_credentials(state) -> bool:
+    """True when the active server has both a url and a token."""
+    return bool(state.current_url() and state.token())
+
+
+def list_method(state, owned: bool):
+    """The state's owned/shared list method for *owned*."""
+    return (
+        state.list_owned_workspaces if owned else state.list_shared_workspaces
+    )
+
+
+def apply_overlay_to(overlay: dict, ws) -> None:
+    """Overlay the freshest running state onto one workspace (#2032)."""
+    wid = str(getattr(ws, "id", "") or "")
+    if wid and wid in overlay:
+        ws.running = overlay[wid]
+
+
+def parse_status_event(raw: str) -> dict | None:
+    """A dict event from one frame, or None when not JSON / not an object."""
+    try:
+        event = json.loads(raw)
+    except (TypeError, ValueError):
+        return None
+    if not isinstance(event, dict):
+        return None
+    return event
+
+
+def safe_on_connect(on_connect) -> None:
+    """Invoke on_connect, isolating exceptions (logged, not fatal)."""
+    if on_connect is None:
+        return
+    try:
+        on_connect()
+    except Exception:  # noqa: BLE001
+        logger.exception("status WS on_connect callback failed")
+
+
+def safe_on_event(on_event, event: dict) -> None:
+    """Invoke on_event, isolating exceptions (logged, not fatal)."""
+    try:
+        on_event(event)
+    except Exception:  # noqa: BLE001
+        logger.exception("status WS event callback failed")
+
+
+def unreachable_error_text(exc) -> str:
+    """The error text for an unreachable list fetch."""
+    return str(exc) or "server unreachable"
 
 
 class MainScreen(StatusScreen):
@@ -484,11 +604,8 @@ class MainScreen(StatusScreen):
     def _apply_filter(self) -> None:
         """Re-populate both lists from cached data with filter + sort."""
         q = self._filter_text
-        owned = self._owned_all
-        shared = self._shared_all
-        if q:
-            owned = [ws for ws in owned if self._matches(ws, q)]
-            shared = [ws for ws in shared if self._matches(ws, q)]
+        owned = filtered_workspaces(self._owned_all, self._matches, q)
+        shared = filtered_workspaces(self._shared_all, self._matches, q)
         owned = self._sort_workspaces(owned)
         shared = self._sort_workspaces(shared)
         empty = "(no matches)" if q else "(no workspaces)"
@@ -504,25 +621,37 @@ class MainScreen(StatusScreen):
             if lv.index is None:
                 lv.index = 0
 
-    def on_key(self, event) -> None:
-        # Escape in the filter input: clear text or hide bar and return.
+    def on_escape_in_filter(self) -> None:
+        """Escape in the filter input: clear text or hide bar and return."""
+        inp = self.query_one("#filter_input", Input)
+        if inp.value:
+            inp.value = ""
+        else:
+            self.query_one("#filter_bar").display = False
+            self._focus_visible_list()
+
+    def on_down_from_tabs(self) -> bool:
+        """Down from the tab strip: focus the active workspace list (#1781)."""
+        lv = self._active_list()
+        if lv is None:
+            return False
+        lv.focus()
+        if lv.index is None:
+            lv.index = 0
+        return True
+
+    def handle_nav_key(self, event) -> bool:
+        """Handle a navigation key; True when consumed."""
         if event.key == "escape" and isinstance(self.focused, Input):
-            inp = self.query_one("#filter_input", Input)
-            if inp.value:
-                inp.value = ""
-            else:
-                self.query_one("#filter_bar").display = False
-                self._focus_visible_list()
-            event.stop()
-            return
-        # Down from the tab strip drops into the active workspace list (#1781).
+            self.on_escape_in_filter()
+            return True
         if event.key == "down" and isinstance(self.focused, Tabs):
-            lv = self._active_list()
-            if lv is not None:
-                event.stop()
-                lv.focus()
-                if lv.index is None:
-                    lv.index = 0
+            return self.on_down_from_tabs()
+        return False
+
+    def on_key(self, event) -> None:
+        if self.handle_nav_key(event):
+            event.stop()
 
     def action_switch_server(self) -> None:
         self.app.push_screen(ServerSwitchScreen())
@@ -547,20 +676,30 @@ class MainScreen(StatusScreen):
         lv = self._active_list()
         return lv.highlighted_child if lv is not None else None
 
+    def _ws_by_name(self, name: str):
+        """The first workspace (owned then shared) matching *name*."""
+        for ws in list(self._owned_all) + list(self._shared_all):
+            if getattr(ws, "name", "") == name:
+                return ws
+        return None
+
+    def _ws_by_item_id(self, item, by_id: dict):
+        """The workspace for a row's workspace_id, when known."""
+        wid = str(getattr(item, "workspace_id", "") or "")
+        if wid and wid in by_id:
+            return by_id[wid]
+        return None
+
     def _highlighted_ws(self):
         """The workspace object for the highlighted row, or None."""
         item = self._highlighted_item()
         if item is None:
             return None
-        wid = str(getattr(item, "workspace_id", "") or "")
         by_id = getattr(self, "_ws_by_id", {}) or {}
-        if wid and wid in by_id:
-            return by_id[wid]
-        name = getattr(item, "name", "") or ""
-        for ws in list(self._owned_all) + list(self._shared_all):
-            if getattr(ws, "name", "") == name:
-                return ws
-        return None
+        by_id_match = self._ws_by_item_id(item, by_id)
+        if by_id_match is not None:
+            return by_id_match
+        return self._ws_by_name(getattr(item, "name", "") or "")
 
     def _require_highlighted(self) -> str | None:
         """Return the highlighted workspace name, or flash a hint + None."""
@@ -822,51 +961,31 @@ class MainScreen(StatusScreen):
 
     async def do_create(self) -> None:
         state = self.app.tui_state
-        try:
-            data = await asyncio.to_thread(state.list_images)
-            default = data.get("default", "") or ""
-            allowed = list(data.get("allowed") or [])
-        except AuthError:
+        images = await fetch_image_defaults(state)
+        if images is None:
             self.app.session_expired()
             return
-        except (httpx.HTTPError, OSError, ValueError) as exc:
-            logger.debug("Could not fetch image list: %s", exc)
-            default, allowed = "", []
+        default, allowed = images
         # #2974: deploy-level nix/sudo toggles moved from the images
         # payload to the authenticated-only /config fields.
-        try:
-            nix_available, sudo_available = await asyncio.to_thread(
-                state.deploy_toggles
-            )
-        except AuthError:
+        toggles = await fetch_deploy_toggles(state)
+        if toggles is None:
             self.app.session_expired()
             return
-        except (httpx.HTTPError, OSError, ValueError) as exc:
-            logger.debug("Could not fetch deploy toggles: %s", exc)
-            nix_available = sudo_available = False
-        try:
-            allow_autostart = await asyncio.to_thread(state.allow_autostart)
-        except (httpx.HTTPError, OSError, ValueError) as exc:
-            logger.debug("Could not fetch autostart config: %s", exc)
-            allow_autostart = False
-        try:
-            default_domains = await asyncio.to_thread(
-                state.default_allowed_domains
-            )
-        except (httpx.HTTPError, OSError, ValueError) as exc:
-            logger.debug("Could not fetch default allowed domains: %s", exc)
-            default_domains = []
+        nix_available, sudo_available = toggles
+        allow_autostart = await fetch_or_default(
+            state.allow_autostart, False, "autostart config"
+        )
+        default_domains = await fetch_or_default(
+            state.default_allowed_domains, [], "default allowed domains"
+        )
         # #2721: the deploy's home-layout default, pre-reflected by the
         # form's Per-handle home checkbox. None (fetch failed) hides the
         # checkbox and omits the field, so the server applies its own
         # default — never a silently forced layout (#2737 review).
-        try:
-            default_per_handle_home = await asyncio.to_thread(
-                state.default_per_handle_home
-            )
-        except (httpx.HTTPError, OSError, ValueError) as exc:
-            logger.debug("Could not fetch home-layout default: %s", exc)
-            default_per_handle_home = None
+        default_per_handle_home = await fetch_or_default(
+            state.default_per_handle_home, None, "home-layout default"
+        )
         self.app.push_screen(
             CreateWorkspaceScreen(
                 allowed=allowed,
@@ -992,9 +1111,7 @@ class MainScreen(StatusScreen):
         if not self._running_overlay:
             return
         for ws in workspaces:
-            wid = str(getattr(ws, "id", "") or "")
-            if wid and wid in self._running_overlay:
-                ws.running = self._running_overlay[wid]
+            apply_overlay_to(self._running_overlay, ws)
 
     def _render_unreachable(self, label: str) -> None:
         """Show *label* as the only row in both workspace lists."""
@@ -1080,18 +1197,12 @@ class MainScreen(StatusScreen):
     async def _safe_list(self, *, owned: bool) -> list:
         state = self.app.tui_state
         try:
-            return await asyncio.to_thread(
-                state.list_owned_workspaces
-                if owned
-                else state.list_shared_workspaces
-            )
+            return await asyncio.to_thread(list_method(state, owned))
         except AuthError:
             raise
         except Exception as exc:
             if is_unreachable(exc):
-                raise ServerUnreachable(
-                    str(exc) or "server unreachable"
-                ) from exc
+                raise ServerUnreachable(unreachable_error_text(exc)) from exc
             # A non-transport failure (e.g. a decode error) with the server
             # reachable: preserve the historical "treat as empty" behaviour
             # rather than mislabel a healthy account as down.
@@ -1219,6 +1330,17 @@ class MainScreen(StatusScreen):
                 self._status_loop, name="status-ws"
             )
 
+    @staticmethod
+    def cancel_superseded(awaiting) -> None:
+        """Cancel (or retrieve) an awaiting task superseded by a drop."""
+        if not awaiting.done():
+            awaiting.cancel()
+        elif not awaiting.cancelled():
+            # Both finished on the same tick: retrieve (and discard)
+            # the outcome so asyncio doesn't warn it was never
+            # retrieved. The drop supersedes it either way.
+            awaiting.exception()
+
     async def _wait_drop_or(self, awaiting: asyncio.Future) -> bool:
         """Await ``awaiting`` unless a server-switch drop fires first.
 
@@ -1240,13 +1362,7 @@ class MainScreen(StatusScreen):
                 waiter.cancel()
             raise
         if waiter in done:
-            if not awaiting.done():
-                awaiting.cancel()
-            elif not awaiting.cancelled():
-                # Both finished on the same tick: retrieve (and discard)
-                # the outcome so asyncio doesn't warn it was never
-                # retrieved. The drop supersedes it either way.
-                awaiting.exception()
+            self.cancel_superseded(awaiting)
             return True
         waiter.cancel()
         return False
@@ -1303,6 +1419,28 @@ class MainScreen(StatusScreen):
             if not listener.done():
                 listener.cancel()
 
+    async def _listener_cycle(self, url: str, token: str) -> bool:
+        """Run one listener to its end, then handle the outcome.
+
+        True to re-dial (switch or elapsed backoff), False to exit
+        (expired / gave up / screen popped).
+        """
+        outcome = await self._run_status_listener(url, token)
+        if outcome == "switched":
+            return True
+        if outcome == "expired":
+            return False
+        self._ws_connected = False
+        # Connection lost (clean close or error). Reconnect with bounded
+        # backoff; the top-of-iteration guard catches a screen pop that
+        # lands during the backoff sleep.
+        delay_outcome = await self._wait_reconnect_delay()
+        if delay_outcome == "switched":
+            # Switch during the backoff sleep: skip the rest of the
+            # delay and re-dial the new server now (#2704).
+            return True
+        return delay_outcome != "exit"
+
     async def _status_loop(self) -> None:
         """Single reachability signal: maintain the status WS and drive the
         unreachable overlay from its lifecycle (#2052).
@@ -1319,7 +1457,7 @@ class MainScreen(StatusScreen):
         the new server immediately (#2704).
         """
         state = self.app.tui_state
-        if not state.current_url() or not state.token():
+        if not has_credentials(state):
             return
         while True:
             # Re-read BOTH url and token every iteration: a server switch
@@ -1339,23 +1477,7 @@ class MainScreen(StatusScreen):
             # captured, so clearing it here keeps the new connection from
             # being torn down the instant it is made.
             self._ws_drop.clear()
-            outcome = await self._run_status_listener(url, token)
-            if outcome == "switched":
-                continue
-            if outcome == "expired":
-                return
-            # The connection is over (clean close or error) — the backend is
-            # no longer WS-reachable from this screen's point of view.
-            self._ws_connected = False
-            # Connection lost (clean close or error). Reconnect with bounded
-            # backoff; the top-of-iteration guard catches a screen pop that
-            # lands during the backoff sleep.
-            delay_outcome = await self._wait_reconnect_delay()
-            if delay_outcome == "switched":
-                # Switch during the backoff sleep: skip the rest of the
-                # delay and re-dial the new server now (#2704).
-                continue
-            if delay_outcome == "exit":
+            if not await self._listener_cycle(url, token):
                 return
 
     async def _wait_reconnect_delay(self) -> str:
@@ -1417,44 +1539,56 @@ class MainScreen(StatusScreen):
         if result in ("expired", "no_token"):
             self.app.session_expired()
 
+    # Host lifecycle event type -> handler method name (#2527/#2661).
+    _LIFECYCLE_HANDLERS = {
+        "host_shutdown": "_lifecycle_host_shutdown",
+        "server_recycle": "_lifecycle_server_recycle",
+        "host_started": "_lifecycle_host_started",
+        "server_schedule_fired": "_lifecycle_schedule_fired",
+    }
+
+    def _lifecycle_host_shutdown(self, event: dict) -> None:
+        self.app.live_extra = "server: shutting down"
+        self._refresh_status()
+        self.app.notify("Server is shutting down", severity="warning")
+
+    def _lifecycle_server_recycle(self, event: dict) -> None:
+        phase = str(event.get("phase") or "")
+        word = {
+            "draining": "preparing to recycle",
+            "recycling": "recycling",
+        }.get(phase, "recycling")
+        self.app.live_extra = f"server: {word}"
+        self._refresh_status()
+        self.app.notify(f"Server is {word}")
+
+    def _lifecycle_host_started(self, event: dict) -> None:
+        self.app.live_extra = "server: back up"
+        self._refresh_status()
+
+    def _lifecycle_schedule_fired(self, event: dict) -> None:
+        action = str(event.get("action") or "action")
+        self.app.live_extra = f"server: scheduled {action} running"
+        self._refresh_status()
+        self.app.notify(
+            f"Scheduled server {action} is happening now",
+            severity="warning",
+        )
+
     def _apply_server_lifecycle_event(self, etype: str, event: dict) -> bool:
         """#2527/#2661: host lifecycle notices become a human-readable
         status line; notification only — the reconnect loop (silent first
         retry, backoff, unreachable overlay) is untouched, so a
         restart/shutdown never visually impedes reconnection. Returns True
         when the event was consumed."""
-        if etype == "host_shutdown":
-            self.app.live_extra = "server: shutting down"
-            self._refresh_status()
-            self.app.notify("Server is shutting down", severity="warning")
-            return True
-        if etype == "server_recycle":
-            phase = str(event.get("phase") or "")
-            word = {
-                "draining": "preparing to recycle",
-                "recycling": "recycling",
-            }.get(phase, "recycling")
-            self.app.live_extra = f"server: {word}"
-            self._refresh_status()
-            self.app.notify(f"Server is {word}")
-            return True
-        if etype == "host_started":
-            self.app.live_extra = "server: back up"
-            self._refresh_status()
-            return True
         if etype == "server_schedule":
             self._apply_server_schedule_event(event)
             return True
-        if etype == "server_schedule_fired":
-            action = str(event.get("action") or "action")
-            self.app.live_extra = f"server: scheduled {action} running"
-            self._refresh_status()
-            self.app.notify(
-                f"Scheduled server {action} is happening now",
-                severity="warning",
-            )
-            return True
-        return False
+        handler = self._LIFECYCLE_HANDLERS.get(etype)
+        if handler is None:
+            return False
+        getattr(self, handler)(event)
+        return True
 
     def _apply_server_schedule_event(self, event: dict) -> None:
         """#2661: pending server stop/recycle — show the next one as
@@ -1473,6 +1607,16 @@ class MainScreen(StatusScreen):
         self.app.live_extra = server_schedule_line(next_up)
         self._refresh_status()
 
+    def _apply_status_list_events(self, etype: str, event: dict) -> None:
+        """The list-mutating status events."""
+        if etype == "workspaces_changed":
+            self.refresh_lists()
+        elif etype == "container_status":
+            self._update_running(
+                str(event.get("workspace_id") or ""),
+                bool(event.get("running")),
+            )
+
     def _on_status_event(self, event: dict) -> None:
         etype = event.get("type", "event")
         if self._apply_server_lifecycle_event(etype, event):
@@ -1483,14 +1627,24 @@ class MainScreen(StatusScreen):
         if etype not in self._STATUS_SILENT_EVENTS:
             self.app.live_extra = f"live: {etype}"
             self._refresh_status()
-        if etype == "workspaces_changed":
-            self.refresh_lists()
-        elif etype == "container_status":
-            self._update_running(
-                str(event.get("workspace_id") or ""),
-                bool(event.get("running")),
-            )
+        self._apply_status_list_events(etype, event)
         self._forward_status_to_detail(event)
+
+    def _patch_running_row(self, item, ws) -> None:
+        """Repaint one list row's ● icon in place."""
+        try:
+            item.query_one(".ws-name").update(self._fmt_name(ws))
+        except NoMatches:
+            pass
+
+    def _patch_running_rows(self, workspace_id: str, ws) -> None:
+        """Repaint the ● icon on the workspace's row in both lists."""
+        for sel in ("#owned_list", "#shared_list"):
+            lv = self.query_one(sel, ListView)
+            for item in lv.query(ListItem):
+                if getattr(item, "workspace_id", None) == workspace_id:
+                    self._patch_running_row(item, ws)
+                    break
 
     def _update_running(self, workspace_id: str, running: bool) -> None:
         """Update a single workspace's ● icon in-place (#1791).
@@ -1510,15 +1664,7 @@ class MainScreen(StatusScreen):
         if ws is None:
             return
         ws.running = running
-        for sel in ("#owned_list", "#shared_list"):
-            lv = self.query_one(sel, ListView)
-            for item in lv.query(ListItem):
-                if getattr(item, "workspace_id", None) == workspace_id:
-                    try:
-                        item.query_one(".ws-name").update(self._fmt_name(ws))
-                    except NoMatches:
-                        pass
-                    break
+        self._patch_running_rows(workspace_id, ws)
         # The highlighted row's running state may have changed — refresh
         # the Stop/Start hint label so it never offers the wrong action.
         self._refresh_action_hints()
@@ -1581,19 +1727,8 @@ async def listen_for_status(
         ping_interval=_WS_PING_INTERVAL,
         ping_timeout=_WS_PING_TIMEOUT,
     ) as ws:
-        if on_connect is not None:
-            try:
-                on_connect()
-            except Exception:  # noqa: BLE001
-                logger.exception("status WS on_connect callback failed")
+        safe_on_connect(on_connect)
         async for raw in ws:
-            try:
-                event = json.loads(raw)
-            except (TypeError, ValueError):
-                continue
-            if not isinstance(event, dict):
-                continue
-            try:
-                on_event(event)
-            except Exception:  # noqa: BLE001
-                logger.exception("status WS event callback failed")
+            event = parse_status_event(raw)
+            if event is not None:
+                safe_on_event(on_event, event)

--- a/src/klangk/klangk/cli/tui/screens/workspace_detail.py
+++ b/src/klangk/klangk/cli/tui/screens/workspace_detail.py
@@ -99,6 +99,13 @@ def _append_str_rows(
             rows.append((label, value))
 
 
+def joined_field_value(value) -> str:
+    """One list/dict field as newline-joined text (a dict as ``k=v`` lines)."""
+    if isinstance(value, dict):
+        return "\n".join(f"{k}={v}" for k, v in value.items())
+    return "\n".join(str(v) for v in value)
+
+
 def _append_joined_rows(
     rows: list[tuple[str, str]], ws, fields: list[tuple[str, str]]
 ) -> None:
@@ -108,12 +115,103 @@ def _append_joined_rows(
         value = getattr(ws, attr)
         if not value:
             continue
-        if isinstance(value, dict):
-            rows.append(
-                (label, "\n".join(f"{k}={v}" for k, v in value.items()))
-            )
-        else:
-            rows.append((label, "\n".join(str(v) for v in value)))
+        rows.append((label, joined_field_value(value)))
+
+
+def body_width(body, screen_width: int) -> int:
+    """The render width for the detail table.
+
+    The body widget's *actual* content width, not the screen width: the
+    screen has horizontal chrome (borders/margins/scroll gutter), so
+    #detail_body is markedly narrower than self.size.width. Rendering at
+    the wider screen width produces full-width lines that the narrower
+    Static then re-wraps, which destroys the value column's hanging
+    indent — wrapped continuation lines fall back to the left margin
+    under the labels (#2190).
+    """
+    return body.container_size.width or body.size.width or screen_width or 80
+
+
+def detail_load_text(load_error) -> str:
+    """The load-failure text (a specific error, or the generic form)."""
+    return load_error or "Could not load workspace."
+
+
+# Event type -> handler method name for apply_status_event.
+STATUS_EVENT_APPLY = {
+    "workspaces_changed": "_apply_workspaces_changed",
+    "terminals_changed": "_apply_terminals_changed",
+    "container_status": "_apply_container_status_event",
+    "service_health": "_apply_service_health_event",
+}
+
+
+def workspace_id_text(ws) -> str:
+    """A workspace's id as text ("" when unset)."""
+    return str(getattr(ws, "id", "") or "")
+
+
+def event_workspace_id(event: dict) -> str:
+    """An event's workspace_id as text ("" when unset)."""
+    return str(event.get("workspace_id") or "")
+
+
+def ids_differ(eid: str, ws_id: str) -> bool:
+    """True when both ids are present and they don't match."""
+    return bool(eid and ws_id and eid != ws_id)
+
+
+def shell_failed(completed) -> bool:
+    """True when an inline shell launch exited non-zero."""
+    return completed is not None and completed.returncode != 0
+
+
+def valid_shared_target(target: str) -> bool:
+    """A ``handle:window`` key with exactly one colon."""
+    return ":" in target and target.count(":") == 1
+
+
+def adoptable_started(event: dict):
+    """The event's service_started_at when numeric, else None.
+
+    Type-checked before adoption: a malformed payload (string stamp)
+    would crash the uptime math later (#2029 audit).
+    """
+    started = event.get("service_started_at")
+    if isinstance(started, (int, float)) and not isinstance(started, bool):
+        return started
+    return None
+
+
+def restart_triggered(was_running: bool, old_started, ws) -> bool:
+    """A container start/restart that invalidates the whole screen (#1924)."""
+    return bool(
+        ws.running
+        and (not was_running or ws.service_started_at != old_started)
+    )
+
+
+def terminal_list_items(terminals: list) -> list:
+    """List rows for the own-terminals list (or the empty placeholder)."""
+    if not terminals:
+        return [ListItem(Label(Text("(no terminals)")), name="")]
+    return [
+        ListItem(
+            Label(
+                Text(
+                    f"{w.get('index', '')}  "
+                    f"{w.get('name') or w.get('index', '')}"
+                )
+            ),
+            name=str(w.get("index", "")),
+        )
+        for w in terminals
+    ]
+
+
+def others_shared_terminals(terminals, my_id) -> list:
+    """Shared windows excluding my own (already in the own list, #2164)."""
+    return [t for t in (terminals or []) if t.get("user_id") != my_id]
 
 
 class WorkspaceDetailScreen(StatusScreen):
@@ -395,7 +493,7 @@ class WorkspaceDetailScreen(StatusScreen):
         ws = self._ws
         body = self.query_one("#detail_body", Static)
         if ws is None:
-            body.update(Text(self._load_error or "Could not load workspace."))
+            body.update(Text(detail_load_text(self._load_error)))
             return
         # Toggle the 's' binding label between Stop / Start.
         self.BINDINGS = self._bindings_list("Stop" if ws.running else "Start")
@@ -406,20 +504,7 @@ class WorkspaceDetailScreen(StatusScreen):
         # survive; from_ansi reads ANSI escapes only, so values that look like
         # markup (e.g. an image named "[img]") still render literally rather
         # than being parsed as Textual markup.
-        #
-        # Render at the body widget's *actual* content width, not the screen
-        # width: the screen has horizontal chrome (borders/margins/scroll
-        # gutter), so #detail_body is markedly narrower than self.size.width.
-        # Rendering at the wider screen width produces full-width lines that
-        # the narrower Static then re-wraps, which destroys the value column's
-        # hanging indent — wrapped continuation lines fall back to the left
-        # margin under the labels (#2190).
-        width = (
-            body.container_size.width
-            or body.size.width
-            or self.size.width
-            or 80
-        )
+        width = body_width(body, self.size.width)
         body.update(
             Text.from_ansi(
                 self._render_detail(
@@ -454,6 +539,15 @@ class WorkspaceDetailScreen(StatusScreen):
         bar.update(Text(banner, style=marking_style(banner)))
 
     @staticmethod
+    def uptime_row(ws) -> tuple[str, str] | None:
+        """The uptime row for a running workspace (None before start)."""
+        if ws.running and ws.service_started_at:
+            elapsed = int(time.time() - ws.service_started_at)
+            if elapsed >= 0:
+                return "uptime", format_uptime(elapsed)
+        return None
+
+    @staticmethod
     def _detail_rows(ws, deploy_banner: str = "") -> list[tuple[str, str]]:
         """Build the (label, value) rows shown in the workspace detail table."""
         rows: list[tuple[str, str]] = [
@@ -461,10 +555,9 @@ class WorkspaceDetailScreen(StatusScreen):
             ("running", "yes" if ws.running else "no"),
             ("health", ws.health or "-"),
         ]
-        if ws.running and ws.service_started_at:
-            elapsed = int(time.time() - ws.service_started_at)
-            if elapsed >= 0:
-                rows.append(("uptime", format_uptime(elapsed)))
+        uptime = WorkspaceDetailScreen.uptime_row(ws)
+        if uptime:
+            rows.append(uptime)
         rows.extend(optional_detail_rows(ws, deploy_banner))
         return rows
 
@@ -570,6 +663,20 @@ class WorkspaceDetailScreen(StatusScreen):
         except NoMatches:
             pass
 
+    def _apply_workspaces_changed(self, event: dict) -> None:
+        """A workspaces_changed push: full reload."""
+        self.run_worker(self._reload_on_status, exit_on_error=False)
+
+    def _apply_container_status_event(self, event: dict) -> None:
+        """A container_status event, then a re-render."""
+        self._apply_container_status(event)
+        self.refresh_display()
+
+    def _apply_service_health_event(self, event: dict) -> None:
+        """A service_health event, then a re-render."""
+        self._apply_service_health(event)
+        self.refresh_display()
+
     def apply_status_event(self, event: dict) -> None:
         """Update running/health from a live status broadcast.
 
@@ -579,29 +686,19 @@ class WorkspaceDetailScreen(StatusScreen):
         """
         if not self._status_event_applies(event):
             return
-        etype = event.get("type")
-        if etype == "workspaces_changed":
-            self.run_worker(self._reload_on_status, exit_on_error=False)
+        handler = STATUS_EVENT_APPLY.get(event.get("type"))
+        if handler is None:
             return
-        if etype == "terminals_changed":
-            self._apply_terminals_changed(event)
-            return
-        if etype == "container_status":
-            self._apply_container_status(event)
-        elif etype == "service_health":
-            self._apply_service_health(event)
-        else:
-            return
-        self.refresh_display()
+        getattr(self, handler)(event)
 
     def _status_event_applies(self, event: dict) -> bool:
         """False when no workspace is mounted or the event is for a
         different workspace."""
         if self._ws is None:
             return False
-        ws_id = str(getattr(self._ws, "id", "") or "")
-        eid = str(event.get("workspace_id") or "")
-        return not (eid and ws_id and eid != ws_id)
+        return not ids_differ(
+            event_workspace_id(event), workspace_id_text(self._ws)
+        )
 
     def _apply_terminals_changed(self, event: dict) -> None:
         """A terminal was added / removed / renamed from another surface.
@@ -628,18 +725,13 @@ class WorkspaceDetailScreen(StatusScreen):
         was_running = self._ws.running
         old_started = self._ws.service_started_at
         self._ws.running = bool(event.get("running"))
-        # Type-check before adopting: a malformed payload (string stamp)
-        # would crash _tick_uptime's ``time.time() - started`` math
-        # later (#2029 audit).
-        started = event.get("service_started_at")
-        if isinstance(started, (int, float)) and not isinstance(started, bool):
+        started = adoptable_started(event)
+        if started is not None:
             self._ws.service_started_at = started
         # A container start or restart invalidates everything — uptime
         # resets, health resets, terminal sessions are gone. Do a full
         # reload so all detail-screen items reflect the new state (#1924).
-        if self._ws.running and (
-            not was_running or self._ws.service_started_at != old_started
-        ):
+        if restart_triggered(was_running, old_started, self._ws):
             self.run_worker(self._reload_on_restart, exit_on_error=False)
 
     def _apply_service_health(self, event: dict) -> None:
@@ -699,22 +791,7 @@ class WorkspaceDetailScreen(StatusScreen):
         async with self._render_lock:
             lv = self.query_one("#term_list", ListView)
             await lv.clear()
-            if not self.terminals:
-                items = [ListItem(Label(Text("(no terminals)")), name="")]
-            else:
-                items = [
-                    ListItem(
-                        Label(
-                            Text(
-                                f"{w.get('index', '')}  "
-                                f"{w.get('name') or w.get('index', '')}"
-                            )
-                        ),
-                        name=str(w.get("index", "")),
-                    )
-                    for w in self.terminals
-                ]
-            mount = lv.extend(items)
+            mount = lv.extend(terminal_list_items(self.terminals))
             # Keep focus on the list; skipped when a modal is open over this
             # screen so a background terminals_changed reload never yanks
             # focus out of the foreground dialog (#1956).
@@ -751,9 +828,7 @@ class WorkspaceDetailScreen(StatusScreen):
         # avoid freezing the TUI on the first detail-page open (#2164
         # review).
         my_id = await asyncio.to_thread(self._current_user_id)
-        self._shared_terminals = [
-            t for t in (terminals or []) if t.get("user_id") != my_id
-        ]
+        self._shared_terminals = others_shared_terminals(terminals, my_id)
         await self._render_shared_terminals()
 
     async def _render_shared_terminals(self) -> None:
@@ -801,24 +876,19 @@ class WorkspaceDetailScreen(StatusScreen):
         """
         return self.app.tui_state.current_user_id()
 
-    def on_list_view_selected(self, event: ListView.Selected) -> None:
-        """Spawn ``klangk shell`` for the selected terminal.
+    def launch_own_terminal(self, terminal: str) -> None:
+        """Shell into the selected own terminal.
 
-        Inline in this terminal (TUI suspended) by default, or in a new
-        terminal window when ``terminal-open-cmd`` is configured (#2685)."""
-        if event.control.id == "shared_term_list":
-            self._launch_shared_terminal(event)
-            return
-        terminal = getattr(event.item, "name", "") or ""
+        The list item is keyed by the window INDEX, but the shell must
+        target the window by its stable id (@N) so the backend selects
+        the existing window instead of creating a duplicate named after
+        the index (#1954). If no id can be resolved — stale list, or a
+        server contract violation (terminal.list_windows always sets
+        id) — refuse to spawn and refresh instead: falling back to the
+        raw index would reproduce the duplicate-window bug.
+        """
         if not terminal or self._ws is None:
             return
-        # The list item is keyed by the window INDEX, but the shell must
-        # target the window by its stable id (@N) so the backend selects
-        # the existing window instead of creating a duplicate named after
-        # the index (#1954). If no id can be resolved — stale list, or a
-        # server contract violation (terminal.list_windows always sets
-        # id) — refuse to spawn and refresh instead: falling back to the
-        # raw index would reproduce the duplicate-window bug.
         target = self._window_id_for(terminal)
         if target is None:
             self.msg(
@@ -827,12 +897,22 @@ class WorkspaceDetailScreen(StatusScreen):
             self.run_worker(self._load_terminals, exit_on_error=False)
             return
         completed = self._launch_shell(self._shell_argv(target))
-        if completed is not None and completed.returncode != 0:
+        if shell_failed(completed):
             # The shell exited non-zero — most likely the window was
             # deleted server-side between list refresh and selection.
             # Refresh so the dead row self-heals instead of failing
             # identically on every re-select (#1955 review).
             self.run_worker(self._load_terminals, exit_on_error=False)
+
+    def on_list_view_selected(self, event: ListView.Selected) -> None:
+        """Spawn ``klangk shell`` for the selected terminal.
+
+        Inline in this terminal (TUI suspended) by default, or in a new
+        terminal window when ``terminal-open-cmd`` is configured (#2685)."""
+        if event.control.id == "shared_term_list":
+            self._launch_shared_terminal(event)
+            return
+        self.launch_own_terminal(getattr(event.item, "name", "") or "")
 
     def _shell_argv(self, target: str) -> list[str]:
         """The ``klangk shell`` argv for a terminal target on this workspace."""
@@ -900,6 +980,23 @@ class WorkspaceDetailScreen(StatusScreen):
             sys.stdout.flush()
             return subprocess.run(cmd)
 
+    def shared_launch_target(self, event) -> str | None:
+        """The validated ``handle:window`` target, or None.
+
+        None means no launch (nothing selected / not mounted) or an
+        invalid key (refresh already queued).
+        """
+        target = getattr(event.item, "name", "") or ""
+        if not target or self._ws is None:
+            return None
+        # A shared window named with a colon would confuse the
+        # ``handle:window`` parser; refuse rather than mis-target.
+        if not valid_shared_target(target):
+            self.msg("Invalid shared terminal — refreshing.", error=True)
+            self.run_worker(self._load_shared_terminals, exit_on_error=False)
+            return None
+        return target
+
     def _launch_shared_terminal(self, event: ListView.Selected) -> None:
         """Join the selected shared terminal via ``klangk shell <ws> <handle>:<win>``.
 
@@ -907,17 +1004,11 @@ class WorkspaceDetailScreen(StatusScreen):
         one the browser uses) — no new server code (#2164). The list item
         is keyed by the join target, so it's passed straight through.
         """
-        target = getattr(event.item, "name", "") or ""
-        if not target or self._ws is None:
-            return
-        # A shared window named with a colon would confuse the
-        # ``handle:window`` parser; refuse rather than mis-target.
-        if ":" not in target or target.count(":") != 1:
-            self.msg("Invalid shared terminal — refreshing.", error=True)
-            self.run_worker(self._load_shared_terminals, exit_on_error=False)
+        target = self.shared_launch_target(event)
+        if target is None:
             return
         completed = self._launch_shell(self._shell_argv(target))
-        if completed is not None and completed.returncode != 0:
+        if shell_failed(completed):
             # The shared window may have been unshared/closed server-side
             # between refresh and selection — refresh the shared list.
             self.run_worker(self._load_shared_terminals, exit_on_error=False)
@@ -964,28 +1055,33 @@ class WorkspaceDetailScreen(StatusScreen):
             "term_list"
         )
 
-    def action_delete_terminal(self) -> None:
+    def highlighted_own_window_key(self) -> str | None:
+        """The own-list highlighted row's key, or None (nothing to delete)."""
         if not self._own_list_focused():
-            return
+            return None
         lv = self.query_one("#term_list", ListView)
         child = lv.highlighted_child
-        if child is None:
-            return
-        if not child.name:
+        if child is None or not child.name:
+            return None
+        return child.name
+
+    def action_delete_terminal(self) -> None:
+        key = self.highlighted_own_window_key()
+        if key is None:
             return
         if len(self.terminals) <= 1:
             self.msg("Can't delete the last terminal.", error=True)
             return
         # Target the window by its stable id (@N), not the row index —
         # a stale list could otherwise close the wrong window (#1965).
-        window_id = self._window_id_for(child.name)
+        window_id = self._window_id_for(key)
         if window_id is None:
             self.msg(
                 "Terminal no longer exists — refreshing list.", error=True
             )
             self.run_worker(self._load_terminals, exit_on_error=False)
             return
-        label = self._terminal_label_for(child.name)
+        label = self._terminal_label_for(key)
         self.run_worker(
             self._do_delete_terminal(window_id, label), exit_on_error=False
         )

--- a/src/klangk/klangk/cli/tui/screens/workspace_form.py
+++ b/src/klangk/klangk/cli/tui/screens/workspace_form.py
@@ -70,6 +70,18 @@ def _cpu_setting(screen: Screen) -> float | None:
     return cpu
 
 
+def set_if_present(settings: dict, key: str, value) -> None:
+    """Record *value* under *key* when it is not None."""
+    if value is not None:
+        settings[key] = value
+
+
+def text_setting(screen: Screen, input_id: str) -> str | None:
+    """A text input's stripped value (None when empty)."""
+    raw = screen.query_one(f"#{input_id}", Input).value.strip()
+    return raw or None
+
+
 def collect_settings(screen: Screen) -> dict | None:
     """Read the resource-limit inputs and return a settings dict, or None.
 
@@ -86,24 +98,18 @@ def collect_settings(screen: Screen) -> dict | None:
         "idle_timeout",
         "Idle timeout must be a whole number of seconds: {raw!r}",
     )
-    if idle is not None:
-        settings["idle_timeout"] = idle
-    cpu = _cpu_setting(screen)
-    if cpu is not None:
-        settings["cpu_limit"] = cpu
-    raw = screen.query_one("#memory_limit", Input).value.strip()
-    if raw:
-        settings["memory_limit"] = raw
+    set_if_present(settings, "idle_timeout", idle)
+    set_if_present(settings, "cpu_limit", _cpu_setting(screen))
+    set_if_present(
+        settings, "memory_limit", text_setting(screen, "memory_limit")
+    )
     pids = _int_setting(
         screen,
         "pids_limit",
         "PIDs limit must be a whole number: {raw!r}",
     )
-    if pids is not None:
-        settings["pids_limit"] = pids
-    raw = screen.query_one("#tmp_size", Input).value.strip()
-    if raw:
-        settings["tmp_size"] = raw
+    set_if_present(settings, "pids_limit", pids)
+    set_if_present(settings, "tmp_size", text_setting(screen, "tmp_size"))
     return settings or None
 
 
@@ -347,6 +353,37 @@ def render_form_list(
         ol.add_option(Option(Text(fmt(item)), id=f"{id_prefix}{i}"))
 
 
+async def edit_images(state) -> tuple[str, list[str]] | None:
+    """(default, allowed) images for the edit form; None on auth failure."""
+    try:
+        data = await asyncio.to_thread(state.list_images)
+    except AuthError:
+        return None
+    except Exception:
+        return "", []
+    return data.get("default", "") or "", list(data.get("allowed") or [])
+
+
+async def edit_toggles(state) -> tuple[bool, bool] | None:
+    """The deploy nix/sudo toggles; None on auth failure."""
+    try:
+        return await asyncio.to_thread(state.deploy_toggles)
+    except AuthError:
+        return None
+    except Exception:
+        return False, False
+
+
+async def edit_autostart(state) -> bool | None:
+    """The deploy autostart flag; None on auth failure."""
+    try:
+        return await asyncio.to_thread(state.allow_autostart)
+    except AuthError:
+        return None
+    except Exception:
+        return False
+
+
 async def open_edit_screen(screen, state, workspace, on_edited) -> None:
     """Load image/autostart metadata off-thread and open the edit form.
 
@@ -356,33 +393,22 @@ async def open_edit_screen(screen, state, workspace, on_edited) -> None:
     failure leaves them disabled; ``AuthError`` ends the session via
     ``session_expired``.
     """
-    try:
-        data = await asyncio.to_thread(state.list_images)
-        default = data.get("default", "") or ""
-        allowed = list(data.get("allowed") or [])
-    except AuthError:
+    images = await edit_images(state)
+    if images is None:
         screen.app.session_expired()
         return
-    except Exception:
-        default, allowed = "", []
+    default, allowed = images
     # #2974: deploy-level nix/sudo toggles moved from the images
     # payload to the authenticated-only /config fields.
-    try:
-        nix_available, sudo_available = await asyncio.to_thread(
-            state.deploy_toggles
-        )
-    except AuthError:
+    toggles = await edit_toggles(state)
+    if toggles is None:
         screen.app.session_expired()
         return
-    except Exception:
-        nix_available = sudo_available = False
-    try:
-        allow_autostart = await asyncio.to_thread(state.allow_autostart)
-    except AuthError:
+    nix_available, sudo_available = toggles
+    allow_autostart = await edit_autostart(state)
+    if allow_autostart is None:
         screen.app.session_expired()
         return
-    except Exception:
-        allow_autostart = False
     screen.app.push_screen(
         EditWorkspaceScreen(
             workspace=workspace,
@@ -394,6 +420,27 @@ async def open_edit_screen(screen, state, workspace, on_edited) -> None:
         ),
         on_edited,
     )
+
+
+def editing_index(screen, editing_attr) -> int | None:
+    """The in-place-edit index attribute, when set."""
+    return getattr(screen, editing_attr) if editing_attr else None
+
+
+def insert_list_entry(
+    entries: list, v: str, idx, replacing: bool, dedupe: bool
+) -> None:
+    """Replace the entry at *idx* in place, or append (dedupe-guarded)."""
+    if replacing:
+        entries[idx] = v
+    elif not dedupe or v not in entries:
+        entries.append(v)
+
+
+def clear_editing_index(screen, editing_attr, replacing: bool) -> None:
+    """Clear the in-place-edit index after a successful replace."""
+    if replacing and editing_attr:
+        setattr(screen, editing_attr, None)
 
 
 class WorkspaceFormMixin:
@@ -490,14 +537,10 @@ class WorkspaceFormMixin:
         if err:
             self.msg(err, error=True)
             return
-        idx = getattr(self, editing_attr) if editing_attr else None
+        idx = editing_index(self, editing_attr)
         replacing = idx is not None and 0 <= idx < len(entries)
-        if replacing:
-            entries[idx] = v
-        elif not dedupe or v not in entries:
-            entries.append(v)
-        if replacing and editing_attr:
-            setattr(self, editing_attr, None)
+        insert_list_entry(entries, v, idx, replacing, dedupe)
+        clear_editing_index(self, editing_attr, replacing)
         inp.value = ""
         self.msg("")
         render()
@@ -683,6 +726,71 @@ class WorkspaceFormMixin:
         super().on_key(event)
 
 
+def create_picker_options(
+    allowed: list[str], default: str
+) -> tuple[list, object]:
+    """(options, preselected value) for the create form's image picker."""
+    if allowed:
+        # Select tuples are (prompt, value). Prompts are rich Text so an
+        # image name containing brackets can't trigger markup parsing.
+        options = [(Text(img), img) for img in allowed]
+        return options, default if default in allowed else None
+    # Couldn't list images — offer a single inert placeholder so the
+    # user can still create; the server applies its default image.
+    return (
+        [(Text("(server default)"), "(server default)")],
+        "(server default)",
+    )
+
+
+def cleared_text(screen: Screen, input_id: str) -> str | None:
+    """A form text input's stripped value, None when empty."""
+    return screen.query_one(f"#{input_id}", Input).value.strip() or None
+
+
+def normalized_list(items) -> list | None:
+    """A copied list, empty (or None) -> None — the body representation."""
+    return list(items or []) or None
+
+
+def normalized_dict(d) -> dict | None:
+    """A copied dict, empty (or None) -> None — the body representation."""
+    return dict(d or {}) or None
+
+
+def cleared(value):
+    """The value normalized to None when empty."""
+    return value or None
+
+
+def http_error_detail(exc: httpx.HTTPStatusError) -> str:
+    """The server's error detail from an HTTPStatusError response."""
+    try:
+        return exc.response.json().get("detail", exc.response.text)
+    except Exception:
+        return exc.response.text or str(exc)
+
+
+def merged_toggles(settings: dict | None, extra: dict) -> dict:
+    """The settings bag with one toggle merged in."""
+    return {**(settings or {}), **extra}
+
+
+def create_toggles(screen, settings: dict | None) -> dict:
+    """The create payload's settings bag with the shown toggles applied."""
+    if screen._nix_available and screen.query_one("#nix", Checkbox).value:
+        settings = merged_toggles(settings, {"nix": True})
+    # #2017: emit only the lock-down (unchecked) — a checked toggle is
+    # the default (follow the deploy posture), and the server setting
+    # is a ceiling, so an explicit True buys nothing over omitting it.
+    if (
+        screen._sudo_available
+        and not screen.query_one("#allow_sudo", Checkbox).value
+    ):
+        settings = merged_toggles(settings, {"allow_sudo": False})
+    return settings
+
+
 class CreateWorkspaceScreen(WorkspaceFormMixin, TabSkipMixin, StatusScreen):
     """Full-screen workspace create form (parity with Flutter
     ``CreateWorkspaceDialog``).
@@ -780,20 +888,9 @@ class CreateWorkspaceScreen(WorkspaceFormMixin, TabSkipMixin, StatusScreen):
         # and the field omitted, so the server applies its own default —
         # never a silently forced layout (#2737 review).
         self._default_per_handle_home = default_per_handle_home
-        if self._allowed:
-            # Select tuples are (prompt, value). Prompts are rich Text so an
-            # image name containing brackets can't trigger markup parsing.
-            self._select_options = [(Text(img), img) for img in self._allowed]
-            self._select_value = (
-                self._default if self._default in self._allowed else None
-            )
-        else:
-            # Couldn't list images — offer a single inert placeholder so the
-            # user can still create; the server applies its default image.
-            self._select_options = [
-                (Text("(server default)"), "(server default)")
-            ]
-            self._select_value = "(server default)"
+        self._select_options, self._select_value = create_picker_options(
+            self._allowed, self._default
+        )
 
     def compose(self) -> ComposeResult:
         # Header / status dock (StatusBar + Footer) come from StatusScreen
@@ -916,10 +1013,6 @@ class CreateWorkspaceScreen(WorkspaceFormMixin, TabSkipMixin, StatusScreen):
     def _create_payload(self) -> dict:
         """Gather the non-name form fields into create-workspace values
         (empty strings/lists -> None, matching the Flutter dialog)."""
-        command = self.query_one("#command", Input).value.strip() or None
-        health_check = (
-            self.query_one("#health_check", Input).value.strip() or None
-        )
         auto = (
             self._allow_autostart
             and self.query_one("#auto_start", Checkbox).value
@@ -930,23 +1023,21 @@ class CreateWorkspaceScreen(WorkspaceFormMixin, TabSkipMixin, StatusScreen):
         # omitted, and the server applies its own.
         phh_cb = self.query_one("#per_handle_home", Checkbox)
         per_handle_home = phh_cb.value if phh_cb.display else None
-        # #2768: free-text classification marking; empty = inherit the
-        # deploy default (KLANGKD_CLASSIFICATION_BANNER).
-        classification_banner = (
-            self.query_one("#classification_banner", Input).value.strip()
-            or None
-        )
         return {
             "image": self._selected_image(),
-            "command": command,
-            "health_check": health_check,
+            "command": cleared_text(self, "command"),
+            "health_check": cleared_text(self, "health_check"),
             "auto": auto,
             "per_handle_home": per_handle_home,
-            "classification_banner": classification_banner,
-            "mounts": list(self._mounts) or None,
-            "env": dict(self._env) or None,
-            "allowed_domains": list(self._allowed_domains) or None,
-            "rejected_domains": list(self._rejected_domains) or None,
+            # #2768: free-text classification marking; empty = inherit the
+            # deploy default (KLANGKD_CLASSIFICATION_BANNER).
+            "classification_banner": cleared_text(
+                self, "classification_banner"
+            ),
+            "mounts": normalized_list(self._mounts),
+            "env": normalized_dict(self._env),
+            "allowed_domains": normalized_list(self._allowed_domains),
+            "rejected_domains": normalized_list(self._rejected_domains),
             "egress_mode": self.query_one("#egress_mode", Select).value,
         }
 
@@ -961,16 +1052,7 @@ class CreateWorkspaceScreen(WorkspaceFormMixin, TabSkipMixin, StatusScreen):
         except ValueError as exc:
             self.msg(str(exc), error=True)
             return
-        if self._nix_available and self.query_one("#nix", Checkbox).value:
-            settings = {**(settings or {}), "nix": True}
-        # #2017: emit only the lock-down (unchecked) — a checked toggle is
-        # the default (follow the deploy posture), and the server setting
-        # is a ceiling, so an explicit True buys nothing over omitting it.
-        if (
-            self._sudo_available
-            and not self.query_one("#allow_sudo", Checkbox).value
-        ):
-            settings = {**(settings or {}), "allow_sudo": False}
+        settings = create_toggles(self, settings)
         self.run_worker(
             self._do_create_workspace(
                 name,
@@ -1027,11 +1109,7 @@ class CreateWorkspaceScreen(WorkspaceFormMixin, TabSkipMixin, StatusScreen):
             self.app.session_expired()
             return
         except httpx.HTTPStatusError as exc:
-            try:
-                detail = exc.response.json().get("detail", exc.response.text)
-            except (ValueError, KeyError):
-                detail = exc.response.text or str(exc)
-            self.msg(f"Failed to create: {detail}", error=True)
+            self.msg(f"Failed to create: {http_error_detail(exc)}", error=True)
             return
         except Exception as exc:
             self.msg(f"Failed to create: {exc}", error=True)
@@ -1066,6 +1144,18 @@ class CreateWorkspaceScreen(WorkspaceFormMixin, TabSkipMixin, StatusScreen):
         )
 
 
+def current_image(workspace) -> str:
+    """The workspace's image ("" when unset)."""
+    return workspace.image or ""
+
+
+def picker_selection(opts: list, cur: str):
+    """The preselected image: the current one, else the first option."""
+    if cur in opts:
+        return cur
+    return opts[0] if opts else None
+
+
 def _edit_picker_options(
     allowed: list[str], workspace: Workspace
 ) -> tuple[list, str | None]:
@@ -1075,14 +1165,14 @@ def _edit_picker_options(
     server's allowed list, pre-selected (untouched = no change). Prompts
     are rich Text so bracket-laden names can't crash.
     """
-    cur = workspace.image or ""
+    cur = current_image(workspace)
     opts = list(allowed)
     if cur and cur not in opts:
         opts.append(cur)
     if opts:
         return (
             [(Text(i), i) for i in opts],
-            cur if cur in opts else (opts[0] if opts else None),
+            picker_selection(opts, cur),
         )
     return [(Text("(none)"), "(none)")], "(none)"
 
@@ -1102,6 +1192,79 @@ def _seeded_setting_values(settings: dict) -> dict[str, str]:
         else "",
         "tmp_size": str(settings.get("tmp_size", "")),
     }
+
+
+def seeded_lists(workspace) -> dict:
+    """The edit form's list seeds (mounts/env/domains) from the workspace."""
+    return {
+        "mounts": list(workspace.mounts or []),
+        "env": dict(workspace.env or {}),
+        "allowed_domains": list(workspace.allowed_domains or []),
+        "rejected_domains": list(workspace.rejected_domains or []),
+    }
+
+
+def seeded_form_state(workspace) -> dict:
+    """The edit form's list/mode seeds from the workspace."""
+    state = seeded_lists(workspace)
+    state["egress_mode"] = workspace.egress_mode or EGRESS_MODE_DEFAULT
+    return state
+
+
+def save_image_value(image) -> str | None:
+    """The image value for the save body (placeholder/empty -> None)."""
+    return image if (image and image != "(none)") else None
+
+
+def edit_general_seeds(ws) -> dict:
+    """The General-pane seeds for the edit form."""
+    return dict(
+        name=ws.name or "",
+        auto_start=ws.auto_start,
+        nix=bool((ws.settings or {}).get("nix")),
+        allow_sudo=bool((ws.settings or {}).get("allow_sudo", True)),
+    )
+
+
+def edit_advanced_seeds(ws) -> dict:
+    """The Advanced-pane seeds for the edit form."""
+    return dict(
+        classification_banner=ws.classification_banner or "",
+        service_command=ws.service_command or "",
+        health_check=ws.health_check or "",
+    )
+
+
+def scalar_fields_changed(body: dict, ws) -> bool:
+    """Whether image / service_command / egress_mode changed
+    (both sides cleared-normalized, #1778/#1749/#2409)."""
+    return (
+        cleared(body["image"]) != cleared(ws.image)
+        or cleared(body["service_command"]) != cleared(ws.service_command)
+        or body["egress_mode"] != (ws.egress_mode or EGRESS_MODE_DEFAULT)
+    )
+
+
+def list_fields_changed(body: dict, orig: dict) -> bool:
+    """Whether any list field differs from its normalized snapshot."""
+    return (
+        body["mounts"] != orig["mounts"]
+        or body["env"] != orig["env"]
+        or body["allowed_domains"] != orig["allowed_domains"]
+        or body["rejected_domains"] != orig["rejected_domains"]
+    )
+
+
+def nix_changed(available: bool, settings: dict, old: dict) -> bool:
+    """Whether the create-time /nix mount toggle flipped (#2233)."""
+    return available and settings.get("nix", False) != bool(old.get("nix"))
+
+
+def sudo_changed(available: bool, settings: dict, old: dict) -> bool:
+    """Whether the create-time sudo posture flipped (#2017)."""
+    return available and settings.get("allow_sudo", True) != bool(
+        old.get("allow_sudo", True)
+    )
 
 
 class EditWorkspaceScreen(WorkspaceFormMixin, TabSkipMixin, StatusScreen):
@@ -1189,18 +1352,16 @@ class EditWorkspaceScreen(WorkspaceFormMixin, TabSkipMixin, StatusScreen):
         # (absent = True = follow the deploy posture). Hidden unless the
         # deploy allows sudo (the knob can only lock down below that).
         self._sudo_available = bool(sudo_available)
-        self._mounts: list[str] = list(workspace.mounts or [])
-        self._env: dict[str, str] = dict(workspace.env or {})
-        self._allowed_domains: list[str] = list(
-            workspace.allowed_domains or []
-        )
+        self._mounts: list[str]
+        seeds = seeded_form_state(workspace)
+        self._mounts = seeds["mounts"]
+        self._env = seeds["env"]
+        self._allowed_domains = seeds["allowed_domains"]
         # #2386: the static deny-list, seeded from the workspace.
-        self._rejected_domains: list[str] = list(
-            workspace.rejected_domains or []
-        )
+        self._rejected_domains = seeds["rejected_domains"]
         # #2409: the workspace's egress mode, seeded for the Netfilter
         # picker. Falls back to the deploy default when unset.
-        self._egress_mode: str = workspace.egress_mode or EGRESS_MODE_DEFAULT
+        self._egress_mode = seeds["egress_mode"]
         # #2721: home layout, seeded from the workspace. Mutable (#2719):
         # a flip applies from the next connect/start.
         self._per_handle_home: bool = bool(workspace.per_handle_home)
@@ -1223,6 +1384,8 @@ class EditWorkspaceScreen(WorkspaceFormMixin, TabSkipMixin, StatusScreen):
         yield from super().compose()
 
     def compose_body(self) -> ComposeResult:
+        general = edit_general_seeds(self._ws)
+        advanced = edit_advanced_seeds(self._ws)
         with NonFocusableVerticalScroll(id="edit_box"):
             yield Static(
                 Text(f"Edit workspace: {self._ws.name}"), classes="title"
@@ -1231,12 +1394,10 @@ class EditWorkspaceScreen(WorkspaceFormMixin, TabSkipMixin, StatusScreen):
             with TabbedContent(id="form_tabs"):
                 yield from compose_general_pane(
                     self.image_select(),
-                    name=self._ws.name or "",
-                    auto_start=self._ws.auto_start,
-                    nix=bool((self._ws.settings or {}).get("nix")),
-                    allow_sudo=bool(
-                        (self._ws.settings or {}).get("allow_sudo", True)
-                    ),
+                    name=general["name"],
+                    auto_start=general["auto_start"],
+                    nix=general["nix"],
+                    allow_sudo=general["allow_sudo"],
                 )
                 yield from compose_mounts_pane()
                 yield from compose_environment_pane()
@@ -1246,11 +1407,9 @@ class EditWorkspaceScreen(WorkspaceFormMixin, TabSkipMixin, StatusScreen):
                 )
                 yield from compose_advanced_pane(
                     per_handle_home=self._per_handle_home,
-                    classification_banner=(
-                        self._ws.classification_banner or ""
-                    ),
-                    service_command=self._ws.service_command or "",
-                    health_check=self._ws.health_check or "",
+                    classification_banner=advanced["classification_banner"],
+                    service_command=advanced["service_command"],
+                    health_check=advanced["health_check"],
                 )
             yield Horizontal(
                 Button("Cancel", id="cancel"),
@@ -1413,13 +1572,9 @@ class EditWorkspaceScreen(WorkspaceFormMixin, TabSkipMixin, StatusScreen):
         """The scalar widget reads for the PUT body (empties -> None)."""
         image = self.query_one("#image", Select).value
         return {
-            "image": image if (image and image != "(none)") else None,
-            "service_command": self.query_one("#command", Input).value.strip()
-            or None,
-            "health_check": self.query_one(
-                "#health_check", Input
-            ).value.strip()
-            or None,
+            "image": save_image_value(image),
+            "service_command": cleared_text(self, "command"),
+            "health_check": cleared_text(self, "health_check"),
             "auto_start": self._allow_autostart
             and self.query_one("#auto_start", Checkbox).value,
             # #2721: home layout is mutable and applies from the next
@@ -1432,10 +1587,9 @@ class EditWorkspaceScreen(WorkspaceFormMixin, TabSkipMixin, StatusScreen):
             # the other PUT fields): an emptied field clears the override so
             # the workspace inherits the deploy default again. Display-time
             # only — never a restart-needed field.
-            "classification_banner": self.query_one(
-                "#classification_banner", Input
-            ).value.strip()
-            or None,
+            "classification_banner": cleared_text(
+                self, "classification_banner"
+            ),
             "egress_mode": self.query_one("#egress_mode", Select).value,
         }
 
@@ -1478,10 +1632,10 @@ class EditWorkspaceScreen(WorkspaceFormMixin, TabSkipMixin, StatusScreen):
         body = {
             "name": name,
             **self._save_field_values(),
-            "mounts": list(self._mounts) or None,
-            "env": dict(self._env) or None,
-            "allowed_domains": list(self._allowed_domains) or None,
-            "rejected_domains": list(self._rejected_domains) or None,
+            "mounts": normalized_list(self._mounts),
+            "env": normalized_dict(self._env),
+            "allowed_domains": normalized_list(self._allowed_domains),
+            "rejected_domains": normalized_list(self._rejected_domains),
         }
         if merged_settings:
             body["settings"] = merged_settings
@@ -1492,10 +1646,10 @@ class EditWorkspaceScreen(WorkspaceFormMixin, TabSkipMixin, StatusScreen):
         """The workspace's list fields, normalized the way the body
         represents them (empty -> None) so a plain != detects a change."""
         return {
-            "mounts": list(ws.mounts or []) or None,
-            "env": dict(ws.env or {}) or None,
-            "allowed_domains": list(ws.allowed_domains or []) or None,
-            "rejected_domains": list(ws.rejected_domains or []) or None,
+            "mounts": normalized_list(ws.mounts),
+            "env": normalized_dict(ws.env),
+            "allowed_domains": normalized_list(ws.allowed_domains),
+            "rejected_domains": normalized_list(ws.rejected_domains),
         }
 
     def _create_time_fields_changed(self, body: dict, ws) -> bool:
@@ -1504,19 +1658,8 @@ class EditWorkspaceScreen(WorkspaceFormMixin, TabSkipMixin, StatusScreen):
         image / service_command normalize both sides to None-when-empty;
         the list fields compare against their normalized snapshot."""
         orig = self._orig_list_fields(ws)
-        return any(
-            [
-                (body["image"] or None) != (ws.image or None),
-                body["mounts"] != orig["mounts"],
-                body["env"] != orig["env"],
-                (body["service_command"] or None)
-                != (ws.service_command or None),
-                body["allowed_domains"] != orig["allowed_domains"],
-                body["rejected_domains"] != orig["rejected_domains"],
-                # #2409: egress_mode is a container-create-time field (it sets
-                # up --network container:<sidecar>), so a change needs a restart.
-                body["egress_mode"] != (ws.egress_mode or EGRESS_MODE_DEFAULT),
-            ]
+        return scalar_fields_changed(body, ws) or list_fields_changed(
+            body, orig
         )
 
     def _settings_changed_since_create(self, body: dict, ws) -> bool:
@@ -1528,13 +1671,8 @@ class EditWorkspaceScreen(WorkspaceFormMixin, TabSkipMixin, StatusScreen):
         flip needs a restart to take effect."""
         settings = body.get("settings") or {}
         old = ws.settings or {}
-        return (
-            self._nix_available
-            and settings.get("nix", False) != bool(old.get("nix"))
-        ) or (
-            self._sudo_available
-            and settings.get("allow_sudo", True)
-            != bool(old.get("allow_sudo", True))
+        return nix_changed(self._nix_available, settings, old) or sudo_changed(
+            self._sudo_available, settings, old
         )
 
     def _restart_needed_after_save(self, body: dict) -> bool:
@@ -1574,6 +1712,29 @@ class EditWorkspaceScreen(WorkspaceFormMixin, TabSkipMixin, StatusScreen):
         if self in self.app.screen_stack:
             self.dismiss(result)
 
+    def prompt_restart_after_save(self, ws_name, dismiss_name) -> None:
+        """Ask whether to restart the running container to apply the save."""
+
+        def _after(restart: bool) -> None:
+            if restart:
+                self.run_worker(
+                    self._do_restart_after_save(ws_name, dismiss_name),
+                    exit_on_error=False,
+                )
+            else:
+                self._safe_dismiss(dismiss_name)
+
+        self.app.push_screen(
+            ConfirmScreen(
+                "A running container is not affected by this edit. "
+                "Restart now to apply?",
+                yes_label="Restart",
+                yes_variant="warning",
+                no_label="Skip",
+            ),
+            _after,
+        )
+
     async def do_save(self, name, body, ws, restart_needed) -> None:
         try:
             await asyncio.to_thread(
@@ -1583,36 +1744,13 @@ class EditWorkspaceScreen(WorkspaceFormMixin, TabSkipMixin, StatusScreen):
             self.app.session_expired()
             return
         except httpx.HTTPStatusError as exc:
-            try:
-                detail = exc.response.json().get("detail", exc.response.text)
-            except Exception:
-                detail = exc.response.text or str(exc)
-            self.msg(f"Failed to save: {detail}", error=True)
+            self.msg(f"Failed to save: {http_error_detail(exc)}", error=True)
             return
         except Exception as exc:
             self.msg(f"Failed to save: {exc}", error=True)
             return
         if restart_needed:
-
-            def _after(restart: bool) -> None:
-                if restart:
-                    self.run_worker(
-                        self._do_restart_after_save(ws.name, name),
-                        exit_on_error=False,
-                    )
-                else:
-                    self._safe_dismiss(name)
-
-            self.app.push_screen(
-                ConfirmScreen(
-                    "A running container is not affected by this edit. "
-                    "Restart now to apply?",
-                    yes_label="Restart",
-                    yes_variant="warning",
-                    no_label="Skip",
-                ),
-                _after,
-            )
+            self.prompt_restart_after_save(ws.name, name)
         else:
             self._safe_dismiss(name)
 

--- a/src/klangk/klangk/cli/tui/state.py
+++ b/src/klangk/klangk/cli/tui/state.py
@@ -65,6 +65,69 @@ class ServerInfo:
     url: str
 
 
+def me_profile_payload(url: str, token: str) -> dict | None:
+    """Fetch ``/auth/me``; None on any failure or malformed payload."""
+    try:
+        resp = http_request(
+            url,
+            "GET",
+            "/api/v1/auth/me",
+            headers={"Authorization": f"Bearer {token}"},
+            timeout=5.0,
+        )
+    except httpx.HTTPError:
+        return None
+    if resp.status_code != 200:
+        return None
+    data = resp.json()
+    if isinstance(data, dict) and isinstance(data.get("id"), str):
+        return data
+    return None
+
+
+def token_status(url: str, token: str) -> str:
+    """ "auth_required" (401), "unreachable", or "ok" for a stored token."""
+    try:
+        resp = http_request(
+            url,
+            "GET",
+            "/api/v1/auth/me",
+            headers={"Authorization": f"Bearer {token}"},
+            timeout=5.0,
+        )
+    except httpx.HTTPError:
+        return "unreachable"
+    if resp.status_code == 401:
+        return "auth_required"
+    return "ok"
+
+
+def login_failure_error(resp) -> LoginError:
+    """A LoginError carrying the server's detail from a non-200 response."""
+    detail = f"HTTP {resp.status_code}"
+    try:
+        detail = resp.json().get("detail", detail)
+    except Exception:
+        pass
+    return LoginError(detail)
+
+
+def aliases_for_url(cfg, url: str) -> list[str]:
+    """The config aliases whose entry points at *url*."""
+    return [a for a, e in cfg.servers.items() if e.url == url]
+
+
+def remove_aliases(aliases: list[str]) -> None:
+    """Remove each alias from klangk.yaml."""
+    for a in aliases:
+        remove_server_from_config(a)
+
+
+def me_cache_valid(cached, cached_url, url) -> bool:
+    """True when the cached /auth/me profile matches *url*."""
+    return cached is not None and cached_url == url
+
+
 class TuiState:
     """Live bridge to CLIConfig / CLIState / KlangkClient.
 
@@ -212,29 +275,16 @@ class TuiState:
         url = self.current_url()
         if url is None:
             return None
-        if self._me is not None and self._me_url == url:
+        if me_cache_valid(self._me, self._me_url, url):
             return self._me
         token = self.token()
         if token is None:
             return None
-        try:
-            resp = http_request(
-                url,
-                "GET",
-                "/api/v1/auth/me",
-                headers={"Authorization": f"Bearer {token}"},
-                timeout=5.0,
-            )
-        except httpx.HTTPError:
-            return None
-        if resp.status_code != 200:
-            return None
-        data = resp.json()
-        if isinstance(data, dict) and isinstance(data.get("id"), str):
+        data = me_profile_payload(url, token)
+        if data is not None:
             self._me = data
             self._me_url = url
-            return data
-        return None
+        return data
 
     def current_user_id(self) -> str | None:
         """The authenticated user's id for the active server (cached)."""
@@ -500,12 +550,7 @@ class TuiState:
         except httpx.HTTPError as exc:
             raise LoginError(f"could not reach server: {exc}") from None
         if resp.status_code != 200:
-            detail = f"HTTP {resp.status_code}"
-            try:
-                detail = resp.json().get("detail", detail)
-            except Exception:
-                pass
-            raise LoginError(detail)
+            raise login_failure_error(resp)
         token = resp.json().get("access_token")
         if not token:
             raise LoginError("server returned no access token")
@@ -567,8 +612,7 @@ class TuiState:
         Returns ``"ok"``, ``"unreachable"``, or ``"auth_required"``.
         """
         config = fetch_config(url)
-        if config == UNREACHABLE:
-            return "unreachable"
+        # UNREACHABLE (a string) fails the isinstance check too.
         if not isinstance(config, dict):
             return "unreachable"
         auth_mode = config.get("auth_modes", "password")
@@ -577,19 +621,7 @@ class TuiState:
         token = self.state().get_token(url)
         if token is None:
             return "auth_required"
-        try:
-            resp = http_request(
-                url,
-                "GET",
-                "/api/v1/auth/me",
-                headers={"Authorization": f"Bearer {token}"},
-                timeout=5.0,
-            )
-            if resp.status_code == 401:
-                return "auth_required"
-        except httpx.HTTPError:
-            return "unreachable"
-        return "ok"
+        return token_status(url, token)
 
     def switch_server(self, url: str) -> None:
         with self._state_lock:
@@ -638,11 +670,10 @@ class TuiState:
         default UDS or None) rather than left dangling.
         """
         cfg = self.cfg()
-        aliases = [a for a, e in cfg.servers.items() if e.url == url]
+        aliases = aliases_for_url(cfg, url)
         if not aliases:
             return False
-        for a in aliases:
-            remove_server_from_config(a)
+        remove_aliases(aliases)
         with self._state_lock:
             state = self.state()
             if state.active_server == url:

--- a/src/klangk/klangk/cli/workspaces.py
+++ b/src/klangk/klangk/cli/workspaces.py
@@ -81,6 +81,55 @@ def short_id(ws_id: str) -> str:
     return f"{ws_id[:3]}…{ws_id[-3:]}"
 
 
+def fetch_shared_workspaces(
+    client, shared: bool, limit, all_pages, sort, order, q
+):
+    """Shared-with-me workspaces when requested, else empty."""
+    if not shared:
+        return []
+    return client.list_shared_workspaces(
+        limit=limit, all_pages=all_pages, sort=sort, order=order, q=q
+    )
+
+
+def workspace_row(ws, shared: bool) -> list[str]:
+    """One rich-table row for an owned workspace."""
+    _, markup = workspace_status(ws)
+    row = [ws.name, short_id(ws.id), markup, ws.created_at[:10]]
+    if shared:
+        row.append("")
+    return row
+
+
+def shared_workspace_row(ws) -> list[str]:
+    """One rich-table row for a shared-with-me workspace (with owner)."""
+    _, markup = workspace_status(ws)
+    return [
+        ws.name,
+        short_id(ws.id),
+        markup,
+        ws.created_at[:10],
+        ws.owner_email or "",
+    ]
+
+
+def print_workspace_table(workspaces, shared_workspaces, shared: bool) -> None:
+    """The rich-table listing (owned workspaces, then shared-with-me)."""
+    console = Console()
+    table = Table(box=None, pad_edge=False)
+    table.add_column("Name", style="bold")
+    table.add_column("ID")
+    table.add_column("Status")
+    table.add_column("Created")
+    if shared:
+        table.add_column("Owner")
+    for ws in workspaces:
+        table.add_row(*workspace_row(ws, shared))
+    for ws in shared_workspaces:
+        table.add_row(*shared_workspace_row(ws))
+    console.print(table)
+
+
 @context.app.command("ls")
 def list_workspaces(
     plain: bool = typer.Option(False, "--plain", help="Plain text output"),
@@ -124,16 +173,8 @@ def list_workspaces(
         order=order,
         q=filter,
     )
-    shared_workspaces = (
-        client.list_shared_workspaces(
-            limit=limit,
-            all_pages=all_workspaces,
-            sort=sort,
-            order=order,
-            q=filter,
-        )
-        if shared
-        else []
+    shared_workspaces = fetch_shared_workspaces(
+        client, shared, limit, all_workspaces, sort, order, filter
     )
     if not workspaces and not shared_workspaces:
         typer.echo("No workspaces found.")
@@ -141,31 +182,7 @@ def list_workspaces(
     if plain:
         _print_plain_listing(workspaces, shared_workspaces)
         return
-    console = Console()
-    table = Table(box=None, pad_edge=False)
-    table.add_column("Name", style="bold")
-    table.add_column("ID")
-    table.add_column("Status")
-    table.add_column("Created")
-    if shared:
-        table.add_column("Owner")
-    for ws in workspaces:
-        _, markup = workspace_status(ws)
-        row = [ws.name, short_id(ws.id), markup, ws.created_at[:10]]
-        if shared:
-            row.append("")
-        table.add_row(*row)
-    for ws in shared_workspaces:
-        _, markup = workspace_status(ws)
-        row = [
-            ws.name,
-            short_id(ws.id),
-            markup,
-            ws.created_at[:10],
-            ws.owner_email or "",
-        ]
-        table.add_row(*row)
-    console.print(table)
+    print_workspace_table(workspaces, shared_workspaces, shared)
 
 
 def _print_plain_listing(workspaces, shared_workspaces) -> None:
@@ -186,28 +203,66 @@ def _print_plain_listing(workspaces, shared_workspaces) -> None:
             )
 
 
+def validated_or_exit(specs: list[str], validate) -> None:
+    """Exit 1 on the first invalid spec in a repeatable-flag list."""
+    for spec in specs:
+        err = validate(spec)
+        if err:
+            context.err.print(f"[red]{err}[/red]")
+            raise typer.Exit(code=1)
+
+
 def validate_create_specs(mount, allow, reject) -> None:
     """Validate repeatable create options up front; exits 1 on the first
     invalid spec."""
     if isinstance(mount, list):
-        for m in mount:
-            err = validate_mount_spec(m)
-            if err:
-                context.err.print(f"[red]{err}[/red]")
-                raise typer.Exit(code=1)
+        validated_or_exit(mount, validate_mount_spec)
     if isinstance(allow, list):
-        for spec in allow:
-            err = validate_allowed_domain_spec(spec)
-            if err:
-                context.err.print(f"[red]{err}[/red]")
-                raise typer.Exit(code=1)
+        validated_or_exit(allow, validate_allowed_domain_spec)
     if isinstance(reject, list):
-        for spec in reject:
-            # CIDR is meaningless for a name-level NXDOMAIN deny-list (#2367).
-            err = validate_allowed_domain_spec(spec, allow_cidr=False)
-            if err:
-                context.err.print(f"[red]{err}[/red]")
-                raise typer.Exit(code=1)
+        # CIDR is meaningless for a name-level NXDOMAIN deny-list (#2367).
+        validated_or_exit(
+            reject,
+            lambda spec: validate_allowed_domain_spec(spec, allow_cidr=False),
+        )
+
+
+def create_workspace_or_exit(
+    client,
+    name,
+    *,
+    image,
+    command,
+    auto_start,
+    mount,
+    env_dict,
+    health_check,
+    allow,
+    reject,
+    settings,
+    per_handle_home,
+    classification_banner,
+):
+    """Create the workspace, exiting 1 with the server's detail on failure."""
+    try:
+        return client.create_workspace(
+            name,
+            image=image,
+            service_command=command,
+            auto_start=auto_start,
+            mounts=mount or None,
+            env=env_dict,
+            health_check=health_check,
+            allowed_domains=allow or None,
+            rejected_domains=reject or None,
+            settings=settings,
+            per_handle_home=per_handle_home,
+            classification_banner=classification_banner,
+        )
+    except httpx.HTTPStatusError as exc:
+        detail = exc.response.json().get("detail", exc.response.text)
+        context.err.print(f"[red]Failed to create workspace:[/red] {detail}")
+        raise typer.Exit(code=1) from None
 
 
 @context.app.command()
@@ -279,25 +334,21 @@ def create(
     settings = build_settings(
         idle_timeout, cpu_limit, memory_limit, pids_limit, allow_sudo
     )
-    try:
-        ws = context.client().create_workspace(
-            name,
-            image=image,
-            service_command=command,
-            auto_start=auto_start,
-            mounts=mount or None,
-            env=env_dict,
-            health_check=health_check,
-            allowed_domains=allow or None,
-            rejected_domains=reject or None,
-            settings=settings,
-            per_handle_home=per_handle_home,
-            classification_banner=classification_banner,
-        )
-    except httpx.HTTPStatusError as exc:
-        detail = exc.response.json().get("detail", exc.response.text)
-        context.err.print(f"[red]Failed to create workspace:[/red] {detail}")
-        raise typer.Exit(code=1) from None
+    ws = create_workspace_or_exit(
+        context.client(),
+        name,
+        image=image,
+        command=command,
+        auto_start=auto_start,
+        mount=mount,
+        env_dict=env_dict,
+        health_check=health_check,
+        allow=allow,
+        reject=reject,
+        settings=settings,
+        per_handle_home=per_handle_home,
+        classification_banner=classification_banner,
+    )
     _out = Console()
     _out.print(f"Created workspace [bold]{name}[/bold] ({ws.id[:12]})")
 
@@ -404,6 +455,31 @@ def start(
     run_workspace_action(name, "start_workspace", "Started")
 
 
+def unique_export_path(name: str, output: Path | None) -> Path:
+    """The export output path; a default name avoids overwriting a file."""
+    out_path = output or Path(f"{name}.tar.gz")
+    if out_path.exists() and output is None:
+        # Don't overwrite — find a unique name
+        stem = name
+        n = 1
+        while out_path.exists():
+            out_path = Path(f"{stem}-{n}.tar.gz")
+            n += 1
+    return out_path
+
+
+def export_error(e: httpx.HTTPStatusError) -> None:
+    """Print the export failure (403 gets the permission hint) and exit."""
+    if e.response.status_code == 403:
+        context.err.print(
+            "[red]Export failed:[/red] permission denied — you need"
+            " the export permission on this workspace"
+        )
+    else:
+        context.err.print(f"[red]Export failed:[/red] {e.response.text}")
+    raise typer.Exit(code=1) from None
+
+
 @context.app.command("export")
 def export_workspace(
     name: str = typer.Argument(..., help="Workspace name"),
@@ -415,14 +491,7 @@ def export_workspace(
     context.require_auth()
     client = context.client()
     ws = context.resolve_or_exit(client, name)
-    out_path = output or Path(f"{name}.tar.gz")
-    if out_path.exists() and output is None:
-        # Don't overwrite — find a unique name
-        stem = name
-        n = 1
-        while out_path.exists():
-            out_path = Path(f"{stem}-{n}.tar.gz")
-            n += 1
+    out_path = unique_export_path(name, output)
     try:
 
         class _EstDownloadColumn(DownloadColumn):
@@ -466,14 +535,7 @@ def export_workspace(
                 final = progress.tasks[task_id].completed
                 progress.update(task_id, total=final, completed=final)
     except httpx.HTTPStatusError as e:
-        if e.response.status_code == 403:
-            context.err.print(
-                "[red]Export failed:[/red] permission denied — you need"
-                " the export permission on this workspace"
-            )
-        else:
-            context.err.print(f"[red]Export failed:[/red] {e.response.text}")
-        raise typer.Exit(code=1) from None
+        export_error(e)
     _out = Console()
     _out.print(f"Exported [bold]{name}[/bold] → {out_path}")
 
@@ -538,21 +600,20 @@ def build_settings(
     allow_sudo: bool | None = None,
 ) -> dict | None:
     """Build a workspace settings dict from CLI flags, or None if all unset."""
-    settings: dict = {}
-    if idle_timeout is not None:
-        settings["idle_timeout"] = idle_timeout
-    if cpu_limit is not None:
-        settings["cpu_limit"] = cpu_limit
-    if memory_limit is not None:
-        settings["memory_limit"] = memory_limit
-    if pids_limit is not None:
-        settings["pids_limit"] = pids_limit
-    # #2017: None (flag omitted) leaves the bag untouched — the workspace
-    # follows the deploy posture. False locks the workspace down; True is
-    # the explicit "follow the server" (the server setting is a ceiling,
-    # so True can never raise sudo above the deploy default).
-    if allow_sudo is not None:
-        settings["allow_sudo"] = allow_sudo
+    values = {
+        "idle_timeout": idle_timeout,
+        "cpu_limit": cpu_limit,
+        "memory_limit": memory_limit,
+        "pids_limit": pids_limit,
+        # #2017: None (flag omitted) leaves the bag untouched — the workspace
+        # follows the deploy posture. False locks the workspace down; True is
+        # the explicit "follow the server" (the server setting is a ceiling,
+        # so True can never raise sudo above the deploy default).
+        "allow_sudo": allow_sudo,
+    }
+    settings = {
+        key: value for key, value in values.items() if value is not None
+    }
     return settings or None
 
 


### PR DESCRIPTION
## Summary

Closes #3042 — tranches T19–T25 of the #2845 A-ratchet: bring every rank-B block in the CLI package (`src/klangk/klangk/cli/`) down to rank A (cyclomatic complexity ≤ 5). **142 blocks across 26 files**; `xenon --max-absolute A` now passes on the whole `cli/` tree.

By tranche (measured at #3042 filing, all since brought to rank A):

- **T19 — `client.py`** (23): the stdin/stdout I/O pumps split into per-byte/per-frame helpers, the terminal window ops (close/create/rename) extracted, the `~.` disconnect state machine isolated.
- **T20 — `tui/screens/main.py`** (14): the status-event and host-lifecycle dispatch moved to tables, the WS reconnect loop split into `_listener_cycle`/`_reconnect_wait`.
- **T21 — `tui/screens/workspace_form.py`** (16): the edit/create form seeds, payload/body builders, and change-detection predicates extracted.
- **T22 — tui other screens** (20): `workspace_detail` (11), `base` (6), `login` (2), `tui/app` (1) — status-event dispatch table, detail-row/render helpers, spatial-nav predicates.
- **T23 — tui consent + state** (17): frame parsing helpers, the WS loop's failure classification extracted, status-event dispatch by name.
- **T24 — cli commands I** (28): `edit`'s interactive list/env editors split into prompt/outcome helpers; `config` yaml (de)serializers extracted; `auth` login arms split; `account`'s handle checks as an ordered table; `workspaces` listing/body builders extracted.
- **T25 — cli commands II** (24): sandbox/monitor/shell/authcmds/mount/admin/transport/etc. — permission gates, env-var tables, backoff/reconnect classification extracted.

## Constraints kept

- Pure extract-function / dispatch-table refactors; no behavior change.
- Full suite + 100% branch coverage green (`-n auto`, CI invocation).
- `klangk.cli` subpackage isolation preserved (no imports from the server package; small helpers duplicated rather than shared).
- TUI spatial navigation untouched (arrow-key bridges intact).

Part of #2845 (ticks the T19–T25 boxes).
