### PR TITLE
Kick only the viewers of an unshared/deleted shared terminal (#3072)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -2000,6 +2000,15 @@ git-credential` (#1700).** `pig-latin` removed; `word-count` dormant.
   from the registry). A reconnecting egress sidecar's registration is now
   identity-guarded, so the stale socket's teardown can no longer drop the
   replacement's registration and leave egress revocations unenforced.
+- **Unsharing or deleting a shared terminal no longer kills every
+  non-owner tmux session in the container (#3072).** One
+  `unshare_window`/`delete_shared_terminal` frame used to run a
+  group-unscoped `tmux kill-session` sweep that terminated other
+  members' live terminals, the workspace service command, and the
+  window watcher (leaving tab-strip sync dead until reconnect). Kicks
+  are now per viewer: only the connections actually viewing the
+  affected window are disconnected, and viewers of the owner's other
+  shared windows keep their sessions.
 - **Terminal share/unshare/close no longer hang clients on refusal paths
   (#3057).** The WebSocket handlers for `share_window`, `unshare_window`,
   `join_shared_terminal`, and the own-window commands (`terminal_new_window`,

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -2008,7 +2008,10 @@ git-credential` (#1700).** `pig-latin` removed; `word-count` dormant.
   window watcher (leaving tab-strip sync dead until reconnect). Kicks
   are now per viewer: only the connections actually viewing the
   affected window are disconnected, and viewers of the owner's other
-  shared windows keep their sessions.
+  shared windows keep their sessions. Deleting an agent-owned shared
+  terminal also works now — the close targeted a tmux session named
+  after the agent's user id instead of the `service` session and
+  always failed with "Failed to delete shared terminal".
 - **Terminal share/unshare/close no longer hang clients on refusal paths
   (#3057).** The WebSocket handlers for `share_window`, `unshare_window`,
   `join_shared_terminal`, and the own-window commands (`terminal_new_window`,

--- a/src/klangk/klangk/terminal.py
+++ b/src/klangk/klangk/terminal.py
@@ -1024,36 +1024,6 @@ class Terminal:
         )
         return await self.list_windows(container_id, session_name)
 
-    async def kill_joiner_sessions(
-        self, container_id: str, owner_handle: str
-    ) -> None:
-        """Kill all session-group sessions except the owner's own session.
-
-        Used when unsharing to disconnect spectators/collaborators.
-        """
-        try:
-            output = await self.tmux_command(
-                container_id,
-                owner_handle,
-                [
-                    "list-sessions",
-                    "-F",
-                    "#{session_name}",
-                ],
-            )
-            for session_name in output.strip().splitlines():
-                if session_name != owner_handle:
-                    try:
-                        await self.tmux_command(
-                            container_id,
-                            owner_handle,
-                            ["kill-session", "-t", session_name],
-                        )
-                    except TerminalError:
-                        pass  # Session may have already exited
-        except TerminalError:
-            pass  # No sessions
-
 
 # ---------------------------------------------------------------------------
 # Shell process (PTY layer — needs podman.bin, no Terminal ref)

--- a/src/klangk/klangk/wshandler/controllers.py
+++ b/src/klangk/klangk/wshandler/controllers.py
@@ -1525,8 +1525,11 @@ class SharedTerminalController:
             self.broadcast_shared_terminals(ws_session)
             return
         match["shared"] = False
-        # Kick spectators/collaborators
-        await self._kick_joiners(self._conn.tmux_session_name())
+        # Kick the viewers of this window only — not every joiner of
+        # the owner's session group (#3072).
+        await self._kick_joiners(
+            ws_session, self._conn.user["id"], msg.get("window_id", "")
+        )
         ws_session.broadcast(
             {
                 "type": "shared_terminal_deleted",
@@ -1581,15 +1584,48 @@ class SharedTerminalController:
             return None
         return match, ws_session
 
-    async def _kick_joiners(self, session_name: str) -> None:
-        """Kill the window's joiner sessions (best-effort)."""
-        try:
-            await self._conn.app.state.terminal.kill_joiner_sessions(
-                self._conn.container_id,
-                session_name,
-            )
-        except Exception:
-            logger.debug("Failed to kill joiner sessions", exc_info=True)
+    @staticmethod
+    def _views_window(
+        viewing: dict | None, owner_user_id: str, window_id: str
+    ) -> bool:
+        """True when a ``viewing_shared`` marker points at this owner's
+        window."""
+        if not viewing:
+            return False
+        return (
+            viewing.get("user_id") == owner_user_id
+            and viewing.get("window_id") == window_id
+        )
+
+    async def _kick_joiners(
+        self, ws_session, owner_user_id: str, window_id: str
+    ) -> None:
+        """Disconnect the connections viewing this shared window (#3072).
+
+        Stopping each viewer's terminal session also kills their grouped
+        tmux session — the same teardown a viewer gets on disconnect.  A
+        group-wide tmux kill is deliberately NOT used: the container's
+        single tmux server also hosts other members' sessions, the
+        agent's ``service`` session, and the window watcher, and even
+        scoped to the owner's session group it would take out viewers
+        of the owner's other still-shared windows.  Best-effort per
+        viewer: one failing stop never blocks the rest or the unshare.
+        """
+        sockets = self._conn.app.state.sockets
+        for sock in list(ws_session.subscribers):
+            conn = sockets.connections.get(sock)
+            if not self._views_window(
+                getattr(conn, "viewing_shared", None),
+                owner_user_id,
+                window_id,
+            ):
+                continue
+            try:
+                await conn.stop_terminal()
+            except Exception:
+                logger.debug(
+                    "Failed to kick shared-terminal viewer", exc_info=True
+                )
 
     @staticmethod
     async def _select_shared_window(
@@ -1893,15 +1929,12 @@ class SharedTerminalController:
         return await self._perm_or_deny("share-terminals")
 
     async def _close_shared_window(
-        self, owner_user_id: str, window_id: str
+        self, ws_session, owner_user_id: str, window_id: str
     ) -> bool:
-        """Close the window (and its joiner sessions); False (after sending
-        the error frame) on failure."""
+        """Disconnect the window's viewers and close it; False (after
+        sending the error frame) on failure."""
         try:
-            await self._conn.app.state.terminal.kill_joiner_sessions(
-                self._conn.container_id,
-                owner_user_id,
-            )
+            await self._kick_joiners(ws_session, owner_user_id, window_id)
             await self._conn.app.state.terminal.close_window(
                 self._conn.container_id,
                 owner_user_id,
@@ -1969,7 +2002,9 @@ class SharedTerminalController:
         if resolved is None:
             return
         ws_session, owner_user_id, window_id, window_name = resolved
-        if not await self._close_shared_window(owner_user_id, window_id):
+        if not await self._close_shared_window(
+            ws_session, owner_user_id, window_id
+        ):
             return
         owner_windows = ws_session.terminal_windows.get(owner_user_id, [])
         owner_windows[:] = [

--- a/src/klangk/klangk/wshandler/controllers.py
+++ b/src/klangk/klangk/wshandler/controllers.py
@@ -1614,10 +1614,8 @@ class SharedTerminalController:
         sockets = self._conn.app.state.sockets
         for sock in list(ws_session.subscribers):
             conn = sockets.connections.get(sock)
-            if not self._views_window(
-                getattr(conn, "viewing_shared", None),
-                owner_user_id,
-                window_id,
+            if conn is None or not self._views_window(
+                conn.viewing_shared, owner_user_id, window_id
             ):
                 continue
             try:
@@ -1935,9 +1933,13 @@ class SharedTerminalController:
         sending the error frame) on failure."""
         try:
             await self._kick_joiners(ws_session, owner_user_id, window_id)
+            # Agent-owned windows live in the standalone ``service``
+            # session, not one named after the agent's user_id — the
+            # same mapping joins use (#3072; targeting the user_id made
+            # every agent-window delete fail in list-windows).
             await self._conn.app.state.terminal.close_window(
                 self._conn.container_id,
-                owner_user_id,
+                self._join_target_for(owner_user_id),
                 window_id,
             )
             return True

--- a/src/klangk/klangkd-tests/tests/test_terminal.py
+++ b/src/klangk/klangkd-tests/tests/test_terminal.py
@@ -1258,55 +1258,6 @@ class TestBuildShellCommandTmuxDisabled:
         assert unique is not None
 
 
-class TestKillJoinerSessions:
-    async def test_kills_non_owner_sessions(self):
-        with patch.object(
-            _terminal,
-            "tmux_command",
-            side_effect=[
-                "admin\nbob-abc123\ncarol-def456\n",  # list-sessions
-                "",  # kill bob
-                "",  # kill carol
-            ],
-        ) as mock_cmd:
-            await _terminal.kill_joiner_sessions("cid", "admin")
-        # Should have called list-sessions + kill for bob and carol
-        assert mock_cmd.call_count == 3
-
-    async def test_no_joiners(self):
-        with patch.object(
-            _terminal,
-            "tmux_command",
-            return_value="admin\n",
-        ) as mock_cmd:
-            await _terminal.kill_joiner_sessions("cid", "admin")
-        # Only list-sessions, no kills
-        assert mock_cmd.call_count == 1
-
-    async def test_kill_session_error_ignored(self):
-        """If kill-session fails for a joiner, continue with others."""
-        with patch.object(
-            _terminal,
-            "tmux_command",
-            side_effect=[
-                "admin\nbob-abc\ncarol-def\n",  # list-sessions
-                TerminalError("already exited"),  # kill bob fails
-                "",  # kill carol succeeds
-            ],
-        ) as mock_cmd:
-            await _terminal.kill_joiner_sessions("cid", "admin")
-        assert mock_cmd.call_count == 3
-
-    async def test_no_sessions(self):
-        with patch.object(
-            _terminal,
-            "tmux_command",
-            side_effect=TerminalError("no sessions"),
-        ):
-            # Should not raise
-            await _terminal.kill_joiner_sessions("cid", "admin")
-
-
 class TestTerminalSessionJoin:
     async def test_join_session_no_socket(self):
         """Joining a session group on default server."""

--- a/src/klangk/klangkd-tests/tests/test_wshandler.py
+++ b/src/klangk/klangkd-tests/tests/test_wshandler.py
@@ -82,7 +82,6 @@ _mock_term.new_window = AsyncMock(return_value=[])
 _mock_term.select_window = AsyncMock()
 _mock_term.close_window = AsyncMock(return_value=[])
 _mock_term.rename_window = AsyncMock()
-_mock_term.kill_joiner_sessions = AsyncMock()
 _mock_term.has_tmux_session = AsyncMock(return_value=False)
 _mock_term.service_cmd_window_exists = AsyncMock(return_value=False)
 
@@ -8878,6 +8877,8 @@ class TestShareWindowHandlers:
     async def test_unshare_window_kicks_joiners(
         self, user, temp_data_dir, app_state
     ):
+        """Unsharing disconnects only the viewers of THAT window — the
+        viewer of another still-shared window keeps their session (#3072)."""
         app_state = _make_app_state()
         sockets = app_state.state.sockets
         sock = _mock_sock()
@@ -8888,8 +8889,22 @@ class TestShareWindowHandlers:
         session = sockets.get_or_create_session("ws-1", app_state)
         session.terminal_windows[user["id"]] = [
             {"name": "1", "index": 0, "id": "@0", "shared": True},
+            {"name": "2", "index": 1, "id": "@1", "shared": True},
         ]
+        viewer = _base_conn(app_state=app_state)
+        viewer.workspace_id = "ws-1"
+        viewer.viewing_shared = {"user_id": user["id"], "window_id": "@0"}
+        other = _base_conn(app_state=app_state)
+        other.workspace_id = "ws-1"
+        other.viewing_shared = {"user_id": user["id"], "window_id": "@1"}
         await session.add_subscriber(sock, "cid")
+        with patch.object(
+            WorkspaceSession, "start_window_sync", lambda s: None
+        ):
+            await session.add_subscriber(viewer.sock, "cid")
+            await session.add_subscriber(other.sock, "cid")
+        sockets.connections[viewer.sock] = viewer
+        sockets.connections[other.sock] = other
         try:
             with (
                 patch.object(
@@ -8897,11 +8912,17 @@ class TestShareWindowHandlers:
                     "check_permission",
                     new=AsyncMock(return_value=True),
                 ),
-                patch.object(_mock_term, "kill_joiner_sessions") as mock_kill,
+                patch.object(
+                    viewer, "stop_terminal", new=AsyncMock()
+                ) as stop_viewer,
+                patch.object(
+                    other, "stop_terminal", new=AsyncMock()
+                ) as stop_other,
             ):
                 await conn.handle_unshare_window({"window_id": "@0"})
             assert session.terminal_windows[user["id"]][0]["shared"] is False
-            mock_kill.assert_awaited_once()
+            stop_viewer.assert_awaited_once()
+            stop_other.assert_not_awaited()
             calls = [c[0][0] for c in sock.send_json.call_args_list]
             deleted = [
                 c for c in calls if c.get("type") == "shared_terminal_deleted"
@@ -8975,9 +8996,7 @@ class TestShareWindowHandlers:
         ]
         await session.add_subscriber(sock, "cid")
         try:
-            with patch.object(_mock_term, "kill_joiner_sessions") as mock_kill:
-                await conn.handle_unshare_window({"window_id": "@0"})
-            mock_kill.assert_not_awaited()
+            await conn.handle_unshare_window({"window_id": "@0"})
             calls = [c[0][0] for c in sock.send_json.call_args_list]
             assert any(c.get("type") == "shared_terminals" for c in calls)
             assert not any(
@@ -9313,6 +9332,8 @@ class TestShareWindowHandlers:
             await conn.handle_unshare_window({"window_id": "@0"})
 
     async def test_unshare_kill_error_handled(self, user, app_state):
+        """A viewer whose teardown raises still gets past the kick: the
+        unshare completes and broadcasts for the others (#3072)."""
         app_state = _make_app_state()
         sockets = app_state.state.sockets
         sock = _mock_sock()
@@ -9324,7 +9345,17 @@ class TestShareWindowHandlers:
         session.terminal_windows[user["id"]] = [
             {"name": "1", "index": 0, "id": "@0", "shared": True}
         ]
+        viewer = _base_conn(app_state=app_state)
+        viewer.workspace_id = "ws-1"
+        viewer.viewing_shared = {"user_id": user["id"], "window_id": "@0"}
         await session.add_subscriber(sock, "cid")
+        # add_subscriber spawns the tmux window watcher against the mock
+        # podman; suppress it (not what this test exercises).
+        with patch.object(
+            WorkspaceSession, "start_window_sync", lambda s: None
+        ):
+            await session.add_subscriber(viewer.sock, "cid")
+        sockets.connections[viewer.sock] = viewer
         try:
             with (
                 patch.object(
@@ -9333,9 +9364,9 @@ class TestShareWindowHandlers:
                     new=AsyncMock(return_value=True),
                 ),
                 patch.object(
-                    _mock_term,
-                    "kill_joiner_sessions",
-                    side_effect=TerminalError("no sessions"),
+                    viewer,
+                    "stop_terminal",
+                    new=AsyncMock(side_effect=OSError("boom")),
                 ),
             ):
                 await conn.handle_unshare_window({"window_id": "@0"})
@@ -9833,7 +9864,6 @@ class TestShareWindowHandlers:
                     "check_permission",
                     new=AsyncMock(return_value=True),
                 ),
-                patch.object(_mock_term, "kill_joiner_sessions"),
                 patch.object(_mock_term, "close_window", return_value=[]),
             ):
                 await conn.handle_delete_shared_terminal(
@@ -9966,7 +9996,6 @@ class TestShareWindowHandlers:
                     "check_permission",
                     new=AsyncMock(return_value=True),
                 ),
-                patch.object(_mock_term, "kill_joiner_sessions"),
                 patch.object(_mock_term, "close_window", return_value=[]),
             ):
                 await conn.handle_delete_shared_terminal(
@@ -9994,7 +10023,7 @@ class TestShareWindowHandlers:
                 ),
                 patch.object(
                     _mock_term,
-                    "kill_joiner_sessions",
+                    "close_window",
                     side_effect=RuntimeError("boom"),
                 ),
             ):
@@ -10211,6 +10240,27 @@ class TestSharedTerminalController:
             app_state = _make_app_state()
         return app_state.state.sockets.get_or_create_session(ws_id, app_state)
 
+    async def _viewer(
+        self, app_state, ws, *, owner_user_id, window_id, stop=None
+    ):
+        """Register a viewer connection for (owner, window) as a session
+        subscriber; returns (sock, stop mock)."""
+        sock = _mock_sock()
+        stop = AsyncMock() if stop is None else stop
+        conn = SimpleNamespace(
+            viewing_shared={"user_id": owner_user_id, "window_id": window_id},
+            stop_terminal=stop,
+            user={"id": "viewer", "email": "viewer@example.com"},
+        )
+        # add_subscriber spawns the tmux window watcher against the mock
+        # podman; suppress it (not what these tests exercise).
+        with patch.object(
+            WorkspaceSession, "start_window_sync", lambda s: None
+        ):
+            await ws.add_subscriber(sock, "cid")
+        app_state.state.sockets.connections[sock] = conn
+        return sock, stop
+
     # --- find_window ---
 
     async def test_find_window_returns_match(self, user, app_state):
@@ -10327,11 +10377,13 @@ class TestSharedTerminalController:
         ws.terminal_windows[user["id"]] = [
             {"id": "@0", "name": "a", "shared": True}
         ]
+        _, stop = await self._viewer(
+            app_state, ws, owner_user_id=user["id"], window_id="@0"
+        )
         try:
-            with patch.object(_mock_term, "kill_joiner_sessions") as kill:
-                await ctrl.unshare_window({"window_id": "@0"})
+            await ctrl.unshare_window({"window_id": "@0"})
             assert ws.terminal_windows[user["id"]][0]["shared"] is False
-            kill.assert_awaited_once_with("cid", "uid")
+            stop.assert_awaited_once()
             sent = [c[0][0] for c in sock.send_json.call_args_list]
             assert not any("Permission" in c.get("message", "") for c in sent)
         finally:
@@ -10340,18 +10392,54 @@ class TestSharedTerminalController:
     async def test_unshare_window_marks_unshared_and_kicks(
         self, user, temp_data_dir, app_state
     ):
+        """Only the viewers of the unshared window are kicked: a viewer
+        of the owner's other still-shared window keeps their session, and
+        a subscriber with no registered connection is skipped (#3072)."""
         app_state = _make_app_state()
         sockets = app_state.state.sockets
         ctrl, _, conn = self._controller(user=user, app_state=app_state)
         ws = self._ws_session(app_state=app_state)
         ws.terminal_windows[user["id"]] = [
+            {"id": "@0", "name": "a", "shared": True},
+            {"id": "@1", "name": "b", "shared": True},
+        ]
+        _, stop_viewing = await self._viewer(
+            app_state, ws, owner_user_id=user["id"], window_id="@0"
+        )
+        _, stop_other = await self._viewer(
+            app_state, ws, owner_user_id=user["id"], window_id="@1"
+        )
+        orphan = _mock_sock()  # subscriber without a registered connection
+        with patch.object(
+            WorkspaceSession, "start_window_sync", lambda s: None
+        ):
+            await ws.add_subscriber(orphan, "cid")
+        try:
+            await ctrl.unshare_window({"window_id": "@0"})
+            assert ws.terminal_windows[user["id"]][0]["shared"] is False
+            stop_viewing.assert_awaited_once()
+            stop_other.assert_not_awaited()
+        finally:
+            sockets.sessions.pop("ws-1", None)
+
+    async def test_unshare_window_other_owners_viewer_not_kicked(
+        self, user, temp_data_dir, app_state
+    ):
+        """A viewer of another owner's window (same window id) is not
+        kicked by this owner's unshare."""
+        app_state = _make_app_state()
+        sockets = app_state.state.sockets
+        ctrl, _, _ = self._controller(user=user, app_state=app_state)
+        ws = self._ws_session(app_state=app_state)
+        ws.terminal_windows[user["id"]] = [
             {"id": "@0", "name": "a", "shared": True}
         ]
+        _, stop = await self._viewer(
+            app_state, ws, owner_user_id="someone-else", window_id="@0"
+        )
         try:
-            with patch.object(_mock_term, "kill_joiner_sessions") as kill:
-                await ctrl.unshare_window({"window_id": "@0"})
-            assert ws.terminal_windows[user["id"]][0]["shared"] is False
-            kill.assert_awaited_once_with("cid", "uid")
+            await ctrl.unshare_window({"window_id": "@0"})
+            stop.assert_not_awaited()
         finally:
             sockets.sessions.pop("ws-1", None)
 
@@ -10368,22 +10456,24 @@ class TestSharedTerminalController:
         ws.terminal_windows["other-user"] = [
             {"id": "@5", "name": "theirs", "shared": True}
         ]
+        _, stop = await self._viewer(
+            app_state, ws, owner_user_id="other-user", window_id="@5"
+        )
         try:
-            with patch.object(_mock_term, "kill_joiner_sessions") as kill:
-                await ctrl.unshare_window({"window_id": "@5"})
+            await ctrl.unshare_window({"window_id": "@5"})
             assert sock.send_json.call_args[0][0]["message"] == (
                 "Window not found"
             )
             assert ws.terminal_windows["other-user"][0]["shared"] is True
-            kill.assert_not_awaited()
+            stop.assert_not_awaited()
         finally:
             sockets.sessions.pop("ws-1", None)
 
     async def test_unshare_window_already_unshared_is_noop(
         self, user, temp_data_dir, app_state
     ):
-        """Unsharing a not-shared window is a cheap no-op — no joiner
-        kills, no shared_terminal_deleted broadcast."""
+        """Unsharing a not-shared window is a cheap no-op — no viewer
+        kicks, no shared_terminal_deleted broadcast."""
         app_state = _make_app_state()
         sockets = app_state.state.sockets
         ctrl, sock, _ = self._controller(user=user, app_state=app_state)
@@ -10391,10 +10481,12 @@ class TestSharedTerminalController:
         ws.terminal_windows[user["id"]] = [
             {"id": "@0", "name": "a", "shared": False}
         ]
+        _, stop = await self._viewer(
+            app_state, ws, owner_user_id=user["id"], window_id="@0"
+        )
         try:
-            with patch.object(_mock_term, "kill_joiner_sessions") as kill:
-                await ctrl.unshare_window({"window_id": "@0"})
-            kill.assert_not_awaited()
+            await ctrl.unshare_window({"window_id": "@0"})
+            stop.assert_not_awaited()
             sent = [c[0][0] for c in sock.send_json.call_args_list]
             assert not any(
                 s.get("type") == "shared_terminal_deleted" for s in sent
@@ -10409,18 +10501,23 @@ class TestSharedTerminalController:
         sockets = app_state.state.sockets
         ctrl, sock, _ = self._controller(user=user, app_state=app_state)
         ws = self._ws_session(app_state=app_state)
-        await ws.add_subscriber(sock, "cid")
+        with patch.object(
+            WorkspaceSession, "start_window_sync", lambda s: None
+        ):
+            await ws.add_subscriber(sock, "cid")
         ws.terminal_windows[user["id"]] = [
             {"id": "@0", "name": "a", "shared": True}
         ]
+        await self._viewer(
+            app_state,
+            ws,
+            owner_user_id=user["id"],
+            window_id="@0",
+            stop=AsyncMock(side_effect=OSError("boom")),
+        )
         try:
-            with patch.object(
-                _mock_term,
-                "kill_joiner_sessions",
-                side_effect=OSError("boom"),
-            ):
-                # Should not raise.
-                await ctrl.unshare_window({"window_id": "@0"})
+            # Should not raise.
+            await ctrl.unshare_window({"window_id": "@0"})
             # Still broadcast the deletion.
             sent = [c[0][0] for c in sock.send_json.call_args_list]
             assert any(
@@ -10602,7 +10699,10 @@ class TestSharedTerminalController:
         sockets = app_state.state.sockets
         ctrl, sock, _ = self._controller(user=user, app_state=app_state)
         ws = self._ws_session(app_state=app_state)
-        await ws.add_subscriber(sock, "cid")
+        with patch.object(
+            WorkspaceSession, "start_window_sync", lambda s: None
+        ):
+            await ws.add_subscriber(sock, "cid")
         ws.terminal_windows["owner-1"] = [
             {"id": "@0", "index": 0, "name": "build", "shared": True},
             {"id": "@1", "index": 1, "name": "other", "shared": False},
@@ -10611,19 +10711,21 @@ class TestSharedTerminalController:
             # owner_user_id != user["id"], so the delete handler calls
             # app_state.state.model.workspaces.get_workspace_by_id to authorize; return a workspace
             # owned by the current user so the delete is permitted.
+            _, stop = await self._viewer(
+                app_state, ws, owner_user_id="owner-1", window_id="@0"
+            )
             with (
                 patch.object(
                     app_state.state.model.workspaces,
                     "get_workspace_by_id",
                     new=AsyncMock(return_value={"user_id": user["id"]}),
                 ),
-                patch.object(_mock_term, "kill_joiner_sessions") as kill,
                 patch.object(_mock_term, "close_window") as close,
             ):
                 await ctrl.delete_shared_terminal(
                     {"user_id": "owner-1", "window_id": "@0"}
                 )
-            kill.assert_awaited_once_with("cid", "owner-1")
+            stop.assert_awaited_once()
             close.assert_awaited_once_with("cid", "owner-1", "@0")
             remaining = ws.terminal_windows["owner-1"]
             assert [w["id"] for w in remaining] == ["@1"]
@@ -10648,7 +10750,7 @@ class TestSharedTerminalController:
         try:
             with patch.object(
                 _mock_term,
-                "kill_joiner_sessions",
+                "close_window",
                 side_effect=OSError("boom"),
             ):
                 await ctrl.delete_shared_terminal(

--- a/src/klangk/klangkd-tests/tests/test_wshandler.py
+++ b/src/klangk/klangkd-tests/tests/test_wshandler.py
@@ -10760,6 +10760,45 @@ class TestSharedTerminalController:
         finally:
             sockets.sessions.pop("ws-1", None)
 
+    async def test_delete_agent_shared_terminal_closes_service_session(
+        self, user, temp_data_dir, app_state
+    ):
+        """Agent-owned windows live in the ``service`` tmux session — the
+        close must target it, not a session named after the agent's
+        user_id (which never exists, so the delete always failed) (#3072)."""
+        app_state = _make_app_state()
+        sockets = app_state.state.sockets
+        ctrl, sock, _ = self._controller(user=user, app_state=app_state)
+        ws = self._ws_session(app_state=app_state)
+        ws.terminal_windows[model.AGENT_USER_ID] = [
+            {"id": "@0", "index": 0, "name": "service-cmd", "shared": True}
+        ]
+        try:
+            _, stop = await self._viewer(
+                app_state,
+                ws,
+                owner_user_id=model.AGENT_USER_ID,
+                window_id="@0",
+            )
+            with (
+                patch.object(
+                    app_state.state.model.workspaces,
+                    "get_workspace_by_id",
+                    new=AsyncMock(return_value={"user_id": user["id"]}),
+                ),
+                patch.object(_mock_term, "close_window") as close,
+            ):
+                await ctrl.delete_shared_terminal(
+                    {"user_id": model.AGENT_USER_ID, "window_id": "@0"}
+                )
+            stop.assert_awaited_once()
+            close.assert_awaited_once_with(
+                "cid", ctrl._join_target_for(model.AGENT_USER_ID), "@0"
+            )
+            assert ws.terminal_windows[model.AGENT_USER_ID] == []
+        finally:
+            sockets.sessions.pop("ws-1", None)
+
     # --- join_shared_terminal ---
 
     async def test_join_shared_terminal_no_container(self, user):


### PR DESCRIPTION
## What

Fixes #3072.

`unshare_window` and `delete_shared_terminal` used to call
`Terminal.kill_joiner_sessions`, which ran `tmux list-sessions` and killed
**every session whose name differed from the owner's**. The container runs
one shared tmux server, so a single unshare frame took out:

- every other member's interactive base session and their live grouped
  connection sessions,
- the agent's standalone `service` session (the workspace service command),
- the window watcher's `__klangk_ctrl-<hex>` control session (push
  window-sync then stayed dead until a reconnect replaced the watcher),
- and even the unsharing owner's own live connection sessions.

## Why not the session-group filter

The issue suggests scoping the sweep with `#{session_grouped}` /
`#{session_group}`. That fixes the collateral damage above, but the second
defect in the issue makes *any* group-wide tmux kill wrong: tmux cannot
distinguish a joiner of the window being unshared from a joiner of the
owner's **other still-shared windows** — both are just grouped sessions
(`<joiner>-<hex>`) in the owner's group. Scoping to the group would still
disconnect viewers of windows that remain shared.

## The fix

Kicks are now **per viewer, at the connection level**: `_kick_joiners`
iterates the workspace session's subscribers and stops the terminal session
of each connection whose `viewing_shared` marker points at the affected
`(owner, window)` — the exact teardown a viewer already gets on disconnect,
which also kills their grouped tmux session
(`TerminalSession._kill_grouped_tmux_session`). Viewers of the owner's
other windows, other members' sessions, the `service` session, and the
window watcher are untouched. `delete_shared_terminal`'s
`_close_shared_window` kicks the same precise set before closing the
window.

`Terminal.kill_joiner_sessions` is dead after this and is removed, along
with its unit tests. Kicks stay best-effort: a viewer whose `stop_terminal`
raises is logged and skipped; the unshare/delete still completes and
broadcasts `shared_terminal_deleted` + the refreshed `shared_terminals`
list (which the frontend already uses to close a viewer's shared view).

## Tests

- Rewritten unshare/delete tests assert the precise kick: the viewer of the
  unshared window is stopped, the viewer of a sibling shared window is not,
  a viewer of another owner's window is not, a subscriber with no
  registered connection is skipped, and a failing `stop_terminal` is
  non-fatal.
- Full backend + CLI suite green at 100% branch coverage; xenon, ruff, and
  all pre-commit hooks pass.
- Changelog entry under `[Unreleased]` → Fixed.
