### PR TITLE
Fix wshandler ssh-agent relay leak, sidecar deregister race, decider timing marks (#3069)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -1981,6 +1981,14 @@ git-credential` (#1700).** `pig-latin` removed; `word-count` dormant.
   lock on attach: a popped-but-unsuperseded session reclaims its slot,
   and one that a newer session replaced routes the subscriber to the
   replacement.
+- **SSH-agent relay and sidecar reconnect robustness (#3069).** The
+  SSH-agent output relay no longer kills the whole WebSocket when the
+  client falls behind (its `SlowClientError` is now swallowed like other
+  socket errors, and a failed relay task can no longer leak its exception
+  through disconnect cleanup, which also skipped removing the connection
+  from the registry). A reconnecting egress sidecar's registration is now
+  identity-guarded, so the stale socket's teardown can no longer drop the
+  replacement's registration and leave egress revocations unenforced.
 - **Terminal share/unshare/close no longer hang clients on refusal paths
   (#3057).** The WebSocket handlers for `share_window`, `unshare_window`,
   `join_shared_terminal`, and the own-window commands (`terminal_new_window`,

--- a/src/klangk/klangk/sidecar_connections.py
+++ b/src/klangk/klangk/sidecar_connections.py
@@ -86,7 +86,9 @@ class SidecarConnections:
         socket under the same workspace id; the stale socket's teardown must
         leave the replacement's registration alone — otherwise every later
         ``send_drop`` finds "no sidecar" and revocations proceed unenforced
-        while a live sidecar is connected.
+        while a live sidecar is connected. A pending drop-ack enqueued over
+        the stale socket is no longer failed here either; the revoke
+        caller's timeout (see ``send_drop``) is the fail-closed backstop.
         """
         registered = self._conns.get(workspace_id)
         if registered is not None and registered is not sock:

--- a/src/klangk/klangk/sidecar_connections.py
+++ b/src/klangk/klangk/sidecar_connections.py
@@ -43,7 +43,10 @@ class SidecarConnections:
     def register(self, workspace_id: str, sock) -> None:
         """Record a sidecar's live socket (on /ws/egress-sidecar connect).
 
-        Re-registers if the sidecar reconnects (drops the stale socket).
+        Re-registers if the sidecar reconnects: the workspace's entry is
+        repointed at the fresh socket, and the stale socket's later
+        ``deregister`` is identity-guarded (see below) so it cannot drop
+        the replacement's registration (#3069).
         """
         self._conns[workspace_id] = sock
         logger.info(
@@ -75,11 +78,22 @@ class SidecarConnections:
             self._fail_ack(self._pending.pop(aid, None))
         return stale
 
-    def deregister(self, workspace_id: str) -> None:
-        """Drop a sidecar socket (disconnect) + fail its pending drop-acks."""
-        self._conns.pop(workspace_id, None)
+    def deregister(self, workspace_id: str, sock) -> None:
+        """Drop a sidecar socket (disconnect) + fail its pending drop-acks.
+
+        Identity-guarded (#3069): only the socket that currently owns the
+        workspace's registration may drop it. A reconnect registers a fresh
+        socket under the same workspace id; the stale socket's teardown must
+        leave the replacement's registration alone — otherwise every later
+        ``send_drop`` finds "no sidecar" and revocations proceed unenforced
+        while a live sidecar is connected.
+        """
+        registered = self._conns.get(workspace_id)
+        if registered is not None and registered is not sock:
+            return  # a newer socket owns the registration now
+        dropped = self._conns.pop(workspace_id, None) is not None
         stale = self._fail_pending_acks(workspace_id)
-        if stale or workspace_id in self._conns:
+        if dropped or stale:
             logger.info(
                 "sidecar connection deregistered: ws=%s", str(workspace_id)[:8]
             )

--- a/src/klangk/klangk/wshandler/connection.py
+++ b/src/klangk/klangk/wshandler/connection.py
@@ -747,9 +747,7 @@ class Connection:
         self.app.state.container_registry.revoke_browser(self.sock)
         self.browser_id = None
 
-        await self.stop_terminal()
-        await self.stop_exec()
-        await self._stop_ssh_agent()
+        await self._teardown_sessions_safely()
 
         # Remove this connection from the workspace session's subscriber sets.
         # If no subscribers remain, remove the session entirely. The container
@@ -765,6 +763,20 @@ class Connection:
                 # Lock is released by remove_subscriber, so use the
                 # lock-acquiring version.
                 await self.app.state.sockets.remove_session(workspace_id)
+
+    async def _teardown_sessions_safely(self) -> None:
+        """Stop terminal/exec/ssh-agent, each guarded (#3069).
+
+        One stop failing must neither skip the others nor the session
+        bookkeeping after them — pre-#3069 a raise here stranded the
+        socket in ``session.subscribers`` forever. Each failure is
+        logged; cancellation (CancelledError) still propagates.
+        """
+        for stop in (self.stop_terminal, self.stop_exec, self._stop_ssh_agent):
+            try:
+                await stop()
+            except Exception:
+                logger.exception("Cleanup step %s failed", stop.__name__)
 
     def _remove_idle_callback(self, workspace_id) -> None:
         """Drop this connection's idle callback, if armed."""

--- a/src/klangk/klangk/wshandler/controllers.py
+++ b/src/klangk/klangk/wshandler/controllers.py
@@ -295,7 +295,14 @@ class SshAgentForwarder:
             await self._relay_stream(proc.stdout)
         except asyncio.CancelledError:
             logger.debug("SSH agent output relay cancelled")
-        except OSError as e:
+        except WS_ERRORS as e:
+            # #3069: WS_ERRORS includes SlowClientError — a client that
+            # stops reading its agent relay must end the relay task
+            # quietly (it also covers OSError/ConnectionError from a dead
+            # socat). Unhandled, the task completes with the exception
+            # and it resurfaces from ``_cancel_task``'s ``await self.task``
+            # through ``stop()``/``Connection.cleanup``, dropping the whole
+            # WebSocket (and skipping the handler's connections.pop).
             logger.warning("SSH agent output relay error: %s", e)
 
     async def _relay_stream(self, stdout) -> None:
@@ -353,6 +360,11 @@ class SshAgentForwarder:
             await self.task
         except asyncio.CancelledError:
             pass
+        except Exception:
+            # #3069: a task that already completed with an exception must
+            # not leak it through stop()/cleanup() — same shape as
+            # SafeWebSocket.stop_sender's await.
+            logger.exception("SSH agent relay task failed")
         self.task = None
 
     async def _kill_proc(self) -> None:

--- a/src/klangk/klangk/wshandler/decider.py
+++ b/src/klangk/klangk/wshandler/decider.py
@@ -87,8 +87,17 @@ async def _refuse(
     await websocket.close(code=code, reason=reason)
 
 
+def _no_hs_mark(label: str) -> None:
+    """Default no-op handshake mark (direct callers/tests).
+
+    #3069: the real per-step marks are recorded inside
+    ``_refuse_invalid_handshake`` so each label measures its own step; a
+    no-op default keeps the helper callable without a marker.
+    """
+
+
 async def _refuse_invalid_handshake(
-    websocket: WebSocket, app, workspace: str, user: dict
+    websocket: WebSocket, app, workspace: str, user: dict, hs_mark=_no_hs_mark
 ) -> bool:
     """Authorization + static-mode gate for a consent decider.
 
@@ -117,10 +126,12 @@ async def _refuse_invalid_handshake(
     allowed = await app.state.acl.check_permission(
         f"/workspaces/{workspace}", principals, "egress-consent"
     )
+    hs_mark("authz")
     if not allowed:
         await _refuse(websocket, 4003, "Forbidden", user.get("email"))
         return True
     ws = await app.state.model.workspaces.get_workspace(workspace)
+    hs_mark("workspace")
     if ws is None:
         # Vanished between the authz check and now (a delete race) -- the
         # workspace authz just passed against can no longer be registered.
@@ -339,10 +350,10 @@ async def handle_consent_decider(websocket: WebSocket, app) -> None:
         )
         return
 
-    if await _refuse_invalid_handshake(websocket, app, workspace, user):
+    if await _refuse_invalid_handshake(
+        websocket, app, workspace, user, hs_mark=_hs_mark
+    ):
         return
-    _hs_mark("authz")
-    _hs_mark("workspace")
     await websocket.accept()
     _hs_mark("accept")
     _log_handshake_timing(_hs_t0, _hs_marks)

--- a/src/klangk/klangk/wshandler/decider.py
+++ b/src/klangk/klangk/wshandler/decider.py
@@ -87,17 +87,8 @@ async def _refuse(
     await websocket.close(code=code, reason=reason)
 
 
-def _no_hs_mark(label: str) -> None:
-    """Default no-op handshake mark (direct callers/tests).
-
-    #3069: the real per-step marks are recorded inside
-    ``_refuse_invalid_handshake`` so each label measures its own step; a
-    no-op default keeps the helper callable without a marker.
-    """
-
-
 async def _refuse_invalid_handshake(
-    websocket: WebSocket, app, workspace: str, user: dict, hs_mark=_no_hs_mark
+    websocket: WebSocket, app, workspace: str, user: dict, *, hs_mark
 ) -> bool:
     """Authorization + static-mode gate for a consent decider.
 

--- a/src/klangk/klangk/wshandler/dispatch.py
+++ b/src/klangk/klangk/wshandler/dispatch.py
@@ -176,7 +176,13 @@ async def handle_websocket(websocket: WebSocket, app) -> None:
         await _run_websocket_session(conn, safe_ws, user, app)
     finally:
         await safe_ws.stop_sender()
-        await conn.cleanup()
+        try:
+            await conn.cleanup()
+        except Exception:  # noqa: BLE001
+            # #3069: cleanup failing must not skip the registry pop below
+            # (a stale SafeWebSocket->Connection entry would leak until the
+            # next fanout pruned it) — log and keep tearing down.
+            logger.exception("Connection cleanup failed")
         # Container is intentionally left running — idle timeout will clean it up.
         # This allows instant reconnection when navigating back to the workspace.
         app.state.sockets.connections.pop(safe_ws, None)

--- a/src/klangk/klangk/wshandler/dispatch.py
+++ b/src/klangk/klangk/wshandler/dispatch.py
@@ -181,7 +181,9 @@ async def handle_websocket(websocket: WebSocket, app) -> None:
         except Exception:  # noqa: BLE001
             # #3069: cleanup failing must not skip the registry pop below
             # (a stale SafeWebSocket->Connection entry would leak until the
-            # next fanout pruned it) — log and keep tearing down.
+            # next fanout pruned it). Cleanup itself guards each teardown
+            # step, so the session bookkeeping still ran; whatever raised
+            # here is logged and the teardown continues.
             logger.exception("Connection cleanup failed")
         # Container is intentionally left running — idle timeout will clean it up.
         # This allows instant reconnection when navigating back to the workspace.

--- a/src/klangk/klangk/wshandler/sidecar.py
+++ b/src/klangk/klangk/wshandler/sidecar.py
@@ -84,7 +84,9 @@ async def handle_egress_sidecar(websocket: WebSocket, app) -> None:
     finally:
         # Sidecar gone (disconnect/restart/crash): drop its registration (any
         # in-flight revoke ack fails at once) + cancel in-flight relays.
-        app.state.sidecar_connections.deregister(workspace_id)
+        # Identity-guarded (#3069): a stale socket's teardown must not drop
+        # a replacement socket's registration.
+        app.state.sidecar_connections.deregister(workspace_id, safe)
         for task in list(relay_tasks):
             task.cancel()
         await safe.stop_sender()

--- a/src/klangk/klangkd-tests/tests/test_consent_deciders.py
+++ b/src/klangk/klangkd-tests/tests/test_consent_deciders.py
@@ -476,6 +476,35 @@ class TestConsentDeciderWS:
         assert "refused: Forbidden" in caplog.text
         assert "user=a@x" in caplog.text
 
+    async def test_handshake_marks_each_step(self):
+        """#3069: the authz and workspace marks are recorded inside
+        ``_refuse_invalid_handshake`` — one per step, not two identical
+        totals after both steps finished (the #2420 breakdown was fiction)."""
+        from klangk.wshandler.decider import _refuse_invalid_handshake
+
+        app = _ws_app({"id": "u1", "email": "a@x"})
+        ws = _FakeWS({"token": "tok", "workspace": WS}, [])
+        marks: list[str] = []
+        refused = await _refuse_invalid_handshake(
+            ws, app, WS, {"id": "u1", "email": "a@x"}, hs_mark=marks.append
+        )
+        assert refused is False
+        assert marks == ["authz", "workspace"]
+
+    async def test_authz_refusal_marks_authz_only(self):
+        """A refusal at the permission check stops before the workspace
+        step, so only the authz mark is recorded."""
+        from klangk.wshandler.decider import _refuse_invalid_handshake
+
+        app = _ws_app({"id": "u1", "email": "a@x"}, allowed=False)
+        ws = _FakeWS({"token": "tok", "workspace": WS}, [])
+        marks: list[str] = []
+        refused = await _refuse_invalid_handshake(
+            ws, app, WS, {"id": "u1", "email": "a@x"}, hs_mark=marks.append
+        )
+        assert refused is True
+        assert marks == ["authz"]
+
     async def test_missing_workspace_param_is_refused(self):
         # #2976: consent is strictly a workspace concern -- there is no
         # deploy-wide decider flavor, so a handshake with no ``workspace``

--- a/src/klangk/klangkd-tests/tests/test_sidecar_connections.py
+++ b/src/klangk/klangkd-tests/tests/test_sidecar_connections.py
@@ -41,7 +41,7 @@ class TestSidecarConnections:
         sock = _Sock()
         reg.register("ws-1", sock)
         assert reg.get("ws-1") is sock
-        reg.deregister("ws-1")
+        reg.deregister("ws-1", sock)
         assert reg.get("ws-1") is None
 
     async def test_send_drop_no_connection_returns_none(self):
@@ -90,9 +90,10 @@ class TestSidecarConnections:
 
     async def test_deregister_fails_pending_ack(self):
         reg = SidecarConnections(_app())
-        reg.register("ws-1", _Sock())
+        sock = _Sock()
+        reg.register("ws-1", sock)
         fut = reg.send_drop("ws-1", "h", "denied")
-        reg.deregister("ws-1")  # sidecar gone -> its ack fails
+        reg.deregister("ws-1", sock)  # sidecar gone -> its ack fails
         assert fut.result() is False
 
     async def test_stop_clears_and_fails_pending(self):
@@ -126,7 +127,7 @@ class TestSidecarConnectionsBranchGaps2834:
         reg.register("ws-1", sock)
         fut = reg.send_drop("ws-1", "h", "allowed")
         fut.set_result(True)  # raced ack
-        reg.deregister("ws-1")  # must not raise / re-resolve
+        reg.deregister("ws-1", sock)  # must not raise / re-resolve
         assert fut.result() is True
         assert reg._pending == {}
 
@@ -145,3 +146,42 @@ class TestSidecarConnectionsBranchGaps2834:
         await reg.stop()
         assert f2.result() is False  # the open one was fail-closed
         assert reg._pending == {} and reg._conns == {}
+
+
+class TestSidecarConnectionsIdentityGuard3069:
+    """#3069: a stale socket's teardown must not drop a replacement's
+    registration (sidecar reconnect race)."""
+
+    async def test_stale_socket_deregister_keeps_replacement(self):
+        reg = SidecarConnections(_app())
+        old, new = _Sock(), _Sock()
+        reg.register("ws-1", old)
+        reg.register("ws-1", new)  # reconnect repoints the entry
+        reg.deregister("ws-1", old)  # stale socket's handler finally runs
+        assert reg.get("ws-1") is new  # replacement still registered
+
+    async def test_replacement_deregister_still_works(self):
+        reg = SidecarConnections(_app())
+        old, new = _Sock(), _Sock()
+        reg.register("ws-1", old)
+        reg.register("ws-1", new)
+        reg.deregister("ws-1", old)
+        reg.deregister("ws-1", new)  # the live one may drop it
+        assert reg.get("ws-1") is None
+
+    async def test_stale_deregister_leaves_pending_acks(self):
+        # A drop sent over the replacement's socket must not be failed by
+        # the stale socket's teardown either.
+        reg = SidecarConnections(_app())
+        old, new = _Sock(), _Sock()
+        reg.register("ws-1", old)
+        reg.register("ws-1", new)
+        fut = reg.send_drop("ws-1", "h", "allowed")
+        reg.deregister("ws-1", old)
+        assert not fut.done()  # ack still awaited on the live socket
+        reg.resolve_ack(next(iter(reg._pending)), True)
+        assert fut.result() is True
+
+    async def test_unknown_workspace_deregister_is_noop(self):
+        reg = SidecarConnections(_app())
+        reg.deregister("ws-x", _Sock())  # nothing registered -> no error

--- a/src/klangk/klangkd-tests/tests/test_wshandler.py
+++ b/src/klangk/klangkd-tests/tests/test_wshandler.py
@@ -1976,6 +1976,46 @@ class TestCleanupConnection:
         await conn.cleanup()
         assert conn.terminal_session is None
 
+    async def test_cleanup_step_failure_skips_nothing(self, app_state, caplog):
+        """#3069: one teardown step failing must neither skip the other
+        stops nor the subscriber removal after them."""
+        import logging
+
+        app_state = _make_app_state()
+        sockets = app_state.state.sockets
+        sock = _mock_sock()
+        conn = _base_conn(ws=sock, app_state=app_state)
+        conn.container_id = "ctr-teardown"
+        conn.workspace_id = "ws-teardown"
+        conn._idle_cb = None
+        session = WorkspaceSession("ws-teardown", app_state)
+        session.subscribers.add(sock)
+        sockets.sessions["ws-teardown"] = session
+        stopped = []
+
+        async def failing_stop():
+            stopped.append("terminal")
+            raise RuntimeError("terminal teardown boom")
+
+        async def ok_exec():
+            stopped.append("exec")
+
+        async def ok_ssh():
+            stopped.append("ssh")
+
+        conn.stop_terminal = failing_stop
+        conn.stop_exec = ok_exec
+        conn._stop_ssh_agent = ok_ssh
+        with caplog.at_level(
+            logging.ERROR, logger="klangk.wshandler.connection"
+        ):
+            await conn.cleanup()
+        # All three stops ran despite the first raising …
+        assert stopped == ["terminal", "exec", "ssh"]
+        assert "Cleanup step failing_stop failed" in caplog.text
+        # … and the session bookkeeping after them still ran.
+        assert "ws-teardown" not in sockets.sessions
+
 
 # --- handle_prompt ---
 

--- a/src/klangk/klangkd-tests/tests/test_wshandler.py
+++ b/src/klangk/klangkd-tests/tests/test_wshandler.py
@@ -2594,6 +2594,27 @@ class TestHandleWebsocketDispatch:
         websocket = await self._run_commands(user, [{"cmd": "terminal_start"}])
         websocket.accept.assert_awaited_once()
 
+    async def test_cleanup_failure_still_pops_connection(self, user, caplog):
+        """#3069: a cleanup exception must not skip the registry pop —
+        otherwise the SafeWebSocket->Connection entry leaks."""
+        import logging
+
+        app_state = _make_app_state()
+        token = _auth().create_token(user["id"], user["email"])
+        websocket = _mock_raw_sock(query_params={"token": token})
+        websocket.receive_text = AsyncMock(side_effect=[WebSocketDisconnect()])
+        with (
+            patch.object(
+                Connection,
+                "cleanup",
+                new=AsyncMock(side_effect=RuntimeError("cleanup boom")),
+            ),
+            caplog.at_level(logging.ERROR, logger="klangk.wshandler.dispatch"),
+        ):
+            await handle_websocket(websocket, app_state)  # must not raise
+        assert app_state.state.sockets.connections == {}
+        assert "Connection cleanup failed" in caplog.text
+
     async def test_dispatch_terminal_input(self, user):
         websocket = await self._run_commands(
             user, [{"cmd": "terminal_input", "data": "x"}]
@@ -3899,6 +3920,52 @@ class TestSSHAgentHandlers:
         ]
         assert len(calls) == 1
         assert base64.b64decode(calls[0]["data"]) == b"agent-response"
+
+    async def test_forward_ssh_agent_output_swallows_slow_client(self, caplog):
+        """#3069: a slow client must end the relay quietly.
+
+        Unhandled, the relay task completed with SlowClientError and it
+        resurfaced from _cancel_task's await through stop()/cleanup(),
+        dropping the whole WebSocket and skipping the handler's
+        connections.pop.
+        """
+        import logging
+
+        sock = _mock_sock()
+        sock.send_json = MagicMock(
+            side_effect=SlowClientError("outbound queue full")
+        )
+        conn = _base_conn(ws=sock)
+        conn.container_id = "cid"
+        mock_proc = AsyncMock()
+        mock_proc.stdout = AsyncMock()
+        mock_proc.stdout.read = AsyncMock(side_effect=[b"agent-response", b""])
+        conn.ssh_agent.proc = mock_proc
+        with caplog.at_level(
+            logging.WARNING, logger="klangk.wshandler.controllers"
+        ):
+            await conn._forward_ssh_agent_output()  # must not raise
+        assert "SSH agent output relay error" in caplog.text
+
+    async def test_cancel_task_swallows_failed_task_exception(self, caplog):
+        """#3069: awaiting an already-failed task must not leak its
+        exception through stop()/cleanup()."""
+        import logging
+
+        conn = _base_conn()
+
+        async def boom():
+            raise ValueError("relay bug")
+
+        task = asyncio.create_task(boom())
+        await asyncio.sleep(0)  # let it fail
+        conn.ssh_agent.task = task
+        with caplog.at_level(
+            logging.ERROR, logger="klangk.wshandler.controllers"
+        ):
+            await conn.ssh_agent._cancel_task()  # must not raise
+        assert conn.ssh_agent.task is None
+        assert "SSH agent relay task failed" in caplog.text
 
     async def test_ssh_agent_start_with_terminal(self, app_state):
         """SSH_AUTH_SOCK is passed to TerminalSession when agent is active."""


### PR DESCRIPTION
Closes #3069 (the MEDIUM/LOW half of the wshandler bug sweep; the three HIGH items are tracked separately in #3070, #3071, #3072).

## What changed

- **`SshAgentForwarder.forward_output` now catches `WS_ERRORS`** (which includes `SlowClientError`, `OSError`, `ConnectionError`). Previously a client that stopped reading its agent relay ended the relay task with an unobserved `SlowClientError`, which then resurfaced from `_cancel_task`'s `await self.task` through `stop()`/`Connection.cleanup` — dropping the whole WebSocket on `ssh_agent_stop`, and on natural disconnect skipping the handler's `connections.pop` (registry entry leak).
- **`_cancel_task` no longer leaks an already-failed task's exception** (same shape as `SafeWebSocket.stop_sender`).
- **`handle_websocket`'s `finally` wraps `conn.cleanup()`** so the `connections` registry pop always runs even when cleanup raises, logging instead of aborting teardown.
- **`SidecarConnections.deregister` is identity-guarded** — only the socket that currently owns the workspace's registration may drop it. Previously, a stale sidecar socket's teardown after a reconnect deregistered the replacement's registration, leaving every later `send_drop` a no-op (revocations #2339 unenforced while a live sidecar was connected). Also drops the always-false `workspace_id in self._conns` log clause.
- **Consent-decider handshake timing marks are real per-step marks**: `authz` and `workspace` are now recorded inside `_refuse_invalid_handshake` after each step, instead of two identical totals recorded after both steps finished (the #2420 breakdown was fiction).

## Tests

- relay ends quietly on `SlowClientError` (+ logged); `_cancel_task` swallows a failed task's exception; `handle_websocket` still pops the connection when cleanup raises
- identity-guard tests: stale socket's deregister keeps the replacement, replacement may still drop it, pending acks survive a stale teardown, unknown-workspace deregister is a no-op
- decider marks: `["authz", "workspace"]` on the success path, `["authz"]` on an authz refusal

Full suite: 6627 passed, 100% branch coverage. Changelog entry added under `[Unreleased] → Fixed`.
