### PR TITLE
ci: ignore docs/ markdown-only PRs in unit-suite triggers (#3051)

### DIFF
--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -7,11 +7,12 @@ on:
   pull_request:
     paths-ignore:
       # Docs/meta files can never affect what this workflow tests — a
-      # PR changing only these starts no run at all (#2957). GitHub
-      # filter patterns are root-anchored, so nested docs/ .md needs
-      # its own entry (#3051). Never widen the .md ignore into
-      # src/containers/: agent-context.md is COPYed into the workspace
-      # image, so a change there is a build-path change.
+      # PR changing only these starts no run at all (#2957). "*.md" is
+      # root-anchored (GitHub globs match full paths; * does not cross
+      # "/"), and docs/**/*.md covers the whole docs tree including
+      # its top level — docs/*.md is belt-and-braces (#3051). Never
+      # widen the .md ignore into src/containers/: agent-context.md is
+      # COPYed into the workspace image — a build-path change.
       - "*.md"
       - "docs/*.md"
       - "docs/**/*.md"

--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -6,9 +6,15 @@ on:
     branches: [release/**]
   pull_request:
     paths-ignore:
-      # Root-only docs/meta files can never affect what this workflow
-      # tests — a PR changing only these starts no run at all (#2957).
+      # Docs/meta files can never affect what this workflow tests — a
+      # PR changing only these starts no run at all (#2957). GitHub
+      # filter patterns are root-anchored, so nested docs/ .md needs
+      # its own entry (#3051). Never widen the .md ignore into
+      # src/containers/: agent-context.md is COPYed into the workspace
+      # image, so a change there is a build-path change.
       - "*.md"
+      - "docs/*.md"
+      - "docs/**/*.md"
       - "zensical.toml"
       - "bootstrap"
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -5,9 +5,15 @@ on:
     branches: [main]
   pull_request:
     paths-ignore:
-      # Root-only docs/meta files can never affect what this workflow
-      # tests — a PR changing only these starts no run at all (#2957).
+      # Docs/meta files can never affect what this workflow tests — a
+      # PR changing only these starts no run at all (#2957). GitHub
+      # filter patterns are root-anchored, so nested docs/ .md needs
+      # its own entry (#3051). Never widen the .md ignore into
+      # src/containers/: agent-context.md is COPYed into the workspace
+      # image, so a change there is a build-path change.
       - "*.md"
+      - "docs/*.md"
+      - "docs/**/*.md"
       - "zensical.toml"
       - "bootstrap"
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -6,11 +6,12 @@ on:
   pull_request:
     paths-ignore:
       # Docs/meta files can never affect what this workflow tests — a
-      # PR changing only these starts no run at all (#2957). GitHub
-      # filter patterns are root-anchored, so nested docs/ .md needs
-      # its own entry (#3051). Never widen the .md ignore into
-      # src/containers/: agent-context.md is COPYed into the workspace
-      # image, so a change there is a build-path change.
+      # PR changing only these starts no run at all (#2957). "*.md" is
+      # root-anchored (GitHub globs match full paths; * does not cross
+      # "/"), and docs/**/*.md covers the whole docs tree including
+      # its top level — docs/*.md is belt-and-braces (#3051). Never
+      # widen the .md ignore into src/containers/: agent-context.md is
+      # COPYed into the workspace image — a build-path change.
       - "*.md"
       - "docs/*.md"
       - "docs/**/*.md"

--- a/.github/workflows/frontend-tests.yml
+++ b/.github/workflows/frontend-tests.yml
@@ -7,11 +7,12 @@ on:
   pull_request:
     paths-ignore:
       # Docs/meta files can never affect what this workflow tests — a
-      # PR changing only these starts no run at all (#2957). GitHub
-      # filter patterns are root-anchored, so nested docs/ .md needs
-      # its own entry (#3051). Never widen the .md ignore into
-      # src/containers/: agent-context.md is COPYed into the workspace
-      # image, so a change there is a build-path change.
+      # PR changing only these starts no run at all (#2957). "*.md" is
+      # root-anchored (GitHub globs match full paths; * does not cross
+      # "/"), and docs/**/*.md covers the whole docs tree including
+      # its top level — docs/*.md is belt-and-braces (#3051). Never
+      # widen the .md ignore into src/containers/: agent-context.md is
+      # COPYed into the workspace image — a build-path change.
       - "*.md"
       - "docs/*.md"
       - "docs/**/*.md"

--- a/.github/workflows/frontend-tests.yml
+++ b/.github/workflows/frontend-tests.yml
@@ -6,9 +6,15 @@ on:
     branches: [release/**]
   pull_request:
     paths-ignore:
-      # Root-only docs/meta files can never affect what this workflow
-      # tests — a PR changing only these starts no run at all (#2957).
+      # Docs/meta files can never affect what this workflow tests — a
+      # PR changing only these starts no run at all (#2957). GitHub
+      # filter patterns are root-anchored, so nested docs/ .md needs
+      # its own entry (#3051). Never widen the .md ignore into
+      # src/containers/: agent-context.md is COPYed into the workspace
+      # image, so a change there is a build-path change.
       - "*.md"
+      - "docs/*.md"
+      - "docs/**/*.md"
       - "zensical.toml"
       - "bootstrap"
 

--- a/.github/workflows/fuzz-check.yml
+++ b/.github/workflows/fuzz-check.yml
@@ -7,11 +7,12 @@ on:
   pull_request:
     paths-ignore:
       # Docs/meta files can never affect what this workflow tests — a
-      # PR changing only these starts no run at all (#2957). GitHub
-      # filter patterns are root-anchored, so nested docs/ .md needs
-      # its own entry (#3051). Never widen the .md ignore into
-      # src/containers/: agent-context.md is COPYed into the workspace
-      # image, so a change there is a build-path change.
+      # PR changing only these starts no run at all (#2957). "*.md" is
+      # root-anchored (GitHub globs match full paths; * does not cross
+      # "/"), and docs/**/*.md covers the whole docs tree including
+      # its top level — docs/*.md is belt-and-braces (#3051). Never
+      # widen the .md ignore into src/containers/: agent-context.md is
+      # COPYed into the workspace image — a build-path change.
       - "*.md"
       - "docs/*.md"
       - "docs/**/*.md"

--- a/.github/workflows/fuzz-check.yml
+++ b/.github/workflows/fuzz-check.yml
@@ -6,9 +6,15 @@ on:
     branches: [release/**]
   pull_request:
     paths-ignore:
-      # Root-only docs/meta files can never affect what this workflow
-      # tests — a PR changing only these starts no run at all (#2957).
+      # Docs/meta files can never affect what this workflow tests — a
+      # PR changing only these starts no run at all (#2957). GitHub
+      # filter patterns are root-anchored, so nested docs/ .md needs
+      # its own entry (#3051). Never widen the .md ignore into
+      # src/containers/: agent-context.md is COPYed into the workspace
+      # image, so a change there is a build-path change.
       - "*.md"
+      - "docs/*.md"
+      - "docs/**/*.md"
       - "zensical.toml"
       - "bootstrap"
 

--- a/.github/workflows/macos-smoke.yml
+++ b/.github/workflows/macos-smoke.yml
@@ -22,11 +22,12 @@ on:
   pull_request:
     paths-ignore:
       # Docs/meta files can never affect what this workflow tests — a
-      # PR changing only these starts no run at all (#2957). GitHub
-      # filter patterns are root-anchored, so nested docs/ .md needs
-      # its own entry (#3051). Never widen the .md ignore into
-      # src/containers/: agent-context.md is COPYed into the workspace
-      # image, so a change there is a build-path change.
+      # PR changing only these starts no run at all (#2957). "*.md" is
+      # root-anchored (GitHub globs match full paths; * does not cross
+      # "/"), and docs/**/*.md covers the whole docs tree including
+      # its top level — docs/*.md is belt-and-braces (#3051). Never
+      # widen the .md ignore into src/containers/: agent-context.md is
+      # COPYed into the workspace image — a build-path change.
       - "*.md"
       - "docs/*.md"
       - "docs/**/*.md"

--- a/.github/workflows/macos-smoke.yml
+++ b/.github/workflows/macos-smoke.yml
@@ -21,9 +21,15 @@ on:
     branches: [release/**]
   pull_request:
     paths-ignore:
-      # Root-only docs/meta files can never affect what this workflow
-      # tests — a PR changing only these starts no run at all (#2957).
+      # Docs/meta files can never affect what this workflow tests — a
+      # PR changing only these starts no run at all (#2957). GitHub
+      # filter patterns are root-anchored, so nested docs/ .md needs
+      # its own entry (#3051). Never widen the .md ignore into
+      # src/containers/: agent-context.md is COPYed into the workspace
+      # image, so a change there is a build-path change.
       - "*.md"
+      - "docs/*.md"
+      - "docs/**/*.md"
       - "zensical.toml"
       - "bootstrap"
 

--- a/.github/workflows/python-deps-audit.yml
+++ b/.github/workflows/python-deps-audit.yml
@@ -21,11 +21,12 @@ on:
   pull_request:
     paths-ignore:
       # Docs/meta files can never affect what this workflow tests — a
-      # PR changing only these starts no run at all (#2957). GitHub
-      # filter patterns are root-anchored, so nested docs/ .md needs
-      # its own entry (#3051). Never widen the .md ignore into
-      # src/containers/: agent-context.md is COPYed into the workspace
-      # image, so a change there is a build-path change.
+      # PR changing only these starts no run at all (#2957). "*.md" is
+      # root-anchored (GitHub globs match full paths; * does not cross
+      # "/"), and docs/**/*.md covers the whole docs tree including
+      # its top level — docs/*.md is belt-and-braces (#3051). Never
+      # widen the .md ignore into src/containers/: agent-context.md is
+      # COPYed into the workspace image — a build-path change.
       - "*.md"
       - "docs/*.md"
       - "docs/**/*.md"

--- a/.github/workflows/python-deps-audit.yml
+++ b/.github/workflows/python-deps-audit.yml
@@ -20,9 +20,15 @@ on:
     - cron: "0 6 * * 2"
   pull_request:
     paths-ignore:
-      # Root-only docs/meta files can never affect what this workflow
-      # tests — a PR changing only these starts no run at all (#2957).
+      # Docs/meta files can never affect what this workflow tests — a
+      # PR changing only these starts no run at all (#2957). GitHub
+      # filter patterns are root-anchored, so nested docs/ .md needs
+      # its own entry (#3051). Never widen the .md ignore into
+      # src/containers/: agent-context.md is COPYed into the workspace
+      # image, so a change there is a build-path change.
       - "*.md"
+      - "docs/*.md"
+      - "docs/**/*.md"
       - "zensical.toml"
       - "bootstrap"
 

--- a/.github/workflows/sidecar-tests.yml
+++ b/.github/workflows/sidecar-tests.yml
@@ -7,11 +7,12 @@ on:
   pull_request:
     paths-ignore:
       # Docs/meta files can never affect what this workflow tests — a
-      # PR changing only these starts no run at all (#2957). GitHub
-      # filter patterns are root-anchored, so nested docs/ .md needs
-      # its own entry (#3051). Never widen the .md ignore into
-      # src/containers/: agent-context.md is COPYed into the workspace
-      # image, so a change there is a build-path change.
+      # PR changing only these starts no run at all (#2957). "*.md" is
+      # root-anchored (GitHub globs match full paths; * does not cross
+      # "/"), and docs/**/*.md covers the whole docs tree including
+      # its top level — docs/*.md is belt-and-braces (#3051). Never
+      # widen the .md ignore into src/containers/: agent-context.md is
+      # COPYed into the workspace image — a build-path change.
       - "*.md"
       - "docs/*.md"
       - "docs/**/*.md"

--- a/.github/workflows/sidecar-tests.yml
+++ b/.github/workflows/sidecar-tests.yml
@@ -6,9 +6,15 @@ on:
     branches: [release/**]
   pull_request:
     paths-ignore:
-      # Root-only docs/meta files can never affect what this workflow
-      # tests — a PR changing only these starts no run at all (#2957).
+      # Docs/meta files can never affect what this workflow tests — a
+      # PR changing only these starts no run at all (#2957). GitHub
+      # filter patterns are root-anchored, so nested docs/ .md needs
+      # its own entry (#3051). Never widen the .md ignore into
+      # src/containers/: agent-context.md is COPYed into the workspace
+      # image, so a change there is a build-path change.
       - "*.md"
+      - "docs/*.md"
+      - "docs/**/*.md"
       - "zensical.toml"
       - "bootstrap"
 

--- a/scripts/tests/test_ci_path_filters.py
+++ b/scripts/tests/test_ci_path_filters.py
@@ -1,0 +1,154 @@
+"""CI path-filter contract tests (#3051).
+
+Pins the ``pull_request`` path filters in the workflow files:
+
+- The seven unit-suite workflows that carry the #2957 ``paths-ignore``
+  block must ignore Markdown files at every docs location (root,
+  ``docs/*.md``, ``docs/**/*.md``). GitHub filter patterns are matched
+  against the full path relative to the repo root and ``*`` does not
+  cross ``/`` — so ``"*.md"`` alone is root-only and a nested
+  docs-only PR still started the full unit suites (observed on #3047).
+- No ``paths-ignore`` entry anywhere may match
+  ``src/containers/workspace/agent-context.md``: it is ``COPY``ed into
+  the workspace image, so an .md change there is a build-path change
+  and must keep triggering the e2e suites.
+- The e2e suites' ``paths:`` allowlists must keep matching that file.
+
+Pure file-content contract — no network, no runners. If one of these
+fails, a workflow edit drifted from the policy; fix the workflow, not
+the test.
+"""
+
+import re
+from pathlib import Path
+
+import yaml
+
+WORKFLOWS_DIR = Path(__file__).resolve().parent.parent.parent / ".github" / "workflows"
+
+# Workflows carrying the #2957/#3051 docs-ignore block on pull_request.
+MD_IGNORE_WORKFLOWS = [
+    "backend-tests.yml",
+    "codeql.yml",
+    "frontend-tests.yml",
+    "fuzz-check.yml",
+    "macos-smoke.yml",
+    "python-deps-audit.yml",
+    "sidecar-tests.yml",
+]
+
+# The docs-ignore entries each of the above must carry (#3051).
+REQUIRED_MD_IGNORES = {"*.md", "docs/*.md", "docs/**/*.md"}
+
+# agent-context.md is COPYed into the workspace image
+# (src/containers/workspace/Dockerfile) — a build-path file despite
+# the .md extension. It must never be paths-ignored, and the e2e
+# allowlists must keep matching it.
+BUILD_PATH_MD = "src/containers/workspace/agent-context.md"
+
+E2E_WORKFLOWS = [
+    "backend-e2e-tests.yml",
+    "cli-e2e-tests.yml",
+    "frontend-e2e-tests.yml",
+]
+
+# Representative .md paths (real files in the tree) used to pin glob
+# semantics: root-only, one level under docs/, nested under docs/.
+ROOT_MD = "README.md"
+DOCS_TOP_MD = "docs/index.md"
+DOCS_NESTED_MD = "docs/features/sandbox.md"
+
+
+def load_workflow(name):
+    with open(WORKFLOWS_DIR / name) as f:
+        return yaml.safe_load(f)
+
+
+def pull_request_trigger(wf):
+    """Return the ``pull_request`` trigger mapping, or None."""
+    # YAML 1.1 parses the bare key `on` as boolean True.
+    on = wf.get("on") or wf.get(True) or {}
+    pr = on.get("pull_request")
+    return pr if isinstance(pr, dict) else None
+
+
+def glob_to_regex(pattern):
+    """Compile a GitHub path-filter glob to a regex over full paths.
+
+    ``*`` matches zero or more non-``/`` characters, ``**`` crosses
+    directory separators, ``?`` is one non-``/`` character, ``[...]``
+    is a character class, everything else is literal.
+    """
+    out, i = "", 0
+    while i < len(pattern):
+        c = pattern[i]
+        if c == "*":
+            if pattern.startswith("**", i):
+                out += ".*"
+                i += 2
+            else:
+                out += "[^/]*"
+                i += 1
+        elif c == "?":
+            out += "[^/]"
+            i += 1
+        elif c == "[":
+            end = pattern.find("]", i)
+            out += pattern[i : end + 1].replace("\\", "\\\\")
+            i = end + 1
+        else:
+            out += re.escape(c)
+            i += 1
+    return re.compile("^" + out + "$")
+
+
+def matches(pattern, path):
+    return glob_to_regex(pattern).match(path) is not None
+
+
+def all_workflows():
+    return sorted(WORKFLOWS_DIR.glob("*.yml"))
+
+
+def test_unit_workflows_ignore_md_at_every_docs_depth():
+    for name in MD_IGNORE_WORKFLOWS:
+        pr = pull_request_trigger(load_workflow(name))
+        assert pr is not None, f"{name}: no pull_request trigger"
+        missing = REQUIRED_MD_IGNORES - set(pr.get("paths-ignore", []))
+        assert not missing, f"{name}: paths-ignore missing {sorted(missing)}"
+
+
+def test_docs_ignore_entries_have_the_intended_semantics():
+    # "docs/**" in the entries must never be a catch-all that also
+    # swallows files outside docs/.
+    assert matches("*.md", ROOT_MD)
+    assert not matches("*.md", DOCS_TOP_MD)
+    assert not matches("*.md", DOCS_NESTED_MD)
+    assert matches("docs/*.md", DOCS_TOP_MD)
+    assert not matches("docs/*.md", DOCS_NESTED_MD)
+    assert matches("docs/**/*.md", DOCS_NESTED_MD)
+
+
+def test_no_paths_ignore_entry_matches_build_path_md():
+    for path in all_workflows():
+        pr = pull_request_trigger(load_workflow(path))
+        if not pr or "paths-ignore" not in pr:
+            continue
+        offenders = [p for p in pr["paths-ignore"] if matches(p, BUILD_PATH_MD)]
+        assert not offenders, (
+            f"{path.name}: paths-ignore {offenders} would skip CI for "
+            f"{BUILD_PATH_MD} — it is COPYed into the workspace image "
+            "(#3051)"
+        )
+
+
+def test_e2e_paths_allowlists_still_match_build_path_md():
+    for name in E2E_WORKFLOWS:
+        pr = pull_request_trigger(load_workflow(name))
+        assert pr is not None, f"{name}: no pull_request trigger"
+        allowlist = pr.get("paths", [])
+        assert any(matches(p, BUILD_PATH_MD) for p in allowlist), (
+            f"{name}: no paths entry matches {BUILD_PATH_MD} — an "
+            "agent-context.md-only change must still start the e2e suite "
+            "(#3051)"
+        )

--- a/scripts/tests/test_ci_path_filters.py
+++ b/scripts/tests/test_ci_path_filters.py
@@ -3,11 +3,12 @@
 Pins the ``pull_request`` path filters in the workflow files:
 
 - The seven unit-suite workflows that carry the #2957 ``paths-ignore``
-  block must ignore Markdown files at every docs location (root,
-  ``docs/*.md``, ``docs/**/*.md``). GitHub filter patterns are matched
-  against the full path relative to the repo root and ``*`` does not
-  cross ``/`` — so ``"*.md"`` alone is root-only and a nested
-  docs-only PR still started the full unit suites (observed on #3047).
+  block must ignore Markdown at every docs location: root ``*.md`` and
+  ``docs/**/*.md`` (the GitHub filter cheat sheet documents
+  ``docs/**/*.md`` as matching ``docs/README.md`` too — ``**/`` spans
+  zero or more directories — while ``*.md`` is root-anchored because
+  ``*`` does not cross ``/``). A nested docs-only PR still started the
+  full unit suites before this (observed on #3047).
 - No ``paths-ignore`` entry anywhere may match
   ``src/containers/workspace/agent-context.md``: it is ``COPY``ed into
   the workspace image, so an .md change there is a build-path change
@@ -17,11 +18,18 @@ Pins the ``pull_request`` path filters in the workflow files:
 Pure file-content contract — no network, no runners. If one of these
 fails, a workflow edit drifted from the policy; fix the workflow, not
 the test.
+
+The glob model below implements exactly the constructs these filters
+use — ``*``, full-segment ``**``, ``[...]`` classes, literals — and
+raises loudly on anything else (negation, ``?``/``+`` quantifiers,
+``**`` inside a segment, unclosed classes) so an unsupported future
+entry fails the suite instead of being silently mis-evaluated.
 """
 
 import re
 from pathlib import Path
 
+import pytest
 import yaml
 
 WORKFLOWS_DIR = Path(__file__).resolve().parent.parent.parent / ".github" / "workflows"
@@ -37,8 +45,10 @@ MD_IGNORE_WORKFLOWS = [
     "sidecar-tests.yml",
 ]
 
-# The docs-ignore entries each of the above must carry (#3051).
-REQUIRED_MD_IGNORES = {"*.md", "docs/*.md", "docs/**/*.md"}
+# The docs-ignore entries each of the above must carry (#3051). The
+# workflows also keep a belt-and-braces "docs/*.md"; only the entries
+# the GitHub cheat sheet guarantees sufficient are required here.
+REQUIRED_MD_IGNORES = {"*.md", "docs/**/*.md"}
 
 # agent-context.md is COPYed into the workspace image
 # (src/containers/workspace/Dockerfile) — a build-path file despite
@@ -61,7 +71,10 @@ DOCS_NESTED_MD = "docs/features/sandbox.md"
 
 def load_workflow(name):
     with open(WORKFLOWS_DIR / name) as f:
-        return yaml.safe_load(f)
+        wf = yaml.safe_load(f)
+    if not isinstance(wf, dict):
+        raise AssertionError(f"{name}: not a workflow mapping")
+    return wf
 
 
 def pull_request_trigger(wf):
@@ -69,36 +82,68 @@ def pull_request_trigger(wf):
     # YAML 1.1 parses the bare key `on` as boolean True.
     on = wf.get("on") or wf.get(True) or {}
     pr = on.get("pull_request")
-    return pr if isinstance(pr, dict) else None
+    if pr is None:
+        return None
+    if not isinstance(pr, dict):
+        raise AssertionError(f"pull_request trigger is not a mapping: {pr!r}")
+    return pr
+
+
+def segment_to_regex(seg):
+    """Translate one `/`-free segment: `*`, `[...]`, literals."""
+    out, i = "", 0
+    while i < len(seg):
+        c = seg[i]
+        if c == "*":
+            out += "[^/]*"
+        elif c in "?+":
+            raise AssertionError(f"unmodeled quantifier in segment {seg!r}")
+        elif c == "[":
+            end = seg.find("]", i)
+            if end == -1:
+                raise AssertionError(f"unclosed character class in {seg!r}")
+            body = seg[i + 1 : end]
+            if body.startswith(("!", "^")):
+                raise AssertionError(f"negated class not modeled: {seg!r}")
+            out += "[" + body.replace("\\", "\\\\") + "]"
+            i = end
+        else:
+            out += re.escape(c)
+        i += 1
+    return out
 
 
 def glob_to_regex(pattern):
     """Compile a GitHub path-filter glob to a regex over full paths.
 
-    ``*`` matches zero or more non-``/`` characters, ``**`` crosses
-    directory separators, ``?`` is one non-``/`` character, ``[...]``
-    is a character class, everything else is literal.
+    ``*`` matches zero or more non-``/`` characters; a full-segment
+    ``**`` matches zero or more directory segments (per the cheat
+    sheet, ``docs/**/*.md`` matches ``docs/README.md`` and
+    ``docs/a/b.md``; leading ``**/x`` matches ``x`` itself);
+    ``[...]`` is a character class; everything else is literal.
     """
-    out, i = "", 0
-    while i < len(pattern):
-        c = pattern[i]
-        if c == "*":
-            if pattern.startswith("**", i):
-                out += ".*"
-                i += 2
+    if pattern.startswith("!"):
+        raise AssertionError(f"negated entry not modeled: {pattern!r}")
+    segs = pattern.split("/")
+    out = ""
+    for idx, seg in enumerate(segs):
+        last = idx == len(segs) - 1
+        if seg == "**":
+            if last:
+                out += ".*"  # "docs/**" — everything under docs/
+            elif idx == 0:
+                # "**/x" — zero or more leading dirs, bare "x" too.
+                out += "(?:[^/]*/)*"
             else:
-                out += "[^/]*"
-                i += 1
-        elif c == "?":
-            out += "[^/]"
-            i += 1
-        elif c == "[":
-            end = pattern.find("]", i)
-            out += pattern[i : end + 1].replace("\\", "\\\\")
-            i = end + 1
+                # Mid-path "**": at least one char per collapsed dir,
+                # so "a/**/b" matches "a/b" but never "ab".
+                out += "(?:[^/]+/)*"
+        elif "**" in seg:
+            raise AssertionError(f"mid-segment '**' not modeled: {pattern!r}")
         else:
-            out += re.escape(c)
-            i += 1
+            out += segment_to_regex(seg)
+            if not last:
+                out += "/"
     return re.compile("^" + out + "$")
 
 
@@ -119,14 +164,26 @@ def test_unit_workflows_ignore_md_at_every_docs_depth():
 
 
 def test_docs_ignore_entries_have_the_intended_semantics():
-    # "docs/**" in the entries must never be a catch-all that also
-    # swallows files outside docs/.
+    # Root "*.md" must stay root-anchored (#2957), and "docs/**/*.md"
+    # must cover the whole docs tree INCLUDING its top level (the
+    # GitHub cheat sheet lists docs/README.md as a match).
     assert matches("*.md", ROOT_MD)
     assert not matches("*.md", DOCS_TOP_MD)
     assert not matches("*.md", DOCS_NESTED_MD)
     assert matches("docs/*.md", DOCS_TOP_MD)
     assert not matches("docs/*.md", DOCS_NESTED_MD)
+    assert matches("docs/**/*.md", DOCS_TOP_MD)
     assert matches("docs/**/*.md", DOCS_NESTED_MD)
+    # Belt-and-braces docs/** must never swallow files outside docs/.
+    assert not matches("docs/**/*.md", BUILD_PATH_MD)
+
+
+def test_glob_model_fails_loud_on_unmodeled_constructs():
+    # Negation re-includes files — mis-modeling it as a literal would
+    # silently invert the contract this suite pins.
+    for bad in ("!src/**", "release/v[0-9", "a**b", "**?.md", "x+"):
+        with pytest.raises(AssertionError):
+            glob_to_regex(bad)
 
 
 def test_no_paths_ignore_entry_matches_build_path_md():


### PR DESCRIPTION
## Summary

Extends #2957 to nested docs: the `pull_request.paths-ignore` entry `"*.md"` is root-anchored (GitHub filter globs match the full path relative to the repo root and `*` does not cross `/`), so a PR changing only `docs/features/sandbox.md`, `docs/reference/*.md`, etc. still started the full unit-suite set on every push (observed on #3047; the cheat sheet also documents `docs/**`-style patterns as root-relative).

Adds `docs/*.md` + `docs/**/*.md` next to the existing root `"*.md"` in the seven workflows carrying the #2957 block:

- `backend-tests.yml`
- `frontend-tests.yml`
- `fuzz-check.yml`
- `macos-smoke.yml`
- `python-deps-audit.yml`
- `sidecar-tests.yml`
- `codeql.yml`

Per the cheat sheet, `docs/**/*.md` alone covers the whole docs tree including its top level (`docs/README.md` is a documented match — `**/` spans zero directories); `docs/*.md` is kept as belt-and-braces.

Deliberately **not** widened into `src/containers/`: `agent-context.md` is `COPY`ed into the workspace image, so an .md change there is a build-path change. The e2e suites trigger via `paths:` allowlists that already match on directory (`src/containers/**`), so `agent-context.md`-only PRs keep starting them, and docs-only PRs were already skipping them — untouched. (The image workflows have no `pull_request` trigger at all — dispatch/call/push-to-main — so nothing to widen there either.)

Also pins the policy with `scripts/tests/test_ci_path_filters.py`:

- the required ignore entries in all seven workflows,
- the glob semantics (root `*.md` does not match `docs/...`; `docs/**/*.md` matches the docs top level and below, per the cheat sheet; nothing escapes `docs/`),
- the glob model fails loudly on constructs it does not faithfully implement (negation `!`, `?`/`+` quantifiers, unclosed/negated `[...]` classes, mid-segment `**`) — an unsupported future entry fails the suite instead of hanging or being silently mis-evaluated,
- no `paths-ignore` entry in *any* workflow matches `src/containers/workspace/agent-context.md` (guards against a future `**/*.md` widening),
- the e2e allowlists still match it.

Closes #3051.

## Test plan

- [x] `python -m pytest scripts/tests -v` (107 passed incl. the 5 new)
- [x] xenon / yamllint / trufflehog pre-commit hooks pass
- [x] Fresh-eyes adversarial review run (recorded under `~/.pi/agent/reviews/mcdonc/klangk/i3051-ignore-md/`): verdict APPROVE; both important findings (glob-model `[`-hang, overclaimed "needs its own entry" comment) addressed in the second commit
- [ ] This PR itself acts as the live check: with only `.github/workflows/*` + `scripts/tests/*` changed, every suite should run; a follow-up docs-only push to a scratch PR should start nothing but the slop-policy workflow.
