### PR TITLE
Fix unsolved flakes: free_port TOCTOU, unshare hang, close-window staleness (#3057)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -481,6 +481,11 @@ sync` report a clear permission-denied error.
 
 ### Added
 
+- **`/health` now reports the instance id (#3057).** The health endpoint
+  returns `{"status": "ok", "instance": "<id>"}` so a caller can confirm
+  it reached the intended klangkd (the id is the same one in
+  `<data_dir>/instance-id` and the podman `klangk.instance` labels). The
+  E2E harnesses use it to detect fixture-server port collisions.
 - **Backup and restore docs (#2999).** New "Backup and Restore" reference
   chapter covering the full-site backup set (data dir, labeled podman
   volumes with their labels, env + config file + `file:` secrets,
@@ -1940,6 +1945,16 @@ git-credential` (#1700).** `pig-latin` removed; `word-count` dormant.
 
 ### Fixed
 
+- **Terminal share/unshare/close no longer hang clients on refusal paths
+  (#3057).** The WebSocket handlers for `share_window`, `unshare_window`,
+  `join_shared_terminal`, and the own-window commands (`terminal_new_window`,
+  `terminal_close_window`, `terminal_rename_window`,
+  `terminal_list_windows`, `terminal_select_window`) sent no frame when the
+  connection had no attached terminal or workspace session, so a client
+  waiting for a confirmation timed out (10s CLI hang in
+  `klangk terminal share`/`unshare`); every refusal now answers with an
+  `error` frame, and unsharing an already-unshared terminal broadcasts the
+  current list so the command exits promptly with a definite outcome.
 - **Static egress: off-list DNS names return NXDOMAIN (#3041).** A
   `static` workspace with egress filtering resolved every off-list name
   through the upstream resolver when the consent stack was wired (which is

--- a/src/frontend/e2e-tests/e2e/terminal-tabs.spec.ts
+++ b/src/frontend/e2e-tests/e2e/terminal-tabs.spec.ts
@@ -133,6 +133,34 @@ async function startTerminalAndGetWindows(
   return msg.windows as WindowInfo[];
 }
 
+/** Poll the server's window list until *predicate* holds (or timeout).
+ *
+ *  Window-list mutations are eventually consistent from a parallel WS
+ *  client's view: a queued pre-mutation broadcast can satisfy a bare
+ *  recvUntil before the mutation's own refreshed list lands (#3057). Each
+ *  round re-queries the authoritative list (terminal_list_windows) instead
+ *  of trusting the first frame. Returns the last-seen list so the caller's
+ *  assertion reports the real state on timeout. */
+async function waitForWindows(
+  client: TerminalWsClient,
+  predicate: (windows: WindowInfo[]) => boolean,
+  timeout = 10_000,
+): Promise<WindowInfo[]> {
+  const deadline = Date.now() + timeout;
+  let windows: WindowInfo[] = [];
+  while (Date.now() < deadline) {
+    client.send({ cmd: "terminal_list_windows" });
+    const msg = await client.recvUntil(
+      (m) => m.type === "terminal_windows",
+      Math.max(deadline - Date.now(), 1_000),
+    );
+    windows = msg.windows as WindowInfo[];
+    if (predicate(windows)) return windows;
+    await new Promise((r) => setTimeout(r, 250));
+  }
+  return windows;
+}
+
 test.describe("terminal tabs", () => {
   test("terminal starts with one window", async ({ page, request }) => {
     const { workspaceId, token, cleanup } = await createAndOpenWorkspace(
@@ -250,12 +278,16 @@ test.describe("terminal tabs", () => {
           cmd: "terminal_close_window",
           index: tempWindow.index,
         });
-        const afterClose = await client.recvUntil(
-          (m) => m.type === "terminal_windows",
-        );
-        const remaining = afterClose.windows as WindowInfo[];
+        // The close handler broadcasts a refreshed terminal_windows list,
+        // but a stale pre-close frame can arrive first — poll the
+        // authoritative list until the closed window is really gone
+        // (#3057).
+        const remaining = (await waitForWindows(
+          client,
+          (ws) => !ws.some((w) => w.id === tempWindow.id),
+        )) as WindowInfo[];
         expect(remaining.length).toBe(1);
-        expect(remaining.some((w) => w.name === "temp")).toBe(false);
+        expect(remaining.some((w) => w.id === tempWindow.id)).toBe(false);
       } finally {
         client.close();
       }

--- a/src/klangk/klangk/api/__init__.py
+++ b/src/klangk/klangk/api/__init__.py
@@ -85,8 +85,14 @@ router = APIRouter()
 
 
 @root_router.get("/health")
-async def health():
-    return {"status": "ok"}
+async def health(app=Depends(get_app_dep)):
+    # The instance id lets a client confirm it reached *this* klangkd —
+    # the E2E harnesses use it to detect a fixture-server port collision
+    # (#3057): /health answering 200 proves a klangkd is up, but only a
+    # matching instance proves it is OURS (a concurrent run's proxy can
+    # own the port and forward to its own server, which would otherwise
+    # pass the readiness probe and receive this run's traffic).
+    return {"status": "ok", "instance": app.state.util.instance_id()}
 
 
 @root_router.get("/empty")

--- a/src/klangk/klangk/cli/terminals.py
+++ b/src/klangk/klangk/cli/terminals.py
@@ -26,6 +26,28 @@ from . import context
 from .sandboxcmd import resolve_workspace_and_url
 
 
+def share_state_confirmed(frame_type: str, window_id: str, shared: bool):
+    """Predicate that confirms a window's share STATE, not just any frame.
+
+    A bare ``frame_is("shared_terminals")`` confirms on the first list
+    frame — which under load can be a stale pre-command broadcast queued
+    ahead of the command's own refresh (#3057). Waits until the target
+    window's presence in the shared list matches the command's intent
+    (present for share, absent for unshare), surfacing server error
+    frames immediately like :func:`frame_is`.
+    """
+
+    def predicate(msg) -> bool:
+        if msg.get("type") == "error":
+            raise ConnectionError(msg.get("message", "terminal error"))
+        if msg.get("type") != frame_type:
+            return False
+        ids = {t.get("window_id") for t in msg.get("terminals", [])}
+        return (window_id in ids) if shared else (window_id not in ids)
+
+    return predicate
+
+
 async def recv_until_event(conn, timeout: float, on_message=None):
     """Wait for the post-``ui_ready`` container_ready event frame.
 
@@ -307,9 +329,15 @@ def _set_terminal_shared(
                 raise typer.Exit(code=1)
 
             await conn.send(json.dumps({"cmd": cmd, "window_id": match["id"]}))
-            # Wait for shared_terminals confirmation
+            # Wait for the refreshed shared_terminals list to actually
+            # reflect the command — a stale pre-command broadcast must not
+            # confirm (#3057).
             await recv_until(
-                conn, frame_is("shared_terminals"), CONFIRM_TIMEOUT
+                conn,
+                share_state_confirmed(
+                    "shared_terminals", match["id"], cmd == "share_window"
+                ),
+                CONFIRM_TIMEOUT,
             )
             context.err.print(f"[green]{done_msg}[/green]")
 

--- a/src/klangk/klangk/wshandler/controllers.py
+++ b/src/klangk/klangk/wshandler/controllers.py
@@ -1294,6 +1294,10 @@ class TerminalController:
         whose window list is the group's, i.e. the owner's. An ungated
         own-window frame mutates the owner's session."""
         if not self._conn.container_id or not self._conn._user_home:
+            # Silent returns here strand confirmation-less clients (the
+            # CLI / E2E specs wait on a frame after sending the command);
+            # a definite error frame closes the hang (#3057).
+            send_error(self._conn.sock, "No workspace terminal attached")
             return False
         return not await refused_without_perm(self._conn, "code-in-isolation")
 
@@ -1409,7 +1413,7 @@ class SharedTerminalController:
     async def share_window(self, msg: dict) -> None:
         """Mark one of the user's own windows as shared."""
 
-        if not self._attached():
+        if not self._require_attached():
             return
         if not await self._perm_or_deny("share-terminals"):
             return
@@ -1429,7 +1433,7 @@ class SharedTerminalController:
         member whose permission was revoked after sharing (#2875).
         """
 
-        if not self._attached():
+        if not self._require_attached():
             return
 
         resolved = self._find_own_window(msg, self._conn.user["id"])
@@ -1437,9 +1441,11 @@ class SharedTerminalController:
             return
         match, ws_session = resolved
         if not match.get("shared"):
-            # Already unshared — a no-op (idempotent, and cheap if a
-            # zero-permission client spams the command: no joiner
-            # kills, no broadcasts).
+            # Already unshared — idempotent, but never silent: broadcast the
+            # current list so a confirmation-less client (``recv_until`` on a
+            # shared_terminals frame, #3057) gets its definite outcome
+            # instead of timing out.
+            self.broadcast_shared_terminals(ws_session)
             return
         match["shared"] = False
         # Kick spectators/collaborators
@@ -1458,6 +1464,14 @@ class SharedTerminalController:
         """True when a container is attached and the user's handle is
         resolved."""
         return bool(self._conn.container_id and self._conn._user_home)
+
+    def _require_attached(self) -> bool:
+        """``_attached`` with a definite refusal: sends an error frame so a
+        confirmation-less client exits fast instead of hanging (#3057)."""
+        if self._attached():
+            return True
+        send_error(self._conn.sock, "No workspace terminal attached")
+        return False
 
     async def _perm_or_deny(self, perm: str) -> bool:
         """True when the connection holds *perm* (sends "Permission
@@ -1479,6 +1493,11 @@ class SharedTerminalController:
             self._conn.workspace_id
         )
         if not ws_session:
+            # Silent returns strand confirmation-less clients (#3057): a
+            # definite error frame lets the CLI exit fast with a reason
+            # instead of blind-timing-out on a shared_terminals frame that
+            # will never come.
+            send_error(self._conn.sock, "No workspace session")
             return None
         match = self.find_window(ws_session, user_id, window_id)
         if match is None:
@@ -1538,7 +1557,7 @@ class SharedTerminalController:
             self._conn.user.get("email"),
             msg,
         )
-        if not self._attached():
+        if not self._require_attached():
             return
         if not await self._perm_or_deny("spectate-on-shared-terminals"):
             return

--- a/src/klangk/klangkc-tests/e2e-tests/test_cli_e2e.py
+++ b/src/klangk/klangkc-tests/e2e-tests/test_cli_e2e.py
@@ -16,7 +16,6 @@ from pathlib import Path
 
 import pytest
 
-from klangk.model import free_port
 import sys
 
 sys.path.insert(
@@ -81,11 +80,10 @@ def _stop_server(server, data_dir=None):
 def server():
     """Start a real Klangk server for the test session."""
     data_dir = tracked_mkdtemp("klangk-cli-e2e-")
-    port = str(free_port())
-    proc, base_url = _start_server(data_dir, port)
+    proc, base_url = _start_server(data_dir)
     yield {
         "url": base_url,
-        "port": port,
+        "port": base_url.rsplit(":", 1)[-1],
         "data_dir": data_dir,
         "proc": proc,
     }
@@ -646,7 +644,6 @@ class TestAutoStart:
         data_dir = tracked_mkdtemp("klangk-autostart-")
         proc, base_url = _start_server(
             data_dir,
-            str(free_port()),
             extra_env={"KLANGKD_ALLOW_AUTOSTART": "1"},
         )
         config_dir = tmp_path_factory.mktemp("klangk-autostart-config")
@@ -756,7 +753,6 @@ class TestSandboxAutoStartServiceCommand:
     WS = "e2e-sandbox-defcmd"
     # Free port (allocated once at class-definition time) so this never
     # collides with the other class-scoped servers or the session server.
-    PORT = str(free_port())
 
     @pytest.fixture(autouse=True, scope="class")
     @staticmethod
@@ -764,7 +760,6 @@ class TestSandboxAutoStartServiceCommand:
         data_dir = tracked_mkdtemp("klangk-sandbox-defcmd-")
         proc, base_url = _start_server(
             data_dir,
-            TestSandboxAutoStartServiceCommand.PORT,
             extra_env={"KLANGKD_ALLOW_AUTOSTART": "1"},
         )
         config_dir = tmp_path_factory.mktemp("klangk-sandbox-defcmd-config")
@@ -1553,7 +1548,6 @@ class TestAllowedMountRoots:
         data_dir = tracked_mkdtemp("klangk-mount-roots-")
         proc, base_url = _start_server(
             data_dir,
-            str(free_port()),
             extra_env={"KLANGKD_ALLOWED_MOUNT_ROOTS": "/tmp,/home"},
         )
         config_dir = tmp_path_factory.mktemp("klangk-mount-roots-config")
@@ -1630,7 +1624,7 @@ class TestVolumeUserIsolation:
         import httpx
 
         data_dir = tracked_mkdtemp("klangk-vol-iso-")
-        proc, base_url = _start_server(data_dir, str(free_port()))
+        proc, base_url = _start_server(data_dir)
 
         # Register a second user via the API
         httpx.post(
@@ -1776,7 +1770,7 @@ class TestTerminalSharing:
     @staticmethod
     def _dedicated_server(tmp_path_factory, request):
         data_dir = tracked_mkdtemp("klangk-terminal-sharing-")
-        proc, base_url = _start_server(data_dir, str(free_port()))
+        proc, base_url = _start_server(data_dir)
         config_dir = tmp_path_factory.mktemp("klangk-terminal-sharing-config")
         env = clean_env(HOME=str(config_dir))
         (config_dir / ".config" / "klangk").mkdir(parents=True)
@@ -2089,7 +2083,6 @@ def short_token_server():
     data_dir = tracked_mkdtemp("klangk-refresh-e2e-")
     proc, base_url = _start_server(
         data_dir,
-        str(free_port()),
         extra_env={"KLANGKD_ACCESS_TOKEN_HOURS": "0.002"},
     )
     yield {"url": base_url, "data_dir": data_dir, "proc": proc}

--- a/src/klangk/klangkc-tests/tests/test_cli.py
+++ b/src/klangk/klangkc-tests/tests/test_cli.py
@@ -4778,6 +4778,76 @@ class TestFrameIsPredicate:
             pred({"type": "error"})
 
 
+class TestShareStateConfirmedPredicate:
+    """terminals.share_state_confirmed: confirm the target window's
+    STATE, not the first shared_terminals frame (#3057).
+
+    A queued stale pre-command broadcast must not confirm share/unshare
+    prematurely; error frames surface immediately like frame_is.
+    """
+
+    def _frames(self, *msgs):
+        class FakeRecv:
+            def __init__(self, frames):
+                self._frames = list(frames)
+
+            async def recv(self):
+                return self._frames.pop(0)
+
+        import json as _json
+
+        return FakeRecv([_json.dumps(m) for m in msgs])
+
+    def _shared_list(self, *window_ids):
+        return {
+            "type": "shared_terminals",
+            "terminals": [
+                {"user_id": "u", "window_name": "w", "window_id": wid}
+                for wid in window_ids
+            ],
+        }
+
+    def test_share_waits_until_window_present(self):
+        from klangk.cli.terminals import share_state_confirmed
+        from klangk.cli.client import recv_until
+
+        # First frame is a stale pre-share broadcast (@0 absent) — the
+        # wait must continue to the refreshed list.
+        conn = self._frames(
+            self._shared_list(),
+            {"type": "terminal_output", "data": "x"},
+            self._shared_list("@0"),
+        )
+        msg = asyncio.run(
+            recv_until(
+                conn, share_state_confirmed("shared_terminals", "@0", True), 5
+            )
+        )
+        assert msg["type"] == "shared_terminals"
+
+    def test_unshare_waits_until_window_absent(self):
+        from klangk.cli.terminals import share_state_confirmed
+        from klangk.cli.client import recv_until
+
+        conn = self._frames(
+            self._shared_list("@0", "@1"),
+            self._shared_list("@1"),
+        )
+        msg = asyncio.run(
+            recv_until(
+                conn, share_state_confirmed("shared_terminals", "@0", False), 5
+            )
+        )
+        assert msg["type"] == "shared_terminals"
+
+    def test_error_frame_raises_immediately(self):
+        from klangk.cli.terminals import share_state_confirmed
+
+        pred = share_state_confirmed("shared_terminals", "@0", True)
+        with pytest.raises(ConnectionError, match="Window not found"):
+            pred({"type": "error", "message": "Window not found"})
+
+
 class TestCliBranchGaps2834:
     """#2834 branch gate: the CLI's guard outcomes the mainline tests
     only take one side of."""

--- a/src/klangk/klangkc-tests/tests/test_cli_main.py
+++ b/src/klangk/klangkc-tests/tests/test_cli_main.py
@@ -1672,6 +1672,7 @@ class TestMainCLI:
                             "user_id": "u1",
                             "handle": "me",
                             "window_name": "build",
+                            "window_id": "@1",
                         },
                     ],
                 }

--- a/src/klangk/klangkd-tests/e2e-tests/_e2e_server.py
+++ b/src/klangk/klangkd-tests/e2e-tests/_e2e_server.py
@@ -102,17 +102,26 @@ _READINESS_TIMEOUT = 240
 # free_port() TOCTOU — release the socket, then klangkd's proxy rebinds it
 # — lets a second fixture server landing in that window steal the port and
 # answer /health for the first run's clients (observed as a cross-run 409
-# "workspace already exists" in the hermes suite). Detection (the /health
-# instance check) plus a redraw-retry makes the collision self-healing
-# instead of flaky. Two retries is plenty: each redraw is a fresh OS
-# ephemeral pick, so a repeat collision needs the same microsecond-scale
-# interleaving twice.
+# "workspace already exists" in the hermes sandbox suite,
+# sandboxes/tests/hermes). Detection (the /health instance check) plus a
+# redraw-retry makes the collision self-healing instead of flaky. Two
+# retries are plenty: a repeat collision needs the same
+# release→rebind steal to land twice, and each redraw is a fresh OS
+# ephemeral pick.
 PORT_CLAIM_ATTEMPTS = 3
 
-# Marker from klangkd's own _check_port_collisions refusal (main.py): an
-# early exit whose output carries it means a concurrent run's proxy bound
-# our drawn port before our klangkd started — retryable with a redraw.
-PORT_COLLISION_MARKER = "Another process is already listening"
+# Retryable early-exit signatures: klangkd's own _check_port_collisions
+# refusal (main.py) — a foreign listener was already bound when our server
+# started — and the proxy engine's bind failure, which is what a foreign
+# listener produces when it binds in the claim-release→rebind window that
+# opens AFTER our server's probe passed. Anything else (a config error,
+# a validator refusal) fails identically on every attempt and must
+# surface immediately.
+PORT_COLLISION_MARKERS = (
+    "Another process is already listening",
+    "caddy failed to bind a listener",
+    "address already in use",
+)
 
 
 class ForeignServerError(RuntimeError):
@@ -147,6 +156,27 @@ def claim_port() -> tuple[int, socket.socket]:
     held = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     held.bind(("127.0.0.1", 0))
     return held.getsockname()[1], held
+
+
+def claim_specific_port(port: int) -> socket.socket:
+    """Bind-and-hold a CALLER-chosen port number until spawn (#3057).
+
+    Suites that pass ``KLANGKD_PORT=str(free_port())`` they drew themselves
+    (the CLI E2E session fixture) otherwise get the full released-socket
+    race this module exists to close. A port that is already taken fails
+    fast here with a clear error, instead of a spawn whose own port probe
+    refuses it.
+    """
+    held = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    try:
+        held.bind(("127.0.0.1", port))
+    except OSError:
+        held.close()
+        raise RuntimeError(
+            f"port {port} requested for the fixture server is already "
+            "in use — cannot claim it (#3057)"
+        )
+    return held
 
 
 # File-streamed server logs from live ``start_server`` handles (#2623).
@@ -306,6 +336,8 @@ def _start_server_once(
     See :func:`start_server` for the parameters; the retry loop lives
     there.
     """
+    auto_data_dir = data_dir is None
+    auto_state_dir = state_dir is None
     if data_dir is None:
         data_dir = os.path.realpath(tracked_mkdtemp("klangk-e2e-"))
     else:
@@ -328,14 +360,18 @@ def _start_server_once(
     # is released only at spawn time — the smallest release→rebind window
     # possible without handing klangkd a pre-bound listener fd.
     claims: list[socket.socket] = []
-    range_port, range_claim = claim_port()
-    claims.append(range_claim)
+    drawn: set[str] = set()
+    if "KLANGKD_PORT_RANGE_START" not in env_overrides:
+        range_port, range_claim = claim_port()
+        claims.append(range_claim)
+        drawn.add("KLANGKD_PORT_RANGE_START")
 
     overrides = dict(env_overrides)
     overrides.setdefault("KLANGKD_DATA_DIR", data_dir)
     overrides.setdefault("KLANGKD_STATE_DIR", state_dir)
     overrides.setdefault("KLANGKD_FRONTEND_DIR", FRONTEND_DIR)
-    overrides.setdefault("KLANGKD_PORT_RANGE_START", str(range_port))
+    if "KLANGKD_PORT_RANGE_START" not in overrides:
+        overrides["KLANGKD_PORT_RANGE_START"] = str(range_port)
 
     uds_path: str | None
     url: str | None
@@ -373,6 +409,21 @@ def _start_server_once(
         uds_path = None
         url = f"http://localhost:{tcp_port}"
 
+    # Caller-SUPPLIED port numbers get the same held-claim treatment
+    # (#3057 review): suites that draw with free_port() themselves (the CLI
+    # E2E session fixture passes KLANGKD_PORT=str(free_port())) otherwise
+    # keep the full released-socket race. Claim the exact number until
+    # spawn; an occupied one fails fast here instead of producing a spawn
+    # whose own port probe refuses it.
+    for key in (
+        "KLANGKD_PORT",
+        "KLANGKD_EGRESS_PORT",
+        "KLANGKD_PORT_RANGE_START",
+    ):
+        value = overrides.get(key)
+        if value is not None and key not in drawn:
+            claims.append(claim_specific_port(int(value)))
+
     env = clean_env(**overrides)
     cmd = ["python3", "-m", "klangk.main"]
     if config is not None:
@@ -386,7 +437,10 @@ def _start_server_once(
     if log_path == "":
         log_file = None
     else:
-        log_file = open(log_path, "w")  # noqa: SIM115
+        # Append, never truncate: a retry after a port collision must not
+        # erase the failed attempt's log — it is the only evidence the
+        # collision happened (#3057 review).
+        log_file = open(log_path, "a")  # noqa: SIM115
     # Release the held port claims only now — klangkd's proxy rebinds them
     # moments later, so this is the smallest release→rebind window the
     # spawn can have (#3057).
@@ -412,6 +466,7 @@ def _start_server_once(
         "url": url,
         "client": client,
         "log_path": log_path,
+        "owns_dirs": (auto_data_dir, auto_state_dir),
     }
     if wait_ready:
         try:
@@ -426,9 +481,11 @@ def _start_server_once(
             )
         except BaseException:
             # Leave no half-started server behind for the retry loop in
-            # :func:`start_server` — kill the proc, sweep containers,
-            # drop the dirs.
-            stop_server(server)
+            # :func:`start_server` — but NOT via stop_server, whose
+            # unconditional rmtree would delete caller-supplied dirs (a
+            # relaunched database, a config file) and convert a retryable
+            # collision into state loss (#3057 review).
+            _abandon_attempt(server)
             raise
     if log_file is not None:
         _active_log_paths.append(log_path)
@@ -494,9 +551,16 @@ def start_server(
     ``<data_dir>/instance-id``; a port stolen by a concurrent E2E run
     (the free_port TOCTOU) is detected and retried on fresh ports
     (:data:`PORT_CLAIM_ATTEMPTS` times) instead of failing the suite
-    (#3057).
+    (#3057). A CALLER-supplied ``KLANGKD_PORT`` pins the ingress port —
+    it still gets a held claim, but no redraw is possible, so a foreign
+    owner is a hard error rather than a retry.
     """
-    attempts = 1 if (uds or not wait_ready) else PORT_CLAIM_ATTEMPTS
+    port_is_drawn = "KLANGKD_PORT" not in env_overrides
+    attempts = (
+        PORT_CLAIM_ATTEMPTS
+        if (not uds and wait_ready and port_is_drawn)
+        else 1
+    )
     for attempt in range(attempts):
         try:
             return _start_server_once(
@@ -508,19 +572,28 @@ def start_server(
                 log_path=log_path,
                 env_overrides=env_overrides,
             )
-        except ForeignServerError:
+        except ForeignServerError as exc:
             # A concurrent run owns the drawn port — always redraw-worthy.
             if attempt + 1 == attempts:
                 raise
+            print(
+                f"start_server: attempt {attempt + 1}/{attempts} answered "
+                f"by a foreign klangkd; redrawing ports and respawning "
+                f"({exc})",
+                flush=True,
+            )
         except EarlyExitError as exc:
-            # Retry an early exit only when klangkd's own port-collision
-            # probe refused to start (someone bound our port first); a
-            # config error fails identically on every attempt, so surface
-            # it immediately.
-            if attempt + 1 == attempts or (
-                PORT_COLLISION_MARKER not in exc.output
-            ):
+            # Retry an early exit only when the output carries a
+            # port-collision signature; a config error fails identically
+            # on every attempt, so surface it immediately.
+            collided = any(m in exc.output for m in PORT_COLLISION_MARKERS)
+            if attempt + 1 == attempts or not collided:
                 raise
+            print(
+                f"start_server: attempt {attempt + 1}/{attempts} exited on "
+                "a port collision; redrawing ports and respawning",
+                flush=True,
+            )
     raise RuntimeError("start_server: no attempt outcome")  # pragma: no cover
 
 
@@ -573,6 +646,43 @@ def _cleanup_containers(data_dir: str) -> None:
     except FileNotFoundError:
         # podman not on PATH (e.g. a partial dev env) — nothing to clean.
         pass
+
+
+def _abandon_attempt(server: dict[str, Any]) -> None:
+    """Tear down a failed spawn attempt, preserving caller-owned dirs.
+
+    :func:`stop_server` is the wrong tool mid-retry: it rmtree's
+    ``data_dir``/``state_dir`` unconditionally, which would delete a
+    caller-provided database (the consent-prune suite relaunches on the
+    same dir) or a config file living there — turning a retryable port
+    collision into state loss. Here: kill the proc, sweep its labelled
+    containers (BEFORE any rmtree — the sweep reads ``instance-id``),
+    close the log file and client, and remove only the tempdirs this
+    harness created (``owns_dirs``).
+    """
+    proc: Popen = server["proc"]
+    try:
+        proc.kill()
+        proc.wait(timeout=5)
+    except (ProcessLookupError, subprocess.TimeoutExpired):
+        pass
+    log_file = getattr(proc, "_log_file", None)
+    if log_file is not None:
+        try:
+            log_file.close()
+        except Exception:
+            pass
+    close_popen_pipes(proc)
+    try:
+        server["client"].close()
+    except Exception:
+        pass
+    _cleanup_containers(server["data_dir"])
+    owns_data_dir, owns_state_dir = server["owns_dirs"]
+    if owns_data_dir:
+        shutil.rmtree(server["data_dir"], ignore_errors=True)
+    if owns_state_dir:
+        shutil.rmtree(server["state_dir"], ignore_errors=True)
 
 
 def stop_server(server: dict[str, Any]) -> None:

--- a/src/klangk/klangkd-tests/e2e-tests/_e2e_server.py
+++ b/src/klangk/klangkd-tests/e2e-tests/_e2e_server.py
@@ -409,21 +409,6 @@ def _start_server_once(
         uds_path = None
         url = f"http://localhost:{tcp_port}"
 
-    # Caller-SUPPLIED port numbers get the same held-claim treatment
-    # (#3057 review): suites that draw with free_port() themselves (the CLI
-    # E2E session fixture passes KLANGKD_PORT=str(free_port())) otherwise
-    # keep the full released-socket race. Claim the exact number until
-    # spawn; an occupied one fails fast here instead of producing a spawn
-    # whose own port probe refuses it.
-    for key in (
-        "KLANGKD_PORT",
-        "KLANGKD_EGRESS_PORT",
-        "KLANGKD_PORT_RANGE_START",
-    ):
-        value = overrides.get(key)
-        if value is not None and key not in drawn:
-            claims.append(claim_specific_port(int(value)))
-
     env = clean_env(**overrides)
     cmd = ["python3", "-m", "klangk.main"]
     if config is not None:

--- a/src/klangk/klangkd-tests/e2e-tests/_e2e_server.py
+++ b/src/klangk/klangkd-tests/e2e-tests/_e2e_server.py
@@ -31,6 +31,7 @@ from __future__ import annotations
 import atexit
 import os
 import shutil
+import socket
 import subprocess
 import tempfile
 import time
@@ -41,7 +42,6 @@ import httpx
 import websockets
 
 from _e2e_env import clean_env, close_popen_pipes
-from klangk.model import free_port
 
 # The launcher is invoked as a module (``python3 -m klangk.main``) from the
 # klangkd-tests dir — the same cwd the prior runtestserver launches used, so
@@ -96,6 +96,58 @@ _UDS_WS_HOST = "ws://klangkd"
 # it room to finish (observed: pre-warm 105-110s + seed ~2s vs a 120s
 # deadline that killed the server 2s before it came up).
 _READINESS_TIMEOUT = 240
+
+# How many times to redraw the TCP ports and respawn when a freshly drawn
+# port turns out to be owned by a concurrent E2E run (#3057). The
+# free_port() TOCTOU — release the socket, then klangkd's proxy rebinds it
+# — lets a second fixture server landing in that window steal the port and
+# answer /health for the first run's clients (observed as a cross-run 409
+# "workspace already exists" in the hermes suite). Detection (the /health
+# instance check) plus a redraw-retry makes the collision self-healing
+# instead of flaky. Two retries is plenty: each redraw is a fresh OS
+# ephemeral pick, so a repeat collision needs the same microsecond-scale
+# interleaving twice.
+PORT_CLAIM_ATTEMPTS = 3
+
+# Marker from klangkd's own _check_port_collisions refusal (main.py): an
+# early exit whose output carries it means a concurrent run's proxy bound
+# our drawn port before our klangkd started — retryable with a redraw.
+PORT_COLLISION_MARKER = "Another process is already listening"
+
+
+class ForeignServerError(RuntimeError):
+    """The drawn TCP port answers /health but is not THIS run's klangkd.
+
+    A concurrent E2E fixture grabbed the released port (the free_port
+    TOCTOU, #3057); its proxy forwards to its own server, which would
+    otherwise pass our readiness probe and silently receive this run's
+    CLI/API traffic.
+    """
+
+
+class EarlyExitError(RuntimeError):
+    """klangkd exited during startup. ``output`` is its drained log."""
+
+    def __init__(self, message: str, output: str):
+        super().__init__(message)
+        self.output = output
+
+
+def claim_port() -> tuple[int, socket.socket]:
+    """Draw an ephemeral port while holding the bound socket.
+
+    free_port() releases before returning, so two concurrent fixture
+    startups can be handed the same number (the OS reuses a just-released
+    ephemeral port for the next ``:0`` bind) and then race to rebind it
+    (#3057). Holding the claim means another fixture's draw cannot pick
+    this port; the caller closes the socket right before spawning klangkd,
+    shrinking the release→rebind window as far as it goes without fd
+    inheritance (the proxy cannot take a pre-bound listener fd).
+    """
+    held = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    held.bind(("127.0.0.1", 0))
+    return held.getsockname()[1], held
+
 
 # File-streamed server logs from live ``start_server`` handles (#2623).
 # Servers launched with ``log_path`` write their combined output to that
@@ -157,14 +209,41 @@ def _terminate(proc: Popen) -> None:
             pass
 
 
+def _instance_matches(resp: httpx.Response, instance_id_path: str) -> bool:
+    """True when a 200 /health response is from THIS run's klangkd.
+
+    The server writes ``<data_dir>/instance-id`` at startup, before it
+    serves; /health echoes it. Our server has answered ⇒ the file exists;
+    a mismatch (or missing file/field) means the port's owner is another
+    klangkd (#3057).
+    """
+    try:
+        with open(instance_id_path) as fh:
+            expected = fh.read().strip()
+    except OSError:
+        return False
+    try:
+        got = resp.json().get("instance", "")
+    except ValueError:
+        return False
+    return bool(got) and got == expected
+
+
 def _wait_ready(
     proc: Popen,
     *,
     uds_path: str | None,
     url: str | None,
     log_path: str | None = None,
+    instance_id_path: str | None = None,
 ) -> None:
-    """Poll ``/health`` until the server is up, else kill + raise with logs."""
+    """Poll ``/health`` until the server is up, else kill + raise with logs.
+
+    With ``instance_id_path`` (TCP mode), a healthy answer is only accepted
+    when the reported instance id matches ``<data_dir>/instance-id`` — the
+    responder must be THIS run's klangkd, not a concurrent fixture that
+    grabbed the drawn port (#3057).
+    """
     if uds_path is not None:
         client = httpx.Client(
             transport=httpx.HTTPTransport(uds=uds_path), base_url=_UDS_HOST
@@ -177,12 +256,24 @@ def _wait_ready(
         last_exc: Exception | None = None
         while time.time() < deadline:
             if proc.poll() is not None:
-                raise RuntimeError(
-                    f"klangkd exited early:\n{_drain_stdout(proc, log_path)}"
+                output = _drain_stdout(proc, log_path)
+                raise EarlyExitError(
+                    f"klangkd exited early:\n{output}", output
                 )
             try:
-                if client.get("/health", timeout=2).status_code == 200:
-                    return
+                resp = client.get("/health", timeout=2)
+                if resp.status_code == 200:
+                    if instance_id_path is None:
+                        return
+                    if _instance_matches(resp, instance_id_path):
+                        return
+                    raise ForeignServerError(
+                        f"{url} answers /health but is a FOREIGN klangkd "
+                        f"(instance mismatch) — a concurrent E2E run "
+                        f"grabbed the drawn port (#3057)"
+                    )
+            except (ForeignServerError, EarlyExitError):
+                raise
             except Exception as exc:  # not up yet
                 last_exc = exc
             time.sleep(0.5)
@@ -198,6 +289,150 @@ def _wait_ready(
         )
     finally:
         client.close()
+
+
+def _start_server_once(
+    *,
+    uds: bool,
+    wait_ready: bool,
+    data_dir: str | None,
+    state_dir: str | None,
+    config: str | None,
+    log_path: str | None,
+    env_overrides: dict[str, str],
+) -> dict[str, Any]:
+    """One spawn attempt (dirs created, ports drawn, readiness checked).
+
+    See :func:`start_server` for the parameters; the retry loop lives
+    there.
+    """
+    if data_dir is None:
+        data_dir = os.path.realpath(tracked_mkdtemp("klangk-e2e-"))
+    else:
+        os.makedirs(data_dir, exist_ok=True)
+    if state_dir is None:
+        state_dir = os.path.realpath(tracked_mkdtemp("klangk-e2e-state-"))
+    else:
+        os.makedirs(state_dir, exist_ok=True)
+    # Default to a file-streamed log inside the data dir so the failure
+    # hooks in ``_e2e_logs`` can attach what the server said (#2623); a
+    # captured pipe is only drainable at process exit and vanishes with
+    # the data dir. An explicit "" forces the old captured-pipe behavior
+    # (the smoketest reads its log while the server runs). #364 still
+    # applies: file streaming also avoids the 64 KB pipe-buffer deadlock.
+    if log_path is None:
+        log_path = os.path.join(data_dir, "klangkd-test-output.log")
+
+    # Draw ports as held claims (#3057): another concurrent fixture's
+    # ``:0`` draw cannot pick a number we currently hold, and each claim
+    # is released only at spawn time — the smallest release→rebind window
+    # possible without handing klangkd a pre-bound listener fd.
+    claims: list[socket.socket] = []
+    range_port, range_claim = claim_port()
+    claims.append(range_claim)
+
+    overrides = dict(env_overrides)
+    overrides.setdefault("KLANGKD_DATA_DIR", data_dir)
+    overrides.setdefault("KLANGKD_STATE_DIR", state_dir)
+    overrides.setdefault("KLANGKD_FRONTEND_DIR", FRONTEND_DIR)
+    overrides.setdefault("KLANGKD_PORT_RANGE_START", str(range_port))
+
+    uds_path: str | None
+    url: str | None
+    if uds:
+        # Headless: no KLANGKD_PORT, proxy suppressed. klangkd binds the UDS.
+        overrides.pop("KLANGKD_PORT", None)
+        overrides.setdefault("_KLANGKD_DISABLE_PROXY", "1")
+        uds_path = os.path.join(state_dir, "klangk.sock")
+        url = None
+    else:
+        # The proxy fronts the UDS on a TCP port; clients hit the proxy. Both the
+        # browser ingress (KLANGKD_PORT) and the container egress
+        # (KLANGKD_EGRESS_PORT, default 8995) are allocated fresh so a test
+        # never collides with a dev klangkd on the default egress port.
+        # If the caller supplied KLANGKD_PORT, honor it (url derives from the
+        # resolved port, not a separate free draw).
+        overrides["_KLANGKD_DISABLE_PROXY"] = ""
+        tcp_port = overrides.get("KLANGKD_PORT")
+        if tcp_port is None:
+            tcp_port, tcp_claim = claim_port()
+            claims.append(tcp_claim)
+            overrides["KLANGKD_PORT"] = str(tcp_port)
+        # Two independent draws can land on the same port when claims are
+        # released at spawn (the OS reuses a just-released ephemeral
+        # port). KLANGKD_EGRESS_PORT must differ from KLANGKD_PORT or the
+        # settings validator rejects it and klangkd exits early — redraw
+        # until distinct so the proxy's two listeners never collide.
+        if "KLANGKD_EGRESS_PORT" not in overrides:
+            egress_port, egress_claim = claim_port()
+            while str(egress_port) == str(tcp_port):
+                egress_claim.close()
+                egress_port, egress_claim = claim_port()
+            claims.append(egress_claim)
+            overrides["KLANGKD_EGRESS_PORT"] = str(egress_port)
+        uds_path = None
+        url = f"http://localhost:{tcp_port}"
+
+    env = clean_env(**overrides)
+    cmd = ["python3", "-m", "klangk.main"]
+    if config is not None:
+        cmd += ["--config", config]
+    else:
+        cmd.append("--config=none")
+    # When a log_path is given, stream the server's output to a file so a
+    # long-lived run can't fill the 64 KB OS pipe buffer and deadlock (#364)
+    # and the failure hooks can read it back (#2623). An empty string means
+    # the caller explicitly wants the captured pipe (drained on failure).
+    if log_path == "":
+        log_file = None
+    else:
+        log_file = open(log_path, "w")  # noqa: SIM115
+    # Release the held port claims only now — klangkd's proxy rebinds them
+    # moments later, so this is the smallest release→rebind window the
+    # spawn can have (#3057).
+    for held in claims:
+        held.close()
+    proc = subprocess.Popen(
+        cmd,
+        cwd=BACKEND_DIR,
+        env=env,
+        stdout=log_file if log_file is not None else subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+    )
+    # Keep a reference so stop_server can close it; mirror the prior CLI
+    # suite's ``proc._log_file`` convention.
+    proc._log_file = log_file  # type: ignore[attr-defined]
+
+    client = httpx_client({"uds_path": uds_path, "url": url})
+    server = {
+        "proc": proc,
+        "data_dir": data_dir,
+        "state_dir": state_dir,
+        "uds_path": uds_path,
+        "url": url,
+        "client": client,
+        "log_path": log_path,
+    }
+    if wait_ready:
+        try:
+            _wait_ready(
+                proc,
+                uds_path=uds_path,
+                url=url,
+                log_path=log_path,
+                instance_id_path=(
+                    None if uds else os.path.join(data_dir, "instance-id")
+                ),
+            )
+        except BaseException:
+            # Leave no half-started server behind for the retry loop in
+            # :func:`start_server` — kill the proc, sweep containers,
+            # drop the dirs.
+            stop_server(server)
+            raise
+    if log_file is not None:
+        _active_log_paths.append(log_path)
+    return server
 
 
 def start_server(
@@ -218,13 +453,14 @@ def start_server(
         ``True`` (default) → UDS-direct: proxy suppressed, bind the socket at
         ``<state_dir>/klangk.sock``, return a UDS-configured ``client``. Use
         this for in-process Python clients.
-        ``False`` → TCP via the proxy: the proxy on a free ``KLANGKD_PORT``, return a
+        ``False`` → TCP via the proxy: the proxy on a free ``KLANGKD_PORT``,
+        return a ``url`` and a TCP ``client``: Use this for CLI / browser
+        suites.
     wait_ready:
         When ``False``, skip the ``/health`` readiness wait and return
         immediately after spawn — for tests whose server is EXPECTED to
         exit during startup (e.g. a past-due scheduled stop firing on
         boot); the default ``True`` treats that as a failure.
-        ``url`` and a TCP ``client``. Use this for CLI / browser suites.
     data_dir, state_dir:
         Optional explicit dirs (created otherwise as tempdirs).
     config:
@@ -252,97 +488,40 @@ def start_server(
     ``server["client"]`` directly). Build additional/custom clients with
     :func:`httpx_client` / :func:`httpx_async_client`, and websockets with
     :func:`ws_connect`. Pass the handle to :func:`stop_server` for teardown.
+
+    In TCP mode the drawn ports are claimed (bound and held) until spawn,
+    and readiness verifies the responder's instance id against this run's
+    ``<data_dir>/instance-id``; a port stolen by a concurrent E2E run
+    (the free_port TOCTOU) is detected and retried on fresh ports
+    (:data:`PORT_CLAIM_ATTEMPTS` times) instead of failing the suite
+    (#3057).
     """
-    if data_dir is None:
-        data_dir = os.path.realpath(tracked_mkdtemp("klangk-e2e-"))
-    if state_dir is None:
-        state_dir = os.path.realpath(tracked_mkdtemp("klangk-e2e-state-"))
-    # Default to a file-streamed log inside the data dir so the failure
-    # hooks in ``_e2e_logs`` can attach what the server said (#2623); a
-    # captured pipe is only drainable at process exit and vanishes with
-    # the data dir. An explicit "" forces the old captured-pipe behavior
-    # (the smoketest reads its log while the server runs). #364 still
-    # applies: file streaming also avoids the 64 KB pipe-buffer deadlock.
-    if log_path is None:
-        log_path = os.path.join(data_dir, "klangkd-test-output.log")
-
-    overrides = dict(env_overrides)
-    overrides.setdefault("KLANGKD_DATA_DIR", data_dir)
-    overrides.setdefault("KLANGKD_STATE_DIR", state_dir)
-    overrides.setdefault("KLANGKD_FRONTEND_DIR", FRONTEND_DIR)
-    overrides.setdefault("KLANGKD_PORT_RANGE_START", str(free_port()))
-
-    uds_path: str | None
-    url: str | None
-    if uds:
-        # Headless: no KLANGKD_PORT, proxy suppressed. klangkd binds the UDS.
-        overrides.pop("KLANGKD_PORT", None)
-        overrides.setdefault("_KLANGKD_DISABLE_PROXY", "1")
-        uds_path = os.path.join(state_dir, "klangk.sock")
-        url = None
-    else:
-        # The proxy fronts the UDS on a TCP port; clients hit the proxy. Both the
-        # browser ingress (KLANGKD_PORT) and the container egress
-        # (KLANGKD_EGRESS_PORT, default 8995) are allocated fresh so a test
-        # never collides with a dev klangkd on the default egress port.
-        # If the caller supplied KLANGKD_PORT, honor it (url derives from the
-        # resolved port, not a separate free draw).
-        overrides["_KLANGKD_DISABLE_PROXY"] = ""
-        tcp_port = overrides.get("KLANGKD_PORT")
-        if tcp_port is None:
-            tcp_port = str(free_port())
-            overrides["KLANGKD_PORT"] = tcp_port
-        # Two independent free_port() draws can return the same port on a
-        # busy runner (the OS reuses the just-released ephemeral port).
-        # KLANGKD_EGRESS_PORT must differ from KLANGKD_PORT or the settings
-        # validator rejects it and klangkd exits early — redraw until
-        # distinct so the proxy's two listeners never collide.
-        egress_port = str(free_port())
-        while egress_port == tcp_port:
-            egress_port = str(free_port())
-        overrides.setdefault("KLANGKD_EGRESS_PORT", egress_port)
-        uds_path = None
-        url = f"http://localhost:{tcp_port}"
-
-    env = clean_env(**overrides)
-    cmd = ["python3", "-m", "klangk.main"]
-    if config is not None:
-        cmd += ["--config", config]
-    else:
-        cmd.append("--config=none")
-    # When a log_path is given, stream the server's output to a file so a
-    # long-lived run can't fill the 64 KB OS pipe buffer and deadlock (#364)
-    # and the failure hooks can read it back (#2623). An empty string means
-    # the caller explicitly wants the captured pipe (drained on failure).
-    if log_path == "":
-        log_file = None
-    else:
-        log_file = open(log_path, "w")  # noqa: SIM115
-    proc = subprocess.Popen(
-        cmd,
-        cwd=BACKEND_DIR,
-        env=env,
-        stdout=log_file if log_file is not None else subprocess.PIPE,
-        stderr=subprocess.STDOUT,
-    )
-    # Keep a reference so stop_server can close it; mirror the prior CLI
-    # suite's ``proc._log_file`` convention.
-    proc._log_file = log_file  # type: ignore[attr-defined]
-    if wait_ready:
-        _wait_ready(proc, uds_path=uds_path, url=url, log_path=log_path)
-
-    client = httpx_client({"uds_path": uds_path, "url": url})
-    if log_file is not None:
-        _active_log_paths.append(log_path)
-    return {
-        "proc": proc,
-        "data_dir": data_dir,
-        "state_dir": state_dir,
-        "uds_path": uds_path,
-        "url": url,
-        "client": client,
-        "log_path": log_path,
-    }
+    attempts = 1 if (uds or not wait_ready) else PORT_CLAIM_ATTEMPTS
+    for attempt in range(attempts):
+        try:
+            return _start_server_once(
+                uds=uds,
+                wait_ready=wait_ready,
+                data_dir=data_dir,
+                state_dir=state_dir,
+                config=config,
+                log_path=log_path,
+                env_overrides=env_overrides,
+            )
+        except ForeignServerError:
+            # A concurrent run owns the drawn port — always redraw-worthy.
+            if attempt + 1 == attempts:
+                raise
+        except EarlyExitError as exc:
+            # Retry an early exit only when klangkd's own port-collision
+            # probe refused to start (someone bound our port first); a
+            # config error fails identically on every attempt, so surface
+            # it immediately.
+            if attempt + 1 == attempts or (
+                PORT_COLLISION_MARKER not in exc.output
+            ):
+                raise
+    raise RuntimeError("start_server: no attempt outcome")  # pragma: no cover
 
 
 def _cleanup_containers(data_dir: str) -> None:

--- a/src/klangk/klangkd-tests/e2e-tests/test_server_schedule_e2e.py
+++ b/src/klangk/klangkd-tests/e2e-tests/test_server_schedule_e2e.py
@@ -19,11 +19,11 @@ import time
 import pytest
 
 from _e2e_server import (
-    free_port,
     start_server,
     stop_server,
     ws_connect as _ws_dial,
 )
+from klangk.model import free_port
 
 
 def _own_server(tag: str):

--- a/src/klangk/klangkd-tests/tests/test_api.py
+++ b/src/klangk/klangkd-tests/tests/test_api.py
@@ -187,7 +187,6 @@ class TestHealth:
         # the E2E harness detects fixture-server port collisions with it
         # (#3057).
         assert body["status"] == "ok"
-        assert body["instance"]
         assert isinstance(body["instance"], str) and body["instance"]
 
 

--- a/src/klangk/klangkd-tests/tests/test_api.py
+++ b/src/klangk/klangkd-tests/tests/test_api.py
@@ -182,7 +182,13 @@ class TestHealth:
     async def test_health(self, client):
         resp = await client.get("/health")
         assert resp.status_code == 200
-        assert resp.json() == {"status": "ok"}
+        body = resp.json()
+        # The instance id lets a caller confirm it reached *this* klangkd —
+        # the E2E harness detects fixture-server port collisions with it
+        # (#3057).
+        assert body["status"] == "ok"
+        assert body["instance"]
+        assert isinstance(body["instance"], str) and body["instance"]
 
 
 class TestEmpty:

--- a/src/klangk/klangkd-tests/tests/test_e2e_imports.py
+++ b/src/klangk/klangkd-tests/tests/test_e2e_imports.py
@@ -1,0 +1,73 @@
+"""Import every backend E2E module from the unit suite (#3057).
+
+The unit suite never collects ``klangkd-tests/e2e-tests``, so an ImportError
+there — a removed re-export, a renamed helper — is only caught by CI's
+backend-e2e job, minutes later and in a different workflow. Importing the
+modules is exactly what pytest collection does first, so it is cheap,
+hermetic, and fails in the same place CI would, just earlier. The removed
+``_e2e_server.free_port`` re-export (an implicit import only
+``test_server_schedule_e2e.py`` relied on) slipped through exactly this gap.
+"""
+
+import importlib.util
+import os
+import sys
+
+import pytest
+
+E2E_DIR = os.path.realpath(
+    os.path.join(os.path.dirname(__file__), "..", "e2e-tests")
+)
+HERMES_DIR = os.path.realpath(
+    os.path.join(
+        os.path.dirname(__file__),
+        "..",
+        "..",
+        "..",
+        "sandboxes",
+        "tests",
+        "hermes",
+    )
+)
+
+
+def e2e_module_files() -> list[str]:
+    """Every E2E python file pytest collection would import.
+
+    test_* modules, conftest, and the ``_*`` helper modules they import.
+    Standalone scripts (e.g. smoketest_egress.py) are excluded — CI runs
+    them as scripts, not via collection.
+    """
+    files: list[str] = []
+    for base in (E2E_DIR, HERMES_DIR):
+        if not os.path.isdir(base):
+            continue
+        for entry in sorted(os.listdir(base)):
+            if not entry.endswith(".py"):
+                continue
+            if (
+                entry.startswith("test_")
+                or entry == "conftest.py"
+                or entry.startswith("_")
+            ):
+                files.append(os.path.join(base, entry))
+    return files
+
+
+@pytest.mark.parametrize("path", e2e_module_files())
+def test_e2e_module_imports(path: str, monkeypatch):
+    # The helper modules resolve their intra-suite imports (`from
+    # _e2e_server import ...`) through the dir on sys.path. spec-based
+    # loading under a unique name avoids sys.modules collisions (two
+    # conftest.py files live under these dirs).
+    monkeypatch.syspath_prepend(os.path.dirname(path))
+    spec = importlib.util.spec_from_file_location(
+        f"e2e_import_check_{os.path.basename(path)[:-3]}", path
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    try:
+        spec.loader.exec_module(module)
+    finally:
+        sys.modules.pop(spec.name, None)

--- a/src/klangk/klangkd-tests/tests/test_wshandler.py
+++ b/src/klangk/klangkd-tests/tests/test_wshandler.py
@@ -6684,7 +6684,9 @@ class TestTerminalWindowHandlers:
         conn = _base_conn(ws=sock)
         conn.container_id = None
         await conn.handle_terminal_new_window({})
-        assert sock.send_json.call_count == 0
+        # Not-attached refusals send a definite error frame — a silent
+        # return strands confirmation-less clients (#3057).
+        assert sock.send_json.call_args[0][0]["type"] == "error"
 
     async def test_new_window_success(self):
         sock = _mock_sock()
@@ -7789,7 +7791,7 @@ class TestTerminalController:
     async def test_new_window_no_container(self):
         ctrl, sock, _ = self._controller(container_id=None)
         await ctrl.new_window({})
-        sock.send_json.assert_not_called()
+        assert sock.send_json.call_args[0][0]["type"] == "error"
 
     async def test_new_window_error_sends_error(self):
         ctrl, sock, _ = self._controller()
@@ -7804,7 +7806,7 @@ class TestTerminalController:
     async def test_close_window_no_container(self):
         ctrl, sock, _ = self._controller(container_id=None)
         await ctrl.close_window({})
-        sock.send_json.assert_not_called()
+        assert sock.send_json.call_args[0][0]["type"] == "error"
 
     async def test_rename_window_no_name_sends_error(self):
         ctrl, sock, _ = self._controller()
@@ -7814,7 +7816,7 @@ class TestTerminalController:
     async def test_list_windows_no_container(self):
         ctrl, sock, _ = self._controller(container_id=None)
         await ctrl.list_windows()
-        sock.send_json.assert_not_called()
+        assert sock.send_json.call_args[0][0]["type"] == "error"
 
     async def test_list_windows_error_sends_error(self):
         ctrl, sock, _ = self._controller()
@@ -7829,7 +7831,7 @@ class TestTerminalController:
     async def test_select_window_no_container(self):
         ctrl, sock, _ = self._controller(container_id=None)
         await ctrl.select_window({"index": 0})
-        sock.send_json.assert_not_called()
+        assert sock.send_json.call_args[0][0]["type"] == "error"
 
     async def test_select_window_uses_grouped_session_name(self):
         ctrl, _, _ = self._controller()
@@ -8338,6 +8340,95 @@ class TestShareWindowHandlers:
             assert len(deleted) == 1
         finally:
             sockets.sessions.pop("ws-1", None)
+
+    async def test_share_window_not_attached_sends_error(self, user):
+        """share_window with no attached container answers with an error
+        frame, never silently — a confirmation-less client hangs on silence
+        (#3057)."""
+        sock = _mock_sock()
+        conn = _base_conn(user=user, ws=sock)
+        conn.workspace_id = "ws-1"
+        conn.container_id = None
+        await conn.handle_share_window({"window_id": "@0"})
+        calls = [c[0][0] for c in sock.send_json.call_args_list]
+        assert any(
+            c.get("type") == "error"
+            and "No workspace terminal attached" in c.get("message", "")
+            for c in calls
+        )
+
+    async def test_unshare_window_not_attached_sends_error(self, user):
+        sock = _mock_sock()
+        conn = _base_conn(user=user, ws=sock)
+        conn.workspace_id = "ws-1"
+        conn.container_id = None
+        await conn.handle_unshare_window({"window_id": "@0"})
+        calls = [c[0][0] for c in sock.send_json.call_args_list]
+        assert any(
+            c.get("type") == "error"
+            and "No workspace terminal attached" in c.get("message", "")
+            for c in calls
+        )
+
+    async def test_unshare_window_no_session_sends_error(self, user):
+        """A missing workspace session is a definite error, not a silent
+        no-op — the CLI waits on a shared_terminals frame after unshare and
+        blind-times-out on silence (#3057)."""
+        sock = _mock_sock()
+        conn = _base_conn(user=user, ws=sock)
+        conn.workspace_id = "ws-no-session"
+        conn.container_id = "cid"
+        conn._user_home = "/home/admin"
+        await conn.handle_unshare_window({"window_id": "@0"})
+        calls = [c[0][0] for c in sock.send_json.call_args_list]
+        assert any(
+            c.get("type") == "error"
+            and "No workspace session" in c.get("message", "")
+            for c in calls
+        )
+
+    async def test_unshare_window_already_unshared_broadcasts(
+        self, user, temp_data_dir, app_state
+    ):
+        """Unsharing an already-unshared window is idempotent AND confirmed:
+        the current shared_terminals list is broadcast so the waiting client
+        exits promptly with a definite outcome (#3057)."""
+        app_state = _make_app_state()
+        sockets = app_state.state.sockets
+        sock = _mock_sock()
+        conn = _base_conn(user=user, ws=sock, app_state=app_state)
+        conn.workspace_id = "ws-1"
+        conn.container_id = "cid"
+        conn._user_home = "/home/admin"
+        session = sockets.get_or_create_session("ws-1", app_state)
+        session.terminal_windows[user["id"]] = [
+            {"name": "1", "index": 0, "id": "@0", "shared": False},
+        ]
+        await session.add_subscriber(sock, "cid")
+        try:
+            with patch.object(_mock_term, "kill_joiner_sessions") as mock_kill:
+                await conn.handle_unshare_window({"window_id": "@0"})
+            mock_kill.assert_not_awaited()
+            calls = [c[0][0] for c in sock.send_json.call_args_list]
+            assert any(c.get("type") == "shared_terminals" for c in calls)
+            assert not any(
+                c.get("type") == "shared_terminal_deleted" for c in calls
+            )
+        finally:
+            sockets.sessions.pop("ws-1", None)
+
+    async def test_join_shared_terminal_not_attached_sends_error(self, user):
+        sock = _mock_sock()
+        conn = _base_conn(user=user, ws=sock)
+        conn.workspace_id = "ws-1"
+        conn.container_id = None
+        await conn.handle_join_shared_terminal({"window_id": "@0"})
+        calls = [c[0][0] for c in sock.send_json.call_args_list]
+        assert any(
+            c.get("type") == "error"
+            and "No workspace terminal attached" in c.get("message", "")
+            for c in calls
+        )
 
     async def test_list_shared_terminals(self, user, temp_data_dir, app_state):
         async with _conn_in_workspace(


### PR DESCRIPTION
Fixes #3057.

## 1. E2E fixtures: `free_port()` TOCTOU (`test_hermes_installs_and_health_check_reports_healthy`)

`free_port()` binds `:0`, releases, and returns the number; two overlapping
E2E runs can draw (and then race to rebind) the same port. When the second
run's proxy wins, it answers `/health` on the first run's URL — readiness
passes against the foreign server, and the first run's CLI traffic (same
fixed fixture creds) lands on it → the observed cross-run
`409: workspace already exists`.

Caddy can't inherit a pre-bound listener fd, so "hold until klangkd binds"
isn't available. Instead, `_e2e_server.py`:

- **claims** the ports (`KLANGKD_PORT`, `KLANGKD_EGRESS_PORT`,
  `KLANGKD_PORT_RANGE_START`) with a bound-and-held socket until the moment
  of spawn — another fixture's `:0` draw can no longer pick a number we
  hold, which was the dominant draw-draw collision;
- **verifies** the responder: `/health` now reports the server's instance
  id (`{"status": "ok", "instance": "<id>"}`), and TCP-mode readiness
  compares it against this run's `<data_dir>/instance-id`. A mismatch
  raises `ForeignServerError`;
- **retries**: `start_server` redraws the ports and respawns (up to
  `PORT_CLAIM_ATTEMPTS = 3`) on a foreign-owned port, and on an early exit
  whose log carries klangkd's own port-collision refusal (other early
  exits still surface immediately — config errors aren't retried).

## 2. CLI E2E: `test_share_and_unshare_terminal` unshare timeout

The server had confirmation-less-client hangs: silent `return`s in
`unshare_window`'s helpers on the no-workspace-session and not-attached
paths, a silent return on the already-unshared path, and the same silent
shape in the own-window commands and `join_shared_terminal`. The CLI's
`recv_until(frame_is("shared_terminals"), 10)` then blind-times-out.

Now every refusal sends a definite `error` frame (surfaced fast by the
CLI's existing `frame_is` error handling), and the idempotent
already-unshared case broadcasts the current `shared_terminals` list —
matching `share_window`'s unconditional broadcast. Affected:
`share_window`, `unshare_window`, `join_shared_terminal`, and
`terminal_new_window` / `terminal_select_window` / `terminal_close_window`
/ `terminal_rename_window` / `terminal_list_windows`.

## 3. Frontend E2E: `close a terminal window` stale list (expected 1, got 2)

The spec asserted on the first `terminal_windows` frame after the close
command — a stale pre-close broadcast can satisfy that first. The spec now
polls the authoritative list (`terminal_list_windows`) until the closed
window (by `@id`, not name) is gone, with a deadline; the asserts then
report the real state only if the poll genuinely failed.

## Tests

- Unit: `/health` instance field; new definite-outcome tests for
  share/unshare/join (not attached, no session, already unshared), and the
  own-window no-container tests flipped from "silent" to "error frame".
- Full backend+CLI suites green with 100% branch coverage; `scripts/tests`
  green (xenon rank-A gate green).
