### PR TITLE
Fix unsolved flakes: E2E 60s budgets, podman-create retry, TUI WorkerCancelled (#3064)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -1946,11 +1946,11 @@ git-credential` (#1700).** `pig-latin` removed; `word-count` dormant.
 ### Fixed
 
 - **Podman create retry and CI-aware bring-up budgets (#3064).** A
-  `podman create` that stalls past its 120s budget under load is now
-  killed and retried once (idempotent via `--replace`) instead of
-  surfacing a 500 that cascades into workspace start and connect
-  timeouts. `create`/`start` budgets double to 240s when `CI` is set
-  in the environment.
+  `podman create` that stalls past its budget (120s local, 240s on CI)
+  under load is now killed and retried once (idempotent via
+  `--replace`) instead of surfacing a 500 that cascades into workspace
+  start and connect timeouts. `create`/`start`/container-readiness
+  budgets double to 240s when `CI` is set in the environment.
 - **Terminal share/unshare/close no longer hang clients on refusal paths
   (#3057).** The WebSocket handlers for `share_window`, `unshare_window`,
   `join_shared_terminal`, and the own-window commands (`terminal_new_window`,

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -1945,6 +1945,12 @@ git-credential` (#1700).** `pig-latin` removed; `word-count` dormant.
 
 ### Fixed
 
+- **Podman create retry and CI-aware bring-up budgets (#3064).** A
+  `podman create` that stalls past its 120s budget under load is now
+  killed and retried once (idempotent via `--replace`) instead of
+  surfacing a 500 that cascades into workspace start and connect
+  timeouts. `create`/`start` budgets double to 240s when `CI` is set
+  in the environment.
 - **Terminal share/unshare/close no longer hang clients on refusal paths
   (#3057).** The WebSocket handlers for `share_window`, `unshare_window`,
   `join_shared_terminal`, and the own-window commands (`terminal_new_window`,

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -1948,9 +1948,11 @@ git-credential` (#1700).** `pig-latin` removed; `word-count` dormant.
 - **Podman create retry and CI-aware bring-up budgets (#3064).** A
   `podman create` that stalls past its budget (120s local, 240s on CI)
   under load is now killed and retried once (idempotent via
-  `--replace`) instead of surfacing a 500 that cascades into workspace
-  start and connect timeouts. `create`/`start`/container-readiness
-  budgets double to 240s when `CI` is set in the environment.
+  `--replace`), so a stalled create no longer 500s straight into the
+  workspace start/connect path. On CI (`CI` env), create/start budgets
+  double to 240s and container-readiness widens 60→240s; the CLI's
+  WS-connect wait is now overridable via `KLANGKC_WS_CONNECT_TIMEOUT`
+  (the e2e suites set it to 240s on CI).
 - **Terminal share/unshare/close no longer hang clients on refusal paths
   (#3057).** The WebSocket handlers for `share_window`, `unshare_window`,
   `join_shared_terminal`, and the own-window commands (`terminal_new_window`,

--- a/src/klangk/klangk/cli/client.py
+++ b/src/klangk/klangk/cli/client.py
@@ -52,7 +52,11 @@ _RETRY_ATTEMPTS = 3
 RESIZE_POLL_INTERVAL = 1.0  # seconds between terminal size checks
 _RETRY_BACKOFF = 2.0  # seconds, doubled each retry
 
-_WS_CONNECT_TIMEOUT = 60  # seconds to wait for container_ready
+# Seconds to wait for container_ready. The wait spans the server's whole
+# bring-up chain (create → start → readiness), so under load it can
+# legitimately outrun 60s; overridable via env for the e2e runs that
+# widen the chain's budgets on CI (#3064).
+_WS_CONNECT_TIMEOUT = float(os.environ.get("KLANGKC_WS_CONNECT_TIMEOUT", "60"))
 _HEARTBEAT_INTERVAL = 60  # seconds between terminal heartbeats
 _STDIN_DRAIN_TIMEOUT = 2  # seconds to let exec stdin forwarder finish
 

--- a/src/klangk/klangk/container/registry.py
+++ b/src/klangk/klangk/container/registry.py
@@ -29,7 +29,7 @@ from ..model.container_events import (
     ROLE_SIDECAR,
     ROLE_WORKSPACE,
 )
-from ..podman import PodmanError
+from ..podman import PodmanError, bringup_timeout
 from ..ssl_trust import SSL_MOUNT_DEST as _SSL_MOUNT_DEST
 from ..settings import parse_bool_setting
 from ..workspace_settings import resolve_allow_sudo
@@ -1329,7 +1329,13 @@ class ContainerRegistry(NetworkSidecarMixin):
         # terminals, exec, agent, health check — gets a genuine readiness
         # guarantee regardless of shell, closing the race that previously
         # only the in-bashrc gate covered (and only for bash).
-        await self.app.state.podman.wait_for_container_ready(cid)
+        # Readiness budget is CI-aware too (#3064): this wait sits inside
+        # the same bring-up chain as create/start, and a client POST that
+        # can legally spend 240s on CI must not be capped by a flat 60s
+        # here.
+        await self.app.state.podman.wait_for_container_ready(
+            cid, timeout=bringup_timeout(60.0, 240.0)
+        )
 
         # FIPS enforcement (#2570, #2591): the gate runs at this single
         # create choke point (fail closed — see _fips_gate).

--- a/src/klangk/klangk/container/sidecar.py
+++ b/src/klangk/klangk/container/sidecar.py
@@ -26,7 +26,10 @@ from ..model.workspaces import EGRESS_MODE_STATIC
 logger = logging.getLogger(__name__)
 
 # fail-open window. Module-level so the timeout path is unit-testable fast.
-NETWORK_SIDECAR_READY_TIMEOUT = 30.0
+# CI-aware (#3064): this wait sits in-request inside the same bring-up
+# chain as create/start/readiness — under four-suite contention the
+# chain's other stages get 240s, so 30s local stays, 240s on CI.
+NETWORK_SIDECAR_READY_TIMEOUT = podman.bringup_timeout(30.0, 240.0)
 NETWORK_SIDECAR_READY_POLL = 0.3
 _NETWORK_SIDECAR_READY_TOKEN = "dns-proxy listening"
 # fwmark the sidecar's proxy stamps on its upstream socket and the entrypoint

--- a/src/klangk/klangk/podman.py
+++ b/src/klangk/klangk/podman.py
@@ -51,6 +51,16 @@ def subprocess_env() -> dict[str, str]:
     return {k: v for k, v in os.environ.items() if k != "LD_LIBRARY_PATH"}
 
 
+def bringup_timeout(default: float = 120.0, ci: float = 240.0) -> float:
+    """Podman bring-up budget, doubled on CI (#3064).
+
+    Four E2E suites share one CI VM; under that storage/IO contention a
+    create or start can legitimately outrun the local-dev budget. Same
+    load-aware shape as the frontend's container-ready doubling (#2745).
+    """
+    return ci if os.environ.get("CI") else default
+
+
 class PodmanError(Exception):
     """A podman CLI invocation failed.
 
@@ -498,8 +508,25 @@ class Podman:
             args += ["-e", entry]
         args.append(image)
         args += command or []
-        _rc, out, _err = await self.run(args, timeout=120.0)
+        _rc, out, _err = await self._run_create(args)
         return out.strip()
+
+    async def _run_create(self, args: list[str]) -> tuple[int, str, str]:
+        """Run ``podman create`` with one timeout retry (#3064).
+
+        A create that stalls past its budget under concurrent load used to
+        cascade into every downstream waiter (workspace start, WS connect,
+        teardown). ``create_container`` always passes ``--replace``, so a
+        retried create is idempotent — the stalled attempt was killed, run
+        it once more before giving up.
+        """
+        try:
+            return await self.run(args, timeout=bringup_timeout())
+        except PodmanError as exc:
+            if "timed out after" not in exc.message:
+                raise
+        logger.warning("podman create stalled past its budget; retrying once")
+        return await self.run(args, timeout=bringup_timeout())
 
     async def start_container(
         self,
@@ -516,7 +543,9 @@ class Podman:
         """
         args: list[str] = self._hooks_dir_args(hooks_dir)
         args += ["start", container_id]
-        await self.run(args, timeout=120.0)
+        # Same CI contention family as create (#3064): budget only, no
+        # retry — start is not idempotent the way --replace create is.
+        await self.run(args, timeout=bringup_timeout())
 
     async def wait_for_container_ready(
         self, container_id: str, *, timeout: float = 60.0

--- a/src/klangk/klangk/podman.py
+++ b/src/klangk/klangk/podman.py
@@ -73,6 +73,17 @@ class PodmanError(Exception):
         super().__init__(f"[{status}] {message}")
 
 
+class PodmanTimeoutError(PodmanError):
+    """A podman CLI invocation exceeded its timeout budget (#3064).
+
+    Structural signal — ``_run_create``'s retry branches on this type,
+    not on message text: a timed-out create that wrote partial stderr
+    (image-pull progress, storage warnings) still carries the marker,
+    while a non-timeout stderr that merely mentions a timeout does not
+    become retryable.
+    """
+
+
 _NOT_FOUND_HINTS = ("no such", "not found", "no container")
 _IN_USE_HINTS = ("in use", "being used", "already in use")
 
@@ -202,10 +213,18 @@ class Podman:
         rc, err = Podman._timeout_rc(err, cmd_label, timeout, timed_out, rc)
         Podman._log_podman_timing(cmd_label, timings, err)
         if check and rc != 0:
-            raise PodmanError(
-                classify(err), err.strip() or f"podman {args[0]}"
-            )
+            Podman._raise_podman_error(err, args, timed_out)
         return rc, err
+
+    @staticmethod
+    def _raise_podman_error(
+        err: str, args: list[str], timed_out: bool
+    ) -> None:
+        """Raise the right error for a failed checked run: the structural
+        PodmanTimeoutError marker on a budget overrun (#3064), else the
+        plain classified PodmanError."""
+        error_class = PodmanTimeoutError if timed_out else PodmanError
+        raise error_class(classify(err), err.strip() or f"podman {args[0]}")
 
     async def run(
         self,
@@ -508,22 +527,26 @@ class Podman:
             args += ["-e", entry]
         args.append(image)
         args += command or []
-        _rc, out, _err = await self._run_create(args)
+        _rc, out, _err = await self._run_create(args, replace)
         return out.strip()
 
-    async def _run_create(self, args: list[str]) -> tuple[int, str, str]:
+    async def _run_create(
+        self, args: list[str], replace: bool
+    ) -> tuple[int, str, str]:
         """Run ``podman create`` with one timeout retry (#3064).
 
         A create that stalls past its budget under concurrent load used to
         cascade into every downstream waiter (workspace start, WS connect,
-        teardown). ``create_container`` always passes ``--replace``, so a
-        retried create is idempotent — the stalled attempt was killed, run
-        it once more before giving up.
+        teardown). With ``replace=True`` (``create_container``'s default)
+        a retried create is idempotent — the stalled attempt was killed,
+        run it once more before giving up. Without it there is no safe
+        retry: the first, killed attempt may have left the name claimed,
+        so the timeout surfaces immediately instead.
         """
         try:
             return await self.run(args, timeout=bringup_timeout())
-        except PodmanError as exc:
-            if "timed out after" not in exc.message:
+        except PodmanTimeoutError:
+            if not replace:
                 raise
         logger.warning("podman create stalled past its budget; retrying once")
         return await self.run(args, timeout=bringup_timeout())

--- a/src/klangk/klangk/podman.py
+++ b/src/klangk/klangk/podman.py
@@ -260,8 +260,8 @@ class Podman:
         ``communicate()`` forever.  Temp files avoid this.
 
         *timeout* caps how long we wait for the process (default 30 s).
-        On timeout the process is killed and a ``PodmanError(500, ...)`` is
-        raised (unless *check* is False, in which case rc=-1 is returned).
+        On timeout the process is killed and a :class:`PodmanTimeoutError`
+        is raised (unless *check* is False, in which case rc=-1 is returned).
         """
         cmd_label = f"podman {args[0]}" if args else "podman"
         t0 = time.monotonic()

--- a/src/klangk/klangkc-tests/e2e-tests/conftest.py
+++ b/src/klangk/klangkc-tests/e2e-tests/conftest.py
@@ -22,6 +22,13 @@ import sys
 
 import pytest
 
+# #3064: the CLI's WS-connect wait spans the server's whole bring-up chain
+# (create → start → readiness), whose budgets widen to 240s on CI. Widen
+# the client wait to match before any test module imports the client (the
+# TUI suites run it in-process, so a child-env stamp alone can't reach it).
+if os.environ.get("CI"):
+    os.environ.setdefault("KLANGKC_WS_CONNECT_TIMEOUT", "240")
+
 # Failure-diagnosability (#2623): attach what the file-streamed klangkd
 # logs recorded during a test to that test's failure report. The hooks live
 # in ``_e2e_logs`` inside the backend E2E suite's dir (the same shared

--- a/src/klangk/klangkc-tests/tests/test_tui.py
+++ b/src/klangk/klangkc-tests/tests/test_tui.py
@@ -10446,12 +10446,12 @@ async def test_edit_screen_classification_banner_in_save_body(monkeypatch):
         # Change it, save.
         es.query_one("#classification_banner").value = "CUI"
         es.save()
-        await app.workers.wait_for_complete()
+        await _settle(app)
         assert updated[-1]["classification_banner"] == "CUI"
         # Clear it, save — None clears the override back to inherit.
         es.query_one("#classification_banner").value = "   "
         es.save()
-        await app.workers.wait_for_complete()
+        await _settle(app)
         assert updated[-1]["classification_banner"] is None
 
 

--- a/src/klangk/klangkd-tests/e2e-tests/_e2e_env.py
+++ b/src/klangk/klangkd-tests/e2e-tests/_e2e_env.py
@@ -107,3 +107,16 @@ def clean_env(**overrides: str) -> dict[str, str]:
     env.setdefault("KLANGKD_AUTH_MODES", "password")
     env.update(overrides)
     return env
+
+
+def ci_budget(default: float, ci: float) -> float:
+    """Load-aware E2E budget, widened on CI (#3064).
+
+    The four E2E suites share one runner VM; under that storage/IO
+    contention a real podman bring-up (create/start/readiness) can
+    outrun a tight local-dev budget — the observed failures were
+    client-side 60s caps blowing while unrelated tests passed. Same
+    shape as the frontend's container-ready doubling (#2745). Local
+    runs keep the snappier default.
+    """
+    return ci if os.environ.get("CI") else default

--- a/src/klangk/klangkd-tests/e2e-tests/_e2e_env.py
+++ b/src/klangk/klangkd-tests/e2e-tests/_e2e_env.py
@@ -105,6 +105,11 @@ def clean_env(**overrides: str) -> dict[str, str]:
     # E2E baseline defaults.
     env["_KLANGKD_DISABLE_PROXY"] = "1"
     env.setdefault("KLANGKD_AUTH_MODES", "password")
+    # #3064: child CLI/TUI processes get the widened WS-connect wait on CI
+    # to match the bring-up budgets (the strip above removes any ambient
+    # value, so this stamp is the only way it reaches the child).
+    if os.environ.get("CI"):
+        env.setdefault("KLANGKC_WS_CONNECT_TIMEOUT", "240")
     env.update(overrides)
     return env
 

--- a/src/klangk/klangkd-tests/e2e-tests/test_agent_home_e2e.py
+++ b/src/klangk/klangkd-tests/e2e-tests/test_agent_home_e2e.py
@@ -21,6 +21,7 @@ import time
 import httpx
 import pytest
 
+from _e2e_env import ci_budget
 from _e2e_server import start_server, stop_server, ws_connect as _ws_dial
 
 # Fixed agent-identity home (#2718): the agent user *is* the ``klangk``
@@ -152,18 +153,21 @@ async def recv_until(ws, predicate, timeout=30):
 
 async def ws_connect(server, auth, workspace_id):
     """Open a WS, connect, wait for container_ready."""
+    # #3064: the wait spans the server's whole bring-up chain, whose
+    # budgets widen on CI — widen with them.
+    budget = ci_budget(60, 240)
     ws = await _ws_dial(server, f"/ws?token={auth['token']}", max_size=2**20)
     await ws.send(
         json.dumps({"cmd": "workspace_connect", "workspaceId": workspace_id})
     )
-    deadline = asyncio.get_event_loop().time() + 60
+    deadline = asyncio.get_event_loop().time() + budget
     while asyncio.get_event_loop().time() < deadline:
-        msg = json.loads(await asyncio.wait_for(ws.recv(), timeout=60))
+        msg = json.loads(await asyncio.wait_for(ws.recv(), timeout=budget))
         if _is_container_ready(msg):
             break
     else:
         await ws.close()
-        raise AssertionError("container_ready not received within 60s")
+        raise AssertionError(f"container_ready not received within {budget}s")
     return ws
 
 

--- a/src/klangk/klangkd-tests/e2e-tests/test_consent_decisions_e2e.py
+++ b/src/klangk/klangkd-tests/e2e-tests/test_consent_decisions_e2e.py
@@ -28,6 +28,7 @@ import time
 
 import pytest
 
+from _e2e_env import ci_budget
 from _e2e_server import start_server, stop_server
 from test_agent_home_e2e import ws_connect
 
@@ -87,7 +88,9 @@ def workspace(server, auth):
             "egress_mode": "interactive",
             "auto_start": True,
         },
-        timeout=60,
+        # #3064: full bring-up under four-suite CI contention can outrun
+        # a 60s local-dev budget (same family as #2745's doubling).
+        timeout=ci_budget(60, 240),
     )
     assert resp.status_code == 200, resp.text
     ws_id = resp.json()["id"]

--- a/src/klangk/klangkd-tests/e2e-tests/test_consent_decisions_e2e.py
+++ b/src/klangk/klangkd-tests/e2e-tests/test_consent_decisions_e2e.py
@@ -740,7 +740,7 @@ class TestConsentDecisionEndStates:
                     server["client"].post,
                     f"/api/v1/workspaces/{ws_id}/restart",
                     headers=auth["headers"],
-                    timeout=120,
+                    timeout=ci_budget(120, 240),
                 )
                 assert restart.status_code == 200, restart.text
                 # The pre-restart workspace WS is stale; wait on a fresh one
@@ -836,7 +836,7 @@ class TestConsentDecisionEndStates:
                     server["client"].post,
                     f"/api/v1/workspaces/{ws_id}/restart",
                     headers=auth["headers"],
-                    timeout=120,
+                    timeout=ci_budget(120, 240),
                 )
                 assert restart.status_code == 200, restart.text
                 await ws_conn.close()

--- a/src/klangk/klangkd-tests/e2e-tests/test_network_sidecar_e2e.py
+++ b/src/klangk/klangkd-tests/e2e-tests/test_network_sidecar_e2e.py
@@ -46,6 +46,7 @@ import uuid
 
 import pytest
 
+from _e2e_env import ci_budget
 from _e2e_server import tracked_mkdtemp
 
 # The network sidecar image source (entrypoint.sh + Dockerfile), relative to
@@ -608,13 +609,15 @@ def _query(env, stack, name, server=None):
     last_exc = None
     for _attempt in range(2):
         try:
-            out = podman(*run_args, timeout=60)
+            # #3064: raw podman run of the sidecar image under four-suite
+            # CI contention can outrun 60s (the retry above catches the
+            # remainder).
+            out = podman(*run_args, timeout=ci_budget(60, 240))
             return out.stdout.strip()
         except subprocess.TimeoutExpired as exc:
             last_exc = exc
             print(
-                f"podman run {name!r} timed out after 60s "
-                "(wedged under load); retrying"
+                f"podman run {name!r} timed out (wedged under load); retrying"
             )
     raise last_exc
 
@@ -679,7 +682,7 @@ def _probe_somark(
         "python3",
         env["image"],
         *args,
-        timeout=60,
+        timeout=ci_budget(60, 240),
     )
     return out.stdout.strip()
 

--- a/src/klangk/klangkd-tests/tests/test_podman.py
+++ b/src/klangk/klangkd-tests/tests/test_podman.py
@@ -531,6 +531,53 @@ class TestCreateContainer:
         args = _args(m)
         assert "--cap-add" not in args
 
+    async def test_timeout_retried_once(self, monkeypatch):
+        """#3064: a create that stalls past its budget is killed and run
+        once more (idempotent via --replace) instead of cascading into
+        every downstream waiter."""
+        calls = []
+
+        async def fake_run(args, *, check=True, stdin_data=None, timeout=None):
+            calls.append(timeout)
+            if len(calls) == 1:
+                raise podman.PodmanError(
+                    500, "podman create timed out after 120.0s"
+                )
+            return 0, "abc\n", ""
+
+        monkeypatch.setattr(_p, "run", fake_run)
+        cid = await _p.create_container("n", "img")
+        assert cid == "abc"
+        assert len(calls) == 2
+        assert calls[0] == calls[1]  # retry gets the same budget
+
+    async def test_non_timeout_error_not_retried(self, monkeypatch):
+        """A real create failure (e.g. name in use) must raise, not retry
+        — only the stall-and-kill timeout shape is retryable."""
+        calls = []
+
+        async def fake_run(args, *, check=True, stdin_data=None, timeout=None):
+            calls.append(timeout)
+            raise podman.PodmanError(409, "name is already in use")
+
+        monkeypatch.setattr(_p, "run", fake_run)
+        with pytest.raises(podman.PodmanError):
+            await _p.create_container("n", "img")
+        assert len(calls) == 1
+
+
+class TestBringupTimeout:
+    """#3064: bring-up budgets double on CI (four E2E suites share one
+    VM; the local-dev default stays snappy). Same shape as #2745."""
+
+    def test_local_default(self, monkeypatch):
+        monkeypatch.delenv("CI", raising=False)
+        assert podman.bringup_timeout() == 120.0
+
+    def test_ci_doubles(self, monkeypatch):
+        monkeypatch.setenv("CI", "true")
+        assert podman.bringup_timeout() == 240.0
+
 
 class TestStartContainer:
     async def test_start(self):

--- a/src/klangk/klangkd-tests/tests/test_podman.py
+++ b/src/klangk/klangkd-tests/tests/test_podman.py
@@ -535,12 +535,13 @@ class TestCreateContainer:
         """#3064: a create that stalls past its budget is killed and run
         once more (idempotent via --replace) instead of cascading into
         every downstream waiter."""
+        monkeypatch.delenv("CI", raising=False)
         calls = []
 
         async def fake_run(args, *, check=True, stdin_data=None, timeout=None):
-            calls.append(timeout)
+            calls.append((args, timeout))
             if len(calls) == 1:
-                raise podman.PodmanError(
+                raise podman.PodmanTimeoutError(
                     500, "podman create timed out after 120.0s"
                 )
             return 0, "abc\n", ""
@@ -549,11 +550,27 @@ class TestCreateContainer:
         cid = await _p.create_container("n", "img")
         assert cid == "abc"
         assert len(calls) == 2
-        assert calls[0] == calls[1]  # retry gets the same budget
+        assert calls[0][1] == calls[1][1] == 120.0  # retry, same budget
+        assert "--replace" in calls[0][0]  # what makes the retry idempotent
+
+    async def test_timeout_without_replace_not_retried(self, monkeypatch):
+        """No --replace, no safe retry: the killed first attempt may have
+        left the name claimed, so the timeout must surface immediately."""
+        monkeypatch.delenv("CI", raising=False)
+
+        async def fake_run(args, *, check=True, stdin_data=None, timeout=None):
+            raise podman.PodmanTimeoutError(
+                500, "podman create timed out after 120.0s"
+            )
+
+        monkeypatch.setattr(_p, "run", fake_run)
+        with pytest.raises(podman.PodmanTimeoutError):
+            await _p.create_container("n", "img", replace=False)
 
     async def test_non_timeout_error_not_retried(self, monkeypatch):
         """A real create failure (e.g. name in use) must raise, not retry
         — only the stall-and-kill timeout shape is retryable."""
+        monkeypatch.delenv("CI", raising=False)
         calls = []
 
         async def fake_run(args, *, check=True, stdin_data=None, timeout=None):
@@ -561,9 +578,35 @@ class TestCreateContainer:
             raise podman.PodmanError(409, "name is already in use")
 
         monkeypatch.setattr(_p, "run", fake_run)
-        with pytest.raises(podman.PodmanError):
+        with pytest.raises(podman.PodmanError) as exc_info:
             await _p.create_container("n", "img")
+        assert not isinstance(exc_info.value, podman.PodmanTimeoutError)
         assert len(calls) == 1
+
+
+class TestRunTimeoutError:
+    async def test_checked_timeout_raises_timeout_error(self):
+        """#3064: on a checked run, a timeout raises PodmanTimeoutError —
+        the structural marker _run_create's retry branches on (a timed-out
+        create with partial stderr would lose a string-only marker)."""
+        mock_proc = _procs(("", "pulling layers...", 0))[0]
+        mock_proc.wait = AsyncMock(side_effect=[asyncio.TimeoutError, 0])
+        mock_proc.kill = MagicMock()
+
+        def side_effect(*args, **kwargs):
+            sf = kwargs.get("stdout")
+            ef = kwargs.get("stderr")
+            if hasattr(sf, "write"):
+                sf.write(b"")
+            if hasattr(ef, "write"):
+                ef.write(b"pulling layers...")
+            return mock_proc
+
+        with patch(EXEC, AsyncMock(side_effect=side_effect)):
+            with pytest.raises(podman.PodmanTimeoutError) as exc_info:
+                await _p.run(["create", "img"], timeout=0.001)
+        # Non-empty stderr survives as the message; the type is the marker.
+        assert "pulling layers" in exc_info.value.message
 
 
 class TestBringupTimeout:


### PR DESCRIPTION
Closes #3064.

Three entries carried over from the flakes omnibus (#2749):

**1. Sidecar/consent 60s class timeouts — CI-aware E2E budgets.** The
~60s-apart errors were the tests' own 60s client budgets, not
pytest-timeout (the 300s per-test stamp from #1594 already covers that).
The consent workspace fixture's create POST and the sidecar suite's two
raw `podman run` call sites now widen 60s → 240s on CI via a shared
`_e2e_env.ci_budget()` helper — the same load-aware shape as #2745's
frontend container-ready doubling. Local runs keep the snappier default.

**2. `podman create timed out after 120.0s` — kill-and-retry.** A create
that stalls past its budget under four-suite concurrency on the shared CI
VM used to 500 and cascade into every downstream waiter (start, WS
connect, teardown's `klangk rm`). `create_container` now routes through
`_run_create`: on a timeout-shaped `PodmanError` it retries once — the
stalled process was already killed by `_wait_podman`, and `--replace`
makes the retry idempotent. Non-timeout failures raise immediately.
`start_container`'s budget doubles on CI too (budget only, no retry —
start isn't idempotent the way `--replace` create is). Both via a new
`podman.bringup_timeout()` (120s local / 240s CI).

**3. TUI `WorkerCancelled` — route through `_settle`.** The
classification-banner test's two raw `await app.workers.wait_for_complete()`
calls raise on the *expected* exclusive-worker cancellation documented in
`_settle`'s docstring; both now use the tolerant retry helper.

Changelog: Fixed entry for the podman create retry + CI budgets (the
test-side changes are test churn, not operator-visible).
