### PR TITLE
T31 (#3052): flip the xenon gate to rank A

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -231,8 +231,8 @@ Every function, method, and block in `src/klangk/klangk/**/*.py`,
 `scripts/**/*.py` must be xenon rank **A or better** (cyclomatic complexity
 ≤ 5), and the per-module and codebase **averages** must also stay rank A
 (≤ 5). The gate runs as the `xenon` pre-commit hook defined in `devenv.nix`
-(`--max-absolute A --max-modules A --max-average A`); it grades the **full
-tree** on every commit made through the devenv shell (`pass_filenames =
+(`--max-absolute A --max-modules A --max-average A`); on every commit that
+stages a graded `.py` file it grades the **full tree** (`pass_filenames =
 false` — a staged subset's average can exceed 5 while the whole tree
 passes, so partial grading would flap). Nothing in CI enforces it yet —
 the hook is the only gate, so do not bypass it with `--no-verify`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -228,13 +228,14 @@ are fine too (`KLANGKD` = daemon, `KLANGKC` = CLI).
 
 Every function, method, and block in `src/klangk/klangk/**/*.py`,
 `src/klangksidecar/klangksidecar/**/*.py`, and
-`scripts/**/*.py` must be xenon rank **B or better** (cyclomatic complexity
-≤ 10), and the per-module and codebase **averages** must also stay rank B
-(≤ 10). The gate runs as the `xenon` pre-commit hook defined in `devenv.nix`
-(`--max-absolute B --max-modules B --max-average B`); it checks the
-staged `.py` files on every commit made through the devenv shell. Nothing
-in CI enforces it yet — the hook is the only gate, so do not bypass it
-with `--no-verify`.
+`scripts/**/*.py` must be xenon rank **A or better** (cyclomatic complexity
+≤ 5), and the per-module and codebase **averages** must also stay rank A
+(≤ 5). The gate runs as the `xenon` pre-commit hook defined in `devenv.nix`
+(`--max-absolute A --max-modules A --max-average A`); it grades the **full
+tree** on every commit made through the devenv shell (`pass_filenames =
+false` — a staged subset's average can exceed 5 while the whole tree
+passes, so partial grading would flap). Nothing in CI enforces it yet —
+the hook is the only gate, so do not bypass it with `--no-verify`.
 
 Check locally before committing:
 
@@ -248,13 +249,12 @@ are extract-function and dispatch tables (see `_EDITOR_BUTTON_HANDLERS` in
 the limit, extract a helper instead of growing it. Never add noqa-style
 escapes or re-widen the gate to make a commit pass.
 
-The legacy F/E/D blocks were already refactored down to C
-(#2800–#2803, #2808–#2814) and the C blocks to B
-(#2817, #2818–#2842); the module and codebase averages came under the gate
-at the same threshold (#2846). The ratchet ultimately tightens to **A**
-(≤ 5) in subsequent tranches, one PR per file/subsystem. Target rank **A**
-for new code where practical — anything looser will only be refactored
-again as the gate tightens.
+The legacy F/E/D blocks were refactored down to C
+(#2800–#2803, #2808–#2814), the C blocks to B
+(#2817, #2818–#2842), the module and codebase averages under the B
+gate (#2846), and finally every block and average to A (#2845, T1–T31).
+New code lands at rank **A** (≤ 5) from the start — the gate will not
+let anything looser through.
 
 ## Process manager: devenv 2.x native (not process-compose)
 

--- a/devenv.nix
+++ b/devenv.nix
@@ -262,11 +262,11 @@ in
     };
     # The complexity gate as a one-word task (#2828): the exact hook
     # invocation over the exact hook file set, so `devenv shell -- xenon`
-    # (ad hoc) and `pre-commit run xenon` (staged) can't drift. Note the
-    # hook grades the STAGED subset; this task grades the whole tree —
-    # stricter or equal, never more lenient.
+    # (ad hoc) and `pre-commit run xenon` (staged) can't drift. At rank A
+    # (#3052) the hook grades the full tree (pass_filenames=false), so
+    # the two invocations are literally identical.
     "klangk:xenon" = {
-      exec = "xenon --max-absolute B --max-modules B --max-average B $(git ls-files 'src/klangk/klangk/*.py' 'src/klangksidecar/klangksidecar/*.py' 'scripts/*.py')";
+      exec = "xenon --max-absolute A --max-modules A --max-average A $(git ls-files 'src/klangk/klangk/*.py' 'src/klangksidecar/klangksidecar/*.py' 'scripts/*.py')";
     };
     # Token-clone scan of the backend (#2904): the same invocation the
     # consolidation issues used (--min-tokens 70). Advisory only — the
@@ -740,20 +740,23 @@ in
     # (#2818-#2842), so the excludes are gone — every production .py file is
     # checked (klangkd + CLI under src/klangk/klangk/, the network sidecar
     # under src/klangksidecar/klangksidecar/, and scripts/).
-    # Module and codebase averages are also gated at B (#2846): --max-modules
+    # Module and codebase averages are also gated (#2846): --max-modules
     # grades each staged module on its own average, so partial staging cannot
     # cause false failures; --max-average used to flap pre-ratchet (a global
     # average over only the staged files), but with every block <= 10 no
-    # subset's average can exceed 10, so B-level flapping is impossible. That
-    # returns only if averages are ratcheted to A — then grade the full tree
-    # (pass_filenames = false) instead of the staged subset.
+    # subset's average could exceed 10, so B-level flapping was impossible.
+    # At rank A (#3052) that returns: a staged subset's average can exceed 5
+    # while the whole tree passes, so the hook now grades the full tree —
+    # pass_filenames = false, the entry enumerates the same git ls-files set
+    # the klangk:xenon task uses, and `files` stays as the run trigger (only
+    # complexity-relevant commits pay the scan).
     xenon = {
       enable = true;
       name = "xenon";
-      entry = "${pkgs.xenon}/bin/xenon --max-absolute B --max-modules B --max-average B";
+      entry = "bash -c 'xenon --max-absolute A --max-modules A --max-average A $(git ls-files \"src/klangk/klangk/*.py\" \"src/klangksidecar/klangksidecar/*.py\" \"scripts/*.py\")'";
       files = "^src/klangk/klangk/.*\\.py$|^src/klangksidecar/klangksidecar/.*\\.py$|^scripts/.*\\.py$";
       language = "system";
-      pass_filenames = true;
+      pass_filenames = false;
     };
     # Dart
     dart-format = {

--- a/devenv.nix
+++ b/devenv.nix
@@ -264,7 +264,7 @@ in
     # invocation over the exact hook file set, so `devenv shell -- xenon`
     # (ad hoc) and `pre-commit run xenon` (staged) can't drift. At rank A
     # (#3052) the hook grades the full tree (pass_filenames=false), so
-    # the two invocations are literally identical.
+    # the two invocations are identical.
     "klangk:xenon" = {
       exec = "xenon --max-absolute A --max-modules A --max-average A $(git ls-files 'src/klangk/klangk/*.py' 'src/klangksidecar/klangksidecar/*.py' 'scripts/*.py')";
     };

--- a/src/klangk/klangk/model/devenv.lock
+++ b/src/klangk/klangk/model/devenv.lock
@@ -1,0 +1,65 @@
+{
+  "nodes": {
+    "devenv": {
+      "locked": {
+        "dir": "src/modules",
+        "lastModified": 1788392306,
+        "narHash": "sha256-q1WIhRCsEs/K5z085IXIWKSPEl9KdGbwdUeekJGQrOM=",
+        "owner": "cachix",
+        "repo": "devenv",
+        "rev": "786cd53885b6697f567f4f51f2b0478760dfe7f9",
+        "type": "github"
+      },
+      "original": {
+        "dir": "src/modules",
+        "owner": "cachix",
+        "repo": "devenv",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "inputs": {
+        "nixpkgs-src": "nixpkgs-src"
+      },
+      "locked": {
+        "lastModified": 1787753358,
+        "narHash": "sha256-Tl77VbWyAKrOfRNQhL6JbQtb/MLzbYa/1RG1gWWfICk=",
+        "owner": "cachix",
+        "repo": "devenv-nixpkgs",
+        "rev": "256551e45f6303e142ab4a98be1bf243feb77dc0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "ref": "rolling",
+        "repo": "devenv-nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1787394516,
+        "narHash": "sha256-pRGOQSClnXNI2iLUG6DYpsGvYcuw0drOutVZFTJNw90=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "c8f90650c15282fa8656a041bfbbd2403997a9a7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "devenv": "devenv",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/src/klangk/klangk/model/migrations/m0026_volumes_admin_surface.py
+++ b/src/klangk/klangk/model/migrations/m0026_volumes_admin_surface.py
@@ -70,14 +70,14 @@ async def _delete_old_seed_rows(db) -> None:
         )
 
 
-async def _admins_group_id(db) -> int | None:
+async def _admins_group_id(db) -> str | None:
     """The ``admins`` group's id, or None when absent (m0021 posture)."""
     cursor = await db.execute("SELECT id FROM groups WHERE name = 'admins'")
     row = await cursor.fetchone()
     return None if row is None else row[0]
 
 
-async def _missing_admin_permissions(db, admins_id: int) -> list[str]:
+async def _missing_admin_permissions(db, admins_id: str) -> list[str]:
     """Seed-position-ordered admin permissions the group lacks."""
     cursor = await db.execute(
         "SELECT permission FROM acl_entries WHERE resource = '/volumes'"
@@ -88,7 +88,7 @@ async def _missing_admin_permissions(db, admins_id: int) -> list[str]:
     return [p for p in ADMIN_PERMISSIONS if p not in held]
 
 
-async def _insert_admin_rows(db, admins_id: int, missing: list[str]) -> None:
+async def _insert_admin_rows(db, admins_id: str, missing: list[str]) -> None:
     """Insert the admin rows at seed positions 0/1, parking survivors."""
     # Park the surviving rows two slots down so positions 0/1 are free.
     # UNIQUE(resource, position) forbids an in-place +2 shift past a

--- a/src/klangk/klangk/model/migrations/m0026_volumes_admin_surface.py
+++ b/src/klangk/klangk/model/migrations/m0026_volumes_admin_surface.py
@@ -59,11 +59,8 @@ OLD_SEED_ROWS = (
 ADMIN_PERMISSIONS = ("view-volumes", "manage-volumes")
 
 
-async def apply(db) -> None:
-    cursor = await db.execute("SELECT COUNT(*) FROM acl_entries")
-    if (await cursor.fetchone())[0] == 0:
-        return  # fresh database — the boot seeds own it
-
+async def _delete_old_seed_rows(db) -> None:
+    """Remove the exact #2946 seed shapes on /volumes."""
     for action, principal_type, system_principal, permission in OLD_SEED_ROWS:
         await db.execute(
             "DELETE FROM acl_entries WHERE resource = '/volumes'"
@@ -72,22 +69,27 @@ async def apply(db) -> None:
             (action, principal_type, system_principal, permission),
         )
 
+
+async def _admins_group_id(db) -> int | None:
+    """The ``admins`` group's id, or None when absent (m0021 posture)."""
     cursor = await db.execute("SELECT id FROM groups WHERE name = 'admins'")
     row = await cursor.fetchone()
-    if row is None:
-        return  # no admins group: nothing to grant (the m0021 posture)
-    admins_id = row[0]
+    return None if row is None else row[0]
 
+
+async def _missing_admin_permissions(db, admins_id: int) -> list[str]:
+    """Seed-position-ordered admin permissions the group lacks."""
     cursor = await db.execute(
         "SELECT permission FROM acl_entries WHERE resource = '/volumes'"
         " AND action = ? AND principal_type = ? AND group_id = ?",
         (ACTION_ALLOW, PRINCIPAL_GROUP, admins_id),
     )
     held = {r[0] for r in await cursor.fetchall()}
-    missing = [p for p in ADMIN_PERMISSIONS if p not in held]
-    if not missing:
-        return
+    return [p for p in ADMIN_PERMISSIONS if p not in held]
 
+
+async def _insert_admin_rows(db, admins_id: int, missing: list[str]) -> None:
+    """Insert the admin rows at seed positions 0/1, parking survivors."""
     # Park the surviving rows two slots down so positions 0/1 are free.
     # UNIQUE(resource, position) forbids an in-place +2 shift past a
     # neighbor, so rows first jump far above the occupied range and
@@ -120,6 +122,22 @@ async def apply(db) -> None:
                 permission,
             ),
         )
+
+
+async def apply(db) -> None:
+    cursor = await db.execute("SELECT COUNT(*) FROM acl_entries")
+    if (await cursor.fetchone())[0] == 0:
+        return  # fresh database — the boot seeds own it
+
+    await _delete_old_seed_rows(db)
+
+    admins_id = await _admins_group_id(db)
+    if admins_id is None:
+        return  # no admins group: nothing to grant
+
+    missing = await _missing_admin_permissions(db, admins_id)
+    if missing:
+        await _insert_admin_rows(db, admins_id, missing)
 
 
 migration = Migration(

--- a/src/klangk/klangk/model/users.py
+++ b/src/klangk/klangk/model/users.py
@@ -196,6 +196,28 @@ def hash_fallback_handle(base: str) -> str:
     return f"{base[: MAX_HANDLE_LEN - 9]}-{suffix}"
 
 
+def _admin_rename_error(current: str, name: str) -> str | None:
+    """The rename-rejection message, or None when the rename is safe.
+
+    Guard logic for ``_reject_admin_group_rename`` (#2995): renaming
+    the ``admins`` group away flips every instance-admin's
+    ``is_admin`` off; renaming another group onto the name mints a
+    fake ``admins`` group. Both rejected; descriptions stay editable
+    and a same-name no-op passes.
+    """
+    if current == ADMIN_GROUP_NAME and name != ADMIN_GROUP_NAME:
+        return (
+            "The admins group cannot be renamed: instance-admin"
+            " status derives from its name (#2995)"
+        )
+    if current != ADMIN_GROUP_NAME and name == ADMIN_GROUP_NAME:
+        return (
+            "The name 'admins' is reserved for the instance-admin"
+            " group (#2995)"
+        )
+    return None
+
+
 async def generate_handle(db, email: str) -> str:
     """Return a unique handle derived from *email* on connection *db*.
 
@@ -718,28 +740,15 @@ class UsersModel(Submodel):
     async def _reject_admin_group_rename(
         self, group_id: str, name: str | None
     ) -> None:
-        """Guard: the ``admins`` group's name is load-bearing (#2995).
-
-        Renaming the group away flips every instance-admin's
-        ``is_admin`` off; renaming another group onto the name mints a
-        fake ``admins`` group. Both rejected; descriptions stay
-        editable and a same-name no-op passes.
-        """
+        """Guard: the ``admins`` group's name is load-bearing (#2995)."""
         if name is None:
             return
         current = await self._group_name(group_id)
         if current is None:
             return
-        if current == ADMIN_GROUP_NAME and name != ADMIN_GROUP_NAME:
-            raise AdminGroupProtectionError(
-                "The admins group cannot be renamed: instance-admin"
-                " status derives from its name (#2995)"
-            )
-        if current != ADMIN_GROUP_NAME and name == ADMIN_GROUP_NAME:
-            raise AdminGroupProtectionError(
-                "The name 'admins' is reserved for the instance-admin"
-                " group (#2995)"
-            )
+        message = _admin_rename_error(current, name)
+        if message is not None:
+            raise AdminGroupProtectionError(message)
 
     async def _reject_admin_group_delete(self, group_id: str) -> None:
         """Guard: the ``admins`` group cannot be deleted (#2995) —


### PR DESCRIPTION
## Summary

Final tranche of the A-ratchet campaign (#2845) — closes #3052, and with it #2845.

- Clear the last two rank-B blocks with pure extract-function refactors (no behavior change):
  - `model/migrations/m0026_volumes_admin_surface.py` — `apply` split into `_delete_old_seed_rows` / `_admins_group_id` / `_missing_admin_permissions` / `_insert_admin_rows`
  - `model/users.py` — the rename-conflict decision moved to module helper `_admin_rename_error`; `_reject_admin_group_rename` is now a thin guard
- Flip the `klangk:xenon` task to `--max-absolute A --max-modules A --max-average A`
- Flip the pre-commit `xenon` hook to A and switch it to full-tree grading (`pass_filenames = false`, entry enumerates the same `git ls-files` set the task uses) — at A a staged subset's average can exceed 5 while the whole tree passes, so partial grading would flap; `files` stays as the run trigger
- AGENTS.md xenon section now documents rank A (≤ 5) and the full-tree hook

## Verification

- `xenon --max-absolute A --max-modules A --max-average A $(git ls-files …)` exits 0 on the full gated set
- `devenv tasks run klangk:xenon` — passes
- `pre-commit run xenon --all-files` — Passed
- Full Python suite the CI way: **6576 passed, 100% branch coverage**
- Commit went through the flipped hook (xenon Passed on a real partial-stage commit)
