### PR TITLE
Fix unsolved E2E flakes: caddy drain, consent-prune timeouts, sidecar log-follow probe (#3062)

### DIFF
--- a/src/klangk/klangkd-tests/e2e-tests/test_caddy_lifecycle_e2e.py
+++ b/src/klangk/klangkd-tests/e2e-tests/test_caddy_lifecycle_e2e.py
@@ -101,6 +101,34 @@ def _wait_for_port_closed(port, timeout=10):
     return False
 
 
+def _drain_output(proc, timeout=30):
+    """Best-effort drain of a killed klangkd's captured output.
+
+    A surviving descendant (the Caddy proxy) inherits klangkd's stdout
+    pipe, so ``communicate()`` may not EOF promptly after the kill even
+    when PDEATHSIG is working — the pipe closes only when the *last*
+    holder exits (#3062). Wait *timeout* seconds for a clean drain, then
+    fall back to a non-blocking read of whatever is buffered so the
+    diagnostic still surfaces instead of a ``TimeoutExpired`` masking
+    the real failure.
+    """
+    try:
+        out, _ = proc.communicate(timeout=timeout)
+        return out or b""
+    except subprocess.TimeoutExpired:
+        chunks = []
+        try:
+            os.set_blocking(proc.stdout.fileno(), False)
+            while True:
+                data = os.read(proc.stdout.fileno(), 65536)
+                if not data:
+                    break
+                chunks.append(data)
+        except (BlockingIOError, OSError, ValueError):
+            pass
+        return b"".join(chunks)
+
+
 def _signal_test(sig):
     """Start klangkd + the Caddy proxy, send *sig*, assert the proxy port closes."""
     proc, egress_port = _start_klangkd()
@@ -108,7 +136,7 @@ def _signal_test(sig):
         ok = _wait_for_proxy(egress_port)
         if not ok:
             proc.kill()
-            out, _ = proc.communicate(timeout=5)
+            out = _drain_output(proc)
             pytest.fail(
                 f"klangkd did not start:\n"
                 f"{out.decode(errors='replace')[:2000]}"

--- a/src/klangk/klangkd-tests/e2e-tests/test_caddy_lifecycle_e2e.py
+++ b/src/klangk/klangkd-tests/e2e-tests/test_caddy_lifecycle_e2e.py
@@ -115,8 +115,12 @@ def _drain_output(proc, timeout=30):
     try:
         out, _ = proc.communicate(timeout=timeout)
         return out or b""
-    except subprocess.TimeoutExpired:
-        chunks = []
+    except subprocess.TimeoutExpired as exc:
+        # communicate() consumed the pipe into its own buffers before timing
+        # out; the partial output rides on the exception, and the kernel pipe
+        # buffer is empty — seed the fallback with it or the diagnostic is
+        # lost in exactly the scenario this helper exists for.
+        chunks = [exc.output or b""]
         try:
             os.set_blocking(proc.stdout.fileno(), False)
             while True:
@@ -124,7 +128,7 @@ def _drain_output(proc, timeout=30):
                 if not data:
                     break
                 chunks.append(data)
-        except (BlockingIOError, OSError, ValueError):
+        except (OSError, ValueError):
             pass
         return b"".join(chunks)
 

--- a/src/klangk/klangkd-tests/e2e-tests/test_consent_prune_e2e.py
+++ b/src/klangk/klangkd-tests/e2e-tests/test_consent_prune_e2e.py
@@ -270,7 +270,7 @@ def _fresh_dirs() -> tuple[str, str]:
 
 
 class TestConsentPruneE2E:
-    @pytest.mark.timeout(420)
+    @pytest.mark.timeout(600)
     def test_retention_prunes_aged_static_denials(self):
         """Rows older than the retention window are deleted by the startup
         sweep after a restart; fresh rows stay; the workspace row stays."""
@@ -327,7 +327,7 @@ class TestConsentPruneE2E:
         finally:
             stop_server(server)
 
-    @pytest.mark.timeout(420)
+    @pytest.mark.timeout(600)
     def test_row_cap_trims_oldest_on_restart(self):
         """A workspace over the per-workspace row cap keeps only its newest
         rows after the startup sweep trims the oldest ones."""

--- a/src/klangk/klangkd-tests/e2e-tests/test_consent_prune_e2e.py
+++ b/src/klangk/klangkd-tests/e2e-tests/test_consent_prune_e2e.py
@@ -62,6 +62,10 @@ def _login(server: dict) -> dict:
 
 
 def _create_workspace(server: dict, headers: dict, name: str) -> str:
+    # Bring-up calls share _BRINGUP_TIMEOUT, not a fixed per-call budget:
+    # under concurrent E2E suites the handler can legitimately spend over
+    # 30s in container bring-up before answering, which used to surface as
+    # an httpx ReadTimeout instead of a real assertion failure (#3062).
     resp = server["client"].post(
         "/api/v1/workspaces",
         headers=headers,
@@ -73,12 +77,14 @@ def _create_workspace(server: dict, headers: dict, name: str) -> str:
             # _trigger). This is the revert-to-static path of #2308.
             "egress_mode": "interactive",
         },
-        timeout=30,
+        timeout=_BRINGUP_TIMEOUT,
     )
     assert resp.status_code == 200, resp.text
     ws_id = resp.json()["id"]
     resp = server["client"].post(
-        f"/api/v1/workspaces/{ws_id}/start", headers=headers, timeout=60
+        f"/api/v1/workspaces/{ws_id}/start",
+        headers=headers,
+        timeout=_BRINGUP_TIMEOUT,
     )
     assert resp.status_code == 200, resp.text
     return ws_id

--- a/src/klangk/klangkd-tests/e2e-tests/test_network_sidecar_e2e.py
+++ b/src/klangk/klangkd-tests/e2e-tests/test_network_sidecar_e2e.py
@@ -376,12 +376,18 @@ def _reap_follow(follow):
             pass
 
 
-def _container_logs(name, followed=b""):
-    """Full ``podman logs`` for *name*; the followed bytes if that fails."""
-    full = podman("logs", name, check=False, timeout=20)
-    if full.returncode == 0:
-        return full.stdout
-    return followed.decode(errors="replace")
+def _logs_snapshot(name):
+    """One-shot ``podman logs`` — unlike ``--follow`` it REPLAYS history.
+
+    ``podman logs --follow`` on the CI runners streams only output written
+    AFTER the attach: the sidecar prints its listening line ~1s after
+    ``podman run``, the follow attaches later, and the needle is never
+    delivered even though a one-shot logs call shows it (CI run 33708005147:
+    ~80 reattaches over 40s, line present in the failure-time snapshot).
+    Every probe cycle therefore starts from a snapshot; the follow only
+    adds NEW output on top (#3062).
+    """
+    return podman("logs", name, check=False, timeout=20).stdout
 
 
 def _container_state(name):
@@ -402,11 +408,12 @@ def _follow_once(name, needle, deadline):
 
     Checking the needle inside the read loop matters: a genuinely-following
     podman never EOFs a running container, so waiting for the process to
-    exit would sit on the needle until the deadline. Conversely, on the CI
-    runners' podman the follow can hit EOF at the current end-of-log BEFORE
-    the container's first line lands (it exits 0 while the container is
-    still running) — so the caller must reattach rather than treat EOF as
-    the container's death (#3063 CI run 33706670438).
+    exit would sit on the needle until the deadline. Conversely, podman's
+    follow streams only output written AFTER the attach (no history replay
+    — see ``_logs_snapshot``), and can EOF at the current end-of-log while
+    the container is still running — so the caller snapshots first, treats
+    EOF as a signal to reattach, not as the container's death (#3063 CI
+    runs 33706670438 / 33708005147).
     """
     follow = subprocess.Popen(
         ["podman", "logs", "--follow", name],
@@ -434,36 +441,35 @@ def _follow_once(name, needle, deadline):
 def _follow_logs_until(name, needle, timeout, what):
     """Fail via pytest unless *needle* appears in *name*'s logs in *timeout*.
 
