### PR TITLE
Normalize live vs replayed egress_request frame shape (#3082)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -1945,6 +1945,13 @@ git-credential` (#1700).** `pig-latin` removed; `word-count` dormant.
 
 ### Fixed
 
+- **`egress_request` frames now carry one request shape on every delivery
+  path (#3082).** A live hold fanned out to deciders carried a request dict
+  without `duration`/`revoked_at`/`revoked_by`, while a connect-time replay
+  of the same held request carried all columns. Both paths now emit the full
+  column set, so clients keying on any field behave identically whether a
+  request arrives live or via replay.
+
 - **Stale consent pause no longer auto-allows in static-mode workspaces
   (#3080).** The consent-pause window (`set_consent_pause`, e.g. a 1d
   pause set by a decider) was honored by the egress gate even after the
@@ -1955,6 +1962,7 @@ git-credential` (#1700).** `pig-latin` removed; `word-count` dormant.
   switch clears the stored window (unrelated edits that merely re-send
   the current mode leave a live pause alone) so it cannot resurrect on a
   later switch back.
+
 - **Consent rate-limit wedge on DB errors (#3081).** When a database
   error struck while recording a decider verdict or expiring a timed-out
   request, the row stayed `pending` forever with no live hold — invisible
@@ -1964,6 +1972,7 @@ git-credential` (#1700).** `pig-latin` removed; `word-count` dormant.
   the verdict and retry expiring the row once; a row that still cannot
   be expired is reaped at the next backend start instead of lingering
   for the retention window.
+
 - **Malformed client frames no longer drop the WebSocket session
   (#3071).** Any command handler exception now gets an error frame and
   the connection stays up, instead of ending the whole session:

--- a/src/klangk/klangk/model/egress_consent.py
+++ b/src/klangk/klangk/model/egress_consent.py
@@ -93,6 +93,13 @@ class EgressConsentModel(Submodel):
         Uses ``INSERT OR IGNORE`` against the partial unique index
         ``idx_egress_consent_pending_dedup`` to atomically deduplicate —
         no TOCTOU between a separate has_pending() check and the insert.
+
+        The row is re-read inside the same transaction (the :meth:`decide`
+        pattern) and returned via :func:`_row_to_dict`, so the returned dict
+        carries the full column set -- the exact shape ``list_requests``
+        rows have. The live ``egress_request`` frame (``_fanout`` in the
+        coordinator) frames this dict, so live and replayed
+        (``snapshot``) frames cannot drift apart (#3082).
         """
         request_id = str(uuid.uuid4())
         requested_at = time.time()
@@ -115,18 +122,7 @@ class EgressConsentModel(Submodel):
             )
             if cursor.rowcount == 0:
                 return None
-        return {
-            "id": request_id,
-            "workspace_id": workspace_id,
-            "dest_host": dest_host,
-            "dest_port": dest_port,
-            "pid": pid,
-            "process_name": process_name,
-            "decision": DECISION_PENDING,
-            "requested_at": requested_at,
-            "decided_at": None,
-            "decided_by": None,
-        }
+            return await _select_row(db, request_id)
 
     async def record_static_denial(
         self,
@@ -177,7 +173,9 @@ class EgressConsentModel(Submodel):
         dest_port: int | None,
     ) -> dict | None:
         """INSERT OR IGNORE one static-mode consent row; the new row, or
-        None when the mode's dedup index already had it."""
+        None when the mode's dedup index already had it. Re-read inside the
+        transaction (like :meth:`create_request`, #3082) so every returned
+        row dict carries the full :func:`_row_to_dict` column set."""
         request_id = str(uuid.uuid4())
         now = time.time()
         async with self.app.state.db.transaction() as db:
@@ -199,18 +197,7 @@ class EgressConsentModel(Submodel):
             )
             if cursor.rowcount == 0:
                 return None
-        return {
-            "id": request_id,
-            "workspace_id": workspace_id,
-            "dest_host": dest_host,
-            "dest_port": dest_port,
-            "pid": None,
-            "process_name": None,
-            "decision": decision,
-            "requested_at": now,
-            "decided_at": now,
-            "decided_by": None,
-        }
+            return await _select_row(db, request_id)
 
     async def get_request(self, request_id: str) -> dict | None:
         """Get a single consent request by ID."""
@@ -722,6 +709,19 @@ class EgressConsentModel(Submodel):
                 cursor = await db.execute(sql, params)
                 removed += cursor.rowcount
         return removed
+
+
+async def _select_row(db, request_id: str) -> dict | None:
+    """Re-read one full row inside an open transaction (the #3082 shape
+    guarantee: an inserted row is returned via the same
+    :func:`_row_to_dict` mapping the read paths use, so a returned dict can
+    never carry a different key set than a ``list_requests`` row)."""
+    cursor = await db.execute(
+        f"SELECT {_EC_COLUMNS} FROM egress_consent WHERE id = ?",  # noqa: S608
+        (request_id,),
+    )
+    row = await cursor.fetchone()
+    return _row_to_dict(row) if row else None
 
 
 def _row_to_dict(row) -> dict:

--- a/src/klangk/klangkd-tests/tests/test_consent_coordinator.py
+++ b/src/klangk/klangkd-tests/tests/test_consent_coordinator.py
@@ -1815,6 +1815,42 @@ class TestConsentCoordinatorPauseIntegration:
         assert fut2.result()["reason"] == "paused"
 
 
+class TestConsentFrameShapeIntegration:
+    """#3082: live fanout and connect-time replay carry one request shape.
+
+    Drives the REAL model: the ``egress_request`` frame ``_fanout`` sends on
+    hold() and the frame ``snapshot()`` returns to a reconnecting decider must
+    carry the same ``request`` key set, so no client can observe a
+    delivery-path-dependent shape.
+    """
+
+    async def test_fanout_and_snapshot_frames_share_request_shape(
+        self, app_state, user
+    ):
+        from klangk.model.workspaces import EGRESS_MODE_INTERACTIVE
+
+        _wire_coordinator_extras(app_state)
+        ws = await app_state.state.model.workspaces.create_workspace(
+            user["id"], "shape-int", egress_mode=EGRESS_MODE_INTERACTIVE
+        )
+        coord = ConsentCoordinator(app_state)
+        await coord.hold(ws["id"], "live.example.com", 443)
+        live = [
+            c.args[1]
+            for c in app_state.state.consent_deciders.broadcast.call_args_list
+            if c.args[1]["type"] == "egress_request"
+        ]
+        assert len(live) == 1
+        replayed = await coord.snapshot(ws["id"])
+        assert len(replayed) == 1
+        assert set(live[0]["request"]) == set(replayed[0]["request"])
+        # the unset lifecycle columns are present-and-None on both paths
+        for frame in (live[0], replayed[0]):
+            assert frame["request"]["duration"] is None
+            assert frame["request"]["revoked_at"] is None
+            assert frame["request"]["revoked_by"] is None
+
+
 class TestCoordinatorBranchGaps2834:
     """#2834 branch gate: hold/fail-close/refresh outcomes the mainline
     revoke + stop tests only take one side of."""

--- a/src/klangk/klangkd-tests/tests/test_model_egress_consent.py
+++ b/src/klangk/klangkd-tests/tests/test_model_egress_consent.py
@@ -160,6 +160,42 @@ async def test_create_request_dedup_returns_none(ec, ws, user):
     assert await ec.count_pending(w["id"]) == 1
 
 
+async def test_create_request_returns_full_column_set(ec, ws, user):
+    """#3082: the returned dict is the exact ``_row_to_dict`` shape.
+
+    The live ``egress_request`` fanout (coordinator ``_fanout``) frames the
+    ``create_request`` return value, while the connect-time replay
+    (``snapshot`` -> ``list_requests``) frames DB rows; both must carry the
+    same key set so a decider sees one shape per delivery path. The unset
+    lifecycle columns come back as explicit ``None``.
+    """
+    w = await ws.create_workspace(user["id"], "shape-ws")
+    req = await ec.create_request(w["id"], "shape.example.com", 443)
+    row = await ec.get_request(req["id"])
+    # full equality, not just key-set: both sides are re-read through the
+    # same _row_to_dict, so a column mis-mapping or value mangling fails
+    # here too (and floats round-trip identically on both sides -- no flake)
+    assert req == row
+    assert req["duration"] is None
+    assert req["decided_at"] is None
+    assert req["decided_by"] is None
+    assert req["revoked_at"] is None
+    assert req["revoked_by"] is None
+
+
+async def test_record_static_rows_return_full_column_set(ec, ws, user):
+    """#3082: the static-mode recorders return the full ``_row_to_dict``
+    shape too (same guarantee as ``create_request``)."""
+    w = await ws.create_workspace(user["id"], "static-shape-ws")
+    denier = await ec.record_static_denial(w["id"], "evil.example.com", 443)
+    allower = await ec.record_static_allow(w["id"], "ok.example.com", 443)
+    for req in (denier, allower):
+        row = await ec.get_request(req["id"])
+        assert req == row
+        assert req["revoked_at"] is None
+        assert req["revoked_by"] is None
+
+
 async def test_record_static_denial_inserts_denied_no_human(ec, ws, user):
     w = await ws.create_workspace(user["id"], "static-denial-ws")
     req = await ec.record_static_denial(w["id"], "evil.com", 443)


### PR DESCRIPTION
## Summary

`egress_request` frames carried different `request` shapes per delivery path: the live fanout (`ConsentCoordinator._register_hold` → `_fanout`) framed the dict returned by `EgressConsentModel.create_request()` (10 keys — no `duration`/`revoked_at`/`revoked_by`), while the connect-time replay (`snapshot()` → `list_requests()`) framed full 13-column `_row_to_dict()` rows. A decider could see different key sets for the same held request depending on delivery path.

## Fix

- `create_request()` and `_record_static_row()` (`record_static_denial`/`record_static_allow`) now re-read the inserted row inside the same transaction and return it via `_row_to_dict` — the pattern `decide()`/`revoke()` already use — so an inserted-row return can never drift from the read shape again.
- New `_select_row()` helper holds the transaction-scoped re-read (all 13 columns via `_EC_COLUMNS`).
- Tests: model tests assert the returned key set equals a `get_request` row (unset lifecycle columns explicit `None`), plus a real-model coordinator integration test comparing the live fanout frame against the `snapshot()` replay frame key-for-key.

Fixes #3082
