### PR TITLE
refactor: zero out the last jscpd clones (#3048)

### DIFF
--- a/scripts/tests/test_ci_path_filters.py
+++ b/scripts/tests/test_ci_path_filters.py
@@ -89,8 +89,20 @@ def pull_request_trigger(wf):
     return pr
 
 
+def char_class_regex(seg, i):
+    """Translate a ``[...]`` class starting at *i*; return
+    ``(regex, index of the closing ``]``)``."""
+    end = seg.find("]", i)
+    if end == -1:
+        raise AssertionError(f"unclosed character class in {seg!r}")
+    body = seg[i + 1 : end]
+    if body.startswith(("!", "^")):
+        raise AssertionError(f"negated class not modeled: {seg!r}")
+    return "[" + body.replace("\\", "\\\\") + "]", end
+
+
 def segment_to_regex(seg):
-    """Translate one `/`-free segment: `*`, `[...]`, literals."""
+    """Translate one ``/``-free segment: ``*``, ``[...]``, literals."""
     out, i = "", 0
     while i < len(seg):
         c = seg[i]
@@ -99,18 +111,34 @@ def segment_to_regex(seg):
         elif c in "?+":
             raise AssertionError(f"unmodeled quantifier in segment {seg!r}")
         elif c == "[":
-            end = seg.find("]", i)
-            if end == -1:
-                raise AssertionError(f"unclosed character class in {seg!r}")
-            body = seg[i + 1 : end]
-            if body.startswith(("!", "^")):
-                raise AssertionError(f"negated class not modeled: {seg!r}")
-            out += "[" + body.replace("\\", "\\\\") + "]"
-            i = end
+            cls, i = char_class_regex(seg, i)
+            out += cls
         else:
             out += re.escape(c)
         i += 1
     return out
+
+
+def doublestar_regex(idx, last):
+    """Regex for a full-segment ``**`` at *idx* (``last`` = final)."""
+    if last:
+        return ".*"  # "docs/**" — everything under docs/
+    if idx == 0:
+        # "**/x" — zero or more leading dirs, bare "x" too.
+        return "(?:[^/]*/)*"
+    # Mid-path "**": at least one char per collapsed dir,
+    # so "a/**/b" matches "a/b" but never "ab".
+    return "(?:[^/]+/)*"
+
+
+def glob_segment_regex(seg, idx, last, pattern):
+    """Regex for one glob segment, trailing ``/`` included unless
+    *last* (``**`` patterns carry their own separators)."""
+    if seg == "**":
+        return doublestar_regex(idx, last)
+    if "**" in seg:
+        raise AssertionError(f"mid-segment '**' not modeled: {pattern!r}")
+    return segment_to_regex(seg) + ("" if last else "/")
 
 
 def glob_to_regex(pattern):
@@ -127,23 +155,7 @@ def glob_to_regex(pattern):
     segs = pattern.split("/")
     out = ""
     for idx, seg in enumerate(segs):
-        last = idx == len(segs) - 1
-        if seg == "**":
-            if last:
-                out += ".*"  # "docs/**" — everything under docs/
-            elif idx == 0:
-                # "**/x" — zero or more leading dirs, bare "x" too.
-                out += "(?:[^/]*/)*"
-            else:
-                # Mid-path "**": at least one char per collapsed dir,
-                # so "a/**/b" matches "a/b" but never "ab".
-                out += "(?:[^/]+/)*"
-        elif "**" in seg:
-            raise AssertionError(f"mid-segment '**' not modeled: {pattern!r}")
-        else:
-            out += segment_to_regex(seg)
-            if not last:
-                out += "/"
+        out += glob_segment_regex(seg, idx, idx == len(segs) - 1, pattern)
     return re.compile("^" + out + "$")
 
 
@@ -163,17 +175,25 @@ def test_unit_workflows_ignore_md_at_every_docs_depth():
         assert not missing, f"{name}: paths-ignore missing {sorted(missing)}"
 
 
-def test_docs_ignore_entries_have_the_intended_semantics():
-    # Root "*.md" must stay root-anchored (#2957), and "docs/**/*.md"
-    # must cover the whole docs tree INCLUDING its top level (the
-    # GitHub cheat sheet lists docs/README.md as a match).
+def test_root_md_glob_is_root_anchored():
+    # #2957: root "*.md" must not cross "/" into docs/.
     assert matches("*.md", ROOT_MD)
     assert not matches("*.md", DOCS_TOP_MD)
     assert not matches("*.md", DOCS_NESTED_MD)
+
+
+def test_docs_doublestar_covers_the_tree_including_its_top():
+    # "docs/**/*.md" must cover the whole docs tree INCLUDING its top
+    # level (the GitHub cheat sheet lists docs/README.md as a match,
+    # because "**/" spans zero directories); "docs/*.md" stays one
+    # level deep.
     assert matches("docs/*.md", DOCS_TOP_MD)
     assert not matches("docs/*.md", DOCS_NESTED_MD)
     assert matches("docs/**/*.md", DOCS_TOP_MD)
     assert matches("docs/**/*.md", DOCS_NESTED_MD)
+
+
+def test_docs_doublestar_never_matches_build_path_md():
     # Belt-and-braces docs/** must never swallow files outside docs/.
     assert not matches("docs/**/*.md", BUILD_PATH_MD)
 
@@ -186,12 +206,17 @@ def test_glob_model_fails_loud_on_unmodeled_constructs():
             glob_to_regex(bad)
 
 
+def paths_ignore_offenders(path):
+    """This workflow's paths-ignore entries that match BUILD_PATH_MD."""
+    pr = pull_request_trigger(load_workflow(path))
+    if not pr or "paths-ignore" not in pr:
+        return []
+    return [p for p in pr["paths-ignore"] if matches(p, BUILD_PATH_MD)]
+
+
 def test_no_paths_ignore_entry_matches_build_path_md():
     for path in all_workflows():
-        pr = pull_request_trigger(load_workflow(path))
-        if not pr or "paths-ignore" not in pr:
-            continue
-        offenders = [p for p in pr["paths-ignore"] if matches(p, BUILD_PATH_MD)]
+        offenders = paths_ignore_offenders(path)
         assert not offenders, (
             f"{path.name}: paths-ignore {offenders} would skip CI for "
             f"{BUILD_PATH_MD} — it is COPYed into the workspace image "

--- a/src/klangk/klangk/cli/client.py
+++ b/src/klangk/klangk/cli/client.py
@@ -270,6 +270,30 @@ def token_expires_soon(token: str) -> bool:
     return _time.time() >= (exp - _REFRESH_MARGIN_SECONDS)
 
 
+# The create-body field names accepted by create_workspace. The cli/
+# isolation rule forbids importing the server's CreateWorkspaceRequest
+# model, so the names are pinned here and checked on entry: pydantic
+# ignores unknown keys, so a typo'd kwarg must fail client-side instead
+# of silently dropping the field (#3048 review).
+CREATE_FIELDS = frozenset(
+    {
+        "image",
+        "service_command",
+        "auto_start",
+        "mounts",
+        "env",
+        "setup_state",
+        "health_check",
+        "allowed_domains",
+        "egress_mode",
+        "rejected_domains",
+        "settings",
+        "per_handle_home",
+        "classification_banner",
+    }
+)
+
+
 class KlangkClient:
     def __init__(self, server_url: str, token: str | None = None):
         self.server_url = server_url
@@ -548,16 +572,23 @@ class KlangkClient:
     def create_workspace(self, name: str, **optional) -> Workspace:
         """Create a workspace (``POST /api/v1/workspaces``).
 
-        Keyword fields mirror the server's ``CreateWorkspaceRequest``
-        body schema (the ``klangk.cli`` isolation rule forbids importing
-        the server's model, so the field list is not repeated here
-        (#3048)). Falsy values are omitted — the server applies its
+        Keyword fields are restricted to ``CREATE_FIELDS`` (they mirror
+        the server's ``CreateWorkspaceRequest`` body schema; the
+        ``klangk.cli`` isolation rule forbids importing the model).
+        Unknown keys raise ``TypeError`` — the server would silently
+        drop them. Falsy values are omitted — the server applies its
         defaults — except ``per_handle_home``, where ``None`` means
         "not chosen" and ``False`` is sent. Empty/None
         ``classification_banner`` inherits the deploy default marking
         (KLANGKD_CLASSIFICATION_BANNER); only a non-empty label sets the
         per-workspace override (#2768).
         """
+        unknown = optional.keys() - CREATE_FIELDS
+        if unknown:
+            raise TypeError(
+                "create_workspace() got unexpected keyword argument(s):"
+                f" {', '.join(sorted(unknown))}"
+            )
         body: dict = {"name": name}
         for key, value in optional.items():
             if value:

--- a/src/klangk/klangk/cli/client.py
+++ b/src/klangk/klangk/cli/client.py
@@ -545,48 +545,27 @@ class KlangkClient:
             settings=w.get("settings"),
         )
 
-    def create_workspace(
-        self,
-        name: str,
-        image: str | None = None,
-        service_command: str | None = None,
-        auto_start: bool = False,
-        mounts: list[str] | None = None,
-        env: dict[str, str] | None = None,
-        setup_state: str | None = None,
-        health_check: str | None = None,
-        allowed_domains: list[str] | None = None,
-        egress_mode: str | None = None,
-        rejected_domains: list[str] | None = None,
-        settings: dict | None = None,
-        per_handle_home: bool | None = None,
-        classification_banner: str | None = None,
-    ) -> Workspace:
+    def create_workspace(self, name: str, **optional) -> Workspace:
+        """Create a workspace (``POST /api/v1/workspaces``).
+
+        Keyword fields mirror the server's ``CreateWorkspaceRequest``
+        body schema (the ``klangk.cli`` isolation rule forbids importing
+        the server's model, so the field list is not repeated here
+        (#3048)). Falsy values are omitted — the server applies its
+        defaults — except ``per_handle_home``, where ``None`` means
+        "not chosen" and ``False`` is sent. Empty/None
+        ``classification_banner`` inherits the deploy default marking
+        (KLANGKD_CLASSIFICATION_BANNER); only a non-empty label sets the
+        per-workspace override (#2768).
+        """
         body: dict = {"name": name}
-        optional = {
-            "image": image,
-            "service_command": service_command,
-            "auto_start": auto_start,
-            "mounts": mounts,
-            "env": env,
-            "setup_state": setup_state,
-            "health_check": health_check,
-            "allowed_domains": allowed_domains,
-            "egress_mode": egress_mode,
-            "rejected_domains": rejected_domains,
-            "settings": settings,
-            # Empty/None = inherit the deploy default marking
-            # (KLANGKD_CLASSIFICATION_BANNER); only a non-empty label sets
-            # the per-workspace override (#2768).
-            "classification_banner": classification_banner,
-        }
         for key, value in optional.items():
             if value:
                 body[key] = value
         # None = not chosen: the server applies the deploy default
         # (KLANGKD_PER_HANDLE_HOME) — same convention as egress_mode.
-        if per_handle_home is not None:
-            body["per_handle_home"] = per_handle_home
+        if optional.get("per_handle_home") is not None:
+            body["per_handle_home"] = optional["per_handle_home"]
         resp = self.post("/api/v1/workspaces", json=body)
         self.check_auth(resp)
         self._raise_for_status(resp)

--- a/src/klangk/klangk/cli/edit.py
+++ b/src/klangk/klangk/cli/edit.py
@@ -12,14 +12,16 @@ import typer
 
 from . import context
 from .options import (
-    ALLOW_OPTION,
-    CPU_LIMIT_OPTION,
-    ENV_OPTION,
-    IDLE_TIMEOUT_OPTION,
-    MEMORY_LIMIT_OPTION,
-    MOUNT_OPTION,
-    PIDS_LIMIT_OPTION,
-    REJECT_OPTION,
+    AllowOption,
+    ClassificationBannerOption,
+    CpuLimitOption,
+    EnvOption,
+    IdleTimeoutOption,
+    MemoryLimitOption,
+    MountOption,
+    PidsLimitOption,
+    RejectOption,
+    SudoOption,
 )
 from .workspaces import build_settings, parse_env_list, prompt, SENTINEL
 from .mount import validate_allowed_domain_spec, validate_mount_spec
@@ -595,33 +597,16 @@ def edit(
             "health (exit 0 = healthy). Use '' to clear."
         ),
     ),