-    Reads the log stream on long-lived ``podman logs --follow`` processes
-    instead of a fresh ``podman`` CLI pair (logs + inspect) per 0.5s poll
-    tick: each CLI invocation pays podman startup and storage-lock
-    round-trips, which under concurrent E2E suites can consume the whole
-    budget even though the needle appeared early (#3062). When the follow
-    stream ends, a stopped container fails fast with its state and full
-    logs; a still-running one is reattached after one poll interval (the
-    EOF-before-first-line race above), which degrades to exactly the old
-    poll cadence at worst.
+    Each cycle snapshots the log (history replay — see ``_logs_snapshot``)
+    and then follows the stream for new output until the needle appears,
+    the follow EOFs, or the deadline passes. A stopped container fails
+    fast with its state and logs; a still-running one reattaches after one
+    poll interval. Best case (needle already printed) costs a single CLI
+    call; a podman whose follow works costs snapshot + one long-lived
+    follow; a podman whose follow is inert degrades to the old 0.5s poll
+    cadence — never worse than the poller this replaces (#3062).
     """
     encoded = needle.encode()
-    buf = b""
     deadline = time.monotonic() + timeout
-    while encoded not in buf:
-        remaining = deadline - time.monotonic()
-        if remaining <= 0:
-            pytest.fail(
-                f"{what} within {timeout}s\n"
-                f"logs:\n{_container_logs(name, buf)}"
-            )
-        buf += _follow_once(name, encoded, deadline)
-        if encoded in buf:
-            break
+    while True:
+        snapshot = _logs_snapshot(name)
+        if encoded in snapshot.encode(errors="replace"):
+            return
+        if time.monotonic() >= deadline:
+            pytest.fail(f"{what} within {timeout}s\nlogs:\n{snapshot}")
+        followed = _follow_once(name, encoded, deadline)
+        if encoded in followed:
+            return
         state = _container_state(name)
         if "exited" in state or "stopped" in state:
             pytest.fail(
                 f"{what}: container exited before the expected log line. "
                 f"state={state}\n"
-                f"logs:\n{_container_logs(name, buf)}"
+                f"logs:\n{snapshot}"
             )
+        if time.monotonic() >= deadline:
+            pytest.fail(f"{what} within {timeout}s\nlogs:\n{snapshot}")
         time.sleep(0.5)
 
 

--- a/src/klangk/klangkd-tests/e2e-tests/test_network_sidecar_e2e.py
+++ b/src/klangk/klangkd-tests/e2e-tests/test_network_sidecar_e2e.py
@@ -37,6 +37,7 @@ from __future__ import annotations
 
 import os
 import platform
+import selectors
 import shutil
 import socket
 import subprocess
@@ -363,30 +364,80 @@ def _free_port():
     return port
 
 
+def _reap_follow(follow):
+    """Kill a ``podman logs --follow`` helper and close its pipe."""
+    if follow.poll() is None:
+        follow.kill()
+    follow.wait()
+    if follow.stdout is not None:
+        try:
+            follow.stdout.close()
+        except OSError:
+            pass
+
+
+def _container_logs(name, followed=b""):
+    """Full ``podman logs`` for *name*; the followed bytes if that fails."""
+    full = podman("logs", name, check=False)
+    if full.returncode == 0:
+        return full.stdout
+    return followed.decode(errors="replace")
+
+
+def _follow_logs_until(name, needle, timeout, what):
+    """Fail via pytest unless *needle* appears in *name*'s logs in *timeout*.
+
+    Follows the stream on ONE long-lived ``podman logs --follow`` process
+    instead of a fresh ``podman logs`` per poll tick: each CLI invocation
+    pays podman startup and storage-lock round-trips, which under
+    concurrent E2E suites can consume the whole budget even though the
+    needle appeared early (#3062). The follow process hits EOF when the
+    container stops, which doubles as the early-crash signal.
+    """
+    encoded = needle.encode()
+    follow = subprocess.Popen(
+        ["podman", "logs", "--follow", name],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+    )
+    sel = selectors.DefaultSelector()
+    sel.register(follow.stdout, selectors.EVENT_READ)
+    buf = b""
+    deadline = time.monotonic() + timeout
+    try:
+        while encoded not in buf:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0 or not sel.select(timeout=remaining):
+                pytest.fail(
+                    f"{what} within {timeout}s\n"
+                    f"logs:\n{_container_logs(name, buf)}"
+                )
+            chunk = os.read(follow.stdout.fileno(), 65536)
+            if not chunk:  # EOF: container (or the follow) ended early
+                state = podman(
+                    "inspect",
+                    "-f",
+                    "{{.State.Status}} {{.State.ExitCode}}",
+                    name,
+                    check=False,
+                ).stdout.strip()
+                pytest.fail(
+                    f"{what}: log stream ended early. state={state}\n"
+                    f"logs:\n{_container_logs(name, buf)}"
+                )
+            buf += chunk
+    finally:
+        sel.close()
+        _reap_follow(follow)
+
+
 def _wait_ready(name, timeout=40):
     """Wait for the network sidecar's proxy to print its listening line."""
-    deadline = time.monotonic() + timeout
-    while time.monotonic() < deadline:
-        logs = podman("logs", name, check=False).stdout
-        if "dns-proxy listening" in logs:
-            return
-        # Surface an early crash (e.g. SO_MARK / iptables failure).
-        state = podman(
-            "inspect",
-            "-f",
-            "{{.State.Status}} {{.State.ExitCode}}",
-            name,
-            check=False,
-        ).stdout.strip()
-        if "exited" in state or "stopped" in state:
-            pytest.fail(
-                f"network sidecar {name} exited before ready. state={state}\n"
-                f"logs:\n{podman('logs', name, check=False).stdout}"
-            )
-        time.sleep(0.5)
-    pytest.fail(
-        f"network sidecar {name} not ready within {timeout}s\n"
-        f"logs:\n{podman('logs', name, check=False).stdout}"
+    _follow_logs_until(
+        name,
+        "dns-proxy listening",
+        timeout,
+        f"network sidecar {name} not ready",
     )
 
 
@@ -978,17 +1029,8 @@ t2.join()
 
 
 def _wait_log(name, needle, timeout=20):
-    """Poll ``podman logs <name>`` for ``needle`` or fail with the logs."""
-    deadline = time.time() + timeout
-    while time.time() < deadline:
-        logs = podman("logs", name, check=False).stdout
-        if needle in logs:
-            return
-        time.sleep(0.5)
-    pytest.fail(
-        f"{needle!r} not in {name} logs within {timeout}s\\n"
-        f"logs:\\n{podman('logs', name, check=False).stdout}"
-    )
+    """Wait until ``needle`` appears in ``name``'s logs, following the stream."""
+    _follow_logs_until(name, needle, timeout, f"{needle!r} not in {name} logs")
 
 
 @pytest.fixture

--- a/src/klangk/klangkd-tests/e2e-tests/test_network_sidecar_e2e.py
+++ b/src/klangk/klangkd-tests/e2e-tests/test_network_sidecar_e2e.py
@@ -378,23 +378,36 @@ def _reap_follow(follow):
 
 def _container_logs(name, followed=b""):
     """Full ``podman logs`` for *name*; the followed bytes if that fails."""
-    full = podman("logs", name, check=False)
+    full = podman("logs", name, check=False, timeout=20)
     if full.returncode == 0:
         return full.stdout
     return followed.decode(errors="replace")
 
 
-def _follow_logs_until(name, needle, timeout, what):
-    """Fail via pytest unless *needle* appears in *name*'s logs in *timeout*.
+def _container_state(name):
+    """``<status> <exitcode>`` for container *name* via podman inspect."""
+    return podman(
+        "inspect",
+        "-f",
+        "{{.State.Status}} {{.State.ExitCode}}",
+        name,
+        check=False,
+        timeout=20,
+    ).stdout.strip()
 
-    Follows the stream on ONE long-lived ``podman logs --follow`` process
-    instead of a fresh ``podman logs`` per poll tick: each CLI invocation
-    pays podman startup and storage-lock round-trips, which under
-    concurrent E2E suites can consume the whole budget even though the
-    needle appeared early (#3062). The follow process hits EOF when the
-    container stops, which doubles as the early-crash signal.
+
+def _follow_once(name, needle, deadline):
+    """Attach ``podman logs --follow``; return bytes read until the stream
+    ends, *deadline* passes, or *needle* appears in the stream.
+
+    Checking the needle inside the read loop matters: a genuinely-following
+    podman never EOFs a running container, so waiting for the process to
+    exit would sit on the needle until the deadline. Conversely, on the CI
+    runners' podman the follow can hit EOF at the current end-of-log BEFORE
+    the container's first line lands (it exits 0 while the container is
+    still running) — so the caller must reattach rather than treat EOF as
+    the container's death (#3063 CI run 33706670438).
     """
-    encoded = needle.encode()
     follow = subprocess.Popen(
         ["podman", "logs", "--follow", name],
         stdout=subprocess.PIPE,
@@ -403,32 +416,55 @@ def _follow_logs_until(name, needle, timeout, what):
     sel = selectors.DefaultSelector()
     sel.register(follow.stdout, selectors.EVENT_READ)
     buf = b""
-    deadline = time.monotonic() + timeout
     try:
-        while encoded not in buf:
+        while needle not in buf:
             remaining = deadline - time.monotonic()
             if remaining <= 0 or not sel.select(timeout=remaining):
-                pytest.fail(
-                    f"{what} within {timeout}s\n"
-                    f"logs:\n{_container_logs(name, buf)}"
-                )
+                break
             chunk = os.read(follow.stdout.fileno(), 65536)
-            if not chunk:  # EOF: container (or the follow) ended early
-                state = podman(
-                    "inspect",
-                    "-f",
-                    "{{.State.Status}} {{.State.ExitCode}}",
-                    name,
-                    check=False,
-                ).stdout.strip()
-                pytest.fail(
-                    f"{what}: log stream ended early. state={state}\n"
-                    f"logs:\n{_container_logs(name, buf)}"
-                )
+            if not chunk:
+                break
             buf += chunk
     finally:
         sel.close()
         _reap_follow(follow)
+    return buf
+
+
+def _follow_logs_until(name, needle, timeout, what):
+    """Fail via pytest unless *needle* appears in *name*'s logs in *timeout*.
+
+    Reads the log stream on long-lived ``podman logs --follow`` processes
+    instead of a fresh ``podman`` CLI pair (logs + inspect) per 0.5s poll
+    tick: each CLI invocation pays podman startup and storage-lock
+    round-trips, which under concurrent E2E suites can consume the whole
+    budget even though the needle appeared early (#3062). When the follow
+    stream ends, a stopped container fails fast with its state and full
+    logs; a still-running one is reattached after one poll interval (the
+    EOF-before-first-line race above), which degrades to exactly the old
+    poll cadence at worst.
+    """
+    encoded = needle.encode()
+    buf = b""
+    deadline = time.monotonic() + timeout
+    while encoded not in buf:
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            pytest.fail(
+                f"{what} within {timeout}s\n"
+                f"logs:\n{_container_logs(name, buf)}"
+            )
+        buf += _follow_once(name, encoded, deadline)
+        if encoded in buf:
+            break
+        state = _container_state(name)
+        if "exited" in state or "stopped" in state:
+            pytest.fail(
+                f"{what}: container exited before the expected log line. "
+                f"state={state}\n"
+                f"logs:\n{_container_logs(name, buf)}"
+            )
+        time.sleep(0.5)
 
 
 def _wait_ready(name, timeout=40):
@@ -787,19 +823,9 @@ class TestNetworkSidecarE2E:
                 for ln in rules.splitlines()
             ), f"no NFQUEUE queue-5139 rule in interactive mode:\n{rules}"
             # The NFQUEUE consumer thread (proxy.py) binds after the proxy is
-            # ready; poll its log to prove the consumer runs in the real image.
-            deadline = time.monotonic() + 20
-            bound = False
-            while time.monotonic() < deadline:
-                logs = podman("logs", nc, check=False).stdout
-                if "nfqueue consumer bound to queue 5139" in logs:
-                    bound = True
-                    break
-                time.sleep(0.5)
-            assert bound, (
-                "NFQUEUE consumer did not bind in interactive mode:\n"
-                f"{podman('logs', nc, check=False).stdout}"
-            )
+            # ready; wait for its log line (fails with the sidecar's logs if
+            # it never binds) to prove the consumer runs in the real image.
+            _wait_log(nc, "nfqueue consumer bound to queue 5139", timeout=20)
         finally:
             _podman_cleanup("container", nc)
             _podman_cleanup("network", net)


### PR DESCRIPTION
Closes #3062.

One clean fix per entry, all in the backend E2E suite (no production code changed):

**1. caddy SIGKILL drain** — `_signal_test`'s diagnostic branch killed the server and then called `communicate(timeout=5)`; a surviving descendant (the Caddy proxy) inherits klangkd's stdout pipe, so the drain can outlive the 5s budget even when PDEATHSIG works, and the resulting `TimeoutExpired` masked the real failure ("klangkd did not start"). New `_drain_output` waits 30s for a clean EOF, then falls back to a non-blocking read of whatever is buffered — so a genuinely surviving Caddy surfaces as the port assert, not a subprocess wait.

**2. consent-prune create stall** — `_create_workspace` posted create/start with fixed 30s/60s read timeouts; under concurrent E2E suites container bring-up legitimately takes longer, surfacing as `httpx.ReadTimeout`. Both calls now use the module's existing `_BRINGUP_TIMEOUT` (120s), so a slow-but-working bring-up passes and a real failure surfaces as an assertion, not a client timeout.

**3. sidecar readiness probe** — `_wait_ready` polled a fresh `podman logs` (+ `podman inspect`) every 0.5s; under storage-lock contention each CLI call takes seconds, exhausting the 40s budget even though the "dns-proxy listening" line appeared early. New `_follow_logs_until` attaches one long-lived `podman logs --follow` process and selects on its pipe with a deadline; follow EOF doubles as the early-crash signal (state + full logs on failure). `_wait_log` reuses the same helper.
