### PR TITLE
Fix crash auto-restart never firing from the sweep path; eviction SIGHUP staleness (#3074)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -1945,6 +1945,16 @@ git-credential` (#1700).** `pig-latin` removed; `word-count` dormant.
 
 ### Fixed
 
+- **Crash auto-restart (#3074).** `KLANGKD_CONTAINER_RESTART_ENABLED`
+  never restarted a workspace: every crash-detected death was
+  misclassified as a user action and left the workspace stopped with no
+  crash state on `/status`. Restart now works as documented (backoff,
+  bounded retries, crash-loop terminal state), and the death cause is
+  recorded for the status API even with restart disabled.
+- **`KLANGKD_MEMORY_EVICTION_ENABLED` reload (#3074).** A SIGHUP config
+  reload that disables memory-pressure eviction now takes effect on the
+  next poll instead of one cycle late, so turning the evictor off under
+  sustained pressure cannot evict one more workspace after the reload.
 - **Podman create retry and CI-aware bring-up budgets (#3064).** A
   `podman create` that stalls past its budget (120s local, 240s on CI)
   under load is now killed and retried once (idempotent via

--- a/src/klangk/klangk/container/crash.py
+++ b/src/klangk/klangk/container/crash.py
@@ -455,7 +455,8 @@ class CrashRecoveryMonitor:
         having begun-and-completed since), and the post-teardown guard —
         run synchronously, with NO await between it and the
         ``create_task`` inside :meth:`schedule_restart` — catches a stop
-        that began while the teardown awaits ran. Any stop beginning
+        that began while the teardown awaits ran, allowing for the
+        teardown's own single epoch bump (#3074). Any stop beginning
         after ``create_task`` cancels the pending task at its entry
         (:meth:`ContainerRegistry.stop_and_remove_container` calls
         ``on_expected_stop` before its first await). Together these make
@@ -506,12 +507,16 @@ class CrashRecoveryMonitor:
         # Post-teardown sync guards (#2524 review): NO await between these
         # checks and either the tracker insert or the create_task inside
         # schedule_restart, so the single-threaded loop cannot interleave
-        # here. A stop that began during the awaits above bumped the
-        # epoch (its entry is synchronous); a user start that raced us
-        # left a fresh container running (registry state present). In
-        # both cases the user action owns the workspace now — record the
-        # death event for viewers, but drop the tracker and never
-        # restart.
+        # here. Our own teardown above bumped the stop epoch by exactly
+        # one (synchronously at its entry), so the guard allows that one
+        # bump; TWO or more bumps mean a stop that began during the
+        # awaits above also ran (its entry is synchronous), and a user
+        # start that raced us left a fresh container running (registry
+        # state present). In both cases the user action owns the
+        # workspace now — record the death event for viewers, but drop
+        # the tracker and never restart (#3074: comparing against the
+        # pre-teardown epoch verbatim tripped on our own bump, so no
+        # sweep-detected death ever scheduled a restart).
         self._finalize_death(registry, ws_id, cause, message, tracker, epoch)
 
     def _finalize_death(
@@ -561,13 +566,33 @@ class CrashRecoveryMonitor:
         captured."""
         return epoch is not None and registry.stop_epoch.get(ws_id, 0) != epoch
 
+    @staticmethod
+    def _stop_epoch_moved_beyond_teardown(
+        registry, ws_id: str, epoch: int | None
+    ) -> bool:
+        """True when the stop epoch moved by more than the crash
+        teardown's own single bump (#3074).
+
+        ``handle_death``'s ``stop_and_remove_container`` call bumps the
+        epoch synchronously at entry, so after the teardown exactly +1
+        over the pre-handling epoch is the monitor itself. A strict
+        inequality (``_stop_epoch_moved``) would flag every death as
+        "user action interleaved"; +2 or more means a user stop also
+        began during the handling awaits — that stop owns the workspace.
+        The entry guards keep the strict form: they run *before* the
+        teardown's bump, so any movement there is a user stop.
+        """
+        return (
+            epoch is not None and registry.stop_epoch.get(ws_id, 0) > epoch + 1
+        )
+
     def _user_action_interleaved(
         self, registry, ws_id: str, epoch: int | None
     ) -> bool:
         """True when a user action raced the death handling and owns the
-        workspace now: a stop began/completed during the awaits, or a
-        start re-created registry state."""
-        if self._stop_epoch_moved(registry, ws_id, epoch):
+        workspace now: a stop began/completed during the awaits (beyond
+        the teardown's own bump), or a start re-created registry state."""
+        if self._stop_epoch_moved_beyond_teardown(registry, ws_id, epoch):
             return True
         return registry.states.get(ws_id) is not None
 

--- a/src/klangk/klangk/container/eviction.py
+++ b/src/klangk/klangk/container/eviction.py
@@ -362,6 +362,19 @@ class MemoryPressureEvictor:
         """Consecutive below-threshold polls before evictions begin."""
         return self.app.state.settings.memory_eviction_sustain_polls
 
+    @property
+    def _enabled(self) -> bool:
+        """Whether the evictor is armed (live off settings)."""
+        return self.app.state.settings.memory_eviction_enabled
+
+    @property
+    def _poll_interval(self) -> float:
+        """Poll interval, floored (live off settings)."""
+        return max(
+            self.app.state.settings.memory_eviction_poll_interval,
+            MIN_POLL_INTERVAL_SECONDS,
+        )
+
     def start(self) -> None:
         """Start the eviction loop (idempotent). Runs until :meth:`stop`."""
         if self._task is None:
@@ -613,13 +626,13 @@ class MemoryPressureEvictor:
         pressured = False
         warned_unreadable = False
         while True:
-            settings = self.app.state.settings
-            interval = max(
-                settings.memory_eviction_poll_interval,
-                MIN_POLL_INTERVAL_SECONDS,
-            )
-            await asyncio.sleep(interval)
-            if not settings.memory_eviction_enabled:
+            await asyncio.sleep(self._poll_interval)
+            # Everything below reads settings LIVE off app.state (never a
+            # snapshot taken before the sleep): a SIGHUP reload swaps the
+            # settings object (#1587), and a pre-sleep snapshot would act
+            # on stale values for one cycle — e.g. evict once more after
+            # the operator disabled eviction (#3074).
+            if not self._enabled:
                 below = 0
                 pressured = False
                 continue

--- a/src/klangk/klangk/container/registry.py
+++ b/src/klangk/klangk/container/registry.py
@@ -601,18 +601,32 @@ class ContainerRegistry(NetworkSidecarMixin):
         pre-existing delete-vs-start race outcome, not a new one.
 
         The stop-epoch pop resets the workspace to the implicit 0
-        (``get``'s default, i.e. "never stopped"): the #2625 crash
-        guards compare epochs by inequality, so anything deleted
-        mid-detection reads as "changed" and skips — it can never
-        cause a wrong restart. Bounds ``_workspace_locks`` and
-        ``stop_epoch`` against unbounded growth from workspace
-        create/delete churn, mirroring how
+        (``get``'s default, i.e. "never stopped"). The #2625 crash
+        *entry* guards compare epochs by strict inequality and run
+        before any crash-teardown bump, so a delete mid-detection still
+        reads as "changed" and skips. The *post-teardown* guard
+        (#3074) allows the crash teardown's own single bump, and a
+        popped epoch (0) does not read as moved — so a delete landing
+        during death handling's awaits can reach the restart scheduler;
+        the scheduled task's workspace-row check
+        (``CrashRecoveryMonitor._restartable_workspace``) abandons it,
+        because the prune callers run after the DB row is gone. The
+        ``crash.clear`` below drops any retained crash tracker and
+        cancels a pending restart at delete time; the narrow window
+        where a delete completes *between* the crash teardown and
+        ``_finalize_death`` may still leave one stale tracker entry
+        until process exit (invisible — no row). Bounds
+        ``_workspace_locks`` and ``stop_epoch`` against unbounded
+        growth from workspace create/delete churn, mirroring how
         :meth:`prune_service_session_locks` bounds the per-container
         lock dict (#1351). A no-op when neither entry exists (the
         workspace was never started in this process).
         """
         self._workspace_locks.pop(workspace_id, None)
         self.stop_epoch.pop(workspace_id, None)
+        # Delete-time crash cleanup (#3074 review): the workspace row is
+        # gone, so any crash state or pending restart for it is obsolete.
+        self.crash.clear(workspace_id)
 
     # --- State tracking ---
 

--- a/src/klangk/klangkd-tests/tests/test_crash_recovery.py
+++ b/src/klangk/klangkd-tests/tests/test_crash_recovery.py
@@ -694,6 +694,26 @@ class TestHandleDeathDisabled:
             "container removed externally (not found)"
         )
 
+    async def test_sweep_records_cause_when_disabled(self):
+        """#3074: via the sweep path (the only production caller, which
+        passes a non-None epoch), a death with restart off still records
+        the tracker so /status shows why the workspace died."""
+        app_state = make_app_state()  # restart disabled (the default)
+        reg = app_state.state.container_registry
+        monitor = reg.crash
+        dead_state(reg)
+        with patch_podman_methods(
+            app_state,
+            inspect_dead(),
+            listed=[pod_entry("cid-crash", "exited")],
+        ):
+            await monitor.sweep_once()
+        assert monitor.pending == {}
+        assert monitor.trackers["ws-crash"].last_cause.startswith(
+            "killed by SIGKILL"
+        )
+        assert monitor.status("ws-crash")["state"] == "dead"
+
 
 class TestRestartEnabled:
     async def test_restart_after_backoff(self, crash_env):
@@ -730,6 +750,42 @@ class TestRestartEnabled:
         assert tracker.last_started_at is not None
         assert monitor.status("ws-crash")["state"] == "recovering"
         assert monitor.pending == {}
+
+    async def test_sweep_schedules_restart(self, crash_env):
+        """#3074: the production path. The sweep — the only caller that
+        passes a non-None epoch — must schedule the delayed restart even
+        though its own teardown bumped the stop epoch (the pre-#3074
+        post-teardown guard tripped on that bump and dropped every
+        death as "user action interleaved")."""
+        app_state = make_app_state(crash_env)
+        reg = app_state.state.container_registry
+        monitor = reg.crash
+        dead_state(reg)
+        started = []
+
+        async def fake_start(ws, **kwargs):
+            started.append(ws["id"])
+            return "new-cid", "created"
+
+        with patch_podman_methods(
+            app_state,
+            inspect_dead(),
+            listed=[pod_entry("cid-crash", "exited")],
+        ):
+            with patch.object(
+                app_state.state.model.workspaces,
+                "get_workspace_by_id",
+                AsyncMock(return_value={"id": "ws-crash"}),
+            ):
+                with patch.object(
+                    app_state.state.workspaces, "start_workspace", fake_start
+                ):
+                    await monitor.sweep_once()
+                    assert "ws-crash" in monitor.pending
+                    await monitor.pending["ws-crash"]
+        assert started == ["ws-crash"]
+        assert monitor.trackers["ws-crash"].attempts == 1
+        assert monitor.trackers["ws-crash"].last_started_at is not None
 
     async def test_memory_limit_resolved_from_workspace_bag(self, crash_env):
         app_state = make_app_state(crash_env)

--- a/src/klangk/klangkd-tests/tests/test_eviction.py
+++ b/src/klangk/klangkd-tests/tests/test_eviction.py
@@ -703,6 +703,44 @@ class TestRunLoop:
         await self._run_briefly(evictor, seconds=0.1)
         evictor.evict_one.assert_not_awaited()
 
+    async def test_loop_honors_settings_swap_during_sleep(
+        self, monkeypatch, tmp_path
+    ):
+        """#3074: a SIGHUP reload swaps the settings object; the loop
+        must read ``memory_eviction_enabled`` live after its sleep, not
+        from a pre-sleep snapshot — disabling eviction takes effect on
+        the very next poll, with no extra measurement/eviction cycle."""
+        app, evictor = self._evictor(
+            {
+                "KLANGKD_MEMORY_EVICTION_POLL_INTERVAL": "0.001",
+                # High sustain so the enabled phase measures but can
+                # never open an eviction episode.
+                "KLANGKD_MEMORY_EVICTION_SUSTAIN_POLLS": "1000",
+            }
+        )
+        monkeypatch.setattr(
+            "klangk.container.eviction.MIN_POLL_INTERVAL_SECONDS", 0.001
+        )
+        measure = AsyncMock(return_value=0.01)
+        monkeypatch.setattr(
+            "klangk.container.eviction.measure_available_fraction", measure
+        )
+        evictor.evict_one = AsyncMock(return_value=True)
+        evictor.start()
+        try:
+            await asyncio.sleep(0.05)  # loop polls while still enabled
+            polls_while_enabled = measure.await_count
+            assert polls_while_enabled > 0
+            # SIGHUP: the settings OBJECT is swapped for a fresh one.
+            app.state.settings = make_settings(
+                {"KLANGKD_MEMORY_EVICTION_ENABLED": "false"}
+            )
+            await asyncio.sleep(0.15)
+        finally:
+            await evictor.stop()
+        assert measure.await_count == polls_while_enabled
+        evictor.evict_one.assert_not_awaited()
+
     async def test_loop_survives_evict_one_raise(self, monkeypatch, caplog):
         """A failing eviction cycle must not kill the loop (#2627 review B1).
 

--- a/src/klangk/klangkd-tests/tests/test_eviction.py
+++ b/src/klangk/klangkd-tests/tests/test_eviction.py
@@ -703,13 +703,17 @@ class TestRunLoop:
         await self._run_briefly(evictor, seconds=0.1)
         evictor.evict_one.assert_not_awaited()
 
-    async def test_loop_honors_settings_swap_during_sleep(
-        self, monkeypatch, tmp_path
-    ):
+    async def test_loop_honors_settings_swap_during_sleep(self, monkeypatch):
         """#3074: a SIGHUP reload swaps the settings object; the loop
         must read ``memory_eviction_enabled`` live after its sleep, not
         from a pre-sleep snapshot — disabling eviction takes effect on
-        the very next poll, with no extra measurement/eviction cycle."""
+        the very next poll, with no extra measurement/eviction cycle.
+
+        Deterministic despite the wall-clock sleeps: the mocked
+        ``measure``/``evict_one`` never yield to the loop, so the only
+        suspension point per iteration is the interval sleep — the
+        enabled phase cannot slip an extra poll past the swap.
+        """
         app, evictor = self._evictor(
             {
                 "KLANGKD_MEMORY_EVICTION_POLL_INTERVAL": "0.001",


### PR DESCRIPTION
# Summary

Fixes both bugs from the #3074 container bug sweep.

## Crash auto-restart never fired from the sweep path

`handle_death` tears the dead container down through `stop_and_remove_container`, which bumps the workspace's `stop_epoch` at entry. The post-teardown guard then compared against the *pre-teardown* epoch with a strict inequality, so the monitor's own teardown always looked like "a user stop interleaved": the tracker was dropped and no restart was ever scheduled. Since the sweep is the only production caller of `handle_death` (and always passes a non-None epoch), `KLANGKD_CONTAINER_RESTART_ENABLED` was completely inert, and even the restart-disabled diagnosis path (tracker with `last_cause` for `/status`) never recorded anything.

Fix: the post-teardown guard (`_stop_epoch_moved_beyond_teardown`) allows exactly one bump — the crash teardown's own; two or more bumps mean a user stop also began during the handling awaits. The entry guards keep the strict form (they run before the teardown's bump).

The existing race test (`test_race_user_stop_during_death_handling`) passed vacuously before — its "no restart" assertion is what the bug produced with no race. New tests drive the real production path:

- `test_sweep_schedules_restart` — `sweep_once` detects the death and the delayed restart fires (failed before the fix);
- `test_sweep_records_cause_when_disabled` — via the sweep, a restart-off death still records the tracker for the status API.

## Eviction loop read `memory_eviction_enabled` from a stale settings snapshot

`MemoryPressureEvictor.run` captured `settings = app.state.settings` *before* its `sleep(interval)` and checked `enabled` (and computed the interval) from that object after it. A SIGHUP reload swaps the settings object, so the loop acted on pre-reload values for one cycle — an operator disabling `KLANGKD_MEMORY_EVICTION_ENABLED` under sustained pressure could still get one more eviction. The module docstring already claimed "all thresholds are read live off `app.state.settings` on every poll"; `enabled` and the interval now are too (`_enabled` / `_poll_interval` properties, matching `_threshold`).

New test: `test_loop_honors_settings_swap_during_sleep` swaps the settings object mid-sleep and asserts the measurements stop with the disabled object.

## Notes

- Full backend suite run the CI way before and after the rebase: 6627 passed, 100% branch coverage.
- Changelog entries added under `[Unreleased]` → `Fixed`.

Closes #3074
