### PR TITLE
Expire stranded pending consent rows on error paths (#3081)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -1960,8 +1960,10 @@ git-credential` (#1700).** `pig-latin` removed; `word-count` dormant.
   request, the row stayed `pending` forever with no live hold — invisible
   to deciders yet counted against the workspace's pending cap
   (`KLANGKD_EGRESS_CONSENT_RATE_LIMIT`), eventually wedging every new
-  request into `rate_limited` denials until restart. Both error paths now
-  retry expiring the row once, so it becomes terminal promptly.
+  request into `rate_limited` denials. Both error paths now fail-close
+  the verdict and retry expiring the row once; a row that still cannot
+  be expired is reaped at the next backend start instead of lingering
+  for the retention window.
 - **Malformed client frames no longer drop the WebSocket session
   (#3071).** Any command handler exception now gets an error frame and
   the connection stays up, instead of ending the whole session:

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -1955,6 +1955,13 @@ git-credential` (#1700).** `pig-latin` removed; `word-count` dormant.
   switch clears the stored window (unrelated edits that merely re-send
   the current mode leave a live pause alone) so it cannot resurrect on a
   later switch back.
+- **Consent rate-limit wedge on DB errors (#3081).** When a database
+  error struck while recording a decider verdict or expiring a timed-out
+  request, the row stayed `pending` forever with no live hold — invisible
+  to deciders yet counted against the workspace's pending cap
+  (`KLANGKD_EGRESS_CONSENT_RATE_LIMIT`), eventually wedging every new
+  request into `rate_limited` denials until restart. Both error paths now
+  retry expiring the row once, so it becomes terminal promptly.
 - **Malformed client frames no longer drop the WebSocket session
   (#3071).** Any command handler exception now gets an error frame and
   the connection stays up, instead of ending the whole session:

--- a/src/klangk/klangk/consent/coordinator.py
+++ b/src/klangk/klangk/consent/coordinator.py
@@ -501,9 +501,12 @@ class ConsentCoordinator:
             # decide() failed (DB error). The hold's own timeout is already
             # cancelled, so we MUST resolve the Future ourselves -- otherwise
             # the sidecar relay awaits it forever ("no hold pending forever").
-            # Fail-close to deny + broadcast so co-deciders drop it; the
-            # pending row is left for GC.
+            # Fail-close to deny + broadcast so co-deciders drop it, and
+            # best-effort expire the row: a hold-less pending row can never
+            # be resolved by anyone yet still occupies a pending-cap slot
+            # (#3081).
             logger.exception("consent: resolve failed; fail-closing to deny")
+            await self._expire_stranded(request_id)
             verdict = {"decision": VERDICT_DENY, "reason": "error"}
             resolved = "expired"
         else:
@@ -802,14 +805,7 @@ class ConsentCoordinator:
         hold = self._holds.pop(request_id, None)
         if hold is None:
             return
-        try:
-            await self.app.state.model.egress_consent.expire_pending(
-                request_id
-            )
-        except Exception:
-            logger.exception(
-                "consent: failed to expire held request %s", request_id[:8]
-            )
+        await self._expire_stranded(request_id)
         if not hold["future"].done():
             hold["future"].set_result(
                 {
@@ -819,6 +815,34 @@ class ConsentCoordinator:
                 }
             )
         self._broadcast_resolved(request_id, hold["workspace_id"], "expired")
+
+    async def _expire_stranded(self, request_id: str) -> None:
+        """Best-effort expire of a pending row whose hold is gone (#3081).
+
+        Called only after the hold was popped (``resolve``'s decide-failure
+        arm, ``_fail_close``): a row left ``pending`` with no live hold can
+        never be resolved -- ``snapshot()`` replays only rows still held,
+        and a verdict for its id returns ``None`` -- yet ``count_pending``
+        keeps counting it against the workspace's pending cap until the
+        retention sweep (default 30 days) or the startup reaper, so enough
+        of them wedge every new hold into ``rate_limited`` denials.
+        Retried once -- a first failure is typically a transient DB error,
+        and the retry re-runs after the failing transaction unwound. A
+        second failure is logged and the row falls back to the startup
+        reaper (``expire_all_pending``).
+        """
+        for attempt in (1, 2):
+            try:
+                await self.app.state.model.egress_consent.expire_pending(
+                    request_id
+                )
+                return
+            except Exception:
+                logger.exception(
+                    "consent: failed to expire held request %s (attempt %d)",
+                    request_id[:8],
+                    attempt,
+                )
 
     def _fanout(self, request: dict) -> None:
         """Broadcast the pending request to the workspace's deciders (#2244).

--- a/src/klangk/klangk/consent/coordinator.py
+++ b/src/klangk/klangk/consent/coordinator.py
@@ -463,6 +463,26 @@ class ConsentCoordinator:
             # rule-management view (#2335 slice A) without a reconnect.
             await self._broadcast_rules(hold["workspace_id"])
 
+    def _pop_hold(
+        self, request_id: str, decider_workspace: str | None
+    ) -> dict | None:
+        """Pop + timeout-cancel a held request, or None when untouchable.
+
+        None when the request is not currently held (already resolved, timed
+        out, never held) or -- defense-in-depth -- when a workspace-scoped
+        decider would decide a request outside its workspace
+        (``decider_workspace``); in that case nothing is popped (we only
+        peeked) -- the hold stays for a decider actually scoped to it.
+        """
+        hold = self._holds.get(request_id)
+        if hold is None:
+            return None
+        if not _hold_in_scope(hold, decider_workspace):
+            return None
+        del self._holds[request_id]
+        hold["task"].cancel()
+        return hold
+
     async def resolve(
         self,
         request_id: str,
@@ -479,20 +499,14 @@ class ConsentCoordinator:
         frame so co-deciders drop it (first-decision-wins across N deciders).
         Returns the verdict dict relayed to the sidecar, or ``None`` if the
         request is not currently held (already resolved, timed out, never
-        held) or -- defense-in-depth -- if a workspace-scoped decider tries to
-        decide a request outside its workspace (``decider_workspace``).
+        held) or outside the decider's workspace (``decider_workspace``).
         """
-        hold = self._holds.get(request_id)
+        hold = self._pop_hold(request_id, decider_workspace)
         if hold is None:
             return None
-        if not _hold_in_scope(hold, decider_workspace):
-            # Restore nothing (we only peeked); the hold stays for a decider
-            # actually scoped to it.
-            return None
-        hold = self._holds.pop(request_id)
-        hold["task"].cancel()
         forever_allow_row: dict | None = None
         forever_deny_row: dict | None = None
+        stranded = False
         try:
             row = await self.app.state.model.egress_consent.decide(
                 request_id, decision, decided_by, duration
@@ -501,14 +515,13 @@ class ConsentCoordinator:
             # decide() failed (DB error). The hold's own timeout is already
             # cancelled, so we MUST resolve the Future ourselves -- otherwise
             # the sidecar relay awaits it forever ("no hold pending forever").
-            # Fail-close to deny + broadcast so co-deciders drop it, and
-            # best-effort expire the row: a hold-less pending row can never
-            # be resolved by anyone yet still occupies a pending-cap slot
-            # (#3081).
+            # Fail-close to deny + broadcast so co-deciders drop it; the row
+            # is expired best-effort AFTER the Future is resolved (below), so
+            # a cancellation during that expire can never hang the relay.
             logger.exception("consent: resolve failed; fail-closing to deny")
-            await self._expire_stranded(request_id)
             verdict = {"decision": VERDICT_DENY, "reason": "error"}
             resolved = "expired"
+            stranded = True
         else:
             (
                 verdict,
@@ -524,6 +537,10 @@ class ConsentCoordinator:
             forever_allow_row,
             forever_deny_row,
         )
+        if stranded:
+            # A hold-less pending row can never be resolved by anyone yet
+            # still occupies a pending-cap slot (#3081); best-effort expire.
+            await self._expire_stranded(request_id)
         return verdict
 
     async def _persist_forever_allow(self, row: dict) -> None:
@@ -826,10 +843,13 @@ class ConsentCoordinator:
         keeps counting it against the workspace's pending cap until the
         retention sweep (default 30 days) or the startup reaper, so enough
         of them wedge every new hold into ``rate_limited`` denials.
-        Retried once -- a first failure is typically a transient DB error,
-        and the retry re-runs after the failing transaction unwound. A
-        second failure is logged and the row falls back to the startup
-        reaper (``expire_all_pending``).
+        Retried once: a first failure is typically transient (a lock
+        timeout that rolled back, say) and sometimes clears on a fresh
+        attempt. The retry can re-block up to ``busy_timeout`` again, so
+        ``stop()`` across N holds serializes at most 2N slow attempts --
+        bounded, and the reaper remains the backstop. A second failure is
+        logged and the row falls back to the startup reaper
+        (``expire_all_pending``).
         """
         for attempt in (1, 2):
             try:

--- a/src/klangk/klangkd-tests/tests/test_consent_coordinator.py
+++ b/src/klangk/klangkd-tests/tests/test_consent_coordinator.py
@@ -969,6 +969,33 @@ class TestConsentCoordinatorResolve:
         assert frame["type"] == "egress_resolved"
         assert frame["decision"] == "expired"
         assert coord._holds == {}  # hold gone, no orphan
+        # #3081: the stranded row is expired best-effort, not left pending
+        # invisible-but-counted against the workspace's pending cap.
+        app.state.model.egress_consent.expire_pending.assert_awaited_once_with(
+            "rid-1"
+        )
+
+    async def test_resolve_expire_retry_recovers_transient_error(self):
+        # #3081: decide() raises AND the first expire attempt fails
+        # transiently -- the single retry lands, the row does not linger
+        # pending for the retention window.
+        app = _app(request=request())
+        app.state.model.egress_consent.decide = AsyncMock(
+            side_effect=RuntimeError("db gone")
+        )
+        app.state.model.egress_consent.expire_pending = AsyncMock(
+            side_effect=[RuntimeError("db locked"), True]
+        )
+        coord = ConsentCoordinator(app)
+        fut = await coord.hold(FULL_WS, "1.2.3.4", 443)
+        verdict = await coord.resolve("rid-1", "allowed", "a@x")
+        assert verdict == {"decision": "deny", "reason": "error"}
+        assert app.state.model.egress_consent.expire_pending.await_count == 2
+        assert all(
+            call.args == ("rid-1",)
+            for call in app.state.model.egress_consent.expire_pending.await_args_list
+        )
+        assert fut.result()["decision"] == "deny"
 
     async def test_concurrent_resolves_first_decision_wins(self):
         # two deciders resolve the same hold concurrently: exactly one wins
@@ -1234,7 +1261,8 @@ class TestConsentCoordinatorTimeout:
 
     async def test_timeout_still_denies_when_expire_raises(self):
         # expire_pending failing must not strand the hold -- it logs + still
-        # resolves the Future deny.
+        # resolves the Future deny. Both attempts fail (#3081 adds one
+        # retry); the row then falls back to the startup reaper.
         app = _app(timeout=0.05, request=request())
         app.state.model.egress_consent.expire_pending = AsyncMock(
             side_effect=RuntimeError("db gone")
@@ -1247,9 +1275,25 @@ class TestConsentCoordinatorTimeout:
             "reason": "timeout",
             "duration": "once",
         }
-        app.state.model.egress_consent.expire_pending.assert_awaited_once_with(
-            "rid-1"
+        assert app.state.model.egress_consent.expire_pending.await_count == 2
+        assert all(
+            call.args == ("rid-1",)
+            for call in app.state.model.egress_consent.expire_pending.await_args_list
         )
+
+    async def test_timeout_expire_retry_recovers_transient_error(self):
+        # #3081: the first expire attempt fails transiently -- the retry
+        # lands and the row does not linger pending with no live hold.
+        app = _app(timeout=0.05, request=request())
+        app.state.model.egress_consent.expire_pending = AsyncMock(
+            side_effect=[RuntimeError("db locked"), True]
+        )
+        coord = ConsentCoordinator(app)
+        fut = await coord.hold(FULL_WS, "1.2.3.4", 443)
+        verdict = await fut
+        assert verdict["decision"] == "deny"
+        assert app.state.model.egress_consent.expire_pending.await_count == 2
+        assert coord._holds == {}
 
 
 class TestConsentCoordinatorStop:

--- a/src/klangk/klangkd-tests/tests/test_consent_coordinator.py
+++ b/src/klangk/klangkd-tests/tests/test_consent_coordinator.py
@@ -997,6 +997,47 @@ class TestConsentCoordinatorResolve:
         )
         assert fut.result()["decision"] == "deny"
 
+    async def test_resolve_expire_double_failure_still_resolves_deny(self):
+        # #3081: decide() raises AND both expire attempts fail -- the Future
+        # still resolves deny (the expire runs after _finish_resolve, so its
+        # failure can never hang the relay); the row falls back to the
+        # startup reaper.
+        app = _app(request=request())
+        app.state.model.egress_consent.decide = AsyncMock(
+            side_effect=RuntimeError("db gone")
+        )
+        app.state.model.egress_consent.expire_pending = AsyncMock(
+            side_effect=RuntimeError("db gone")
+        )
+        coord = ConsentCoordinator(app)
+        fut = await coord.hold(FULL_WS, "1.2.3.4", 443)
+        verdict = await coord.resolve("rid-1", "allowed", "a@x")
+        assert verdict == {"decision": "deny", "reason": "error"}
+        assert fut.done() and fut.result()["decision"] == "deny"
+        assert app.state.model.egress_consent.expire_pending.await_count == 2
+
+    async def test_resolve_error_arm_resolves_future_before_expire(self):
+        # The stranded expire is awaited only AFTER the Future is resolved:
+        # a cancellation delivered during the (best-effort) expire can no
+        # longer hang the sidecar relay awaiting the Future.
+        app = _app(request=request())
+        app.state.model.egress_consent.decide = AsyncMock(
+            side_effect=RuntimeError("db gone")
+        )
+        coord = ConsentCoordinator(app)
+        fut = await coord.hold(FULL_WS, "1.2.3.4", 443)
+        fut_done_at_expire: list[bool] = []
+
+        async def _expire(request_id):
+            fut_done_at_expire.append(fut.done())
+
+        app.state.model.egress_consent.expire_pending = AsyncMock(
+            side_effect=_expire
+        )
+        verdict = await coord.resolve("rid-1", "allowed", "a@x")
+        assert verdict == {"decision": "deny", "reason": "error"}
+        assert fut_done_at_expire == [True]
+
     async def test_concurrent_resolves_first_decision_wins(self):
         # two deciders resolve the same hold concurrently: exactly one wins
         # (one decide() write), the other is a no-op (returns None).


### PR DESCRIPTION
## Summary

- Fixes #3081. When `decide()` raised inside `ConsentCoordinator.resolve()` (or `expire_pending()` raised inside `_fail_close`), the hold was popped and the Future denied, but the DB row stayed `decision='pending'` with no live hold. Such rows are invisible to deciders (`snapshot()` replays only live holds), unresolvable (a verdict for their id returns `None`), yet counted by `count_pending()` — each one permanently occupies a slot of the workspace's pending cap (`egress_consent_rate_limit`, default 50) until the 30-day retention sweep or a backend restart. Enough of them wedge every new request into `rate_limited` denials.

- Both error arms now route through a shared `_expire_stranded()` helper: a best-effort `expire_pending(request_id)` with one retry (a first failure is typically a transient DB error), logging and falling back to the startup reaper (`expire_all_pending`) when both attempts fail. The fail-close verdict/broadcast behavior is unchanged.

## Testing

- Updated `test_resolve_fail_closes_when_decide_raises` and `test_timeout_still_denies_when_expire_raises` to assert the expire attempts.
- Added `test_resolve_expire_retry_recovers_transient_error` and `test_timeout_expire_retry_recovers_transient_error` for the retry-lands case.
- Full CI-style suite green: 6675 passed, 100% branch coverage maintained; xenon rank A.
