### PR TITLE
Fail consent pause closed on egress-mode switch (#3080)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -1951,9 +1951,10 @@ git-credential` (#1700).** `pig-latin` removed; `word-count` dormant.
   workspace's `egress_mode` was switched away from `interactive`, so a
   static (default-deny) workspace auto-allowed every off-list
   destination for the rest of the window. The pause is now applied only
-  while the workspace is in interactive mode, and an `egress_mode`
-  update clears the stored window so it cannot resurrect on a later
-  switch back.
+  while the workspace is in interactive mode, and an actual `egress_mode`
+  switch clears the stored window (unrelated edits that merely re-send
+  the current mode leave a live pause alone) so it cannot resurrect on a
+  later switch back.
 - **Malformed client frames no longer drop the WebSocket session
   (#3071).** Any command handler exception now gets an error frame and
   the connection stays up, instead of ending the whole session:

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -1945,6 +1945,15 @@ git-credential` (#1700).** `pig-latin` removed; `word-count` dormant.
 
 ### Fixed
 
+- **Stale consent pause no longer auto-allows in static-mode workspaces
+  (#3080).** The consent-pause window (`set_consent_pause`, e.g. a 1d
+  pause set by a decider) was honored by the egress gate even after the
+  workspace's `egress_mode` was switched away from `interactive`, so a
+  static (default-deny) workspace auto-allowed every off-list
+  destination for the rest of the window. The pause is now applied only
+  while the workspace is in interactive mode, and an `egress_mode`
+  update clears the stored window so it cannot resurrect on a later
+  switch back.
 - **Malformed client frames no longer drop the WebSocket session
   (#3071).** Any command handler exception now gets an error frame and
   the connection stays up, instead of ending the whole session:

--- a/src/klangk/klangk/consent/coordinator.py
+++ b/src/klangk/klangk/consent/coordinator.py
@@ -12,7 +12,10 @@ awaits that Future and sends the verdict back over its socket (#2311).
 Fail-closed throughout:
 
 - no decider registered (or workspace not opted in) -> immediate static
-  denial (no hold, no pending row, deny verdict at once);
+  denial (no hold, no pending row, deny verdict at once); the sole
+  exception is a live consent-pause window (#2332), and that too is
+  honored only in interactive egress mode (#3080) -- a static workspace
+  never auto-allows;
 - decider too slow -> the per-hold timeout expires the row + denies;
 - coordinator shutdown -> every in-flight hold is denied (a sidecar restart's
   in-process holds die with the process, and the orphaned pending rows are
@@ -35,7 +38,7 @@ import asyncio
 import logging
 import time
 
-from .egress import workspace_is_interactive
+from .egress import workspace_is_interactive, workspace_opted_in
 from ..model.egress_consent import (
     DECISION_ALLOWED,
     DECISION_DENIED,
@@ -285,6 +288,10 @@ class ConsentCoordinator:
     ) -> asyncio.Future:
         """Gate-check a blocked egress and create a hold; return its verdict Future.
 
+        - egress_mode allow -> record + allow at once (default-permit).
+        - interactive mode + a live pause window -> the paused gate (#2332;
+          honored only in interactive mode, #3080: a stale pause must not
+          auto-allow egress in a static/allow workspace).
         - not interactive (no decider, or workspace not opted in) -> record a
           static denial and resolve the Future deny at once (no pending row,
           no hold, no timeout) -- the sidecar denies immediately.
@@ -325,7 +332,10 @@ class ConsentCoordinator:
         it for a decider); a recorded deny still blocks. Sets
         ``consent_paused_until`` on the workspace to ``now + duration`` and
         broadcasts a refreshed ``egress_rules`` frame so every decider sees
-        the pause window. Returns ``{"ok": bool, "until": float | None}`` --
+        the pause window. The window is honored only while the workspace
+        stays in interactive egress mode: an ``egress_mode`` update clears
+        it (#3080), and the hold gate ignores it outside interactive mode
+        regardless. Returns ``{"ok": bool, "until": float | None}`` --
         ``ok`` is False for an unknown duration or a missing workspace.
         """
         secs = _PAUSE_SECONDS.get(duration)
@@ -359,7 +369,20 @@ class ConsentCoordinator:
         Reads ``consent_paused_until`` live and compares against ``now``, so a
         pause self-expires the moment its window elapses (no sweep needed for
         correctness -- the gate re-evaluates on every hold).
+
+        #3080: honored only while the workspace is in interactive egress
+        mode. A pause set in an interactive epoch must not auto-allow
+        off-list egress after the workspace is switched to static (or
+        allow) -- those modes answer before the pause is consulted, so a
+        static workspace stays default-deny for the whole stale window.
+        The decider-liveness half of interactivity is deliberately NOT
+        required here: a decider pauses prompting and then walks away, so
+        the window must keep auto-allowing after the decider disconnects
+        (that is the pause's purpose), while the mode gate above still
+        bounds it to opted-in workspaces.
         """
+        if not await workspace_opted_in(self.app, workspace_id):
+            return False
         until = await self.app.state.model.workspaces.get_consent_pause(
             workspace_id
         )

--- a/src/klangk/klangk/consent/coordinator.py
+++ b/src/klangk/klangk/consent/coordinator.py
@@ -333,13 +333,22 @@ class ConsentCoordinator:
         ``consent_paused_until`` on the workspace to ``now + duration`` and
         broadcasts a refreshed ``egress_rules`` frame so every decider sees
         the pause window. The window is honored only while the workspace
-        stays in interactive egress mode: an ``egress_mode`` update clears
-        it (#3080), and the hold gate ignores it outside interactive mode
-        regardless. Returns ``{"ok": bool, "until": float | None}`` --
-        ``ok`` is False for an unknown duration or a missing workspace.
+        stays in interactive egress mode: an actual ``egress_mode`` switch
+        clears it (#3080), the hold gate ignores it outside interactive mode
+        regardless, and a pause set on a workspace since switched away from
+        interactive is refused (``ok`` False). Returns
+        ``{"ok": bool, "until": float | None}`` -- ``ok`` is False for an
+        unknown duration, a non-interactive workspace, or a missing
+        workspace.
         """
         secs = _PAUSE_SECONDS.get(duration)
         if secs is None:
+            return {"ok": False, "until": None}
+        if not await workspace_opted_in(self.app, workspace_id):
+            # #3086 review: the pause is an interactive-mode affordance --
+            # a lingering decider socket (connected before a mode switch)
+            # must not store a new inert window that only confuses the
+            # rules view; the hold gate would ignore it regardless.
             return {"ok": False, "until": None}
         until = time.time() + secs
         if not await self.app.state.model.workspaces.set_consent_pause(

--- a/src/klangk/klangk/consent/egress.py
+++ b/src/klangk/klangk/consent/egress.py
@@ -38,13 +38,25 @@ logger = logging.getLogger(__name__)
 PRUNE_INTERVAL = 3600.0
 
 
+async def workspace_opted_in(app, workspace_id: str) -> bool:
+    """True iff the workspace exists and its ``egress_mode`` is interactive.
+
+    The workspace-side half of interactivity (#2308) -- the runtime half is
+    a live decider. Also the gate for the consent pause (#2332): the pause
+    is a decider prompting affordance, honored only in interactive mode so
+    a pause left over from an interactive epoch cannot auto-allow egress
+    from a workspace since switched to static/allow (#3080, fail-closed).
+    """
+    ws = await app.state.model.workspaces.get_workspace(workspace_id)
+    return bool(ws) and ws.get("egress_mode") == EGRESS_MODE_INTERACTIVE
+
+
 async def workspace_is_interactive(app, workspace_id: str) -> bool:
     # #2308: interactivity is runtime state -- a workspace is interactive
     # only while a live consent decider is registered for it, AND the
     # workspace has opted in (egress_mode). No decider -> static behavior
     # (clean denial, no held connection).
-    ws = await app.state.model.workspaces.get_workspace(workspace_id)
-    if not ws or ws.get("egress_mode") != EGRESS_MODE_INTERACTIVE:
+    if not await workspace_opted_in(app, workspace_id):
         return False
     return app.state.consent_deciders.has_decider(workspace_id)
 

--- a/src/klangk/klangk/model/workspaces.py
+++ b/src/klangk/klangk/model/workspaces.py
@@ -146,6 +146,18 @@ SORT_COLUMNS = {"created": "created_at", "name": "name"}
 CLASSIFICATION_BANNER_MAX_LEN = 120
 
 
+def _clear_stale_consent_pause(to_set: dict) -> None:
+    """End any consent-pause window carried by an ``egress_mode`` write (#3080).
+
+    The pause is an interactive-mode decider affordance; a mode switch must
+    not leave a stale window behind (it would auto-allow off-list egress
+    again if the workspace returned to interactive mode later). Mutates
+    ``to_set`` in place so the clear rides the same atomic UPDATE.
+    """
+    if "egress_mode" in to_set:
+        to_set["consent_paused_until"] = None
+
+
 def _banner_character_error(v: str) -> str | None:
     """Error message for control/invisible characters in a marking.
 
@@ -1055,6 +1067,7 @@ class WorkspacesModel(Submodel):
         }
         if not to_set:
             return False
+        _clear_stale_consent_pause(to_set)
         set_clause = ", ".join(f"{k} = ?" for k in to_set)
         values = list(to_set.values()) + [workspace_id, user_id]
         async with self.app.state.db.transaction() as db:

--- a/src/klangk/klangk/model/workspaces.py
+++ b/src/klangk/klangk/model/workspaces.py
@@ -146,16 +146,28 @@ SORT_COLUMNS = {"created": "created_at", "name": "name"}
 CLASSIFICATION_BANNER_MAX_LEN = 120
 
 
-def _clear_stale_consent_pause(to_set: dict) -> None:
-    """End any consent-pause window carried by an ``egress_mode`` write (#3080).
+def _mode_switch_pause_clear(to_set: dict) -> tuple[str, list]:
+    """(SET-clause tail, extra params) ending a consent pause on a real
+    egress-mode switch (#3080).
 
     The pause is an interactive-mode decider affordance; a mode switch must
     not leave a stale window behind (it would auto-allow off-list egress
-    again if the workspace returned to interactive mode later). Mutates
-    ``to_set`` in place so the clear rides the same atomic UPDATE.
+    again if the workspace returned to interactive mode later). But both
+    first-party clients echo ``egress_mode`` in every workspace-save payload
+    (#3086 review), so the clear must not fire on a no-op echo either -- a
+    routine rename would otherwise cancel a live pause. The CASE compares
+    against the row's pre-update mode (SQLite evaluates SET expressions
+    against the old row), so the window ends only when the write actually
+    switches modes, atomically in the same UPDATE.
     """
-    if "egress_mode" in to_set:
-        to_set["consent_paused_until"] = None
+    if "egress_mode" not in to_set:
+        return "", []
+    return (
+        ", consent_paused_until ="
+        " CASE WHEN egress_mode IS NOT ?"
+        " THEN NULL ELSE consent_paused_until END",
+        [to_set["egress_mode"]],
+    )
 
 
 def _banner_character_error(v: str) -> str | None:
@@ -1067,9 +1079,9 @@ class WorkspacesModel(Submodel):
         }
         if not to_set:
             return False
-        _clear_stale_consent_pause(to_set)
-        set_clause = ", ".join(f"{k} = ?" for k in to_set)
-        values = list(to_set.values()) + [workspace_id, user_id]
+        clause_tail, extra = _mode_switch_pause_clear(to_set)
+        set_clause = ", ".join(f"{k} = ?" for k in to_set) + clause_tail
+        values = list(to_set.values()) + extra + [workspace_id, user_id]
         async with self.app.state.db.transaction() as db:
             cursor = await db.execute(
                 f"UPDATE workspaces SET {set_clause}"  # noqa: S608

--- a/src/klangk/klangkd-tests/tests/test_consent_coordinator.py
+++ b/src/klangk/klangkd-tests/tests/test_consent_coordinator.py
@@ -811,6 +811,42 @@ class TestConsentCoordinatorHoldPaused:
         fut = await coord.hold(FULL_WS, "1.2.3.4", 443)
         assert fut.result()["decision"] == "allow"
 
+    async def test_stale_pause_in_static_mode_fails_closed(self):
+        # #3080: a pause set while interactive must not auto-allow after
+        # the workspace is switched to static -- the static denial wins
+        # (the pause is an interactive-mode affordance only).
+        import time
+
+        app = _app(request=request(), egress_mode="static")
+        app.state.model.workspaces.get_consent_pause = AsyncMock(
+            return_value=time.time() + 600
+        )
+        coord = ConsentCoordinator(app)
+        fut = await coord.hold(FULL_WS, "1.2.3.4", 443)
+        assert fut.result() == {"decision": "deny", "reason": "static"}
+        app.state.model.egress_consent.record_static_denial.assert_awaited_once_with(
+            FULL_WS, "1.2.3.4", 443
+        )
+        # the pause-path lookup was never consulted
+        app.state.model.egress_consent.active_verdict_for.assert_not_awaited()
+
+    async def test_paused_survives_decider_disconnect(self):
+        # The decider-liveness half of interactivity is deliberately NOT
+        # required for the pause (#3080 note): a decider pauses prompting
+        # and walks away -- the window keeps auto-allowing (the mode is
+        # still interactive) instead of flipping every off-list
+        # destination to static denials.
+        import time
+
+        app = _app(request=request(), has_decider=False)
+        app.state.model.workspaces.get_consent_pause = AsyncMock(
+            return_value=time.time() + 600
+        )
+        coord = ConsentCoordinator(app)
+        fut = await coord.hold(FULL_WS, "1.2.3.4", 443)
+        assert fut.result()["reason"] == "paused"
+        app.state.model.egress_consent.record_static_denial.assert_not_awaited()
+
     async def test_expired_pause_falls_through_to_normal_gate(self):
         # A pause whose window elapsed is not paused -> the normal interactive
         # gate applies (here: a decider is present -> hold).
@@ -1607,6 +1643,49 @@ class TestConsentCoordinatorPauseIntegration:
         # 5. a NEW hold after the resolve still auto-allows (pause durable)
         fut2 = await coord.hold(ws["id"], "other.example.com", 80)
         assert fut2.result()["reason"] == "paused"
+
+    async def test_mode_switch_to_static_ends_pause_and_fails_closed(
+        self, app_state, user
+    ):
+        # #3080: the reported bug -- pause while interactive, then switch
+        # the workspace to static. Every off-list hold must deny as static
+        # (not auto-allow on the stale window), the stored window is
+        # cleared by the mode write, and switching back to interactive
+        # does not resurrect it (prompting resumes).
+        from klangk.model.workspaces import (
+            EGRESS_MODE_INTERACTIVE,
+            EGRESS_MODE_STATIC,
+        )
+
+        _wire_coordinator_extras(app_state)
+        wsm = app_state.state.model.workspaces
+        ws = await wsm.create_workspace(
+            user["id"], "pause-stale", egress_mode=EGRESS_MODE_INTERACTIVE
+        )
+        coord = ConsentCoordinator(app_state)
+        assert (await coord.pause(ws["id"], "1d"))["ok"] is True
+        assert (
+            await wsm.update_workspace(
+                ws["id"], user["id"], egress_mode=EGRESS_MODE_STATIC
+            )
+            is True
+        )
+        verdict = (
+            await coord.hold(ws["id"], "offlist.example.com", 443)
+        ).result()
+        assert verdict == {"decision": "deny", "reason": "static"}
+        assert await wsm.get_consent_pause(ws["id"]) is None
+        # back to interactive: no resurrection -- the hold is held for a
+        # decider instead of auto-allowed
+        assert (
+            await wsm.update_workspace(
+                ws["id"], user["id"], egress_mode=EGRESS_MODE_INTERACTIVE
+            )
+            is True
+        )
+        fut = await coord.hold(ws["id"], "other.example.com", 443)
+        assert not fut.done()
+        assert coord._holds
 
     async def test_paused_respects_a_real_recorded_deny(self, app_state, user):
         # I2 (#2332): the security property -- a recorded in-effect deny still

--- a/src/klangk/klangkd-tests/tests/test_consent_coordinator.py
+++ b/src/klangk/klangkd-tests/tests/test_consent_coordinator.py
@@ -720,6 +720,17 @@ class TestConsentCoordinatorPause:
         assert result == {"ok": False, "until": None}
         app.state.consent_deciders.broadcast.assert_not_called()
 
+    async def test_pause_refuses_outside_interactive_mode(self):
+        # #3086 review: the pause is an interactive-mode affordance -- a
+        # decider connected before a switch to static must not store a new
+        # inert window (the hold gate would ignore it regardless).
+        app = _app(egress_mode="static")
+        coord = ConsentCoordinator(app)
+        result = await coord.pause(FULL_WS, "1h")
+        assert result == {"ok": False, "until": None}
+        app.state.model.workspaces.set_consent_pause.assert_not_awaited()
+        app.state.consent_deciders.broadcast.assert_not_called()
+
     async def test_unpause_clears_and_broadcasts(self):
         app = _app()
         coord = ConsentCoordinator(app)
@@ -1674,6 +1685,10 @@ class TestConsentCoordinatorPauseIntegration:
             await coord.hold(ws["id"], "offlist.example.com", 443)
         ).result()
         assert verdict == {"decision": "deny", "reason": "static"}
+        assert await wsm.get_consent_pause(ws["id"]) is None
+        # a lingering decider cannot store a fresh window on the now-static
+        # workspace either (#3086 review)
+        assert (await coord.pause(ws["id"], "1h"))["ok"] is False
         assert await wsm.get_consent_pause(ws["id"]) is None
         # back to interactive: no resurrection -- the hold is held for a
         # decider instead of auto-allowed

--- a/src/klangk/klangkd-tests/tests/test_model_workspaces.py
+++ b/src/klangk/klangkd-tests/tests/test_model_workspaces.py
@@ -14,6 +14,7 @@ import pytest
 
 from klangk.model.acl import ACTION_ALLOW, PRINCIPAL_USER
 from klangk.model.workspaces import (
+    EGRESS_MODE_INTERACTIVE,
     EGRESS_MODE_STATIC,
     SETUP_STATE_COMPLETE,
     SETUP_STATE_PENDING,
@@ -86,16 +87,34 @@ async def test_set_consent_pause_missing_workspace_false(ws):
 
 
 async def test_update_workspace_egress_mode_clears_consent_pause(ws, user):
-    # #3080: an egress_mode write ends the consent-pause window -- the
-    # pause is an interactive-mode affordance and must not outlive a mode
-    # switch (a stale window would auto-allow off-list egress again if the
-    # workspace were later switched back to interactive).
+    # #3080: an actual egress-mode switch ends the consent-pause window --
+    # the pause is an interactive-mode affordance and must not outlive a
+    # mode switch (a stale window would auto-allow off-list egress again
+    # if the workspace were later switched back to interactive).
     row = await ws.create_workspace(user["id"], "pause-mode")
     await ws.set_consent_pause(row["id"], 1234.5)
     assert await ws.update_workspace(
         row["id"], user["id"], egress_mode=EGRESS_MODE_STATIC
     )
     assert await ws.get_consent_pause(row["id"]) is None
+
+
+async def test_update_workspace_mode_echo_keeps_consent_pause(ws, user):
+    # #3086 review: both first-party clients echo egress_mode in every
+    # save payload; a no-op echo (same stored mode, possibly alongside
+    # unrelated edits like a rename) must not cancel a live pause.
+    row = await ws.create_workspace(user["id"], "pause-echo")
+    await ws.set_consent_pause(row["id"], 1234.5)
+    assert await ws.update_workspace(
+        row["id"],
+        user["id"],
+        name="renamed",
+        egress_mode=EGRESS_MODE_INTERACTIVE,
+    )
+    got = await ws.get_workspace_by_id(row["id"])
+    assert got["name"] == "renamed"
+    assert got["egress_mode"] == EGRESS_MODE_INTERACTIVE
+    assert await ws.get_consent_pause(row["id"]) == 1234.5
 
 
 async def test_update_workspace_other_fields_keep_consent_pause(ws, user):

--- a/src/klangk/klangkd-tests/tests/test_model_workspaces.py
+++ b/src/klangk/klangkd-tests/tests/test_model_workspaces.py
@@ -14,6 +14,7 @@ import pytest
 
 from klangk.model.acl import ACTION_ALLOW, PRINCIPAL_USER
 from klangk.model.workspaces import (
+    EGRESS_MODE_STATIC,
     SETUP_STATE_COMPLETE,
     SETUP_STATE_PENDING,
 )
@@ -82,6 +83,27 @@ async def test_set_consent_pause_clear_with_none(ws, user):
 
 async def test_set_consent_pause_missing_workspace_false(ws):
     assert await ws.set_consent_pause("no-such-ws", 1234.0) is False
+
+
+async def test_update_workspace_egress_mode_clears_consent_pause(ws, user):
+    # #3080: an egress_mode write ends the consent-pause window -- the
+    # pause is an interactive-mode affordance and must not outlive a mode
+    # switch (a stale window would auto-allow off-list egress again if the
+    # workspace were later switched back to interactive).
+    row = await ws.create_workspace(user["id"], "pause-mode")
+    await ws.set_consent_pause(row["id"], 1234.5)
+    assert await ws.update_workspace(
+        row["id"], user["id"], egress_mode=EGRESS_MODE_STATIC
+    )
+    assert await ws.get_consent_pause(row["id"]) is None
+
+
+async def test_update_workspace_other_fields_keep_consent_pause(ws, user):
+    # A write that does not touch egress_mode leaves the window alone.
+    row = await ws.create_workspace(user["id"], "pause-keep")
+    await ws.set_consent_pause(row["id"], 1234.5)
+    assert await ws.update_workspace(row["id"], user["id"], name="renamed")
+    assert await ws.get_consent_pause(row["id"]) == 1234.5
 
 
 async def test_get_consent_pause_missing_workspace_none(ws):


### PR DESCRIPTION
Fixes #3080

## Summary

Fixes the #3080 fail-open: the consent-pause gate in `ConsentCoordinator.hold` ran before the egress-mode gate, so a pause set while a workspace was `interactive` kept auto-allowing off-list egress with `{"decision": "allow", "reason": "paused"}` after the workspace was switched to `static` — a default-deny workspace failed open for the remainder of the pause window (up to a day).

Two changes, both suggested in the issue:

- **Gate fix** (`consent/egress.py`, `consent/coordinator.py`): the pause is now honored only while the workspace's `egress_mode` is interactive. New `workspace_opted_in` predicate (the workspace-side half of `workspace_is_interactive`, which now builds on it); `_is_paused` consults it first, so a static workspace answers with the static denial regardless of a stale stored window. The decider-liveness half of interactivity is deliberately *not* required — a decider pauses prompting and then walks away, so the window must keep auto-allowing after the decider disconnects (now pinned by `test_paused_survives_decider_disconnect`); the mode gate alone bounds the fail-open.
- **Persistence fix** (`model/workspaces.py`): an actual `egress_mode` switch in `update_workspace` now clears `consent_paused_until` in the same atomic UPDATE (`CASE WHEN egress_mode IS NOT ?` against the pre-update row), so a later switch back to interactive cannot resurrect an auto-allow window set in a previous mode epoch. A no-op mode echo does not clear — both first-party clients re-send `egress_mode` on every save, and a routine rename must not cancel a live pause (review follow-up). `pause()` also refuses non-interactive workspaces, so a lingering decider socket cannot store fresh inert windows.

## Tests

- Mock-level: stale pause + `egress_mode=static` → `{"decision": "deny", "reason": "static"}`, pause-path lookup never consulted; paused + no decider (interactive mode) still auto-allows.
- Real-model integration: pause `1d` → `update_workspace(egress_mode=static)` → hold denies static and the stored window reads `None` → switch back to interactive → a new hold is held for the decider (no resurrection).
- Model: `egress_mode` update clears a set pause; a non-mode update leaves it untouched.

Full backend suite green the CI way (6678 passed, 100% branch coverage), xenon A-gate green.

🤖 Generated with [pi](https://github.com/earendil-works/pi-coding-agent)

