### PR TITLE
fix(cli-e2e): restore login after TestLogout wipes shared config (#3058)

### DIFF
--- a/src/klangk/klangkc-tests/e2e-tests/test_cli_e2e.py
+++ b/src/klangk/klangkc-tests/e2e-tests/test_cli_e2e.py
@@ -1184,6 +1184,32 @@ class TestAuthError:
 
 
 class TestLogout:
+    @pytest.fixture(autouse=True, scope="class")
+    @staticmethod
+    def _restore_login(cli_config):
+        """Re-login after the class so later tests keep a working config.
+
+        ``test_logout`` clears the server entry from the CLI config
+        (``CLIState.clear_credentials``), and the config is shared by the
+        whole xdist worker (``cli_config`` is session-scoped). Without
+        restoring the login, every later test on this worker without its
+        own re-login fixture fails with "No server configured" depending
+        on scheduling (#3058).
+        """
+        yield
+        run(
+            [
+                "klangk",
+                "login",
+                cli_config["server_url"],
+                "test@example.com",
+                "--password-file",
+                "-",
+            ],
+            input="testpass\n",
+            env=cli_config["env"],
+        )
+
     def test_logout(self, cli_config):
         result = run(
             ["klangk", "logout"],

--- a/src/klangk/klangkc-tests/e2e-tests/test_cli_e2e.py
+++ b/src/klangk/klangkc-tests/e2e-tests/test_cli_e2e.py
@@ -1197,7 +1197,7 @@ class TestLogout:
         on scheduling (#3058).
         """
         yield
-        run(
+        result = run(
             [
                 "klangk",
                 "login",
@@ -1209,6 +1209,7 @@ class TestLogout:
             input="testpass\n",
             env=cli_config["env"],
         )
+        assert result.returncode == 0, result.stderr
 
     def test_logout(self, cli_config):
         result = run(


### PR DESCRIPTION
## Summary

- `TestLogout::test_logout` runs a real `klangk logout`, which clears the
  server entry from the session-shared CLI config
  (`CLIState.clear_credentials` removes `servers[url]` and nulls
  `active_server`). Since `cli_config` is session-scoped, every later
  class on the same xdist worker without its own autouse `_login`
  fixture failed with "No server configured" — purely as a function of
  scheduling (#3050's CI failure; #3050 then papered over it by adding
  yet another per-class fixture).
- Adds a class-scoped autouse `_restore_login` fixture on `TestLogout`
  whose teardown re-runs the standard `klangk login` (the `_ensure_login`
  pattern) after the class finishes, so the session state it destroys is
  restored instead of leaked. Future unprotected classes are protected
  by construction; the existing per-class `_login` fixtures stay as
  belt-and-suspenders.

## Testing

- Targeted run of `TestLogout` plus a temporary unprotected class placed
  after it (runs `klangk status` expecting `logged_in`, no login fixture
  of its own): all passed; the temp class was removed after verifying.
  The fix is in test infrastructure only — CI runs the authoritative
  full CLI e2e suite.