-    mount: list[str] | None = MOUNT_OPTION,
-    env: list[str] | None = ENV_OPTION,
-    allow: list[str] | None = ALLOW_OPTION,
-    reject: list[str] | None = REJECT_OPTION,
-    idle_timeout: int | None = IDLE_TIMEOUT_OPTION,
-    cpu_limit: float | None = CPU_LIMIT_OPTION,
-    memory_limit: str | None = MEMORY_LIMIT_OPTION,
-    pids_limit: int | None = PIDS_LIMIT_OPTION,
-    allow_sudo: bool | None = typer.Option(
-        None,
-        "--sudo/--no-sudo",
-        help=(
-            "Workspace sudo posture (server-permitting): off unless the "
-            "workspace opts in with --sudo. --no-sudo locks it down "
-            "(no passwordless sudo). Applies when the container is next "
-            "created"
-        ),
-    ),
-    classification_banner: str | None = typer.Option(
-        None,
-        "--classification-banner",
-        help=(
-            "Classification marking shown as a persistent banner on the "
-            "workspace page (free text, e.g. UNCLASSIFIED, CUI, SECRET). "
-            "Use '' to clear back to the server default"
-        ),
-    ),
+    mount: MountOption = None,
+    env: EnvOption = None,
+    allow: AllowOption = None,
+    reject: RejectOption = None,
+    idle_timeout: IdleTimeoutOption = None,
+    cpu_limit: CpuLimitOption = None,
+    memory_limit: MemoryLimitOption = None,
+    pids_limit: PidsLimitOption = None,
+    allow_sudo: SudoOption = None,
+    classification_banner: ClassificationBannerOption = None,
 ) -> None:
     """Edit workspace settings.
 

--- a/src/klangk/klangk/cli/options.py
+++ b/src/klangk/klangk/cli/options.py
@@ -87,8 +87,8 @@ ClassificationBannerOption = Annotated[
         help=(
             "Classification marking shown as a persistent banner on the "
             "workspace page (free text, e.g. UNCLASSIFIED, CUI, SECRET). "
-            "Empty or omitted = the server default "
-            "(KLANGKD_CLASSIFICATION_BANNER)"
+            "'' = the server default (KLANGKD_CLASSIFICATION_BANNER); "
+            "omitted = the server default on create, unchanged on edit"
         ),
     ),
 ]

--- a/src/klangk/klangk/cli/options.py
+++ b/src/klangk/klangk/cli/options.py
@@ -1,50 +1,94 @@
-"""Shared ``typer.Option`` declarations for the workspace commands.
+"""Shared ``typer`` flag definitions for the workspace commands.
 
-The create and edit commands expose the same repeatable flags with the
-same help text; declaring each option once keeps the two signatures from
-drifting (#2904). Reusing one ``OptionInfo`` across commands is safe —
-typer reads it when building each command's click parameters and never
-mutates it.
+The create and edit commands expose the same repeatable/resource-limit
+flags with the same help text; declaring each option once keeps the two
+signatures from drifting (#2904, #3048). Each ``Annotated`` alias below
+carries the full option definition — annotation, flag spelling, help —
+so a command signature only spells the parameter name and its ``None``
+default (``mount: MountOption = None``). Reusing one definition across
+commands is safe: typer copies the ``OptionInfo`` per command when it
+builds the click parameters and never mutates the original.
 """
 
 from __future__ import annotations
 
