### PR TITLE
fix(egress): NXDOMAIN off-list DNS names in static mode (#3041)

### DIFF
--- a/docs/architecture/egress-flow.md
+++ b/docs/architecture/egress-flow.md
@@ -21,9 +21,12 @@ is about what happens at runtime, inside the [network sidecar][egress-issue].
    (`allowed_domains`) or an in-effect consent allow resolves normally and
    each resolved IP gets a port-scoped `ACCEPT` rule — no consent involved.
    A name on the reject-list (`rejected_domains`) gets `NXDOMAIN`
-   unconditionally. An off-list name **still resolves** (the workspace gets
-   the IP), but the proxy only records the IP→host mapping — the connection
-   itself is gated next.
+   unconditionally. An off-list name in `interactive`/`allow` mode **still
+   resolves** (the workspace gets the IP), but the proxy only records the
+   IP→host mapping — the connection itself is gated next. In `static` mode
+   the off-list name gets `NXDOMAIN` locally — the query is never forwarded
+   (#3041), so there is no resolution oracle and no DNS exfiltration
+   channel.
 2. **The connection SYN is gate 2.** The kernel `OUTPUT` chain walks its
    rules top-down: learned `ACCEPT`/`REJECT` rules (inserted at the top at
    runtime) first, then the static startup rules (loopback, established,
@@ -63,13 +66,13 @@ flowchart TD
         LRN["forward upstream, answer the client,<br/>install port-scoped ACCEPT rules for each<br/>resolved IP (lifetime: DNS TTL, capped at a<br/>timed allow's remaining window)"]
         REC["forward upstream, answer the client,<br/>record the IP-to-host mapping only - NO ACCEPT"]
         NXD["NXDOMAIN"]
-        CLI{"consent wiring configured?"}
+        MODE{"KLANGKNETWORK_EGRESS_MODE<br/>+ consent wiring?"}
         RJ -->|"match - unconditional, every mode"| NXD
         RJ -->|no| PF
         PF -->|match| LRN
-        PF -->|no| CLI
-        CLI -->|yes| REC
-        CLI -->|"no (no consent endpoint)"| NXD
+        PF -->|no| MODE
+        MODE -->|"interactive/allow (consent wired)"| REC
+        MODE -->|"static - refused locally, never forwarded (#3041)<br/>or no consent wiring"| NXD
     end
     REDIR --> RJ
 
@@ -182,13 +185,13 @@ leading-dot form to cover subdomains.
 
 The two sides of a verdict are deliberately asymmetric:
 
-|                   | Allow                                                                                                | Deny                                                                                        |
-| ----------------- | ---------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
-| Fast path         | learned `ACCEPT` rule (per-IP) + hostname memory                                                     | forged RST (immediate `ECONNREFUSED`) + temporary `REJECT` rule (per-IP)                    |
-| Memory scope      | hostname:port in the in-session allow list; future DNS lookups of the host allow-learn automatically | hostname:port in the in-session deny list — covers CDN-rotated IPs the per-IP REJECT misses |
-| Lifetime          | the verdict's duration (`once` learns nothing)                                                       | the verdict's duration (`once` rejects only that connection)                                |
-| Across restarts   | `forever` → appended to `allowed_domains` (persisted, re-read at sidecar start)                      | `forever` → appended to `rejected_domains` (persisted)                                      |
-| Static complement | a name off the allow-list resolves but is denied at the SYN                                          | a name on the reject-list never resolves (`NXDOMAIN`)                                       |
+|                   | Allow                                                                                                                              | Deny                                                                                        |
+| ----------------- | ---------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
+| Fast path         | learned `ACCEPT` rule (per-IP) + hostname memory                                                                                   | forged RST (immediate `ECONNREFUSED`) + temporary `REJECT` rule (per-IP)                    |
+| Memory scope      | hostname:port in the in-session allow list; future DNS lookups of the host allow-learn automatically                               | hostname:port in the in-session deny list — covers CDN-rotated IPs the per-IP REJECT misses |
+| Lifetime          | the verdict's duration (`once` learns nothing)                                                                                     | the verdict's duration (`once` rejects only that connection)                                |
+| Across restarts   | `forever` → appended to `allowed_domains` (persisted, re-read at sidecar start)                                                    | `forever` → appended to `rejected_domains` (persisted)                                      |
+| Static complement | a name off the allow-list is denied at gate 1 (`static` NXDOMAINs it, #3041; `interactive`/`allow` resolve it and deny at the SYN) | a name on the reject-list never resolves (`NXDOMAIN`)                                       |
 
 An allow is hostname-shaped and forward-looking (the next DNS query
 re-learns fresh IPs); a deny is IP-shaped at the kernel (REJECT on the

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -1940,6 +1940,17 @@ git-credential` (#1700).** `pig-latin` removed; `word-count` dormant.
 
 ### Fixed
 
+- **Static egress: off-list DNS names return NXDOMAIN (#3041).** A
+  `static` workspace with egress filtering resolved every off-list name
+  through the upstream resolver when the consent stack was wired (which is
+  every filtered workspace) — a resolution oracle and a DNS exfiltration
+  channel that bypassed the allow-list. klangkd now passes the workspace's
+  `egress_mode` to the network sidecar explicitly
+  (`KLANGKNETWORK_EGRESS_MODE`), and the sidecar refuses off-list queries
+  locally in `static` mode. `interactive` and `allow` modes are unchanged
+  (they resolve and gate the connection at the SYN). See
+  [Egress filtering](features/egress-filtering.md).
+
 - **Tab-strip sync survives a container restart (#3015).** The
   server's tmux window watcher was built once per workspace session
   and never replaced when the container was recycled while members

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -1948,7 +1948,11 @@ git-credential` (#1700).** `pig-latin` removed; `word-count` dormant.
   `egress_mode` to the network sidecar explicitly
   (`KLANGKNETWORK_EGRESS_MODE`), and the sidecar refuses off-list queries
   locally in `static` mode. `interactive` and `allow` modes are unchanged
-  (they resolve and gate the connection at the SYN). See
+  (they resolve and gate the connection at the SYN). The fix lives in the
+  sidecar image: on manual-registry deploys update `network_sidecar_image`
+  together with klangkd, or the env var is silently ignored (the all-in-one
+  host image embeds both). A mode change on a running workspace takes effect
+  at the next container start, like allow-list edits. See
   [Egress filtering](features/egress-filtering.md).
 
 - **Tab-strip sync survives a container restart (#3015).** The

--- a/docs/features/egress-filtering.md
+++ b/docs/features/egress-filtering.md
@@ -15,7 +15,10 @@ mode** (`egress_mode`, default `interactive` for new workspaces):
   ever. Off-list DNS names return NXDOMAIN — the query never reaches an
   upstream resolver (#3041), so there is no resolution oracle and no DNS
   exfiltration channel; denied attempts recorded in the audit log are the
-  connects that were dialed directly by IP.
+  connects that were dialed directly by IP. The mode is fixed at sidecar
+  start — flipping a running workspace `interactive`→`static` keeps the old
+  DNS behavior until its next container start, like allow-list edits
+  (#2281, #3041).
 - **`allow`** — default-permit with a deny-list: every host is reachable
   except names in `rejected_domains`; off-list egress is recorded and
   auto-allowed with no prompt (#2406).
@@ -63,7 +66,7 @@ gate at NFQUEUE, the consent loop, and the verdict — is in
    **allow-lists resolved IPs at runtime** — so a domain whose IPs rotate
    (CDN, DNS round-robin) stays reachable without a container restart,
    and a denied domain returns NXDOMAIN in `static` mode (#3041: the
-   query is refused locally — it is never forwarded, so the mode is no
+   query is refused locally — it is never forwarded, so there is no
    resolution oracle and no DNS exfiltration channel). In `interactive`
    and `allow` modes an off-list name resolves normally, but the proxy
    records the IP-to-name mapping and installs no allow rule (#2324) —

--- a/docs/features/egress-filtering.md
+++ b/docs/features/egress-filtering.md
@@ -12,7 +12,10 @@ mode** (`egress_mode`, default `interactive` for new workspaces):
   [Interactive egress consent](#interactive-egress-consent).
 - **`static`** — the classic allow-list: declare `allowed_domains` up
   front; everything else is denied and recorded for audit. No prompting,
-  ever.
+  ever. Off-list DNS names return NXDOMAIN — the query never reaches an
+  upstream resolver (#3041), so there is no resolution oracle and no DNS
+  exfiltration channel; denied attempts recorded in the audit log are the
+  connects that were dialed directly by IP.
 - **`allow`** — default-permit with a deny-list: every host is reachable
   except names in `rejected_domains`; off-list egress is recorded and
   auto-allowed with no prompt (#2406).
@@ -59,7 +62,13 @@ gate at NFQUEUE, the consent loop, and the verdict — is in
    proxy. The proxy resolves each query against a real upstream, and
    **allow-lists resolved IPs at runtime** — so a domain whose IPs rotate
    (CDN, DNS round-robin) stays reachable without a container restart,
-   and a denied domain returns NXDOMAIN. This replaces the create-time
+   and a denied domain returns NXDOMAIN in `static` mode (#3041: the
+   query is refused locally — it is never forwarded, so the mode is no
+   resolution oracle and no DNS exfiltration channel). In `interactive`
+   and `allow` modes an off-list name resolves normally, but the proxy
+   records the IP-to-name mapping and installs no allow rule (#2324) —
+   resolution succeeding does _not_ mean egress is permitted; the gate is
+   the SYN. This replaces the create-time
    IP-pinning the old OCI hook model used (#2255). A resolved IP is allowed
    **only for the DNS response's TTL**; the proxy re-resolves on the next
    query and a background sweep removes the allow-rule once the TTL
@@ -838,9 +847,12 @@ netfilter_default_domains:
 - **DNS is redirected to the sidecar's proxy, not blocked.** Outbound
   `:53` is `REDIRECT`ed to the sidecar's FQDN DNS proxy, which resolves
   against a real upstream and allow-lists the IPs at runtime; a denied
-  domain returns NXDOMAIN. This does **not** prevent DNS tunneling through
-  the proxy to attacker-controlled domains (data can still be encoded in
-  DNS queries). Treat the filter as an egress allow-list, not a complete
+  domain returns NXDOMAIN (`static` refuses the query locally, #3041;
+  `interactive`/`allow` resolve it but gate the connection). This does
+  **not** prevent DNS tunneling through the proxy to attacker-controlled
+  **allow-listed** domains or in `interactive`/`allow` mode (data can still
+  be encoded in DNS queries). Treat the filter as an egress allow-list,
+  not a complete
   anti-exfiltration guarantee against DNS-based channels.
 - **Ruleset immutability depends on the runtime capability set.** The
   sidecar installs the iptables rules in the shared netns, and the

--- a/src/containers/network/README.md
+++ b/src/containers/network/README.md
@@ -60,17 +60,18 @@ klangkd `egress_port` here (#2254 B1).
 
 ## Configuration (env)
 
-| var                                   | default    | meaning                                                                     |
-| ------------------------------------- | ---------- | --------------------------------------------------------------------------- |
-| `KLANGKNETWORK_EGRESS_ALLOW`          | _(empty)_  | comma-separated allow-list: `host[:port]`, `*.domain[:port]`, or CIDR       |
-| `KLANGKNETWORK_EGRESS_UPSTREAM`       | `8.8.8.8`  | real upstream the proxy forwards to                                         |
-| `KLANGKNETWORK_EGRESS_BACKEND_PORT`   | _(empty)_  | klangkd backend port on host.containers.internal                            |
-| `KLANGKNETWORK_EGRESS_LISTEN_PORT`    | `15353`    | UDP port the proxy listens on                                               |
-| `KLANGKNETWORK_EGRESS_MARK`           | `75`       | fwmark for the proxy's upstream socket (must match entrypoint.sh)           |
-| `KLANGKNETWORK_EGRESS_SWEEP_INTERVAL` | `5`        | seconds between learned-IP TTL-expiry sweeps                                |
-| `KLANGKNETWORK_EGRESS_MIN_TTL`        | `30`       | floor for a learned IP's lifetime (a 0-TTL response must not yank the rule) |
-| `KLANGKNETWORK_IPTABLES`              | `iptables` | iptables binary path                                                        |
-| `KLANGKNETWORK_EGRESS_DEBUG`          | unset      | if set, log each allow/deny decision                                        |
+| var                                   | default    | meaning                                                                                                    |
+| ------------------------------------- | ---------- | ---------------------------------------------------------------------------------------------------------- |
+| `KLANGKNETWORK_EGRESS_ALLOW`          | _(empty)_  | comma-separated allow-list: `host[:port]`, `*.domain[:port]`, or CIDR                                      |
+| `KLANGKNETWORK_EGRESS_MODE`           | `static`   | how off-list names are treated: `static` NXDOMAINs them; `interactive`/`allow` resolve + record (SYN gate) |
+| `KLANGKNETWORK_EGRESS_UPSTREAM`       | `8.8.8.8`  | real upstream the proxy forwards to                                                                        |
+| `KLANGKNETWORK_EGRESS_BACKEND_PORT`   | _(empty)_  | klangkd backend port on host.containers.internal                                                           |
+| `KLANGKNETWORK_EGRESS_LISTEN_PORT`    | `15353`    | UDP port the proxy listens on                                                                              |
+| `KLANGKNETWORK_EGRESS_MARK`           | `75`       | fwmark for the proxy's upstream socket (must match entrypoint.sh)                                          |
+| `KLANGKNETWORK_EGRESS_SWEEP_INTERVAL` | `5`        | seconds between learned-IP TTL-expiry sweeps                                                               |
+| `KLANGKNETWORK_EGRESS_MIN_TTL`        | `30`       | floor for a learned IP's lifetime (a 0-TTL response must not yank the rule)                                |
+| `KLANGKNETWORK_IPTABLES`              | `iptables` | iptables binary path                                                                                       |
+| `KLANGKNETWORK_EGRESS_DEBUG`          | unset      | if set, log each allow/deny decision                                                                       |
 
 ## Allow-list semantics (#2256)
 

--- a/src/containers/network/entrypoint.sh
+++ b/src/containers/network/entrypoint.sh
@@ -98,13 +98,16 @@ esac
 # --- egress consent gate (#2242 recording -> #2311 half B -> #2324 SYN gate):
 # queue blocked packets to the sidecar's own NFQUEUE consumer (proxy.py)
 # whenever a consent endpoint is configured. Consent gates the connection SYN,
-# not the DNS query: non-allow-listed names resolve (the workspace gets the IP),
-# and the first packet to that IP is queued here pending a verdict (allow ->
+# not the DNS query: in interactive/allow modes a non-allow-listed name
+# resolves (the workspace gets the IP) and the first packet to that IP is
+# queued here pending a verdict (allow ->
 # pkt.accept() + learn the IP, then conntrack's ESTABLISHED,RELATED rule passes
 # the rest); deny/timeout/WS-down -> the proxy forges a RST directly from the
 # queue callback so connect() gets ECONNREFUSED at once (#2345), with a
 # temporary iptables REJECT (tcp-reset) rule as a backstop); klangkd records the
-# decision.
+# decision. In static mode the DNS layer NXDOMAINs off-list names (#3041), so
+# the SYNs reaching this queue are IP-literal connects -- their denies are
+# recorded the same way.
 # Gating the SYN (not the DNS query) gives the human the kernel's connect
 # timeout (~127s) instead of a DNS resolver's <=30s getaddrinfo cap. The sidecar
 # is the netns owner with NET_ADMIN, so it reads its own NFQUEUE -- no host-side

--- a/src/klangk/klangk/container/sidecar.py
+++ b/src/klangk/klangk/container/sidecar.py
@@ -272,7 +272,7 @@ class NetworkSidecarMixin:
         name = self.network_sidecar_name(workspace_id, slug)
         # Pick an upstream that differs from the REDIRECT target (1.1.1.1).
         env, binds = self._network_sidecar_env(
-            workspace_id, allowed_domains, rejected_domains
+            workspace_id, allowed_domains, rejected_domains, egress_mode
         )
 
         # Label the network sidecar with this klangk instance so the startup reaper
@@ -482,6 +482,7 @@ class NetworkSidecarMixin:
         workspace_id: str,
         allowed_domains: list[str] | None,
         rejected_domains: list[str] | None,
+        egress_mode: str,
     ) -> tuple[list[str], list[str]]:
         """(env, binds) for the network sidecar container."""
         upstream = self._network_sidecar_upstream()
@@ -489,6 +490,13 @@ class NetworkSidecarMixin:
             f"KLANGKNETWORK_EGRESS_ALLOW={','.join(allowed_domains or [])}",
             f"KLANGKNETWORK_EGRESS_REJECT={','.join(rejected_domains or [])}",
             f"KLANGKNETWORK_EGRESS_UPSTREAM={upstream}",
+            # The workspace's egress mode, passed EXPLICITLY (#3041): the
+            # sidecar must key its off-list DNS behavior on this, not on
+            # consent-client presence (the consent stack is wired on every
+            # filtered workspace below, static included, so presence says
+            # nothing about the mode). static -> NXDOMAIN off-list names;
+            # interactive/allow -> resolve + record for the SYN gate.
+            f"KLANGKNETWORK_EGRESS_MODE={egress_mode}",
             # The klangkd backend port (LLM proxy + bridge on
             # host.containers.internal). The network sidecar allow-lists it statically
             # — it's a /etc/hosts entry the FQDN proxy can't learn (#2254 B1).
@@ -509,11 +517,12 @@ class NetworkSidecarMixin:
         binds = []
         # #2242/#2311: consent recording runs for every filtered workspace
         # when the consent stack is wired, regardless of egress_mode -- the
-        # mode only affects the recorded decision (static=denied+no-human,
+        # mode affects the recorded decision (static=denied+no-human,
         # interactive=pending), applied by the coordinator over the sidecar
-        # WS. The workspace JWT is bind-mounted in and refreshed on rotation
-        # (write_sidecar_token), not baked in env (it rotates). The sweeper
-        # attribute gates the stack being present at all.
+        # WS, and the sidecar's off-list DNS behavior (the EGRESS_MODE env
+        # above, #3041). The workspace JWT is bind-mounted in and refreshed
+        # on rotation (write_sidecar_token), not baked in env (it rotates).
+        # The sweeper attribute gates the stack being present at all.
         if getattr(self.app.state, "consent_sweeper", None) is not None:
             consent_env, binds = self._consent_stack_env(workspace_id)
             env.extend(consent_env)

--- a/src/klangk/klangk/container/sidecar.py
+++ b/src/klangk/klangk/container/sidecar.py
@@ -21,6 +21,7 @@ from ..model.container_events import (
     EVENT_STOP,
     ROLE_SIDECAR,
 )
+from ..model.workspaces import EGRESS_MODE_STATIC
 
 logger = logging.getLogger(__name__)
 
@@ -244,7 +245,7 @@ class NetworkSidecarMixin:
         self,
         workspace_id: str,
         allowed_domains: list[str] | None,
-        egress_mode: str = "static",
+        egress_mode: str = EGRESS_MODE_STATIC,
         rejected_domains: list[str] | None = None,
         publish: list[tuple[int, int]] | None = None,
         slug: str = "",

--- a/src/klangk/klangkc-tests/e2e-tests/test_cli_e2e.py
+++ b/src/klangk/klangkc-tests/e2e-tests/test_cli_e2e.py
@@ -1838,6 +1838,29 @@ class TestTerminalSharing:
 class TestContainerReplace:
     """Verify podman --replace handles stale/crashed containers."""
 
+    @pytest.fixture(autouse=True)
+    @staticmethod
+    def _login(cli_config):
+        """Ensure logged in for this test class.
+
+        TestLogout (scheduled anywhere under xdist) wipes the server entry
+        from the session-shared CLI config, so any class WITHOUT its own
+        re-login fails with "no server configured" when it lands after it
+        on the same worker. Same pattern as TestExportSymlinks et al.
+        """
+        run(
+            [
+                "klangk",
+                "login",
+                cli_config["server_url"],
+                "test@example.com",
+                "--password-file",
+                "-",
+            ],
+            input="testpass\n",
+            env=cli_config["env"],
+        )
+
     def test_exec_after_external_stop(self, cli_config):
         """Kill a workspace container externally, then exec again.
 

--- a/src/klangk/klangkd-tests/e2e-tests/test_network_sidecar_e2e.py
+++ b/src/klangk/klangkd-tests/e2e-tests/test_network_sidecar_e2e.py
@@ -725,6 +725,8 @@ class TestNetworkSidecarE2E:
                 "KLANGKNETWORK_EGRESS_ALLOW=allowed.test",
                 "-e",
                 "KLANGKNETWORK_EGRESS_CONSENT_URL=http://fake-klangkd:8995/internal/egress-consent/events",
+                "-e",
+                "KLANGKNETWORK_EGRESS_MODE=interactive",
                 env["image"],
             )
             _wait_ready(nc)
@@ -1068,6 +1070,12 @@ def consent_stack(env):
             f"KLANGKNETWORK_EGRESS_ALLOW=allowed.test,{ver_ip}/32:8995",
             "-e",
             f"KLANGKNETWORK_EGRESS_CONSENT_URL=http://{ver_ip}:8995",
+            # #3041: the mode is explicit now (a consent URL alone no longer
+            # implies interactive). This stack models an interactive workspace:
+            # off-list names must resolve + record so the trigger's SYNs hit
+            # NFQUEUE and surface as egress frames at the verifier.
+            "-e",
+            "KLANGKNETWORK_EGRESS_MODE=interactive",
             env["image"],
         )
         _wait_ready(nc)

--- a/src/klangk/klangkd-tests/e2e-tests/test_network_sidecar_e2e.py
+++ b/src/klangk/klangkd-tests/e2e-tests/test_network_sidecar_e2e.py
@@ -390,12 +390,15 @@ def _wait_ready(name, timeout=40):
     )
 
 
-@pytest.fixture
-def stack(env):
-    """A fresh (fake-upstream + network sidecar) pair on an isolated network.
+def _boot_stack(env, extra_sidecar_env=()):
+    """Create an isolated (fake-upstream + network sidecar) pair on a fresh
+    network (#3041 refactor of the ``stack`` fixture so tests can boot the
+    same pair with extra sidecar env, e.g. the consent stack).
 
-    Yields (upstream_ip, network_sidecar_name). The network sidecar
-    allow-lists allowed.test and points its upstream at the fake server.
+    Returns ``(upstream_ip, fu_name, nc_name, net_name)``; the CALLER owns
+    teardown (``_podman_cleanup`` the containers, then the network). The
+    sidecar allow-lists allowed.test and points its upstream at the fake
+    server; ``extra_sidecar_env`` are extra ``-e`` args for the sidecar.
     """
     net = f"netc-e2e-{uuid.uuid4().hex[:8]}"
     fu = f"netc-fu-{uuid.uuid4().hex[:8]}"
@@ -442,9 +445,26 @@ def stack(env):
             f"KLANGKNETWORK_EGRESS_UPSTREAM={upstream_ip}",
             "-e",
             "KLANGKNETWORK_EGRESS_ALLOW=allowed.test",
+            *extra_sidecar_env,
             env["image"],
         )
         _wait_ready(nc)
+        return upstream_ip, fu, nc, net
+    except BaseException:
+        _podman_cleanup("container", nc, fu)
+        _podman_cleanup("network", net)
+        raise
+
+
+@pytest.fixture
+def stack(env):
+    """A fresh (fake-upstream + network sidecar) pair on an isolated network.
+
+    Yields (upstream_ip, network_sidecar_name). The network sidecar
+    allow-lists allowed.test and points its upstream at the fake server.
+    """
+    upstream_ip, fu, nc, net = _boot_stack(env)
+    try:
         yield upstream_ip, nc
     finally:
         _podman_cleanup("container", nc, fu)
@@ -571,6 +591,27 @@ def _probe_somark(
     return out.stdout.strip()
 
 
+# The consent-stack env a production filtered sidecar gets (#2242/#2311):
+# CONSENT_URL is set on every filtered workspace regardless of egress_mode,
+# so these mirror the exact #3041 configuration. The host is unreachable on
+# purpose -- the WS client retries in the background and the DNS-path
+# behavior under test does not depend on the connection being up. The two
+# variants differ ONLY in KLANGKNETWORK_EGRESS_MODE.
+def _consent_stack_env(mode):
+    return (
+        "-e",
+        "KLANGKNETWORK_EGRESS_CONSENT_URL="
+        "http://fake-klangkd:8995/internal/egress-consent/events",
+        "-e",
+        f"KLANGKNETWORK_EGRESS_MODE={mode}",
+    )
+
+
+_CONSENT_STACK_STATIC_ENV = _consent_stack_env("static")
+
+_CONSENT_STACK_INTERACTIVE_ENV = _consent_stack_env("interactive")
+
+
 class TestNetworkSidecarE2E:
     """The network sidecar enforces FQDN egress + closes the upstream bypass."""
 
@@ -594,6 +635,37 @@ class TestNetworkSidecarE2E:
     def test_denied_domain_is_nxdomain(self, env, stack):
         # A name not on the allow-list is denied by the proxy.
         assert _query(env, stack, "denied.test") == "NXDOMAIN"
+
+    def test_static_mode_offlist_nxdomain_with_consent_wired(self, env):
+        # #3041: the regression. Production wires the consent stack (CONSENT_
+        # URL) on EVERY filtered workspace -- static included -- and the sidecar
+        # used to infer "interactive" from client presence, so a static
+        # workspace FORWARDED off-list queries to the upstream (a resolution
+        # oracle + DNS exfil channel through the allow-list). With the explicit
+        # KLANGKNETWORK_EGRESS_MODE=static, the off-list name (one the fake
+        # upstream WOULD answer: exfil.test -> 6.6.6.6) must NXDOMAIN locally.
+        # The unreachable consent host is deliberate: the client retries in the
+        # background and DNS behavior must not depend on the WS being up.
+        upstream_ip, fu, nc, net = _boot_stack(env, _CONSENT_STACK_STATIC_ENV)
+        try:
+            assert _query(env, (upstream_ip, nc), "exfil.test") == "NXDOMAIN"
+        finally:
+            _podman_cleanup("container", nc, fu)
+            _podman_cleanup("network", net)
+
+    def test_interactive_mode_offlist_resolves_with_consent_wired(self, env):
+        # The interactive counterpart (same consent-wired sidecar, only the
+        # mode differs): an off-list name resolves + records (#2324) -- the
+        # hold is at the connection SYN (NFQUEUE), not at the DNS query, so
+        # resolution succeeding is the mode's contract, not a leak.
+        upstream_ip, fu, nc, net = _boot_stack(
+            env, _CONSENT_STACK_INTERACTIVE_ENV
+        )
+        try:
+            assert _query(env, (upstream_ip, nc), "exfil.test") == "A 6.6.6.6"
+        finally:
+            _podman_cleanup("container", nc, fu)
+            _podman_cleanup("network", net)
 
     def test_network_sidecar_marks_upstream_rule(self, env, stack):
         # The mechanism: the network sidecar's OUTPUT allows upstream:53 only

--- a/src/klangk/klangkd-tests/tests/test_container.py
+++ b/src/klangk/klangkd-tests/tests/test_container.py
@@ -867,6 +867,9 @@ class TestStartContainer:
         assert kwargs["dns"] == ["1.1.1.1"]
         assert "KLANGKNETWORK_EGRESS_ALLOW=github.com:443" in kwargs["env"]
         assert "KLANGKNETWORK_EGRESS_UPSTREAM=8.8.8.8" in kwargs["env"]
+        # #3041: the egress mode is passed explicitly (default static) so the
+        # sidecar never infers it from consent-client presence.
+        assert "KLANGKNETWORK_EGRESS_MODE=static" in kwargs["env"]
         # #2254 review: the network sidecar is labelled with this klangk instance so
         # the startup reaper culls any leftover network sidecar at boot.
         assert (
@@ -1476,11 +1479,60 @@ class TestStartContainer:
             for e in env
         )
         assert "KLANGKNETWORK_EGRESS_NFQUEUE_NUM=5139" in env
+        assert "KLANGKNETWORK_EGRESS_MODE=interactive" in env
         assert not any("TOKEN" in e for e in env)
         # the workspace token was written to the bind-mounted file ...
         assert (tmp_path / "ws-tokens" / WS).read_text() == "ws-tok"
         # ... and bind-mounted read-only into the sidecar
         assert any("workspace-token:ro" in b for b in kwargs.get("binds", []))
+
+    async def test_start_network_sidecar_static_mode_env_with_consent(
+        self, monkeypatch, tmp_path
+    ):
+        # #3041: the exact misconfiguration the bug lived in -- a STATIC
+        # workspace with the consent stack wired (every filtered workspace
+        # gets CONSENT_URL, #2242/#2311). The mode env must say static so the
+        # sidecar NXDOMAINs off-list names despite the consent client being
+        # present (it used to infer interactive from client presence and
+        # resolve them -- a resolution oracle + DNS exfil channel).
+        import types as _types
+
+        WS = "abcdef12-abcd-1234-5678-bbbbbbbbbbbb"
+        monkeypatch.setattr(
+            self.registry.app.state.settings,
+            "network_sidecar_image",
+            "net-img",
+        )
+        monkeypatch.setattr(
+            self.registry.app.state.settings, "egress_port", "8997"
+        )
+        monkeypatch.setattr(
+            self.registry.app.state.settings, "data_dir", str(tmp_path)
+        )
+        monkeypatch.setattr(
+            self.registry.app.state,
+            "consent_sweeper",
+            _types.SimpleNamespace(),
+            raising=False,
+        )
+        monkeypatch.setattr(
+            self.registry.app.state,
+            "auth",
+            _types.SimpleNamespace(create_workspace_token=lambda ws: "ws-tok"),
+            raising=False,
+        )
+        from klangk import netfilter as _nf
+
+        monkeypatch.setattr(_nf, "detect_host_resolvers", lambda: ["8.8.8.8"])
+        with patch_podman(self.registry) as p:
+            await self.registry.start_network_sidecar(
+                WS, ["github.com:443"], egress_mode="static"
+            )
+        env = p.create_container.call_args.kwargs["env"]
+        # consent stack wired ...
+        assert any("KLANGKNETWORK_EGRESS_CONSENT_URL=" in e for e in env)
+        # ... AND the mode says static -- the pair the sidecar keys on.
+        assert "KLANGKNETWORK_EGRESS_MODE=static" in env
 
     def test_write_sidecar_token_atomic(self, monkeypatch, tmp_path):
         # The sidecar reads this file per POST; writes must be atomic (no

--- a/src/klangksidecar/klangksidecar/app.py
+++ b/src/klangksidecar/klangksidecar/app.py
@@ -128,7 +128,9 @@ def resolve_ws_host(consent_url: str) -> str | None:
 
 async def start_consent_client() -> SidecarConsentClient | None:
     """Start the WS consent client when consent is configured (a
-    :data:`config.CONSENT_URL`), else None (static mode)."""
+    :data:`config.CONSENT_URL`), else None. Note: consent is wired on every
+    filtered workspace (#2242/#2311), so a client here does NOT imply
+    interactive mode -- see :data:`config.EGRESS_MODE` (#3041)."""
     if not config.CONSENT_URL:
         return None
     client = consent.SidecarConsentClient(
@@ -145,7 +147,8 @@ def bind_dns_socket() -> socket.socket:
     s.setblocking(False)
     print(
         f"dns-proxy listening on 127.0.0.1:{LISTEN_PORT} "
-        f"(upstream={UPSTREAM[0]}, allowed={allowlist.SPECS})",
+        f"(upstream={UPSTREAM[0]}, allowed={allowlist.SPECS}, "
+        f"mode={config.EGRESS_MODE})",
         flush=True,
     )
     return s

--- a/src/klangksidecar/klangksidecar/config.py
+++ b/src/klangksidecar/klangksidecar/config.py
@@ -52,6 +52,19 @@ QUEUE_NUM = int(os.environ.get("KLANGKNETWORK_EGRESS_NFQUEUE_NUM", "5139"))
 CONSENT_URL = os.environ.get("KLANGKNETWORK_EGRESS_CONSENT_URL", "")
 
 
+# The workspace's egress_mode (#3041), passed explicitly by klangkd so the
+# DNS proxy does NOT infer the mode from client presence -- the consent stack
+# is wired on EVERY filtered workspace (static included; #2242/#2311), so a
+# present client no longer implies interactive. 'static' -> an off-list name
+# NXDOMAINs (no query reaches the upstream: no resolution oracle, no DNS
+# exfil channel); 'interactive' -> resolves + records (the SYN is consent-held
+# at NFQUEUE); 'allow' -> resolves + records (the coordinator auto-allows at
+# the SYN, #2406). The default is the fail-closed 'static': a sidecar whose
+# klangkd predates the var (and wires consent on every workspace) denies
+# off-list names rather than resolving them.
+EGRESS_MODE = os.environ.get("KLANGKNETWORK_EGRESS_MODE", "static")
+
+
 # How long to await a verdict before fail-closing to deny. The consent gate is
 # the connection SYN (NFQUEUE), so this can match the kernel's connect timeout
 # (tcp_syn_retries ~= 127s) -- far longer than a DNS resolver's <=30s getaddrinfo

--- a/src/klangksidecar/klangksidecar/config.py
+++ b/src/klangksidecar/klangksidecar/config.py
@@ -65,6 +65,16 @@ CONSENT_URL = os.environ.get("KLANGKNETWORK_EGRESS_CONSENT_URL", "")
 EGRESS_MODE = os.environ.get("KLANGKNETWORK_EGRESS_MODE", "static")
 
 
+# The modes in which an off-list (deny-classified) name may resolve + record
+# (#3041). Deliberately a WHITELIST, not `!= "static"`: an unrecognized value
+# (a typo, a future enum member) must fail CLOSED (NXDOMAIN), never silently
+# take the permissive resolve branch. The env var is a bare string and the
+# sidecar is the last line of defense (klangkd's DB column is bare TEXT with
+# no CHECK constraint; the daemon coerces on write, but a hand-launched or
+# future writer may not).
+RESOLVING_MODES = frozenset({"interactive", "allow"})
+
+
 # How long to await a verdict before fail-closing to deny. The consent gate is
 # the connection SYN (NFQUEUE), so this can match the kernel's connect timeout
 # (tcp_syn_retries ~= 127s) -- far longer than a DNS resolver's <=30s getaddrinfo

--- a/src/klangksidecar/klangksidecar/resolve.py
+++ b/src/klangksidecar/klangksidecar/resolve.py
@@ -3,7 +3,9 @@
 query_name / a_records_with_ttl / nxdomain_for wrap dnspython; decision
 classifies a query; respond_allowed / forward_and_learn learn + reply (allow
 path), respond_recorded / forward_and_record record IP->host without an
-ACCEPT (consent-at-SYN path, #2324); handle_packet routes one query.
+ACCEPT (consent-at-SYN path, #2324); handle_packet routes one query — an
+off-list name NXDOMAINs in static mode and resolves+records in
+interactive/allow (#3041).
 """
 
 from __future__ import annotations
@@ -18,7 +20,7 @@ import dns.rcode
 
 from . import allowlist, rules
 from .allowlist import ports_for, rejected_for
-from .config import DEBUG, MARK, UPSTREAM
+from .config import DEBUG, EGRESS_MODE, MARK, UPSTREAM
 from .rules import fmt_ports, learn_all
 
 if TYPE_CHECKING:
@@ -231,12 +233,18 @@ async def send_denied(
     qname: str,
     client: SidecarConsentClient | None,
 ) -> None:
-    """The deny path: interactive mode resolves + responds + records IP->host
-    (the SYN is consent-gated at NFQUEUE, not held here at the DNS query);
-    static mode (no client) NXDOMAINs."""
+    """The deny path (#3041): interactive/allow mode (a consent client + a
+    non-static :data:`EGRESS_MODE`) resolves + responds + records IP->host (the
+    SYN is consent-gated at NFQUEUE, not held here at the DNS query; ``allow``
+    auto-allows at that same gate, #2406); static mode NXDOMAINs even though
+    the consent client is wired -- no off-list query may reach the upstream (a
+    resolution oracle + DNS exfil channel bypassing the allow-list). The mode
+    is keyed on the explicit env var, NOT on client presence: the consent
+    stack is wired on every filtered workspace (static included,
+    #2242/#2311)."""
     if DEBUG:
         print(f"deny  {qname}", flush=True)
-    if client is not None:
+    if client is not None and EGRESS_MODE != "static":
         await forward_and_record(s, data, addr, qname)
     else:
         send_nxdomain(s, data, addr)
@@ -266,10 +274,12 @@ async def handle_packet(
     """Classify + route one DNS query (the per-packet body of :func:`async_main`).
 
     Allow-listed names forward + learn (ACCEPT). A denied name in interactive
-    mode (a consent client) resolves + responds + records IP->host but installs
-    NO ACCEPT -- its connection SYN is consent-gated at NFQUEUE (#2324), so the
-    human decision window is the kernel's connect timeout (~127s), not the
-    resolver's <=30s getaddrinfo cap. Static mode (no client) -> NXDOMAIN.
+    or allow mode resolves + responds + records IP->host but installs
+    NO ACCEPT -- its connection SYN is consent-gated at NFQUEUE (#2324), so
+    the human decision window is the kernel's connect timeout (~127s), not
+    the resolver's <=30s getaddrinfo cap. Static mode -> NXDOMAIN for every
+    off-list name, keyed on the explicit :data:`EGRESS_MODE` (#3041) -- see
+    :func:`send_denied`.
     """
     try:
         qname = query_name(data)

--- a/src/klangksidecar/klangksidecar/resolve.py
+++ b/src/klangksidecar/klangksidecar/resolve.py
@@ -20,7 +20,7 @@ import dns.rcode
 
 from . import allowlist, rules
 from .allowlist import ports_for, rejected_for
-from .config import DEBUG, EGRESS_MODE, MARK, UPSTREAM
+from .config import DEBUG, EGRESS_MODE, MARK, RESOLVING_MODES, UPSTREAM
 from .rules import fmt_ports, learn_all
 
 if TYPE_CHECKING:
@@ -233,18 +233,18 @@ async def send_denied(
     qname: str,
     client: SidecarConsentClient | None,
 ) -> None:
-    """The deny path (#3041): interactive/allow mode (a consent client + a
-    non-static :data:`EGRESS_MODE`) resolves + responds + records IP->host (the
-    SYN is consent-gated at NFQUEUE, not held here at the DNS query; ``allow``
-    auto-allows at that same gate, #2406); static mode NXDOMAINs even though
-    the consent client is wired -- no off-list query may reach the upstream (a
-    resolution oracle + DNS exfil channel bypassing the allow-list). The mode
-    is keyed on the explicit env var, NOT on client presence: the consent
-    stack is wired on every filtered workspace (static included,
-    #2242/#2311)."""
+    """The deny path (#3041): interactive/allow mode (a consent client +
+    :data:`EGRESS_MODE` in :data:`RESOLVING_MODES`) resolves + responds + records
+    IP->host (the SYN is consent-gated at NFQUEUE, not held here at the DNS
+    query; ``allow`` auto-allows at that same gate, #2406); every other mode --
+    static, an unrecognized value, or no consent client -- NXDOMAINs, so no
+    off-list query may reach the upstream (a resolution oracle + DNS exfil
+    channel bypassing the allow-list). The mode is keyed on the explicit env
+    var, NOT on client presence: the consent stack is wired on every filtered
+    workspace (static included, #2242/#2311)."""
     if DEBUG:
         print(f"deny  {qname}", flush=True)
-    if client is not None and EGRESS_MODE != "static":
+    if client is not None and EGRESS_MODE in RESOLVING_MODES:
         await forward_and_record(s, data, addr, qname)
     else:
         send_nxdomain(s, data, addr)

--- a/src/klangksidecar/tests/test_proxy.py
+++ b/src/klangksidecar/tests/test_proxy.py
@@ -2573,10 +2573,12 @@ def test_duration_ttl_mapping(proxy):
 
 
 class TestHandlePacket:
-    """The per-packet DNS routing (#2311 half B, #2324): classify -> forward /
-    resolve+record / NXDOMAIN. A statically-allow-listed name forwards + learns;
-    a denied name in interactive mode resolves + records IP->host (its SYN is
-    consent-gated at NFQUEUE); static mode (no client) -> NXDOMAIN."""
+    """The per-packet DNS routing (#2311 half B, #2324, #3041): classify ->
+    forward / resolve+record / NXDOMAIN. A statically-allow-listed name forwards
+    + learns; a denied name in interactive mode resolves + records IP->host
+    (its SYN is consent-gated at NFQUEUE); allow mode likewise resolves +
+    records (auto-allowed at the SYN, #2406); static mode NXDOMAINs every
+    off-list name even when a consent client is wired (#3041)."""
 
     async def test_allowed_name_forwards_and_learns(self, proxy, monkeypatch):
         monkeypatch.setattr(proxy.resolve, "query_name", lambda wire: "allowed.test")
@@ -2596,9 +2598,12 @@ class TestHandlePacket:
         await proxy.handle_packet(s, b"q", ("1.2.3.4", 53), None)
         s.sendto.assert_called_once_with(b"NXD", ("1.2.3.4", 53))
 
-    async def test_denied_with_client_resolves_and_records(self, proxy, monkeypatch):
+    async def test_denied_with_client_interactive_resolves_and_records(
+        self, proxy, monkeypatch
+    ):
         # Interactive: a denied name resolves + records IP->host (NO ACCEPT) so
         # its SYN is consent-gated at NFQUEUE -- it is NOT held at the DNS query.
+        monkeypatch.setattr(proxy.resolve, "EGRESS_MODE", "interactive")
         monkeypatch.setattr(proxy.resolve, "query_name", lambda wire: "evil.test")
         monkeypatch.setattr(proxy.allowlist, "SPECS", [])
         rec = AsyncMock()
@@ -2611,6 +2616,44 @@ class TestHandlePacket:
         await proxy.handle_packet(s, b"q", ("1.2.3.4", 53), client)
         rec.assert_awaited_once_with(s, b"q", ("1.2.3.4", 53), "evil.test")
         nxd.assert_not_called()  # not NXDOMAIN -- resolves for the SYN gate
+
+    async def test_denied_with_client_static_sends_nxdomain(self, proxy, monkeypatch):
+        # #3041: the consent stack is wired on EVERY filtered workspace
+        # (static included), so a present client must NOT imply that a denied
+        # name may resolve. Static mode NXDOMAINs it -- no off-list query
+        # reaches the upstream (no resolution oracle, no DNS exfil channel).
+        monkeypatch.setattr(proxy.resolve, "EGRESS_MODE", "static")
+        monkeypatch.setattr(proxy.resolve, "query_name", lambda wire: "evil.test")
+        monkeypatch.setattr(proxy.allowlist, "SPECS", [])
+        monkeypatch.setattr(proxy.resolve, "nxdomain_for", lambda d: b"NXD")
+        rec = AsyncMock()
+        monkeypatch.setattr(proxy.resolve, "forward_and_record", rec)
+        client = MagicMock()
+        client.connected = True
+        s = MagicMock()
+        await proxy.handle_packet(s, b"q", ("1.2.3.4", 53), client)
+        s.sendto.assert_called_once_with(b"NXD", ("1.2.3.4", 53))
+        rec.assert_not_awaited()  # NEVER forwarded -- that is the fix
+
+    async def test_denied_with_client_allow_resolves_and_records(
+        self, proxy, monkeypatch
+    ):
+        # Allow mode is default-permit (#2406): off-list DNS must resolve
+        # (record IP->host) so the SYN can hit the NFQUEUE gate, where the
+        # coordinator auto-allows. NXDOMAINing here would break allow mode.
+        monkeypatch.setattr(proxy.resolve, "EGRESS_MODE", "allow")
+        monkeypatch.setattr(proxy.resolve, "query_name", lambda wire: "any.test")
+        monkeypatch.setattr(proxy.allowlist, "SPECS", [])
+        rec = AsyncMock()
+        monkeypatch.setattr(proxy.resolve, "forward_and_record", rec)
+        nxd = MagicMock()
+        monkeypatch.setattr(proxy.resolve, "send_nxdomain", nxd)
+        client = MagicMock()
+        client.connected = True
+        s = MagicMock()
+        await proxy.handle_packet(s, b"q", ("1.2.3.4", 53), client)
+        rec.assert_awaited_once_with(s, b"q", ("1.2.3.4", 53), "any.test")
+        nxd.assert_not_called()
 
     async def test_malformed_query_is_dropped(self, proxy, monkeypatch):
         def _boom(wire):

--- a/src/klangksidecar/tests/test_proxy.py
+++ b/src/klangksidecar/tests/test_proxy.py
@@ -2655,6 +2655,28 @@ class TestHandlePacket:
         rec.assert_awaited_once_with(s, b"q", ("1.2.3.4", 53), "any.test")
         nxd.assert_not_called()
 
+    async def test_denied_with_client_unknown_mode_sends_nxdomain(
+        self, proxy, monkeypatch
+    ):
+        # #3041 review: the resolve gate is a WHITELIST (RESOLVING_MODES), not
+        # `!= "static"` -- an unrecognized env value (a typo, a future enum
+        # member) must fail CLOSED (NXDOMAIN), never silently resolve.
+        for bogus in ("Static", "interactive ", "frozen", ""):
+            monkeypatch.setattr(proxy.resolve, "EGRESS_MODE", bogus)
+            monkeypatch.setattr(proxy.resolve, "query_name", lambda wire: "evil.test")
+            monkeypatch.setattr(proxy.allowlist, "SPECS", [])
+            monkeypatch.setattr(proxy.resolve, "nxdomain_for", lambda d: b"NXD")
+            rec = AsyncMock()
+            monkeypatch.setattr(proxy.resolve, "forward_and_record", rec)
+            client = MagicMock()
+            client.connected = True
+            s = MagicMock()
+            await proxy.handle_packet(s, b"q", ("1.2.3.4", 53), client)
+            s.sendto.assert_called_once_with(b"NXD", ("1.2.3.4", 53))
+            rec.assert_not_awaited()
+            s.reset_mock()
+            rec.reset_mock()
+
     async def test_malformed_query_is_dropped(self, proxy, monkeypatch):
         def _boom(wire):
             raise RuntimeError("bad wire")


### PR DESCRIPTION
Fixes #3041.

## The bug

In `static` egress mode, off-list DNS names **resolved normally** instead of
returning NXDOMAIN. `resolve.py`'s deny branch discriminated the mode by "is a
consent client present?" — but `KLANGKNETWORK_EGRESS_CONSENT_URL` is wired on
**every** filtered workspace by design (#2242/#2311, so consent *recording*
works in all modes), so a static workspace always had a client, always took the
interactive branch (`forward_and_record`), and forwarded every off-list lookup
verbatim to the upstream resolver.

The data plane held (no ACCEPT installed, SYN dropped — verified twice in the
issue), but the *query* leaked: a resolution oracle and a DNS exfiltration
channel that bypassed the allow-list, in the mode that promises "everything
else is denied".

## The fix

Pass the workspace's egress mode to the sidecar explicitly instead of inferring
it from client presence:

- **klangkd** (`container/sidecar.py`): `start_network_sidecar` (which already
  receives `egress_mode`) now passes it into the sidecar env as
  `KLANGKNETWORK_EGRESS_MODE`.
- **klangksidecar** (`config.py`): `EGRESS_MODE` from the env var, with a
  **fail-closed default of `static`** — a sidecar whose klangkd predates the
  var (and wires consent on every workspace) denies off-list names rather than
  resolving them.
- **klangksidecar** (`resolve.py`): the deny branch keys on
  `client is not None and EGRESS_MODE != "static"`:
  - `static` → NXDOMAIN locally; the query never reaches the upstream
  - `interactive` → resolve + record, SYN consent-held at NFQUEUE (#2324, unchanged)
  - `allow` → resolve + record, coordinator auto-allows at the SYN (#2406, unchanged)

The `rejected_domains` deny-list (runs before the mode branch) and the NFQUEUE
recording gate are unchanged — static denied-attempt recording still works for
IP-literal connects.

## Verification

- Sidecar unit suite (292, 100% branch) + backend suite (6577, 100% branch)
  green; xenon passed.
- New regression tests: unit (static-with-client NXDOMAINs; interactive/allow
  resolve+record), klangkd env (static + consent wired carries
  `EGRESS_MODE=static`), and real-podman e2e (consent-wired sidecar: `static`
  NXDOMAINs a name the upstream would answer; `interactive` resolves it).
- Egress consent smoketest against the rebuilt sidecar image:
  **64/64 pass, 0 findings, 0 mismatches** (allow-mode default-permit, pause,
  no-decider denial phases all green).
- Direct probe of the exact issue configuration (rebuilt image, consent wired,
  unreachable klangkd host): `static` → NXDOMAIN, `interactive` → `A 6.6.6.6`.
