### PR TITLE
Fix session orphan race in add_subscriber (#3070)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -1960,6 +1960,17 @@ git-credential` (#1700).** `pig-latin` removed; `word-count` dormant.
   treated as a deletion — popping the form and the screen mid-rename. The
   screen now re-resolves the workspace by id on a name miss, adopts the
   new name, and stays mounted; only a genuinely deleted workspace pops.
+- **Connects can no longer attach to a torn-down workspace session
+  (#3070).** A WebSocket connect that raced the last member's
+  disconnect could attach to a session already removed from the
+  connection registry: the new member then silently missed every
+  workspace broadcast (terminal tabs, shared terminals, lifecycle
+  events) until reconnecting, and the orphaned session's background
+  token-renewal task and window watcher leaked for the life of the
+  process. The registry mapping is now re-verified under the session
+  lock on attach: a popped-but-unsuperseded session reclaims its slot,
+  and one that a newer session replaced routes the subscriber to the
+  replacement.
 - **Terminal share/unshare/close no longer hang clients on refusal paths
   (#3057).** The WebSocket handlers for `share_window`, `unshare_window`,
   `join_shared_terminal`, and the own-window commands (`terminal_new_window`,

--- a/src/klangk/klangk/wshandler/session.py
+++ b/src/klangk/klangk/wshandler/session.py
@@ -356,6 +356,12 @@ class WorkspaceSession:
         yet, ``start_token_renewal`` is called under the session lock so
         two concurrent callers cannot both observe ``expiry is None``
         and create duplicate renewal tasks.
+
+        Side effect callers must know about: on the reclaim path this
+        method re-registers the session into ``sockets.sessions``
+        itself, so callers must have resolved the session through
+        ``get_or_create_session`` (never a bare constructor) for the
+        registry to stay consistent.
         """
         async with self.lock:
             target = self._mapping_target()
@@ -902,7 +908,18 @@ class WebSocketState:
             await session.reset()
 
     async def remove_session_locked(self, session: WorkspaceSession) -> None:
-        """Remove session when caller already holds ``session.lock``."""
+        """Remove session when caller already holds ``session.lock``.
+
+        Same guards as :meth:`remove_session`: a session with remaining
+        subscribers is left in place, and a mapping that has moved on to
+        another session owns its own lifecycle (#3070) — a caller holding
+        a *stale* session's lock must not pop the replacement's slot and
+        reset it, reintroducing the orphan this file guards against.
+        """
+        if session.subscribers:
+            return
+        if self.sessions.get(session.workspace_id) is not session:
+            return
         self.sessions.pop(session.workspace_id, None)
         await session.reset()
 

--- a/src/klangk/klangk/wshandler/session.py
+++ b/src/klangk/klangk/wshandler/session.py
@@ -340,20 +340,69 @@ class WorkspaceSession:
     ) -> None:
         """Register a connection as a subscriber (acquires lock).
 
+        #3070: the caller resolves this session via
+        ``get_or_create_session`` without a lock, so a last-disconnect
+        ``remove_session`` may pop and ``reset()`` it in the gap before
+        this lock acquisition. Under the lock the registry mapping is
+        re-verified (:meth:`_mapping_target`): a popped session with no
+        replacement reclaims its slot, and a session a replacement has
+        superseded routes the subscriber to the replacement instead —
+        attaching to a superseded session would orphan the subscriber
+        (every later ``get_session`` resolves a different session, so
+        workspace broadcasts are missed) and leak the orphan's
+        token-renewal task and window watcher for the process life.
+
         When *token_expiry* is provided and no renewal loop is running
         yet, ``start_token_renewal`` is called under the session lock so
         two concurrent callers cannot both observe ``expiry is None``
         and create duplicate renewal tasks.
         """
         async with self.lock:
-            self.container_id = container_id
-            self.subscribers.add(sock)
-            if (
-                token_expiry is not None
-                and self.workspace_token_expiry is None
-            ):
-                self.start_token_renewal(token_expiry)
-            self.start_window_sync()
+            target = self._mapping_target()
+            if target is self:
+                self.container_id = container_id
+                self.subscribers.add(sock)
+                if (
+                    token_expiry is not None
+                    and self.workspace_token_expiry is None
+                ):
+                    self.start_token_renewal(token_expiry)
+                self.start_window_sync()
+                return
+        # Superseded while the caller held its reference (#3070): our
+        # lock is released; attach on the mapped session, which
+        # re-verifies its own mapping under its own lock.
+        await target.add_subscriber(
+            sock, container_id, token_expiry=token_expiry
+        )
+
+    def _mapping_target(self) -> "WorkspaceSession":
+        """Under the session lock: the session a new subscriber joins.
+
+        The #3070 re-verification of the ``sockets.sessions`` mapping,
+        with no await between the read and the write below (atomic in
+        the event loop):
+
+        - ``self`` when already mapped, when registry-less
+          (``app=None`` test sessions), or after reclaiming a slot that
+          a racing last-disconnect ``remove_session`` popped while no
+          replacement was created in the gap — the session was already
+          ``reset()`` under that lock, so it is empty and fresh for the
+          new subscriber, and its disconnect cleanup finds it via the
+          mapping again.
+        - the mapped replacement when another session owns the slot:
+          the caller's reference is stale and must not be attached to.
+        """
+        if self.app is None:
+            return self
+        sessions = self.app.state.sockets.sessions
+        mapped = sessions.get(self.workspace_id)
+        if mapped is None:
+            sessions[self.workspace_id] = self
+            return self
+        if mapped is self:
+            return self
+        return mapped
 
     async def remove_subscriber(self, sock: SafeWebSocket) -> bool:
         """Unregister a connection (acquires lock).
@@ -840,6 +889,14 @@ class WebSocketState:
         async with session.lock:
             # Re-check: someone may have added a subscriber while we waited.
             if session.subscribers:
+                return
+            # #3070: the mapping may have moved while we waited for this
+            # lock — the session we resolved may have been popped, its
+            # slot reclaimed or replaced by another. Only the mapped
+            # session's own teardown pops; a moved-on mapping owns its
+            # lifecycle (the stale session was already reset by whoever
+            # popped it).
+            if self.sessions.get(workspace_id) is not session:
                 return
             self.sessions.pop(workspace_id, None)
             await session.reset()

--- a/src/klangk/klangkd-tests/tests/test_wshandler.py
+++ b/src/klangk/klangkd-tests/tests/test_wshandler.py
@@ -5821,6 +5821,104 @@ class TestCleanupSubscriberRace:
         sockets.sessions.pop("ws-conc", None)
 
 
+class TestSessionOrphanRace:
+    """#3070: ``add_subscriber`` must never attach to a session that a
+    racing last-disconnect ``remove_session`` already popped from the
+    registry — such a subscriber misses every later workspace broadcast
+    (``get_session`` resolves a different session) and the orphan's
+    token-renewal task and window watcher leak for the process life."""
+
+    async def test_popped_session_reclaims_its_slot(self, app_state):
+        """The #3070 interleaving: connection B resolves the session,
+        then A's last-disconnect ``remove_subscriber`` +
+        ``remove_session`` run to completion (pop + reset) before B's
+        ``add_subscriber`` acquires the lock — B's session reclaims the
+        empty slot instead of taking B as an orphan subscriber."""
+        app_state = _make_app_state()
+        sockets = app_state.state.sockets
+        sock_a = _mock_sock()
+        session = sockets.get_or_create_session("ws-3070-reclaim", app_state)
+        with patch.object(
+            WorkspaceSession, "start_window_sync", lambda s: None
+        ):
+            await session.add_subscriber(sock_a, "cid")
+
+            # Connection A (last disconnect) runs to completion.
+            assert await session.remove_subscriber(sock_a) is True
+            await sockets.remove_session("ws-3070-reclaim")
+            assert "ws-3070-reclaim" not in sockets.sessions
+
+            # Connection B's add finally acquires the lock.
+            sock_b = _mock_sock()
+            await session.add_subscriber(sock_b, "cid")
+
+        assert sockets.sessions["ws-3070-reclaim"] is session
+        assert sock_b in session.subscribers
+
+        # And B's own disconnect still finds the mapped session and
+        # tears it down — pre-fix, cleanup resolved nothing, so the
+        # orphan's token-renewal task and window watcher leaked.
+        assert await session.remove_subscriber(sock_b) is True
+        await sockets.remove_session("ws-3070-reclaim")
+        assert "ws-3070-reclaim" not in sockets.sessions
+
+    async def test_superseded_session_routes_to_replacement(self, app_state):
+        """When a replacement session was created in the pop→add gap,
+        the stale reference must not attach: the subscriber is routed
+        to the mapped replacement instead."""
+        app_state = _make_app_state()
+        sockets = app_state.state.sockets
+        session = sockets.get_or_create_session("ws-3070-swap", app_state)
+        # The racing last-disconnect pop, then a replacement connection
+        # creating a fresh session before B's add runs.
+        sockets.sessions.pop("ws-3070-swap")
+        await session.reset()
+        replacement = sockets.get_or_create_session("ws-3070-swap", app_state)
+
+        sock = _mock_sock()
+        with patch.object(
+            WorkspaceSession, "start_window_sync", lambda s: None
+        ):
+            await session.add_subscriber(sock, "cid")
+
+        assert sock not in session.subscribers
+        assert sock in replacement.subscribers
+        assert sockets.sessions["ws-3070-swap"] is replacement
+
+    async def test_registryless_session_attaches_directly(self, app_state):
+        """A bare session (``app=None``, no registry to verify against)
+        keeps the direct attach."""
+        sock = _mock_sock()
+        session = WorkspaceSession("ws-3070-noapp")
+        with patch.object(
+            WorkspaceSession, "start_window_sync", lambda s: None
+        ):
+            await session.add_subscriber(sock, "cid")
+        assert sock in session.subscribers
+
+    async def test_remove_session_skips_moved_on_mapping(self, app_state):
+        """#3070: when the mapping moves while ``remove_session`` waits
+        for the lock, the mapped replacement owns its lifecycle — the
+        stale remover must not pop or reset it."""
+        app_state = _make_app_state()
+        sockets = app_state.state.sockets
+        session = sockets.get_or_create_session("ws-3070-moved", app_state)
+
+        with patch.object(WorkspaceSession, "reset", new_callable=AsyncMock):
+            async with session.lock:
+                remover = asyncio.create_task(
+                    sockets.remove_session("ws-3070-moved")
+                )
+                await asyncio.sleep(0)  # remover queues on the lock
+                # The slot moves while it waits (reclaimed/replaced).
+                replacement = WorkspaceSession("ws-3070-moved", app_state)
+                sockets.sessions["ws-3070-moved"] = replacement
+            await remover
+
+            assert sockets.sessions["ws-3070-moved"] is replacement
+            WorkspaceSession.reset.assert_not_awaited()
+
+
 class TestWsDebugLogging:
     async def test_recv_logged_when_debug(self, user, monkeypatch, app_state):
         app_state = _make_app_state()

--- a/src/klangk/klangkd-tests/tests/test_wshandler.py
+++ b/src/klangk/klangkd-tests/tests/test_wshandler.py
@@ -5725,6 +5725,37 @@ class TestRemoveSessionLocked:
         finally:
             sockets.sessions.pop("ws-locked-rm", None)
 
+    async def test_keeps_session_with_subscribers(self, app_state):
+        """The locked variant re-checks subscribers too (#3070): a
+        session someone re-attached to under the lock is not popped."""
+        app_state = _make_app_state()
+        sockets = app_state.state.sockets
+        session = sockets.get_or_create_session("ws-locked-sub", app_state)
+        try:
+            async with session.lock:
+                session.subscribers.add(_mock_sock())
+                await sockets.remove_session_locked(session)
+            assert "ws-locked-sub" in sockets.sessions
+        finally:
+            session.subscribers.clear()
+            sockets.sessions.pop("ws-locked-sub", None)
+
+    async def test_skips_moved_on_mapping(self, app_state):
+        """The locked variant re-checks mapping identity too (#3070): a
+        caller holding a stale session's lock must not pop the slot a
+        replacement session now owns."""
+        app_state = _make_app_state()
+        sockets = app_state.state.sockets
+        session = sockets.get_or_create_session("ws-locked-moved", app_state)
+        replacement = WorkspaceSession("ws-locked-moved", app_state)
+        try:
+            async with session.lock:
+                sockets.sessions["ws-locked-moved"] = replacement
+                await sockets.remove_session_locked(session)
+            assert sockets.sessions["ws-locked-moved"] is replacement
+        finally:
+            sockets.sessions.pop("ws-locked-moved", None)
+
 
 class TestGetOrCreateSessionAtomicity:
     async def test_returns_same_session_for_same_workspace(self, app_state):
@@ -5848,12 +5879,18 @@ class TestSessionOrphanRace:
             await sockets.remove_session("ws-3070-reclaim")
             assert "ws-3070-reclaim" not in sockets.sessions
 
-            # Connection B's add finally acquires the lock.
+            # Connection B's add finally acquires the lock — with a
+            # token expiry, so the reclaimed session re-arms renewal.
             sock_b = _mock_sock()
-            await session.add_subscriber(sock_b, "cid")
+            expiry = datetime.now(timezone.utc) + timedelta(hours=12)
+            await session.add_subscriber(sock_b, "cid", token_expiry=expiry)
 
         assert sockets.sessions["ws-3070-reclaim"] is session
         assert sock_b in session.subscribers
+        # The leak property: renewal re-established on the reclaimed
+        # session, then torn down (task cancelled and cleared) by B's
+        # own disconnect — pre-fix the orphan's task ran forever.
+        assert session._token_renewal_task is not None
 
         # And B's own disconnect still finds the mapped session and
         # tears it down — pre-fix, cleanup resolved nothing, so the
@@ -5861,6 +5898,38 @@ class TestSessionOrphanRace:
         assert await session.remove_subscriber(sock_b) is True
         await sockets.remove_session("ws-3070-reclaim")
         assert "ws-3070-reclaim" not in sockets.sessions
+        assert session._token_renewal_task is None
+
+    async def test_reclaim_restarts_window_watcher(self, app_state):
+        """A reclaimed session is fresh for the watcher logic: reset()
+        stopped the old watcher, so the re-attached subscriber's
+        add_subscriber builds a new one instead of reusing the dead
+        field (the #3015 path reads ``_window_watcher is None``)."""
+        app_state = _make_app_state()
+        sockets = app_state.state.sockets
+        sock_a, sock_b = _mock_sock(), _mock_sock()
+        session = sockets.get_or_create_session("ws-3070-watch", app_state)
+        with patch("klangk.wshandler.session.WindowEventWatcher") as wc:
+            wc.return_value.start = AsyncMock()
+            wc.return_value.stop = AsyncMock()
+
+            await session.add_subscriber(sock_a, "cid")  # watcher #1
+            assert await session.remove_subscriber(sock_a) is True
+            await sockets.remove_session("ws-3070-watch")  # pop + reset
+
+            await session.add_subscriber(sock_b, "cid")  # reclaim
+
+            # A fresh watcher was built for the reclaimed session.
+            assert wc.call_count == 2
+            assert session._window_watcher is wc.return_value
+
+            # Final teardown stops it and leaves no watcher behind.
+            assert await session.remove_subscriber(sock_b) is True
+            await sockets.remove_session("ws-3070-watch")
+            for _ in range(3):
+                await asyncio.sleep(0)  # drain the spawned stop task
+            assert session._window_watcher is None
+            assert wc.return_value.stop.await_count == 2
 
     async def test_superseded_session_routes_to_replacement(self, app_state):
         """When a replacement session was created in the pop→add gap,


### PR DESCRIPTION
## Summary

Fixes the #3070 session orphan race found in the wshandler bug sweep (#3069).

A connecting WebSocket resolves the workspace session via `get_or_create_session` (no lock). A last-disconnect cleanup can then run `remove_subscriber` → `remove_session` (pop from `sockets.sessions` + `reset()`) in the gap before the connector's `add_subscriber` acquires the session lock — leaving the new subscriber attached to a session no longer in the registry. Consequences: the subscriber misses every later workspace broadcast (`terminal_windows`, `shared_terminals`, lifecycle events) because `get_session` resolves a different (new) session; on disconnect its cleanup resolves the *new* session, so the orphan is never removed and its token-renewal task + window watcher leak for the process life.

## Fix

- **`WorkspaceSession.add_subscriber`** now re-verifies the registry mapping under the session lock via a new `_mapping_target` helper:
  - still mapped → attach as before;
  - popped with no replacement → the session reclaims its empty slot (it was already `reset()` under that lock, so it is fresh; disconnect cleanup finds it via the mapping again);
  - superseded by a replacement → the subscriber is routed to the mapped replacement, after releasing the stale session's lock (no nested session locks, no deadlock cycle — removal paths take only one session lock).
- **`WebSocketState.remove_session`** additionally re-checks mapping identity after acquiring the lock, so a remover that resolved a stale session cannot pop or reset a mapping that has moved on (that mapping owns its lifecycle).

## Tests

New `TestSessionOrphanRace` class in `test_wshandler.py`:

- the full interleaving (last-disconnect completes before the connector's add) → slot reclaimed, subscriber on the mapped session, and its later disconnect tears it down (the pre-fix leak);
- superseded session routes the subscriber to the replacement;
- registry-less (`app=None`) session keeps the direct attach;
- `remove_session` skips a mapping that moved while it waited for the lock.

Full Python suite the CI way: 6622 passed, 100% branch coverage held; xenon gate passed.