+from typing import Annotated
+
 import typer
 
-MOUNT_OPTION = typer.Option(
-    None,
-    "--mount",
-    help="Mount, repeatable (e.g. /home/me/src:/work/src, nix-vol:/nix)",
-)
-ENV_OPTION = typer.Option(
-    None,
-    "--env",
-    help="Environment variable, repeatable (e.g. KEY=VALUE)",
-)
-ALLOW_OPTION = typer.Option(
-    None,
-    "--allow",
-    help="Allowed egress domain, repeatable (e.g. github.com:443, pypi.org)",
-)
-REJECT_OPTION = typer.Option(
-    None,
-    "--reject",
-    help=(
-        "Rejected egress domain (NXDOMAIN'd), repeatable "
-        "(e.g. evil.example.com). CIDR ranges are not supported."
+MountOption = Annotated[
+    list[str] | None,
+    typer.Option(
+        "--mount",
+        help="Mount, repeatable (e.g. /home/me/src:/work/src, nix-vol:/nix)",
     ),
-)
-IDLE_TIMEOUT_OPTION = typer.Option(
-    None,
-    "--idle-timeout",
-    help="Idle timeout in seconds (0 = never idle out)",
-)
-CPU_LIMIT_OPTION = typer.Option(
-    None, "--cpu-limit", help="CPU limit (e.g. 2.0)"
-)
-MEMORY_LIMIT_OPTION = typer.Option(
-    None, "--memory-limit", help="Memory limit (e.g. 4g, 512m)"
-)
-PIDS_LIMIT_OPTION = typer.Option(
-    None, "--pids-limit", help="PIDs limit (e.g. 512)"
-)
+]
+EnvOption = Annotated[
+    list[str] | None,
+    typer.Option(
+        "--env",
+        help="Environment variable, repeatable (e.g. KEY=VALUE)",
+    ),
+]
+AllowOption = Annotated[
+    list[str] | None,
+    typer.Option(
+        "--allow",
+        help=(
+            "Allowed egress domain, repeatable (e.g. github.com:443, pypi.org)"
+        ),
+    ),
+]
+RejectOption = Annotated[
+    list[str] | None,
+    typer.Option(
+        "--reject",
+        help=(
+            "Rejected egress domain (NXDOMAIN'd), repeatable"
+            " (e.g. evil.example.com). CIDR ranges are not supported."
+        ),
+    ),
+]
+IdleTimeoutOption = Annotated[
+    int | None,
+    typer.Option(
+        "--idle-timeout",
+        help="Idle timeout in seconds (0 = never idle out)",
+    ),
+]
+CpuLimitOption = Annotated[
+    float | None,
+    typer.Option("--cpu-limit", help="CPU limit (e.g. 2.0)"),
+]
+MemoryLimitOption = Annotated[
+    str | None,
+    typer.Option("--memory-limit", help="Memory limit (e.g. 4g, 512m)"),
+]
+PidsLimitOption = Annotated[
+    int | None,
+    typer.Option("--pids-limit", help="PIDs limit (e.g. 512)"),
+]
+SudoOption = Annotated[
+    bool | None,
+    typer.Option(
+        "--sudo/--no-sudo",
+        help=(
+            "Workspace sudo posture (server-permitting): off unless the "
+            "workspace opts in with --sudo. --no-sudo locks it down "
+            "(no passwordless sudo). Applies when the container is next "
+            "created"
+        ),
+    ),
+]
+ClassificationBannerOption = Annotated[
+    str | None,
+    typer.Option(
+        "--classification-banner",
+        help=(
+            "Classification marking shown as a persistent banner on the "
+            "workspace page (free text, e.g. UNCLASSIFIED, CUI, SECRET). "
+            "Empty or omitted = the server default "
+            "(KLANGKD_CLASSIFICATION_BANNER)"
+        ),
+    ),
+]

--- a/src/klangk/klangk/cli/workspaces.py
+++ b/src/klangk/klangk/cli/workspaces.py
@@ -29,14 +29,16 @@ from .client import WorkspaceNotFoundError
 from . import context
 from .mount import validate_allowed_domain_spec, validate_mount_spec
 from .options import (
-    ALLOW_OPTION,
-    CPU_LIMIT_OPTION,
-    ENV_OPTION,
-    IDLE_TIMEOUT_OPTION,
-    MEMORY_LIMIT_OPTION,
-    MOUNT_OPTION,
-    PIDS_LIMIT_OPTION,
-    REJECT_OPTION,
+    AllowOption,
+    ClassificationBannerOption,
+    CpuLimitOption,
+    EnvOption,
+    IdleTimeoutOption,
+    MemoryLimitOption,
+    MountOption,
+    PidsLimitOption,
+    RejectOption,
+    SudoOption,
 )
 
 
@@ -299,33 +301,16 @@ def create(
         "-c",
         help="Service shell command (see `klangk edit --command`).",
     ),
-    mount: list[str] | None = MOUNT_OPTION,
-    env: list[str] | None = ENV_OPTION,
-    allow: list[str] | None = ALLOW_OPTION,
-    reject: list[str] | None = REJECT_OPTION,
-    idle_timeout: int | None = IDLE_TIMEOUT_OPTION,
-    cpu_limit: float | None = CPU_LIMIT_OPTION,
-    memory_limit: str | None = MEMORY_LIMIT_OPTION,
-    pids_limit: int | None = PIDS_LIMIT_OPTION,
-    allow_sudo: bool | None = typer.Option(
-        None,
-        "--sudo/--no-sudo",
-        help=(
-            "Workspace sudo posture (server-permitting): off unless this "
-            "workspace opts in with --sudo. --no-sudo locks it down "
-            "(no passwordless sudo); omitting the flag also means off. "
-            "Applies when the container is next created"
-        ),
-    ),
-    classification_banner: str | None = typer.Option(
-        None,
-        "--classification-banner",
-        help=(
-            "Classification marking shown as a persistent banner on the "
-            "workspace page (free text, e.g. UNCLASSIFIED, CUI, SECRET). "
-            "Omitted = the server default (KLANGKD_CLASSIFICATION_BANNER)"
-        ),
-    ),
+    mount: MountOption = None,
+    env: EnvOption = None,
+    allow: AllowOption = None,
+    reject: RejectOption = None,
+    idle_timeout: IdleTimeoutOption = None,
+    cpu_limit: CpuLimitOption = None,
+    memory_limit: MemoryLimitOption = None,
+    pids_limit: PidsLimitOption = None,
+    allow_sudo: SudoOption = None,
+    classification_banner: ClassificationBannerOption = None,
 ) -> None:
     """Create a new workspace."""
     context.require_auth()

