### PR TITLE
Fix unsolved flakes: TUI rename race, PTY readiness budgets, tab-speed diagnostics (#3065)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -1953,6 +1953,13 @@ git-credential` (#1700).** `pig-latin` removed; `word-count` dormant.
   double to 240s and container-readiness widens 60→240s; the CLI's
   WS-connect wait is now overridable via `KLANGKC_WS_CONNECT_TIMEOUT`
   (the e2e suites set it to 240s on CI).
+- **Renaming a workspace no longer kicks the TUI detail screen back to the
+  list (#3065).** The `workspaces_changed` push fired by the rename can
+  reach the open detail screen before the edit form's save dismisses, so
+  the reload resolved the workspace by its old name, missed, and was
+  treated as a deletion — popping the form and the screen mid-rename. The
+  screen now re-resolves the workspace by id on a name miss, adopts the
+  new name, and stays mounted; only a genuinely deleted workspace pops.
 - **Terminal share/unshare/close no longer hang clients on refusal paths
   (#3057).** The WebSocket handlers for `share_window`, `unshare_window`,
   `join_shared_terminal`, and the own-window commands (`terminal_new_window`,

--- a/src/frontend/e2e-tests/e2e/helpers.ts
+++ b/src/frontend/e2e-tests/e2e/helpers.ts
@@ -418,6 +418,11 @@ export async function openWorkspace(
   // race where a separate waitForTerminalReady listener misses the frame.
   let resolveContainer: () => void;
   let resolveTerminal: (() => void) | null = null;
+  // #3065: latch the terminal frame. The terminal wait's budget starts
+  // when the container becomes ready (below), so a terminal_started
+  // frame that lands in the gap before that wait is armed must not be
+  // lost to a null resolveTerminal.
+  let terminalSeen = false;
   const secs = Math.round(containerTimeout / 1000);
   const containerPromise = new Promise<void>((resolve, reject) => {
     resolveContainer = resolve;
@@ -426,23 +431,38 @@ export async function openWorkspace(
       containerTimeout,
     );
   });
-  const terminalPromise = waitForTerminal
-    ? new Promise<void>((resolve, reject) => {
-        resolveTerminal = resolve;
-        setTimeout(
-          () =>
-            reject(new Error(`Terminal did not become ready within ${secs}s`)),
-          containerTimeout,
-        );
-      })
-    : Promise.resolve();
+  // #3065: the terminal phase gets its OWN full budget, counted from
+  // container_ready — not the container budget's remainder. Under CI's
+  // four-suite contention a container that comes up at, say, 200s left
+  // the terminal start (PTY bring-up) with a fraction of the budget and
+  // failed as "Terminal did not become ready within 240s" even though
+  // the terminal phase itself had barely started.
+  const terminalWait = waitForTerminal
+    ? () =>
+        new Promise<void>((resolve, reject) => {
+          if (terminalSeen) {
+            resolve();
+            return;
+          }
+          resolveTerminal = resolve;
+          setTimeout(
+            () =>
+              reject(
+                new Error(`Terminal did not become ready within ${secs}s`),
+              ),
+            containerTimeout,
+          );
+        })
+    : () => Promise.resolve();
 
   page.on("websocket", (ws: { on: Function }) => {
     ws.on("framereceived", (frame: { payload: string | Buffer }) => {
       const text = frame.payload.toString();
       if (text.includes("container_ready")) resolveContainer!();
-      if (resolveTerminal && text.includes("terminal_started"))
-        resolveTerminal();
+      if (text.includes("terminal_started")) {
+        terminalSeen = true;
+        if (resolveTerminal) resolveTerminal();
+      }
     });
   });
 
@@ -455,7 +475,7 @@ export async function openWorkspace(
   await page.goto(`/#/workspace/${workspaceId}`, { waitUntil: "load" });
   await waitForFlutter(page);
   await containerPromise;
-  await terminalPromise;
+  await terminalWait();
   await dismissAccessibility(page);
 }
 

--- a/src/frontend/e2e-tests/e2e/helpers.ts
+++ b/src/frontend/e2e-tests/e2e/helpers.ts
@@ -399,8 +399,9 @@ export async function createWorkspace(
  *  shared-home provisioning can exceed the old 120s — the failing test
  *  then burned its retry on the same starved bring-up. 120s stays the
  *  local-dev default via the explicit override; CI inherits the
- *  load-tolerant budget. */
-const CONTAINER_READY_TIMEOUT = process.env.CI ? 240_000 : 120_000;
+ *  load-tolerant budget. Exported so the parallel-WS specs reuse the
+ *  same family budget for their container/PTY phases (#3065). */
+export const CONTAINER_READY_TIMEOUT = process.env.CI ? 240_000 : 120_000;
 
 /** Open a workspace in the browser and wait for the container to be ready. */
 export async function openWorkspace(

--- a/src/frontend/e2e-tests/e2e/tab-speed.spec.ts
+++ b/src/frontend/e2e-tests/e2e/tab-speed.spec.ts
@@ -2,7 +2,10 @@ import { test, expect } from "@playwright/test";
 import WebSocket from "ws";
 import { createAndOpenWorkspace, API_BASE } from "./helpers";
 
-test("new terminal tab round-trip completes within 2 seconds", async ({
+// #3065: the title said "2 seconds" long after the assert moved to 10s
+// (#2649) — the mismatch misled flake triage into re-litigating the
+// budget instead of the real failure (readiness-hang in setup).
+test("new terminal tab round-trip completes within 10 seconds", async ({
   page,
   request,
 }) => {

--- a/src/frontend/e2e-tests/e2e/terminal-tabs.spec.ts
+++ b/src/frontend/e2e-tests/e2e/terminal-tabs.spec.ts
@@ -2,6 +2,17 @@ import { test, expect } from "@playwright/test";
 import WebSocket from "ws";
 import { createAndOpenWorkspace, API_BASE } from "./helpers";
 
+// #3065: CI-aware budget for the parallel-WS path's container and PTY
+// bring-up phases (connect handshake, container_ready waits,
+// terminal_start). They sat at a flat 60s while the page path already
+// doubles its readiness budget to 240s on CI (#2745) — under the
+// four-suite VM contention the WS path's budget blew first ("recv timed
+// out" / "connect timed out") and the retry only passed once the load
+// spike had passed. Post-readiness command round-trips (new window,
+// rename, close, list) keep the 60s default: they are cheap against an
+// already-running container.
+const CONTAINER_PHASE_TIMEOUT = process.env.CI ? 240_000 : 60_000;
+
 // Helper: open a parallel WebSocket, connect to the workspace, wait for
 // container_ready, then expose send/receive for window management commands.
 
@@ -90,7 +101,7 @@ async function connectToWorkspace(
     const timeout = setTimeout(() => {
       ws.close();
       reject(new Error("connect timed out"));
-    }, 60_000);
+    }, CONTAINER_PHASE_TIMEOUT);
 
     const client = new TerminalWsClient(ws);
 
@@ -106,7 +117,10 @@ async function connectToWorkspace(
     // Drive through the connection flow
     (async () => {
       // Wait for container_ready
-      await client.recvUntil((m) => m.type === "container_ready");
+      await client.recvUntil(
+        (m) => m.type === "container_ready",
+        CONTAINER_PHASE_TIMEOUT,
+      );
       // Send ui_ready
       client.send({ cmd: "ui_ready" });
       // Wait for container_ready
@@ -114,6 +128,7 @@ async function connectToWorkspace(
         (m) =>
           m.type === "event" &&
           (m.event as Record<string, unknown>)?.name === "container_ready",
+        CONTAINER_PHASE_TIMEOUT,
       );
       clearTimeout(timeout);
       resolve(client);
@@ -129,7 +144,12 @@ async function startTerminalAndGetWindows(
   client: TerminalWsClient,
 ): Promise<WindowInfo[]> {
   client.send({ cmd: "terminal_start", cols: 80, rows: 24 });
-  const msg = await client.recvUntil((m) => m.type === "terminal_windows");
+  // PTY bring-up in a just-started container: same CI contention
+  // family as the container phases (#3065).
+  const msg = await client.recvUntil(
+    (m) => m.type === "terminal_windows",
+    CONTAINER_PHASE_TIMEOUT,
+  );
   return msg.windows as WindowInfo[];
 }
 

--- a/src/frontend/e2e-tests/e2e/terminal-tabs.spec.ts
+++ b/src/frontend/e2e-tests/e2e/terminal-tabs.spec.ts
@@ -1,17 +1,20 @@
 import { test, expect } from "@playwright/test";
 import WebSocket from "ws";
-import { createAndOpenWorkspace, API_BASE } from "./helpers";
+import {
+  createAndOpenWorkspace,
+  API_BASE,
+  CONTAINER_READY_TIMEOUT,
+} from "./helpers";
 
-// #3065: CI-aware budget for the parallel-WS path's container and PTY
-// bring-up phases (connect handshake, container_ready waits,
-// terminal_start). They sat at a flat 60s while the page path already
-// doubles its readiness budget to 240s on CI (#2745) — under the
-// four-suite VM contention the WS path's budget blew first ("recv timed
-// out" / "connect timed out") and the retry only passed once the load
-// spike had passed. Post-readiness command round-trips (new window,
-// rename, close, list) keep the 60s default: they are cheap against an
+// #3065: the parallel-WS path's container and PTY bring-up phases (connect
+// handshake, container_ready waits, terminal_start) sat at a flat 60s while
+// the page path already carried the CI-aware readiness budget (#2745) —
+// under the four-suite VM contention the WS path's budget blew first
+// ("recv timed out" / "connect timed out") and the retry only passed once
+// the load spike had passed. They reuse the same exported family budget.
+// Post-readiness command round-trips (new window, rename, close, list)
+// keep the 60s recvUntil default: they are cheap against an
 // already-running container.
-const CONTAINER_PHASE_TIMEOUT = process.env.CI ? 240_000 : 60_000;
 
 // Helper: open a parallel WebSocket, connect to the workspace, wait for
 // container_ready, then expose send/receive for window management commands.
@@ -101,7 +104,7 @@ async function connectToWorkspace(
     const timeout = setTimeout(() => {
       ws.close();
       reject(new Error("connect timed out"));
-    }, CONTAINER_PHASE_TIMEOUT);
+    }, CONTAINER_READY_TIMEOUT);
 
     const client = new TerminalWsClient(ws);
 
@@ -119,7 +122,7 @@ async function connectToWorkspace(
       // Wait for container_ready
       await client.recvUntil(
         (m) => m.type === "container_ready",
-        CONTAINER_PHASE_TIMEOUT,
+        CONTAINER_READY_TIMEOUT,
       );
       // Send ui_ready
       client.send({ cmd: "ui_ready" });
@@ -128,7 +131,7 @@ async function connectToWorkspace(
         (m) =>
           m.type === "event" &&
           (m.event as Record<string, unknown>)?.name === "container_ready",
-        CONTAINER_PHASE_TIMEOUT,
+        CONTAINER_READY_TIMEOUT,
       );
       clearTimeout(timeout);
       resolve(client);
@@ -148,7 +151,7 @@ async function startTerminalAndGetWindows(
   // family as the container phases (#3065).
   const msg = await client.recvUntil(
     (m) => m.type === "terminal_windows",
-    CONTAINER_PHASE_TIMEOUT,
+    CONTAINER_READY_TIMEOUT,
   );
   return msg.windows as WindowInfo[];
 }

--- a/src/frontend/e2e-tests/playwright.config.ts
+++ b/src/frontend/e2e-tests/playwright.config.ts
@@ -49,7 +49,14 @@ const webkitUse = {
 
 export default defineConfig({
   testDir: "./e2e",
-  timeout: 300_000,
+  // #3065: on CI the test timeout must exceed the worst-case setup chain
+  // (register + workspace-create retries + login) PLUS the 240s
+  // container-readiness budget — otherwise a slow-but-succeeding setup
+  // pushes the readiness wait into the hard 300s kill, which surfaces as
+  // an opaque "Test timeout of 300000ms exceeded" instead of the
+  // diagnostic readiness rejection (and the burn wastes the retry budget
+  // on the same starved bring-up). Locally 300s stays plenty.
+  timeout: process.env.CI ? 480_000 : 300_000,
   retries: process.env.CI ? 1 : 0,
   workers: process.env.KLANGKBUILD_E2E_WORKERS
     ? /^\d+$/.test(process.env.KLANGKBUILD_E2E_WORKERS)

--- a/src/frontend/e2e-tests/playwright.config.ts
+++ b/src/frontend/e2e-tests/playwright.config.ts
@@ -49,14 +49,15 @@ const webkitUse = {
 
 export default defineConfig({
   testDir: "./e2e",
-  // #3065: on CI the test timeout must exceed the worst-case setup chain
-  // (register + workspace-create retries + login) PLUS the 240s
-  // container-readiness budget — otherwise a slow-but-succeeding setup
-  // pushes the readiness wait into the hard 300s kill, which surfaces as
-  // an opaque "Test timeout of 300000ms exceeded" instead of the
-  // diagnostic readiness rejection (and the burn wastes the retry budget
-  // on the same starved bring-up). Locally 300s stays plenty.
-  timeout: process.env.CI ? 480_000 : 300_000,
+  // #3065: on CI the test timeout must exceed the worst-case chain a
+  // waitForTerminal test can run: setup (register + workspace-create
+  // retries + login) + the 240s container-readiness budget + the
+  // terminal phase's own 240s (counted from container_ready, #3065) —
+  // otherwise the chain runs into the hard kill, which surfaces as an
+  // opaque "Test timeout exceeded" instead of the diagnostic readiness
+  // rejection (and the burn wastes the retry budget on the same starved
+  // bring-up). Locally 300s stays plenty.
+  timeout: process.env.CI ? 600_000 : 300_000,
   retries: process.env.CI ? 1 : 0,
   workers: process.env.KLANGKBUILD_E2E_WORKERS
     ? /^\d+$/.test(process.env.KLANGKBUILD_E2E_WORKERS)

--- a/src/klangk/klangk/cli/client.py
+++ b/src/klangk/klangk/cli/client.py
@@ -660,12 +660,28 @@ class KlangkClient:
 
         Raises WorkspaceNotFoundError if not found.
         """
+        return self._resolve_workspace(lambda w: w.name == name, name)
+
+    def find_workspace_by_id(self, ws_id: str) -> Workspace:
+        """Find a workspace by id (owned or shared).
+
+        Raises WorkspaceNotFoundError if not found. Lets the TUI tell a
+        rename from a deletion when a name-based resolve misses (#3065).
+        """
+        return self._resolve_workspace(lambda w: w.id == ws_id, ws_id)
+
+    def _resolve_workspace(self, matches, key: str) -> Workspace:
+        """Scan owned + shared workspaces for the first match.
+
+        Shared fetch/match shape of :meth:`resolve_workspace` and
+        :meth:`find_workspace_by_id`.
+        """
         all_ws = self.list_workspaces(
             all_pages=True
         ) + self.list_shared_workspaces(all_pages=True)
-        match = next((w for w in all_ws if w.name == name), None)
+        match = next((w for w in all_ws if matches(w)), None)
         if match is None:
-            raise WorkspaceNotFoundError(name)
+            raise WorkspaceNotFoundError(key)
         return match
 
     def delete_workspace(self, name: str) -> None:

--- a/src/klangk/klangk/cli/client.py
+++ b/src/klangk/klangk/cli/client.py
@@ -14,6 +14,7 @@ from pathlib import Path
 import re
 import select
 import socket
+from collections.abc import Callable
 import struct
 import sys
 import termios
@@ -670,7 +671,9 @@ class KlangkClient:
         """
         return self._resolve_workspace(lambda w: w.id == ws_id, ws_id)
 
-    def _resolve_workspace(self, matches, key: str) -> Workspace:
+    def _resolve_workspace(
+        self, matches: Callable[[Workspace], bool], key: str
+    ) -> Workspace:
         """Scan owned + shared workspaces for the first match.
 
         Shared fetch/match shape of :meth:`resolve_workspace` and

--- a/src/klangk/klangk/cli/tui/screens/workspace_detail.py
+++ b/src/klangk/klangk/cli/tui/screens/workspace_detail.py
@@ -772,25 +772,37 @@ class WorkspaceDetailScreen(StatusScreen):
         response travel different connections, with no ordering
         guarantee). Resolving by the old name then misses — which is
         indistinguishable from deletion until the workspace is
-        re-resolved by id. When it is found, adopt the current name,
-        reload, and refresh the workspace list. Returns False when the
-        workspace is truly gone (or the by-id lookup itself fails — keep
-        the screen mounted and let the next push decide), so the caller
-        pops.
+        re-resolved by id.
+
+        Returns True when the screen must stay mounted: the workspace
+        was found by id (adopt its current name, render it, refresh the
+        workspace list), or the by-id lookup itself failed — an expired
+        session surfaces the app-wide overlay (same posture as
+        ``_load``'s AuthError arm), and any other failure degrades to the
+        current display and lets the next push decide. Returns False only
+        for a workspace that is genuinely gone, so the caller pops.
         """
-        if not wid:
-            return False
         try:
             ws = await asyncio.to_thread(
                 self.app.tui_state.find_workspace_by_id, wid
             )
+        except WorkspaceNotFoundError:
+            # By id it is gone too — genuinely deleted.
+            return False
+        except AuthError:
+            self.app.session_expired()
+            return True
         except Exception as exc:  # noqa: BLE001 — a failed lookup is not deletion
             logger.warning("Rename recovery lookup failed: %s", exc)
-            return False
+            return True
+        # Adopt the freshly fetched object directly. Re-resolving by name
+        # would pay a third list fetch and re-open the exact race this
+        # recovers from (a second rename landing between the two).
+        self._ws = ws
         self._name = ws.name
-        await self._load()
-        if self._missing:
-            return False
+        self._missing = False
+        self._load_error = None
+        self.refresh_display()
         self.app.refresh_workspaces()
         return True
 

--- a/src/klangk/klangk/cli/tui/screens/workspace_detail.py
+++ b/src/klangk/klangk/cli/tui/screens/workspace_detail.py
@@ -748,8 +748,12 @@ class WorkspaceDetailScreen(StatusScreen):
         # SIGHUP-reloaded KLANGKD_CLASSIFICATION_BANNER re-marks here as
         # well, not just on fresh screen mounts (#2768 review).
         await self._refresh_deploy_banner()
+        # Capture the id before _load(): a miss clears _ws, and the
+        # rename recovery below needs the id to re-resolve under the
+        # workspace's current name (#3065).
+        wid = workspace_id_text(self._ws)
         await self._load()
-        if self._missing:
+        if self._missing and not await self.adopt_rename(wid):
             # The workspace was deleted out from under this screen. Pop any
             # modal sitting on top first (edit form / confirm dialog), then
             # self -- a bare pop_screen() would dismiss only the TOP screen,
@@ -758,6 +762,37 @@ class WorkspaceDetailScreen(StatusScreen):
             self.app.pop_above(self)
             if self.app.screen is self:
                 self.app.pop_screen()
+
+    async def adopt_rename(self, wid: str) -> bool:
+        """Recover when the old name missed because of a rename (#3065).
+
+        The PUT that renames a workspace broadcasts ``workspaces_changed``;
+        that push can reach this screen before the edit form's
+        save-and-dismiss adopts the new name (the broadcast and the PUT
+        response travel different connections, with no ordering
+        guarantee). Resolving by the old name then misses — which is
+        indistinguishable from deletion until the workspace is
+        re-resolved by id. When it is found, adopt the current name,
+        reload, and refresh the workspace list. Returns False when the
+        workspace is truly gone (or the by-id lookup itself fails — keep
+        the screen mounted and let the next push decide), so the caller
+        pops.
+        """
+        if not wid:
+            return False
+        try:
+            ws = await asyncio.to_thread(
+                self.app.tui_state.find_workspace_by_id, wid
+            )
+        except Exception as exc:  # noqa: BLE001 — a failed lookup is not deletion
+            logger.warning("Rename recovery lookup failed: %s", exc)
+            return False
+        self._name = ws.name
+        await self._load()
+        if self._missing:
+            return False
+        self.app.refresh_workspaces()
+        return True
 
     async def _reload_on_restart(self) -> None:
         """Full reload after a container start/restart (#1924).

--- a/src/klangk/klangk/cli/tui/state.py
+++ b/src/klangk/klangk/cli/tui/state.py
@@ -323,6 +323,14 @@ class TuiState:
     def find_workspace(self, name: str) -> Workspace:
         return self.client().resolve_workspace(name)
 
+    def find_workspace_by_id(self, ws_id: str) -> Workspace:
+        """Resolve a workspace by id (owned or shared).
+
+        The detail screen uses this to tell a rename from a deletion
+        when a name-based resolve misses (#3065).
+        """
+        return self.client().find_workspace_by_id(ws_id)
+
     def restart_workspace(self, name: str) -> None:
         self.client().restart_workspace(name)
 

--- a/src/klangk/klangkc-tests/tests/test_cli.py
+++ b/src/klangk/klangkc-tests/tests/test_cli.py
@@ -1203,6 +1203,24 @@ class TestKlangkClient:
             with pytest.raises(AuthError, match="Session expired"):
                 client.list_workspaces()
 
+    def test_find_workspace_by_id(self):
+        # #3065: id-based resolve (owned or shared) — the TUI's
+        # rename-vs-deletion recovery on a name miss.
+        client = KlangkClient("http://test:8995", "token")
+        mine = Workspace(id="ws-mine", name="alpha", created_at="x")
+        shared = Workspace(id="ws-shared", name="beta", created_at="x")
+        client.list_workspaces = MagicMock(return_value=[mine])
+        client.list_shared_workspaces = MagicMock(return_value=[shared])
+        assert client.find_workspace_by_id("ws-shared") is shared
+        assert client.find_workspace_by_id("ws-mine") is mine
+
+    def test_find_workspace_by_id_not_found(self):
+        client = KlangkClient("http://test:8995", "token")
+        client.list_workspaces = MagicMock(return_value=[])
+        client.list_shared_workspaces = MagicMock(return_value=[])
+        with pytest.raises(WorkspaceNotFoundError):
+            client.find_workspace_by_id("nope")
+
     def test_duplicate_workspace(self):
         client = KlangkClient("http://test:8995", "token")
         fake_ws = MagicMock(id="src-id")

--- a/src/klangk/klangkc-tests/tests/test_tui.py
+++ b/src/klangk/klangkc-tests/tests/test_tui.py
@@ -461,6 +461,19 @@ def test_current_url_none_when_unconfigured(redirect_xdg):
     assert t.is_authenticated() is False
 
 
+def test_state_find_workspace_by_id_delegates(monkeypatch):
+    """#3065: TuiState.find_workspace_by_id delegates to the client."""
+    from unittest.mock import MagicMock
+
+    t = TuiState()
+    sent = []
+    fake_client = MagicMock()
+    fake_client.find_workspace_by_id = lambda wid: sent.append(wid) or "WS"
+    monkeypatch.setattr(t, "client", lambda: fake_client)
+    assert t.find_workspace_by_id("wid-1") == "WS"
+    assert sent == ["wid-1"]
+
+
 def test_reentry_auth_persists(redirect_xdg):
     """Credentials survive TuiState re-creation (#1813)."""
     add_server_to_config("srv", "https://srv.example")
@@ -2801,6 +2814,31 @@ async def _settle(app):
         except (WorkerCancelled, WorkerFailed):
             continue
         break
+
+
+async def _quiesce(app, pilot):
+    """Drain the worker pool to true quiescence (#3065).
+
+    ``_settle`` gathers the workers present at call time and breaks after
+    one successful gather — a worker spawned at another worker's tail (the
+    post-edit reload chain: save → reload → list refresh) can already be
+    registered when that gather returns, yet never be awaited, leaving the
+    test to assert mid-flight. Re-gather until a gather finds the pool
+    empty, flush one message cycle, and confirm nothing spawned in it
+    (registration of a worker started from a message callback lands a tick
+    later). Same exclusive-cancellation tolerance as ``_settle``.
+    """
+    from textual.worker import WorkerCancelled, WorkerFailed
+
+    while True:
+        try:
+            await app.workers.wait_for_complete()
+        except (WorkerCancelled, WorkerFailed):
+            continue
+        if not len(app.workers):
+            await pilot.pause()
+            if not len(app.workers):
+                break
 
 
 async def _highlight_first(pilot, app, *, pane="#owned_list"):
@@ -8293,14 +8331,22 @@ async def test_detail_pops_when_workspace_deleted(monkeypatch):
             return a
         raise WorkspaceNotFoundError("gone")
 
+    def gone_by_id(wid):
+        raise WorkspaceNotFoundError(wid)
+
     st.find_workspace = find
+    st.find_workspace_by_id = gone_by_id
     app = KlangkApp(st)
     async with app.run_test() as pilot:
         app.push_screen(WorkspaceDetailScreen("alpha"))
         await pilot.pause()
         assert isinstance(app.screen, WorkspaceDetailScreen)
         app.screen.apply_status_event({"type": "workspaces_changed"})
-        await pilot.pause()
+        await _settle(app)
+        for _ in range(50):
+            if not isinstance(app.screen, WorkspaceDetailScreen):
+                break
+            await asyncio.sleep(0.02)
         assert isinstance(app.screen, MainScreen)  # popped back to the list
 
 
@@ -10969,42 +11015,49 @@ async def test_create_screen_tab_left_right_switches(monkeypatch):
 async def test_edit_rename_propagates_to_detail_and_list(monkeypatch):
     # #1778/#1768: renaming via the edit form must update the detail screen's
     # name (so it doesn't 404) and refresh the list (so the new name shows).
+    #
+    # #3065: the find stub is name-keyed, not a fixed pop queue. The flow
+    # legitimately issues several background loads (mount, the visit
+    # auto-start's post-restart reload, the post-edit reload), and a queue
+    # sized to an exact call count exhausts when worker starvation adds or
+    # delays a load — the flake: the extra lookup popped from an empty list
+    # and the assertion observed a stale, pre-rename resolution. Keying by
+    # name resolves any number of loads consistently, and _settle drains
+    # the reload spawned inside the save worker deterministically (a fixed
+    # pause count could observe it mid-flight under load).
     async def noop(*a, **k):
         return None
 
     monkeypatch.setattr(scr_main, "listen_for_status", noop)
     original = _wsobj("alpha", image="base", running=False)
     renamed = _wsobj("renamed", image="base")
-    # Three loads consume the list: mount, the visit auto-start's
-    # post-restart re-load (both resolve by "alpha"), and the
-    # post-edit reload (resolves by "renamed").
-    returns = [original, original, renamed]
     finds = []
+
+    def find(n):
+        finds.append(n)
+        return renamed if n == "renamed" else original
+
     st = _ws(
         list_images=lambda: {"default": "base", "allowed": ["base", "py:3"]},
         allow_autostart=lambda: True,
         update_workspace=lambda wid, **f: None,
     )
-    st.find_workspace = lambda n: finds.append(n) or returns.pop(0)
+    st.find_workspace = find
     app = KlangkApp(st)
     async with app.run_test() as pilot:
         app.push_screen(WorkspaceDetailScreen("alpha"))
         await pilot.pause()
         assert app.screen._name == "alpha"
         app.screen.action_edit()
-        await app.workers.wait_for_complete()
-        await pilot.pause()
+        await _quiesce(app, pilot)
         es = app.screen
         es.query_one("#name").value = "renamed"
         es.save()
-        await app.workers.wait_for_complete()
         # The post-edit reload worker is spawned from inside the save
-        # worker, so wait_for_complete above may return before it has
-        # finished its refresh+load hops — give it event-loop cycles
-        # before asserting (#2768 review: the reload now also re-fetches
-        # the deploy marking, one extra to_thread hop).
-        for _ in range(10):
-            await pilot.pause()
+        # worker (which itself spawns the banner refresh + a list refresh
+        # off-thread), so drain the whole worker pool to quiescence, not
+        # a fixed number of pauses.
+        await _quiesce(app, pilot)
         # back on detail; name adopted + reloaded by the new name
         assert isinstance(app.screen, WorkspaceDetailScreen)
         assert app.screen._name == "renamed"
@@ -13662,7 +13715,11 @@ async def test_detail_reload_on_status_pops_modal_above(monkeypatch):
         def gone(n):
             raise WorkspaceNotFoundError("gone")
 
+        def gone_by_id(wid):
+            raise WorkspaceNotFoundError(wid)
+
         st.find_workspace = gone
+        st.find_workspace_by_id = gone_by_id
         d.apply_status_event({"type": "workspaces_changed"})
         await app.workers.wait_for_complete()
         await pilot.pause()
@@ -14599,8 +14656,12 @@ class TestDetailScreenBranchGaps2834:
             async def _noop_load():
                 pass
 
+            def _gone(wid):
+                raise WorkspaceNotFoundError(wid)
+
             screen._load = _noop_load
             screen._refresh_deploy_banner = _noop_load
+            app.tui_state.find_workspace_by_id = _gone
             screen._missing = True
             await screen._reload_on_status()
             for _ in range(50):
@@ -14610,6 +14671,77 @@ class TestDetailScreenBranchGaps2834:
             # The modal above was popped along with the dead detail
             # screen: back on the list (never the orphaned modal).
             assert not isinstance(app.screen, ConfirmScreen)
+
+    async def test_reload_on_status_adopts_rename_and_keeps_modal(self):
+        # #3065: the workspaces_changed push fired by a rename PUT can
+        # land while the edit form is still on top (the broadcast and
+        # the PUT response travel different connections). The old-name
+        # resolve then misses — the screen must recover by id (adopt the
+        # new name, reload, refresh the list) instead of treating the
+        # miss as deletion and popping the form + itself.
+        renamed = _wsobj("renamed", running=True)
+        async with self._detail() as (app, screen):
+            from klangk.cli.tui.screens.base import ConfirmScreen
+
+            await _settle(app)
+            app.push_screen(ConfirmScreen("form?"))
+            await asyncio.sleep(0)
+
+            def renamed_only(n):
+                if n == "renamed":
+                    return renamed
+                raise WorkspaceNotFoundError(n)
+
+            app.tui_state.find_workspace = renamed_only
+            app.tui_state.find_workspace_by_id = lambda wid: renamed
+            screen.apply_status_event({"type": "workspaces_changed"})
+            await _settle(app)
+            # Renamed, not deleted: the screen adopted the new name and
+            # stayed mounted under the still-open form.
+            assert screen._name == "renamed"
+            assert screen._ws is renamed
+            assert isinstance(app.screen, ConfirmScreen)
+            assert screen in app.screen_stack
+
+    async def test_reload_on_status_adoption_still_missing_pops(self):
+        # The by-id recovery found the workspace, but the name resolve
+        # still missed after adoption — treat the screen as dead (#3065).
+        renamed = _wsobj("renamed", running=True)
+        async with self._detail() as (app, screen):
+            await _settle(app)
+
+            def never(n):
+                raise WorkspaceNotFoundError(n)
+
+            app.tui_state.find_workspace = never
+            app.tui_state.find_workspace_by_id = lambda wid: renamed
+            screen.apply_status_event({"type": "workspaces_changed"})
+            await _settle(app)
+            for _ in range(50):
+                if screen not in app.screen_stack:
+                    break
+                await asyncio.sleep(0.02)
+            assert screen not in app.screen_stack
+
+    async def test_reload_on_status_without_ws_pops(self):
+        # No workspace object was ever resolved: there is no id to
+        # recover by, so a missing screen pops (#3065 guard branch).
+        async with self._detail() as (app, screen):
+            await _settle(app)
+
+            async def _noop_load():
+                pass
+
+            screen._load = _noop_load
+            screen._refresh_deploy_banner = _noop_load
+            screen._ws = None
+            screen._missing = True
+            await screen._reload_on_status()
+            for _ in range(50):
+                if screen not in app.screen_stack:
+                    break
+                await asyncio.sleep(0.02)
+            assert screen not in app.screen_stack
 
     async def test_reload_on_restart_missing_skips_terminals(self):
         async with self._detail() as (app, screen):
@@ -14984,8 +15116,12 @@ class TestFinalBranchGaps2834:
                 async def _noop_load():
                     pass
 
+                def _gone(wid):
+                    raise WorkspaceNotFoundError(wid)
+
                 screen._load = _noop_load
                 screen._refresh_deploy_banner = _noop_load
+                app.tui_state.find_workspace_by_id = _gone
                 screen._missing = True
                 real_pop = app.pop_above
 

--- a/src/klangk/klangkc-tests/tests/test_tui.py
+++ b/src/klangk/klangkc-tests/tests/test_tui.py
@@ -2817,16 +2817,18 @@ async def _settle(app):
 
 
 async def _quiesce(app, pilot):
-    """Drain the worker pool to true quiescence (#3065).
+    """Drain the worker pool past tail-spawned workers (#3065).
 
     ``_settle`` gathers the workers present at call time and breaks after
     one successful gather — a worker spawned at another worker's tail (the
     post-edit reload chain: save → reload → list refresh) can already be
     registered when that gather returns, yet never be awaited, leaving the
     test to assert mid-flight. Re-gather until a gather finds the pool
-    empty, flush one message cycle, and confirm nothing spawned in it
-    (registration of a worker started from a message callback lands a tick
-    later). Same exclusive-cancellation tolerance as ``_settle``.
+    empty, flush one message cycle, and confirm nothing spawned in it —
+    which closes the one-message-hop deferred registration this flow
+    needs (deeper message→message→worker chains would need another hop,
+    but no such chain exists here). Same exclusive-cancellation tolerance
+    as ``_settle``.
     """
     from textual.worker import WorkerCancelled, WorkerFailed
 
@@ -14703,37 +14705,68 @@ class TestDetailScreenBranchGaps2834:
             assert isinstance(app.screen, ConfirmScreen)
             assert screen in app.screen_stack
 
-    async def test_reload_on_status_adoption_still_missing_pops(self):
-        # The by-id recovery found the workspace, but the name resolve
-        # still missed after adoption — treat the screen as dead (#3065).
-        renamed = _wsobj("renamed", running=True)
+    async def test_reload_on_status_adoption_lookup_failure_keeps_screen(
+        self,
+    ):
+        # The by-id lookup failing transiently (network blip) is NOT a
+        # deletion: keep the screen mounted and let the next push decide
+        # (#3065) — do not destroy the user's open form.
         async with self._detail() as (app, screen):
             await _settle(app)
 
-            def never(n):
+            def gone(n):
                 raise WorkspaceNotFoundError(n)
 
-            app.tui_state.find_workspace = never
-            app.tui_state.find_workspace_by_id = lambda wid: renamed
+            def net_down(wid):
+                raise RuntimeError("net down")
+
+            app.tui_state.find_workspace = gone
+            app.tui_state.find_workspace_by_id = net_down
             screen.apply_status_event({"type": "workspaces_changed"})
             await _settle(app)
-            for _ in range(50):
-                if screen not in app.screen_stack:
-                    break
+            for _ in range(10):
                 await asyncio.sleep(0.02)
-            assert screen not in app.screen_stack
+            assert screen in app.screen_stack
+
+    async def test_reload_on_status_adoption_auth_error_overlays(
+        self,
+    ):
+        # An expired session surfacing during recovery takes _load's
+        # AuthError posture: the app-wide overlay, screen stays mounted
+        # (#3065) — not the deletion pop.
+        async with self._detail() as (app, screen):
+            await _settle(app)
+
+            def gone(n):
+                raise WorkspaceNotFoundError(n)
+
+            def expired(wid):
+                raise AuthError("expired")
+
+            app.tui_state.find_workspace = gone
+            app.tui_state.find_workspace_by_id = expired
+            screen.apply_status_event({"type": "workspaces_changed"})
+            await _settle(app)
+            for _ in range(10):
+                await asyncio.sleep(0.02)
+            assert screen in app.screen_stack
+            assert isinstance(app.screen, SessionExpiredScreen)
 
     async def test_reload_on_status_without_ws_pops(self):
         # No workspace object was ever resolved: there is no id to
-        # recover by, so a missing screen pops (#3065 guard branch).
+        # recover by, so a missing screen pops (#3065).
         async with self._detail() as (app, screen):
             await _settle(app)
 
             async def _noop_load():
                 pass
 
+            def _gone(wid):
+                raise WorkspaceNotFoundError(wid)
+
             screen._load = _noop_load
             screen._refresh_deploy_banner = _noop_load
+            app.tui_state.find_workspace_by_id = _gone
             screen._ws = None
             screen._missing = True
             await screen._reload_on_status()


### PR DESCRIPTION
## Summary

Fixes the three still-open flake entries of #3065. Forensics on the original
CI run ([33119174910](https://github.com/mcdonc/klangk/actions/runs/33119174910/job/98681524924))
corrected one premise: the `tab-speed` first attempt never reached the
round-trip measurement — its "Round-trip: 3977ms" log was the *retry*; the
first attempt burned the whole 300s test timeout inside setup with no
diagnostic. All three entries share the four-suite VM contention family.

### 1. CLI TUI rename queue race (`test_edit_rename_propagates_to_detail_and_list`)

Two fixes, one product and one test:

- **Product — rename mistaken for deletion.** The `PUT` that renames a
  workspace broadcasts `workspaces_changed`; that push can reach the open
  detail screen *before* the edit form's save dismisses (broadcast and PUT
  response travel different connections, no ordering). The status reload then
  resolved the OLD name, missed, and followed the deletion path — popping the
  edit form and the detail screen out from under the user mid-rename. The
  screen now re-resolves the workspace **by id** on a name miss
  (`adopt_rename`), adopts the current name, reloads, and refreshes the list;
  only a genuinely deleted workspace (by-id miss too) pops. Adds
  `KlangkClient.find_workspace_by_id` (+ `TuiState` delegation), sharing the
  list-fetch shape with `resolve_workspace`.
- **Test — exactly-sized stub queue.** The `find_workspace` stub popped from
  a fixed-size queue; worker starvation adding or delaying a background load
  exhausted it ("pop from empty list") and the assertion observed a stale,
  pre-rename resolution. The stub is now **name-keyed** (any number of loads
  resolves consistently), and the fixed 10-pause wait is replaced by a
  worker-pool **quiesce drain** (`_quiesce`: `_settle` breaks after one
  successful gather, which can return while the tail-spawned reload worker is
  already registered but unawaited).

### 2. Frontend E2E PTY readiness (`Terminal did not become ready within 240s` / `recv timed out`)

- **Conflated budget, page path** (`helpers.ts`): the `terminal_started` wait
  shared the container budget's clock — a container that came up late in the
  240s window left PTY bring-up a fraction of it. The terminal phase now gets
  its own full budget counted **from `container_ready`**, with a frame latch
  so a `terminal_started` frame landing in the arming gap isn't lost.
- **Left-behind 60s budgets, parallel-WS path** (`terminal-tabs.spec.ts`):
  the connect handshake, `container_ready` waits, and `terminal_start` sat at
  a flat 60s while the page path already doubled to 240s on CI (#2745) — the
  WS path's budget blew first. They now use the same CI-aware 240s
  (`CONTAINER_PHASE_TIMEOUT`); post-readiness command round-trips keep 60s.

### 3. `tab-speed` 300s opaque kill

- The first attempt died at the hard 300s Playwright kill inside its
  bounded-but-cumulative setup chain (register/create retries + login) with
  no error surfaced, then the warm retry passed. The CI test timeout rises
  to **480s** so the 240s readiness budgets reject *diagnostically* before
  the hard kill (local stays 300s).
- The spec title said "2 seconds" long after the assert moved to 10s
  (#2649) — renamed to match; the stale number misled triage into
  re-litigating the budget instead of the real failure.

## Testing

- Full two-suite run the CI way: 6624 passed, 100% branch coverage.
- The rename test ×12 under deliberate 72-core CPU spin load: stable.
- `npx playwright test --list` transpiles all 199 specs; no Dart changes.
- test-push gate green (testmon + flutter unit).

Fixes #3065