--- a/src/klangk/klangk/model/workspaces.py
+++ b/src/klangk/klangk/model/workspaces.py
@@ -639,24 +639,17 @@ class WorkspacesModel(Submodel):
                 )
 
     async def create_workspace_with_acl(
-        self,
-        user_id: str,
-        name: str,
-        image: str | None = None,
-        service_command: str | None = None,
-        auto_start: bool = False,
-        mounts: list[str] | None = None,
-        env: dict[str, str] | None = None,
-        setup_state: str = SETUP_STATE_COMPLETE,
-        health_check: str | None = None,
-        allowed_domains: list[str] | None = None,
-        rejected_domains: list[str] | None = None,
-        settings: dict | None = None,
-        egress_mode: str = EGRESS_MODE_DEFAULT,
-        per_handle_home: bool = True,
-        classification_banner: str | None = None,
+        self, user_id: str, name: str, **create_kwargs
     ) -> dict:
         """Create a workspace row AND seed its owner ACE + role groups.
+
+        Takes the create keyword arguments (``image``,
+        ``service_command``, ``auto_start``, ``mounts``, ``env``,
+        ``setup_state``, ``health_check``, ``allowed_domains``,
+        ``rejected_domains``, ``settings``, ``egress_mode``,
+        ``per_handle_home``, ``classification_banner``), validated by
+        :func:`_validated_create_kwargs` — the single declaration of
+        that signature (#3048).
 
         The row insert and the ACL/group seeding run in a **single
         transaction**, so any failure rolls the whole thing back — no
@@ -672,21 +665,7 @@ class WorkspacesModel(Submodel):
                 " wildcard owner ACE + owners-group membership makes its"
                 " UUID a privileged principal) — system agent"
             )
-        insert = _validated_create_kwargs(
-            image=image,
-            service_command=service_command,
-            auto_start=auto_start,
-            mounts=mounts,
-            env=env,
-            setup_state=setup_state,
-            health_check=health_check,
-            allowed_domains=allowed_domains,
-            rejected_domains=rejected_domains,
-            settings=settings,
-            egress_mode=egress_mode,
-            per_handle_home=per_handle_home,
-            classification_banner=classification_banner,
-        )
+        insert = _validated_create_kwargs(**create_kwargs)
         async with self.app.state.db.transaction() as db:
             ws = await self._insert_workspace_row(db, user_id, name, **insert)
             await self.seed_workspace_acl(db, ws, user_id)

--- a/src/klangk/klangkc-tests/tests/test_cli.py
+++ b/src/klangk/klangkc-tests/tests/test_cli.py
@@ -1252,6 +1252,16 @@ class TestKlangkClient:
             client.create_workspace("n2")
             assert "egress_mode" not in client.post.call_args.kwargs["json"]
 
+    def test_create_workspace_rejects_unknown_fields(self):
+        # The **optional signature must not swallow typo'd kwargs: the
+        # server's pydantic model ignores unknown keys, so a typo would
+        # silently drop the field (#3048 review).
+        client = KlangkClient("http://test:8995", "token")
+        with patch.object(client, "post") as post:
+            with pytest.raises(TypeError, match="bogus"):
+                client.create_workspace("n", bogus=1)
+            post.assert_not_called()
+
     def test_create_workspace_includes_per_handle_home(self):
         client = KlangkClient("http://test:8995", "token")
         mock_resp = MagicMock(status_code=200)


### PR DESCRIPTION
Closes #3048.

## Summary

Final jscpd consolidation tranche. `jscpd src/klangk/klangk --min-tokens 70` (the `klangk:jscpd` task) now reports **0 clones, 0.00% duplicated lines** — down from 3 pairs / 37 lines (0.06%) at filing, and 27 pairs / 452 lines (0.78%) at #2904.

Note: the issue's fourth pair (`api/workspaces.py:284 ↔ :445`) was already consolidated by #3033's `WorkspaceBodyFields` base class before the issue was filed — the issue's scan predated that commit (see the re-validation comment on the issue). This PR clears the three pairs that remained.

## How each pair was cleared

- **`model/workspaces.py` create-params signature** — `create_workspace_with_acl` now takes `**create_kwargs`, the same pattern the row-only `create_workspace` below it already used. The 14-parameter signature is declared exactly once, on `_validated_create_kwargs` (which the row-only path already funnels through). All callers pass keywords; no call-site changes.
- **`cli/edit.py` ↔ `cli/workspaces.py` option block** — `cli/options.py` (created by #2904 for the shared `OptionInfo` constants) now exports `Annotated` flag aliases (`MountOption` … `PidsLimitOption`, `SudoOption`, `ClassificationBannerOption`) that carry the full option definition: type, flag spelling, help text. Both command signatures reference them (`mount: MountOption = None`), so each shared flag is defined in one place and the remaining parameter lines sit below the 70-token clone threshold. The two `--sudo` help texts and two `--classification-banner` help texts were unified into one text that is accurate for both commands (empty or omitted = server default). `--help` output verified unchanged in shape.
- **`cli/client.py:549 ↔ workspaces.py:519` (isolation-boundary pair)** — restructured inside `cli/`: `KlangkClient.create_workspace` now takes `**optional`, mirroring `update_workspace(**fields)` directly below it, instead of re-declaring the 14-field server-side parameter list across the `cli/` isolation boundary. Request bodies are byte-identical (same falsy-filter, same `per_handle_home`/`classification_banner` conventions, now documented in the docstring). A `CREATE_FIELDS` guard raises `TypeError` on unknown kwargs — the server's pydantic model silently ignores unknown body keys, so without the guard a typo'd kwarg would silently drop the field. No exclusion in jscpd config was needed — the acceptance criteria's "0 clones" arm is met.

## Ride-along (blocking commit)

The rank-A full-tree xenon gate from #3056 currently fails on `main` because of four rank-B blocks in `scripts/tests/test_ci_path_filters.py` (#3053) — every devenv-shell commit was blocked by the pre-commit hook. First commit fixes those (extract `char_class_regex` / `doublestar_regex` / `glob_segment_regex`, split the 9-assert semantics test, extract `paths_ignore_offenders`); behavior unchanged, `scripts/tests` 109 passed. It is a self-contained commit if you'd rather land it separately first.

## Verification

- `jscpd src/klangk/klangk --min-tokens 70`: **0 clones**
- Full backend + CLI suite the CI way (`-n auto`): **6582 passed, 100% branch coverage** (`klangk` package)
- `scripts/tests`: 109 passed
- Full-tree xenon gate (`pre-commit run xenon --all-files`): Passed (all touched files rank A)
- No changelog entry (internal refactor, per the issue)
- The optional follow-up from the issue (flip a `--max-duplicate-rate` gate to blocking in CI) is deliberately **not** included — separate decision, needs its own issue.

## Review follow-up

A fresh-eyes adversarial review found two issues, both fixed in the last commit: the unified `--classification-banner` help text was wrong for `edit` (omitted keeps the current marking; only `''` clears), and the `**optional` signature let typo'd kwargs be silently dropped by the server (`extra=ignore`) — now guarded by `CREATE_FIELDS` with `TypeError`. The review otherwise verified: request bodies byte-identical across 16 call shapes, CLI surface identical, glob engine byte-identical across 22 patterns, no scanner-evasion (at `--min-tokens 60` no edit↔workspaces pair appears), no coverage holes.
