### PR TITLE
Fix consent coordinator nits: cancel awaits, triple DB read, revoke ack race, shared forever entries, rate_limit=0 (#3083)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -1587,6 +1587,11 @@ stop)`) and a `server: stop at 23:00 (in 1h 12m)` status line in the
 
 ### Changed
 
+- **`KLANGKD_EGRESS_CONSENT_RATE_LIMIT=0` now means unlimited (#3083).**
+  Previously `0` denied every interactive consent hold (the pending cap
+  compared `>= 0`); it now disables the per-workspace pending cap, matching
+  the retention knobs where `0` turns a bound off.
+
 - **Server admin schedule list (#3002).** The explanatory paragraph
   ("A stop exits the server process…") no longer renders above the
   schedule list on the Server admin tab; the list now fills the tab
@@ -1962,7 +1967,6 @@ git-credential` (#1700).** `pig-latin` removed; `word-count` dormant.
   switch clears the stored window (unrelated edits that merely re-send
   the current mode leave a live pause alone) so it cannot resurrect on a
   later switch back.
-
 - **Consent rate-limit wedge on DB errors (#3081).** When a database
   error struck while recording a decider verdict or expiring a timed-out
   request, the row stayed `pending` forever with no live hold — invisible
@@ -1972,6 +1976,13 @@ git-credential` (#1700).** `pig-latin` removed; `word-count` dormant.
   the verdict and retry expiring the row once; a row that still cannot
   be expired is reaped at the next backend start instead of lingering
   for the retention window.
+- **Consent revoke races and shared `forever` entries** (#3083). Two
+  deciders revoking the same verdict concurrently no longer show a
+  misleading "revoke failed — still in effect" ack on the losing side
+  (it is now an idempotent success). Revoking one of two identical
+  `forever` verdicts for the same `host:port` no longer retracts the
+  durable allow/reject-list entry the surviving verdict still needs
+  (it is retracted only when the last `forever` verdict sharing it goes).
 
 - **Malformed client frames no longer drop the WebSocket session
   (#3071).** Any command handler exception now gets an error frame and

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -1587,7 +1587,7 @@ stop)`) and a `server: stop at 23:00 (in 1h 12m)` status line in the
 
 ### Changed
 
-- **`KLANGKD_EGRESS_CONSENT_RATE_LIMIT=0` now means unlimited (#3083).**
+- **`KLANGKD_EGRESS_CONSENT_RATE_LIMIT=0`** now means unlimited (#3083).
   Previously `0` denied every interactive consent hold (the pending cap
   compared `>= 0`); it now disables the per-workspace pending cap, matching
   the retention knobs where `0` turns a bound off.

--- a/src/klangk/klangk/consent/__init__.py
+++ b/src/klangk/klangk/consent/__init__.py
@@ -3,9 +3,10 @@
 The former flat modules became single-responsibility submodules:
 
 - :mod:`.egress`      — was ``klangk/consent.py``: the egress-consent
-  retention sweep (:class:`EgressConsentSweeper`) plus
-  ``workspace_is_interactive``. (The event-intake half of the original
-  design was superseded by the sidecar WS + coordinator, #2311.)
+  retention sweep (:class:`EgressConsentSweeper`). (The event-intake
+  half of the original design was superseded by the sidecar WS +
+  coordinator, #2311; the interactivity predicate moved onto the
+  coordinator with the single workspace-row read, #3083.)
 - :mod:`.deciders`    — was ``klangk/consent_deciders.py``: the runtime
   registry of live consent deciders (``ConsentDeciderRegistry``).
 - :mod:`.coordinator` — was ``klangk/consent_coordinator.py``: decision
@@ -25,5 +26,4 @@ from .deciders import ConsentDeciderRegistry as ConsentDeciderRegistry
 from .egress import (
     EgressConsentSweeper as EgressConsentSweeper,
     PRUNE_INTERVAL as PRUNE_INTERVAL,
-    workspace_is_interactive as workspace_is_interactive,
 )

--- a/src/klangk/klangk/consent/coordinator.py
+++ b/src/klangk/klangk/consent/coordinator.py
@@ -38,16 +38,17 @@ import asyncio
 import logging
 import time
 
-from .egress import workspace_is_interactive, workspace_opted_in
+from .egress import workspace_opted_in
 from ..model.egress_consent import (
     DECISION_ALLOWED,
     DECISION_DENIED,
     DECISION_PENDING,
+    DECISION_REVOKED,
     DURATION_DEFAULT,
     DURATION_FOREVER,
     DURATION_ONCE,
 )
-from ..model.workspaces import EGRESS_MODE_ALLOW
+from ..model.workspaces import EGRESS_MODE_ALLOW, EGRESS_MODE_INTERACTIVE
 
 logger = logging.getLogger(__name__)
 
@@ -127,11 +128,11 @@ def _forever_allow_entry(row: dict) -> str | None:
     in-memory ACCEPT for this session; durability is simply withheld
     (#2368)."""
     host = row.get("dest_host")
-    port = row.get("dest_port")
     workspace_id = row.get("workspace_id")
     if not host or not workspace_id:
         return None
-    if not port:
+    entry = _forever_entry(host, row.get("dest_port"), DECISION_ALLOWED)
+    if entry is None:
         logger.info(
             "consent: forever allow of port-less dest %s ws=%s not "
             "persisted (a bare host would broaden to all-ports); "
@@ -139,8 +140,7 @@ def _forever_allow_entry(row: dict) -> str | None:
             host,
             str(workspace_id)[:8],
         )
-        return None
-    return f"{host}:{port}"
+    return entry
 
 
 def _forever_deny_entry(row: dict) -> str | None:
@@ -151,10 +151,20 @@ def _forever_deny_entry(row: dict) -> str | None:
     NXDOMAIN'd before resolution), so the whole host is the natural unit,
     and "block more" is the safe direction."""
     host = row.get("dest_host")
-    port = row.get("dest_port")
     workspace_id = row.get("workspace_id")
     if not host or not workspace_id:
         return None
+    return _forever_entry(host, row.get("dest_port"), DECISION_DENIED)
+
+
+def _forever_entry(host: str, port, decision: str) -> str | None:
+    """The durable-list entry a ``forever`` verdict of ``decision`` maps
+    to (#3083): ``host:port`` when ported, a bare ``host`` for a port-less
+    deny, or ``None`` for a port-less allow (never persisted -- see
+    :func:`_forever_allow_entry`). One builder for the persist and retract
+    sides so the two cannot drift apart."""
+    if decision == DECISION_ALLOWED:
+        return f"{host}:{port}" if port else None
     return f"{host}:{port}" if port else host
 
 
@@ -202,16 +212,34 @@ class ConsentCoordinator:
         Kept so every ``app.state`` subsystem has a uniform start/stop pair.
         """
 
+    async def _cancel_hold_task(self, task: asyncio.Task) -> None:
+        """Cancel a hold's timeout task and await its completion (#3083).
+
+        Awaiting delivers the cancellation and reaps the task before the
+        caller moves on -- otherwise a shutdown that closes the loop first
+        emits "Task was destroyed but it is pending" noise. The task ends
+        cancelled (``await`` raises) when it never started -- its body's
+        ``except CancelledError`` never engaged -- so swallow that: the hold
+        was already popped and is fail-closed by the caller.
+        """
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+
     async def stop(self) -> None:
         """Fail-close every in-flight hold (coordinator shutdown / sidecar gone).
 
         Each orphaned pending row is expired (audit) and its Future resolved
         deny, so a sidecar restart leaves no leaked allow and no hung relay.
+        The hold's timeout task is cancelled AND awaited (#3083) so no
+        pending task outlives the coordinator.
         """
         for request_id in list(self._holds):
             hold = self._holds.get(request_id)
             if hold is not None:
-                hold["task"].cancel()
+                await self._cancel_hold_task(hold["task"])
             await self._fail_close(request_id, reason="shutdown")
 
     async def _allow_mode_verdict(
@@ -272,7 +300,11 @@ class ConsentCoordinator:
         """The interactive path: a deny Future for a rate-limited or
         duplicate request, else the registered hold's verdict Future."""
         consent = self.app.state.model.egress_consent
-        if await consent.count_pending(workspace_id) >= self.rate_limit:
+        # rate_limit == 0 disables the cap (unlimited pending holds),
+        # matching the retention knobs where 0 means off (#3083).
+        if self.rate_limit > 0 and (
+            await consent.count_pending(workspace_id) >= self.rate_limit
+        ):
             return _completed_verdict(
                 {"decision": VERDICT_DENY, "reason": "rate_limited"}
             )
@@ -287,6 +319,10 @@ class ConsentCoordinator:
         self, workspace_id: str, dst: str, dport: int | None
     ) -> asyncio.Future:
         """Gate-check a blocked egress and create a hold; return its verdict Future.
+
+        One ``get_workspace`` read serves all three gates (#3083): the
+        egress_mode (allow vs static vs interactive) and the live
+        ``consent_paused_until`` window both come off the fetched row.
 
         - egress_mode allow -> record + allow at once (default-permit).
         - interactive mode + a live pause window -> the paused gate (#2332;
@@ -303,13 +339,16 @@ class ConsentCoordinator:
           timeout, and fan out to the workspace's deciders (#2244 stub).
         """
         try:
-            if await self._is_allow(workspace_id):
+            ws = await self.app.state.model.workspaces.get_workspace(
+                workspace_id
+            )
+            if self._ws_is_allow(ws):
                 return await self._allow_mode_verdict(workspace_id, dst, dport)
-            if await self._is_paused(workspace_id):
+            if self._ws_is_paused(ws):
                 return await self._paused_gate_verdict(
                     workspace_id, dst, dport
                 )
-            if not await self.is_interactive(workspace_id):
+            if not self._ws_is_interactive(ws, workspace_id):
                 return await self._static_denial_verdict(
                     workspace_id, dst, dport
                 )
@@ -372,12 +411,19 @@ class ConsentCoordinator:
             await self._broadcast_rules(workspace_id)
         return {"ok": ok}
 
-    async def _is_paused(self, workspace_id: str) -> bool:
+    @staticmethod
+    def _ws_is_allow(ws: dict | None) -> bool:
+        """egress_mode == allow: default-permit (record + allow, no prompt) (#2406)."""
+        return bool(ws) and ws.get("egress_mode") == EGRESS_MODE_ALLOW
+
+    @staticmethod
+    def _ws_is_paused(ws: dict | None) -> bool:
         """Is consent prompting paused for the workspace right now (#2332)?
 
-        Reads ``consent_paused_until`` live and compares against ``now``, so a
-        pause self-expires the moment its window elapses (no sweep needed for
-        correctness -- the gate re-evaluates on every hold).
+        Read off the single workspace-row fetch (``consent_paused_until``),
+        compared against ``now`` so a pause self-expires the moment its
+        window elapses (no sweep needed for correctness -- the gate
+        re-evaluates on every hold).
 
         #3080: honored only while the workspace is in interactive egress
         mode. A pause set in an interactive epoch must not auto-allow
@@ -387,15 +433,23 @@ class ConsentCoordinator:
         The decider-liveness half of interactivity is deliberately NOT
         required here: a decider pauses prompting and then walks away, so
         the window must keep auto-allowing after the decider disconnects
-        (that is the pause's purpose), while the mode gate above still
-        bounds it to opted-in workspaces.
+        (that is the pause's purpose), while the mode gate still bounds it
+        to opted-in workspaces.
         """
-        if not await workspace_opted_in(self.app, workspace_id):
+        if not ws or ws.get("egress_mode") != EGRESS_MODE_INTERACTIVE:
             return False
-        until = await self.app.state.model.workspaces.get_consent_pause(
-            workspace_id
-        )
+        until = ws.get("consent_paused_until")
         return until is not None and until > time.time()
+
+    def _ws_is_interactive(self, ws: dict | None, workspace_id: str) -> bool:
+        """Interactive iff the workspace opted in AND a live decider exists (#2308).
+
+        The decider check is registry state (in-memory, no DB read), so with
+        the workspace row already fetched this costs no extra round-trip.
+        """
+        if not ws or ws.get("egress_mode") != EGRESS_MODE_INTERACTIVE:
+            return False
+        return self.app.state.consent_deciders.has_decider(workspace_id)
 
     async def _paused_verdict(
         self, workspace_id: str, dst: str, dport: int | None
@@ -463,16 +517,22 @@ class ConsentCoordinator:
             # rule-management view (#2335 slice A) without a reconnect.
             await self._broadcast_rules(hold["workspace_id"])
 
-    def _pop_hold(
+    async def _pop_hold(
         self, request_id: str, decider_workspace: str | None
     ) -> dict | None:
-        """Pop + timeout-cancel a held request, or None when untouchable.
+        """Pop + reap a held request's timeout task, or None when untouchable.
 
         None when the request is not currently held (already resolved, timed
         out, never held) or -- defense-in-depth -- when a workspace-scoped
         decider would decide a request outside its workspace
         (``decider_workspace``); in that case nothing is popped (we only
         peeked) -- the hold stays for a decider actually scoped to it.
+
+        The pop and the timeout-task ``cancel()`` are synchronous -- no await
+        between them (the load-bearing invariant in ``_timeout``'s docstring)
+        -- and the task is then cancelled AND awaited (#3083) so it is
+        reaped before the caller moves on (no "Task was destroyed but it is
+        pending" noise when the loop closes first).
         """
         hold = self._holds.get(request_id)
         if hold is None:
@@ -480,7 +540,7 @@ class ConsentCoordinator:
         if not _hold_in_scope(hold, decider_workspace):
             return None
         del self._holds[request_id]
-        hold["task"].cancel()
+        await self._cancel_hold_task(hold["task"])
         return hold
 
     async def resolve(
@@ -501,7 +561,7 @@ class ConsentCoordinator:
         request is not currently held (already resolved, timed out, never
         held) or outside the decider's workspace (``decider_workspace``).
         """
-        hold = self._pop_hold(request_id, decider_workspace)
+        hold = await self._pop_hold(request_id, decider_workspace)
         if hold is None:
             return None
         forever_allow_row: dict | None = None
@@ -647,18 +707,12 @@ class ConsentCoordinator:
                 str(workspace_id)[:8],
             )
 
-    def _retract_spec(self, row: dict, decision: str):
-        """``(remove callable, entry)`` for the durable-list retract, or
-        ``None`` when there is nothing to retract."""
-        host = row.get("dest_host")
-        port = row.get("dest_port")
+    def _durable_remove(self, decision: str):
+        """The workspaces-model remover for one durable list (allow vs deny)."""
+        workspaces = self.app.state.model.workspaces
         if decision == DECISION_ALLOWED:
-            if not port:
-                return None  # port-less allow was never persisted
-            remove = self.app.state.model.workspaces.remove_allowed_domain
-            return remove, f"{host}:{port}"
-        remove = self.app.state.model.workspaces.remove_rejected_domain
-        return remove, (f"{host}:{port}" if port else host)
+            return workspaces.remove_allowed_domain
+        return workspaces.remove_rejected_domain
 
     async def _remove_list_entry(
         self, remove, workspace_id: str, entry: str, decision: str
@@ -682,6 +736,42 @@ class ConsentCoordinator:
                 str(workspace_id)[:8],
             )
 
+    def _maps_to_forever_entry(
+        self, other: dict, decision: str, entry: str
+    ) -> bool:
+        """Does ``other`` (an in-effect row) still need the durable ``entry``?"""
+        if other["decision"] != decision:
+            return False
+        if other.get("duration") != DURATION_FOREVER:
+            return False
+        shared = _forever_entry(
+            other.get("dest_host"), other.get("dest_port"), decision
+        )
+        return shared is not None and shared.lower() == entry.lower()
+
+    async def _forever_entry_still_shared(
+        self, row: dict, decision: str, entry: str
+    ) -> bool:
+        """True when another in-effect ``forever`` verdict still maps to
+        ``entry`` (#3083).
+
+        Two ``forever`` verdicts for the same ``host:port`` share ONE
+        durable ``allowed_domains``/``rejected_domains`` entry, so revoking
+        either row must not retract the entry while the survivor is still
+        in effect -- that would silently strip its cross-restart
+        durability while ``list_active`` still shows it. The revoked row is
+        already marked ``revoked`` (excluded from ``list_active``), so the
+        id filter is defense-in-depth only.
+        """
+        rows = await self.app.state.model.egress_consent.list_active(
+            row["workspace_id"]
+        )
+        return any(
+            self._maps_to_forever_entry(other, decision, entry)
+            for other in rows
+            if other["id"] != row["id"]
+        )
+
     async def _retract_forever_entry(self, row: dict, decision: str) -> None:
         """Retract the durable list entry a ``forever`` verdict added (#2370).
 
@@ -691,6 +781,9 @@ class ConsentCoordinator:
         verdict does not re-apply on the next sidecar restart. The deciding
         connection's in-memory ACCEPT/REJECT + ``_SESSION_HOST_ALLOWS``/
         ``_VERDICT_CACHE`` were already cleared by the drop the caller sent.
+
+        Skipped while another in-effect ``forever`` verdict still maps to
+        the same entry (#3083, :meth:`_forever_entry_still_shared`).
 
         Best-effort (failures logged + swallowed): the row is already revoked,
         so a persistence failure only risks the entry re-applying on restart,
@@ -702,10 +795,19 @@ class ConsentCoordinator:
         workspace_id = row.get("workspace_id")
         if not host or not workspace_id:
             return
-        spec = self._retract_spec(row, decision)
-        if spec is None:
+        entry = _forever_entry(host, row.get("dest_port"), decision)
+        if entry is None:
             return
-        remove, entry = spec
+        if await self._forever_entry_still_shared(row, decision, entry):
+            logger.info(
+                "consent: forever %s entry %s kept -- another in-effect "
+                "forever verdict shares it ws=%s",
+                decision,
+                entry,
+                str(workspace_id)[:8],
+            )
+            return
+        remove = self._durable_remove(decision)
         await self._remove_list_entry(remove, workspace_id, entry, decision)
 
     def _revocable(
@@ -744,6 +846,63 @@ class ConsentCoordinator:
         except asyncio.TimeoutError:
             return False
 
+    async def _row_revoked(self, request_id: str, revoked_by: str) -> bool:
+        """Mark the row revoked; True when it IS revoked afterwards.
+
+        A concurrent duplicate revoke can lose the ``UPDATE`` (the winner
+        flipped the row first) -- the row-already-revoked outcome is an
+        idempotent success (#3083), not a failure: the rule is dropped and
+        the row is revoked either way, so the losing decider must not see
+        "revoke failed -- still in effect".
+        """
+        if (
+            await self.app.state.model.egress_consent.revoke(
+                request_id, revoked_by
+            )
+            is not None
+        ):
+            return True
+        fresh = await self.app.state.model.egress_consent.get_request(
+            request_id
+        )
+        return fresh is not None and fresh["decision"] == DECISION_REVOKED
+
+    async def _apply_revoke(
+        self, row: dict, request_id: str, revoked_by: str
+    ) -> bool:
+        """Drop the sidecar rule, mark the row revoked, retract the durable
+        ``forever`` entry. True when the verdict is undone (or was already
+        undone by a concurrent revoke)."""
+        workspace_id = row["workspace_id"]
+        # Ask the sidecar to drop its rule for this host+decision.
+        if not await self._sidecar_acked_drop(
+            workspace_id, row["dest_host"], row["decision"]
+        ):
+            return False
+        if not await self._row_revoked(request_id, revoked_by):
+            return False
+        # #2370: retract the durable list entry a `forever` verdict added so it
+        # does not re-apply on the next sidecar restart. Best-effort (failures
+        # logged + swallowed): the row is already revoked and the in-memory
+        # rules already dropped, so a failure only risks re-application on
+        # restart, not a broken revoke.
+        if row.get("duration") == DURATION_FOREVER:
+            await self._retract_forever_entry(row, row["decision"])
+        return True
+
+    def _already_revoked_in_scope(
+        self, row: dict | None, decider_workspace: str | None
+    ) -> bool:
+        """#3083: True for a row a concurrent revoke already flipped to
+        ``revoked`` (within the decider's scope) -- an idempotent success
+        for :meth:`revoke`, not a failure."""
+        if row is None or row["decision"] != DECISION_REVOKED:
+            return False
+        return (
+            decider_workspace is None
+            or row["workspace_id"] == decider_workspace
+        )
+
     async def revoke(
         self,
         request_id: str,
@@ -755,43 +914,31 @@ class ConsentCoordinator:
 
         Drops the sidecar's learned rule for the verdict's host (immediate,
         not waiting for the duration/restart) and marks the row ``revoked``.
-        Returns True if revoked; False if the request isn't an active verdict,
-        is outside the decider's workspace (``decider_workspace``), or the
-        sidecar never acked the drop. Fail-closed: a connected-but-
-        unresponsive sidecar leaves the row enforced rather than falsely
-        marking it revoked (the view must not claim "not in effect" while the
-        rule still fires).
+        Returns True if revoked -- including when a concurrent revoke
+        already did it (idempotent success at either race window: the row
+        already reads revoked, or the ``UPDATE`` loses, #3083); False if the
+        request isn't a verdict, is outside the decider's workspace
+        (``decider_workspace``), or the sidecar never acked the drop.
+        Fail-closed: a connected-but-unresponsive sidecar leaves the row
+        enforced rather than falsely marking it revoked (the view must not
+        claim "not in effect" while the rule still fires).
         """
         row = await self.app.state.model.egress_consent.get_request(request_id)
         if not self._revocable(row, decider_workspace):
-            return False
-        workspace_id = row["workspace_id"]
-        host = row["dest_host"]
-        decision = row["decision"]
+            # A concurrent revoke that already flipped the row did the full
+            # work (rule drop + forever retract + rules broadcast); ack
+            # idempotently instead of failing (#3083).
+            return self._already_revoked_in_scope(row, decider_workspace)
         # NOTE (#2370): a `forever` verdict also lives in the workspace's
         # allowed_domains/rejected_domains (added in resolve, #2368/#2369),
-        # which the sidecar re-reads on restart. The drop above cleared the
-        # in-memory rules + _SESSION_HOST_ALLOWS/_VERDICT_CACHE; retract the durable
-        # entry too (after the row is marked revoked) so the verdict does not
-        # re-apply on the next sidecar restart.
-        # Ask the sidecar to drop its rule for this host+decision.
-        if not await self._sidecar_acked_drop(workspace_id, host, decision):
+        # which the sidecar re-reads on restart. The drop clears the
+        # in-memory rules + _SESSION_HOST_ALLOWS/_VERDICT_CACHE; the durable
+        # entry is retracted inside _apply_revoke (after the row is marked
+        # revoked) so the verdict does not re-apply on the next sidecar
+        # restart.
+        if not await self._apply_revoke(row, request_id, revoked_by):
             return False
-        if (
-            await self.app.state.model.egress_consent.revoke(
-                request_id, revoked_by
-            )
-            is None
-        ):
-            return False
-        # #2370: retract the durable list entry a `forever` verdict added so it
-        # does not re-apply on the next sidecar restart. Best-effort (failures
-        # logged + swallowed): the row is already revoked and the in-memory
-        # rules already dropped, so a failure only risks re-application on
-        # restart, not a broken revoke.
-        if row.get("duration") == DURATION_FOREVER:
-            await self._retract_forever_entry(row, decision)
-        await self._broadcast_rules(workspace_id)
+        await self._broadcast_rules(row["workspace_id"])
         return True
 
     async def _timeout(self, request_id: str) -> None:
@@ -984,12 +1131,3 @@ class ConsentCoordinator:
             return
         if frame is not None:
             self.app.state.consent_deciders.broadcast(workspace_id, frame)
-
-    async def is_interactive(self, workspace_id: str) -> bool:
-        """Interactive iff the workspace opted in AND a live decider exists (#2308)."""
-        return await workspace_is_interactive(self.app, workspace_id)
-
-    async def _is_allow(self, workspace_id: str) -> bool:
-        """egress_mode == allow: default-permit (record + allow, no prompt) (#2406)."""
-        ws = await self.app.state.model.workspaces.get_workspace(workspace_id)
-        return bool(ws) and ws.get("egress_mode") == EGRESS_MODE_ALLOW

--- a/src/klangk/klangk/consent/coordinator.py
+++ b/src/klangk/klangk/consent/coordinator.py
@@ -157,7 +157,7 @@ def _forever_deny_entry(row: dict) -> str | None:
     return _forever_entry(host, row.get("dest_port"), DECISION_DENIED)
 
 
-def _forever_entry(host: str, port, decision: str) -> str | None:
+def _forever_entry(host: str, port: int | None, decision: str) -> str | None:
     """The durable-list entry a ``forever`` verdict of ``decision`` maps
     to (#3083): ``host:port`` when ported, a bare ``host`` for a port-less
     deny, or ``None`` for a port-less allow (never persisted -- see
@@ -217,16 +217,29 @@ class ConsentCoordinator:
 
         Awaiting delivers the cancellation and reaps the task before the
         caller moves on -- otherwise a shutdown that closes the loop first
-        emits "Task was destroyed but it is pending" noise. The task ends
-        cancelled (``await`` raises) when it never started -- its body's
-        ``except CancelledError`` never engaged -- so swallow that: the hold
-        was already popped and is fail-closed by the caller.
+        emits "Task was destroyed but it is pending" noise. Two outcomes
+        are swallowed on purpose:
+
+        - the task ends cancelled: either it never started (its body's
+          ``except CancelledError`` never engaged) or the cancellation
+          landed mid-``_fail_close`` -- the hold was already popped either
+          way, so the caller fail-closes it;
+        - the task died from a real exception (a bug in the timeout path):
+          logged here so one poisoned hold can never abort ``stop()``'s
+          fail-close loop for the remaining holds (or blow up ``resolve``).
+
+        A cancellation of the CALLER itself (delivered at this await while
+        the child ends not-cancelled) is re-raised -- swallowing it would
+        eat the caller's cancellation and unbalance its cancel count.
         """
         task.cancel()
         try:
             await task
         except asyncio.CancelledError:
-            pass
+            if not task.cancelled():
+                raise
+        except Exception:
+            logger.exception("consent: timeout task failed while reaping")
 
     async def stop(self) -> None:
         """Fail-close every in-flight hold (coordinator shutdown / sidecar gone).
@@ -420,8 +433,10 @@ class ConsentCoordinator:
     def _ws_is_paused(ws: dict | None) -> bool:
         """Is consent prompting paused for the workspace right now (#2332)?
 
-        Read off the single workspace-row fetch (``consent_paused_until``),
-        compared against ``now`` so a pause self-expires the moment its
+        Read off the single workspace-row fetch (``consent_paused_until``;
+        the column is REAL-or-NULL by schema and the model's write path
+        only ever stores numeric-or-NULL, so no extra type guard is
+        needed), compared against ``now`` so a pause self-expires the moment its
         window elapses (no sweep needed for correctness -- the gate
         re-evaluates on every hold).
 
@@ -1070,11 +1085,10 @@ class ConsentCoordinator:
     async def _rules_frame_for(self, ws: dict, workspace_id: str) -> dict:
         """The assembled frame: static lists, grouped in-effect verdicts,
         and the live pause window (#2332, read fresh so a self-expired pause
-        shows as cleared)."""
+        shows as cleared). The pause comes off the same fetched row as the
+        lists (#3083) -- one fewer read, and the view cannot disagree with
+        the hold gate's snapshot of the window."""
         rows = await self.app.state.model.egress_consent.list_active(
-            workspace_id
-        )
-        until = await self.app.state.model.workspaces.get_consent_pause(
             workspace_id
         )
         return {
@@ -1085,7 +1099,7 @@ class ConsentCoordinator:
             "reject_list": ws.get("rejected_domains") or [],
             "allowed": _by_decision(rows, DECISION_ALLOWED),
             "denied": _by_decision(rows, DECISION_DENIED),
-            "paused": _pause_frame(until),
+            "paused": _pause_frame(ws.get("consent_paused_until")),
         }
 
     @staticmethod

--- a/src/klangk/klangk/consent/egress.py
+++ b/src/klangk/klangk/consent/egress.py
@@ -1,4 +1,4 @@
-"""Egress-consent retention sweep + interactivity predicate.
+"""Egress-consent retention sweep.
 
 The event half of the original #2242 design (sidecar POSTs each blocked
 destination to an HTTP endpoint; ``EgressConsentMonitor.submit`` → persist →
@@ -8,15 +8,17 @@ expire) never shipped. #2311 replaced it with the sidecar's WebSocket
 allows/denials, creates pending requests, arms timeouts, and fans out to
 deciders — synchronously, returning a verdict Future so the sidecar can
 hold the connection SYN in the kernel. A queued POST could not answer a
-held connection, which is why the coordinator design won.
+held connection, which is why the coordinator design won. The
+runtime-interactivity predicate lives on the coordinator itself
+(``_ws_is_interactive``) since #3083 folded it into the single
+workspace-row read; :func:`workspace_opted_in` (the workspace-side half,
+#3080) stays here for the pause paths.
 
 What remains here is periodic retention (:class:`EgressConsentSweeper`,
 #2303) — bounding ``egress_consent`` table growth past the retention
-window / per-workspace cap — plus the :func:`workspace_is_interactive`
-predicate the coordinator gate-checks with. Since #2924 the same sweeper
-also prunes the ``container_events`` audit table (retention window +
-deploy-wide row cap) — the one hourly housekeeping loop for every
-bounded table.
+window / per-workspace cap — since #2924 joined by the
+``container_events`` prune (retention window + deploy-wide row cap) —
+the one hourly housekeeping loop for every bounded table.
 """
 
 from __future__ import annotations
@@ -49,16 +51,6 @@ async def workspace_opted_in(app, workspace_id: str) -> bool:
     """
     ws = await app.state.model.workspaces.get_workspace(workspace_id)
     return bool(ws) and ws.get("egress_mode") == EGRESS_MODE_INTERACTIVE
-
-
-async def workspace_is_interactive(app, workspace_id: str) -> bool:
-    # #2308: interactivity is runtime state -- a workspace is interactive
-    # only while a live consent decider is registered for it, AND the
-    # workspace has opted in (egress_mode). No decider -> static behavior
-    # (clean denial, no held connection).
-    if not await workspace_opted_in(app, workspace_id):
-        return False
-    return app.state.consent_deciders.has_decider(workspace_id)
 
 
 class EgressConsentSweeper(IntervalWorker):

--- a/src/klangk/klangk/model/workspaces.py
+++ b/src/klangk/klangk/model/workspaces.py
@@ -251,7 +251,8 @@ _WORKSPACE_FULL_COLUMNS = (
     "SELECT id, user_id, name, container_id, num_ports, image,"
     " service_command, auto_start, setup_state, health_check,"
     " mounts, env, allowed_domains, rejected_domains, settings,"
-    " egress_mode, per_handle_home, classification_banner"
+    " egress_mode, per_handle_home, classification_banner,"
+    " consent_paused_until"
 )
 
 
@@ -290,11 +291,14 @@ def _workspace_core_fields(row, *, auto_start=True) -> dict:
 
 
 def _workspace_row_to_dict(row, *, auto_start=True) -> dict:
-    """The full-row shape: core fields plus the owner-only columns."""
+    """The full-row shape: core fields plus the owner-only columns and
+    ``consent_paused_until`` (surfaced so the consent coordinator's hold
+    gate reads mode + pause off one fetch, #3083)."""
     return {
         **_workspace_core_fields(row, auto_start=auto_start),
         "user_id": row["user_id"],
         "num_ports": row["num_ports"],
+        "consent_paused_until": row["consent_paused_until"],
     }
 
 

--- a/src/klangk/klangk/settings.py
+++ b/src/klangk/klangk/settings.py
@@ -1157,8 +1157,9 @@ class KlangkSettings(BaseSettings):
     network_sidecar_image: str = "klangk-network-sidecar"
     # egress_consent_rate_limit / egress_consent_timeout: interactive-mode
     # consent monitor (#2242) tuning. rate_limit caps pending requests per
-    # workspace (anti attention-flood from adversarial containers); timeout
-    # is how long a request stays pending before the monitor auto-expires it
+    # workspace (anti attention-flood from adversarial containers); 0
+    # disables the cap (unlimited pending holds, #3083). timeout is how long
+    # a request stays pending before the monitor auto-expires it
     # (DECISION_EXPIRED). Now that consent gates the connection SYN (#2324)
     # the human window is the kernel's connect timeout (~127s), so the default
     # matches it (was 30s when the gate was the DNS query, bounded by

--- a/src/klangk/klangk/wshandler/decider.py
+++ b/src/klangk/klangk/wshandler/decider.py
@@ -103,7 +103,7 @@ async def _refuse_invalid_handshake(
     (its non-allow-listed egress is denied immediately with a static
     verdict). Refuse a workspace-scoped decider at registration so the
     static/interactive boundary is structural (enforced here), not just
-    behavioral (the coordinator's hold-time ``is_interactive`` gate stays
+    behavioral (the coordinator's hold-time interactivity gate stays
     as defense-in-depth). Reads the same egress_mode the coordinator does.
 
     NB: these closes run before websocket.accept(), so the ASGI server

--- a/src/klangk/klangkd-tests/tests/test_consent.py
+++ b/src/klangk/klangkd-tests/tests/test_consent.py
@@ -1,6 +1,6 @@
 """Unit tests for :mod:`klangk.consent.egress` — the retention sweeper
-(#2303) and ``workspace_is_interactive`` (#2308). Event intake lives in the
-coordinator (see test_consent_coordinator.py); the sweeper only prunes.
+(#2303). Event intake lives in the coordinator (see
+test_consent_coordinator.py); the sweeper only prunes.
 """
 
 from __future__ import annotations
@@ -26,45 +26,11 @@ def _app(
     container_events = types.SimpleNamespace(
         prune=events_prune or AsyncMock(return_value=0)
     )
-    workspaces = AsyncMock()
-    workspaces.get_workspace = AsyncMock(
-        return_value={"egress_mode": "interactive"}
-    )
     app.state.model = types.SimpleNamespace(
         egress_consent=egress_consent,
         container_events=container_events,
-        workspaces=workspaces,
-    )
-    app.state.consent_deciders = types.SimpleNamespace(
-        has_decider=lambda workspace_id: True
     )
     return app
-
-
-class TestWorkspaceIsInteractive:
-    async def test_interactive_with_decider(self):
-        assert await consent.workspace_is_interactive(_app(), FULL_WS)
-
-    async def test_missing_workspace(self):
-        app = _app()
-        app.state.model.workspaces.get_workspace = AsyncMock(return_value=None)
-        assert not await consent.workspace_is_interactive(app, FULL_WS)
-
-    async def test_static_mode(self):
-        app = _app()
-        app.state.model.workspaces.get_workspace = AsyncMock(
-            return_value={"egress_mode": "static"}
-        )
-        assert not await consent.workspace_is_interactive(app, FULL_WS)
-
-    async def test_no_decider_registered(self):
-        # #2308: interactivity is runtime state — no live decider means
-        # static behavior (clean denial, no held connection).
-        app = _app()
-        app.state.consent_deciders = types.SimpleNamespace(
-            has_decider=lambda workspace_id: False
-        )
-        assert not await consent.workspace_is_interactive(app, FULL_WS)
 
 
 class TestEgressConsentSweeper:

--- a/src/klangk/klangkd-tests/tests/test_consent_coordinator.py
+++ b/src/klangk/klangkd-tests/tests/test_consent_coordinator.py
@@ -13,6 +13,7 @@ import json
 import types
 from unittest.mock import AsyncMock, Mock
 
+import pytest
 from fastapi import WebSocketDisconnect
 
 from klangk import auth
@@ -811,23 +812,31 @@ class TestConsentCoordinatorRules:
 
     async def test_rules_frame_includes_active_pause_window(self):
         # #2332: a live pause window is surfaced in the egress_rules frame so
-        # deciders render the pause indicator + remaining time.
+        # deciders render the pause indicator + remaining time. The window
+        # comes off the fetched workspace row (#3083 single-read design).
         import time
 
         app = _app()
         until = time.time() + 900
-        app.state.model.workspaces.get_consent_pause = AsyncMock(
-            return_value=until
+        app.state.model.workspaces.get_workspace = AsyncMock(
+            return_value={
+                "egress_mode": "interactive",
+                "consent_paused_until": until,
+            }
         )
         coord = ConsentCoordinator(app)
         frame = await coord.rules_frame(FULL_WS)
         assert frame["paused"] == {"paused": True, "until": until}
+        app.state.model.workspaces.get_consent_pause.assert_not_awaited()
 
     async def test_rules_frame_expired_pause_is_none(self):
         # A pause whose window has elapsed reads as not-paused (self-expiry).
         app = _app()
-        app.state.model.workspaces.get_consent_pause = AsyncMock(
-            return_value=1.0  # far in the past
+        app.state.model.workspaces.get_workspace = AsyncMock(
+            return_value={
+                "egress_mode": "interactive",
+                "consent_paused_until": 1.0,  # far in the past
+            }
         )
         coord = ConsentCoordinator(app)
         frame = await coord.rules_frame(FULL_WS)
@@ -1570,6 +1579,45 @@ class TestConsentCoordinatorStop:
         app.state.model.egress_consent.expire_pending.assert_awaited_once_with(
             "rid-1"
         )
+
+    async def test_cancel_hold_task_reraises_callers_cancellation(self):
+        # If the CALLER is cancelled while awaiting a child that ends NOT
+        # cancelled, the cancellation must propagate -- swallowing it would
+        # eat the caller's cancellation and unbalance its cancel count.
+        app = _app(request=request())
+        coord = ConsentCoordinator(app)
+        swallowed = asyncio.Event()
+
+        async def _swallowing_child():
+            try:
+                await asyncio.sleep(30)
+            except asyncio.CancelledError:
+                swallowed.set()
+                return  # end NOT cancelled (mirrors _timeout's except arm)
+
+        child = asyncio.create_task(_swallowing_child())
+        await asyncio.sleep(0)  # child now suspended in its sleep
+        wrapper = asyncio.create_task(coord._cancel_hold_task(child))
+        await swallowed.wait()  # child reaped our cancel and returned
+        wrapper.cancel()  # wrapper is queued-to-resume: _must_cancel is set
+        with pytest.raises(asyncio.CancelledError):
+            await wrapper
+        assert child.done() and not child.cancelled()
+
+    async def test_cancel_hold_task_swallows_poisoned_task_exception(self):
+        # A timeout task that died from a REAL exception (a bug in the
+        # timeout path) must not abort stop()'s fail-close loop for the
+        # remaining holds: the exception is logged and the reap continues.
+        app = _app(request=request())
+        coord = ConsentCoordinator(app)
+
+        async def _poisoned_child():
+            raise RuntimeError("poisoned")
+
+        child = asyncio.create_task(_poisoned_child())
+        await asyncio.sleep(0)  # child completed, exception stored
+        await coord._cancel_hold_task(child)  # must not raise
+        assert child.done() and not child.cancelled()
 
     async def test_stop_is_idempotent(self):
         app = _app(request=request())

--- a/src/klangk/klangkd-tests/tests/test_consent_coordinator.py
+++ b/src/klangk/klangkd-tests/tests/test_consent_coordinator.py
@@ -69,6 +69,7 @@ def _app(
         return_value=(
             {
                 "egress_mode": egress_mode,
+                "consent_paused_until": None,
                 "allowed_domains": allowed_domains,
                 "rejected_domains": rejected_domains,
             }
@@ -214,6 +215,35 @@ class TestConsentCoordinatorRevoke:
         assert await coord.revoke("rid-1", "a@x") is False
         app.state.sidecar_connections.send_drop.assert_not_called()
 
+    async def test_revoke_already_revoked_row_is_idempotent(self):
+        # #3083, the wider window: the concurrent winner committed before
+        # our first read, so the row already reads revoked -> idempotent
+        # success, not a misleading "revoke failed" ack. The winner already
+        # dropped the rule + retracted, so no second drop is sent.
+        app = _app()
+        app.state.model.egress_consent.get_request = AsyncMock(
+            return_value=_active_row(decision="revoked")
+        )
+        app.state.model.egress_consent.revoke = AsyncMock(return_value=None)
+        coord = ConsentCoordinator(app)
+        assert await coord.revoke("rid-1", "a@x") is True
+        app.state.sidecar_connections.send_drop.assert_not_called()
+        app.state.model.egress_consent.revoke.assert_not_awaited()
+
+    async def test_revoke_already_revoked_outside_scope_returns_false(self):
+        # A revoked row OUTSIDE the decider's workspace stays a refusal.
+        app = _app()
+        app.state.model.egress_consent.get_request = AsyncMock(
+            return_value=_active_row(decision="revoked")
+        )
+        app.state.model.egress_consent.revoke = AsyncMock(return_value=None)
+        coord = ConsentCoordinator(app)
+        assert (
+            await coord.revoke("rid-1", "a@x", decider_workspace="other")
+            is False
+        )
+        app.state.sidecar_connections.send_drop.assert_not_called()
+
     async def test_revoke_outside_decider_workspace_returns_false(self):
         app = _app()
         app.state.model.egress_consent.get_request = AsyncMock(
@@ -227,7 +257,9 @@ class TestConsentCoordinatorRevoke:
         app.state.sidecar_connections.send_drop.assert_not_called()
 
     async def test_revoke_model_returns_none_returns_false(self):
-        # race: the row changed under us -> model.revoke returns None
+        # race: the row changed under us -> model.revoke returns None AND the
+        # re-read shows the row is NOT revoked (e.g. it flipped back to
+        # pending) -> failure (the row may still be enforced).
         app = _app()
         app.state.model.egress_consent.get_request = AsyncMock(
             return_value=_active_row()
@@ -235,6 +267,22 @@ class TestConsentCoordinatorRevoke:
         app.state.model.egress_consent.revoke = AsyncMock(return_value=None)
         coord = ConsentCoordinator(app)
         assert await coord.revoke("rid-1", "a@x") is False
+
+    async def test_revoke_losing_race_with_duplicate_is_idempotent(self):
+        # #3083: two deciders revoke the same verdict concurrently; the
+        # loser's model.revoke UPDATE matches nothing (the winner flipped the
+        # row) -> re-read shows the row already revoked -> idempotent success,
+        # not a misleading "revoke failed -- still in effect" ack.
+        app = _app()
+        active = _active_row()
+        revoked = _active_row(decision="revoked")
+        app.state.model.egress_consent.get_request = AsyncMock(
+            side_effect=[active, revoked]
+        )
+        app.state.model.egress_consent.revoke = AsyncMock(return_value=None)
+        coord = ConsentCoordinator(app)
+        assert await coord.revoke("rid-1", "a@x") is True
+        assert app.state.model.egress_consent.get_request.await_count == 2
 
     async def test_revoke_forever_allow_retracts_allowed_domains(self):
         # #2370: revoking a forever allow retracts the durable allowed_domains
@@ -360,6 +408,104 @@ class TestConsentCoordinatorRevoke:
         assert await coord.revoke("rid-1", "a@x") is True
         app.state.model.workspaces.remove_allowed_domain.assert_not_awaited()
 
+    def _forever_app(self, decision="allowed", survivors=()):
+        """An app whose get_request returns an active ``forever`` row whose
+        revoke succeeds, with ``survivors`` as the in-effect rows
+        ``list_active`` reports (#3083 shared-entry tests)."""
+        app = _app(active_rows=list(survivors))
+        row = _active_row(decision=decision)
+        row["duration"] = "forever"
+        app.state.model.egress_consent.get_request = AsyncMock(
+            side_effect=[row, row]
+        )
+        app.state.model.egress_consent.revoke = AsyncMock(
+            return_value=_active_row(decision="revoked")
+        )
+        return app, row
+
+    async def test_revoke_forever_keeps_entry_shared_with_survivor(self):
+        # #3083: two forever allows for the same host:port share ONE
+        # allowed_domains entry; revoking one row must NOT retract it while
+        # the survivor is still in effect.
+        survivor = _active_row(req_id="rid-2")
+        survivor["duration"] = "forever"
+        app, _row = self._forever_app(survivors=[survivor])
+        coord = ConsentCoordinator(app)
+        assert await coord.revoke("rid-1", "a@x") is True
+        app.state.model.workspaces.remove_allowed_domain.assert_not_awaited()
+
+    async def test_revoke_forever_retracts_when_survivor_differs(self):
+        # The survivor is for a different port -> a different durable entry
+        # -> the revoked row's entry is still retracted.
+        survivor = _active_row(req_id="rid-2")
+        survivor["duration"] = "forever"
+        survivor["dest_port"] = 8443
+        app, _row = self._forever_app(survivors=[survivor])
+        coord = ConsentCoordinator(app)
+        assert await coord.revoke("rid-1", "a@x") is True
+        app.state.model.workspaces.remove_allowed_domain.assert_awaited_once_with(
+            FULL_WS, "1.2.3.4:443"
+        )
+
+    async def test_revoke_forever_retracts_when_survivor_not_forever(self):
+        # A tilrestart survivor never owned the durable entry (only forever
+        # verdicts persist one) -> the revoked row's entry is retracted.
+        survivor = _active_row(req_id="rid-2")  # duration tilrestart
+        app, _row = self._forever_app(survivors=[survivor])
+        coord = ConsentCoordinator(app)
+        assert await coord.revoke("rid-1", "a@x") is True
+        app.state.model.workspaces.remove_allowed_domain.assert_awaited_once_with(
+            FULL_WS, "1.2.3.4:443"
+        )
+
+    async def test_revoke_forever_retracts_when_survivor_other_decision(self):
+        # A forever DENY survivor maps to rejected_domains, a different list
+        # -> the revoked allow's entry is still retracted.
+        survivor = _active_row(req_id="rid-2", decision="denied")
+        survivor["duration"] = "forever"
+        app, _row = self._forever_app(survivors=[survivor])
+        coord = ConsentCoordinator(app)
+        assert await coord.revoke("rid-1", "a@x") is True
+        app.state.model.workspaces.remove_allowed_domain.assert_awaited_once_with(
+            FULL_WS, "1.2.3.4:443"
+        )
+
+    async def test_revoke_forever_deny_shared_entry_kept(self):
+        # The deny mirror of the shared-entry guard.
+        survivor = _active_row(req_id="rid-2", decision="denied")
+        survivor["duration"] = "forever"
+        app, _row = self._forever_app(decision="denied", survivors=[survivor])
+        coord = ConsentCoordinator(app)
+        assert await coord.revoke("rid-1", "a@x") is True
+        app.state.model.workspaces.remove_rejected_domain.assert_not_awaited()
+
+    async def test_revoke_forever_ignores_survivor_with_same_id(self):
+        # Defense-in-depth: a survivor carrying the SAME id as the revoked
+        # row (a stale concurrent read) is filtered out -- the entry is
+        # retracted, not kept alive by the row being revoked.
+        stale = _active_row(req_id="rid-1")
+        stale["duration"] = "forever"
+        app, _row = self._forever_app(survivors=[stale])
+        coord = ConsentCoordinator(app)
+        assert await coord.revoke("rid-1", "a@x") is True
+        app.state.model.workspaces.remove_allowed_domain.assert_awaited_once_with(
+            FULL_WS, "1.2.3.4:443"
+        )
+
+    async def test_revoke_forever_ignores_portless_allow_survivor(self):
+        # A port-less forever-allow survivor maps to NO durable entry (it
+        # was never persisted), so it cannot keep the revoked row's entry
+        # alive -- the entry is retracted.
+        survivor = _active_row(req_id="rid-2")
+        survivor["duration"] = "forever"
+        survivor["dest_port"] = 0
+        app, _row = self._forever_app(survivors=[survivor])
+        coord = ConsentCoordinator(app)
+        assert await coord.revoke("rid-1", "a@x") is True
+        app.state.model.workspaces.remove_allowed_domain.assert_awaited_once_with(
+            FULL_WS, "1.2.3.4:443"
+        )
+
 
 class TestConsentCoordinatorGate:
     async def test_no_decider_records_static_and_denies_at_once(self):
@@ -437,6 +583,28 @@ class TestConsentCoordinatorGate:
         assert not fut.done()  # held, awaiting verdict
         assert "rid-1" in coord._holds
         app.state.model.egress_consent.create_request.assert_awaited_once()
+
+    async def test_hold_reads_the_workspace_row_once(self):
+        # #3083: all three gates (allow mode, pause, interactivity) are
+        # served by ONE get_workspace read -- previously the allow gate and
+        # the interactivity predicate each fetched the row (and the pause
+        # gate a third read via get_consent_pause).
+        app = _app(request=request())
+        coord = ConsentCoordinator(app)
+        await coord.hold(FULL_WS, "1.2.3.4", 443)
+        app.state.model.workspaces.get_workspace.assert_awaited_once_with(
+            FULL_WS
+        )
+        app.state.model.workspaces.get_consent_pause.assert_not_awaited()
+
+    async def test_rate_limit_zero_means_unlimited(self):
+        # #3083: 0 disables the cap (matching the retention knobs), NOT
+        # "deny every hold" -- even with pending rows over any count.
+        app = _app(count_pending=999, rate_limit=0, request=request())
+        coord = ConsentCoordinator(app)
+        fut = await coord.hold(FULL_WS, "1.2.3.4", 443)
+        assert not fut.done()  # held, not rate-limited
+        assert "rid-1" in coord._holds
 
     async def test_hold_db_error_fail_closes_to_deny(self):
         # a DB/model failure during the static-deny recording must not crash the
@@ -756,15 +924,26 @@ class TestConsentCoordinatorPause:
 
 
 class TestConsentCoordinatorHoldPaused:
+    def _paused_app(self, *, egress_mode="interactive", **kwargs):
+        """An app whose workspace row carries a live pause window (#2332;
+        since #3083 hold() reads the pause off the workspace row, not via
+        get_consent_pause -- the row's egress_mode carries the #3080
+        interactive-only pause gate)."""
+        import time
+
+        app = _app(**kwargs)
+        app.state.model.workspaces.get_workspace = AsyncMock(
+            return_value={
+                "egress_mode": egress_mode,
+                "consent_paused_until": time.time() + 600,
+            }
+        )
+        return app
+
     async def test_paused_auto_allows_no_hold(self):
         # #2332: while paused, a destination with no in-effect verdict is
         # auto-allowed at once -- no hold, no pending row, no static denial.
-        import time
-
-        app = _app(request=request())
-        app.state.model.workspaces.get_consent_pause = AsyncMock(
-            return_value=time.time() + 600
-        )
+        app = self._paused_app(request=request())
         coord = ConsentCoordinator(app)
         fut = await coord.hold(FULL_WS, "1.2.3.4", 443)
         verdict = fut.result()
@@ -777,12 +956,7 @@ class TestConsentCoordinatorHoldPaused:
     async def test_paused_respects_recorded_deny(self):
         # A recorded in-effect deny still blocks while paused (the pause does
         # not override existing verdicts).
-        import time
-
-        app = _app(request=request())
-        app.state.model.workspaces.get_consent_pause = AsyncMock(
-            return_value=time.time() + 600
-        )
+        app = self._paused_app(request=request())
         app.state.model.egress_consent.active_verdict_for = AsyncMock(
             return_value={
                 "id": "rid-1",
@@ -803,12 +977,7 @@ class TestConsentCoordinatorHoldPaused:
 
     async def test_paused_allow_verdict_still_allows(self):
         # An in-effect ALLOW verdict is respected too (allow either way).
-        import time
-
-        app = _app(request=request())
-        app.state.model.workspaces.get_consent_pause = AsyncMock(
-            return_value=time.time() + 600
-        )
+        app = self._paused_app(request=request())
         app.state.model.egress_consent.active_verdict_for = AsyncMock(
             return_value={
                 "id": "rid-1",
@@ -825,12 +994,10 @@ class TestConsentCoordinatorHoldPaused:
     async def test_stale_pause_in_static_mode_fails_closed(self):
         # #3080: a pause set while interactive must not auto-allow after
         # the workspace is switched to static -- the static denial wins
-        # (the pause is an interactive-mode affordance only).
-        import time
-
-        app = _app(request=request(), egress_mode="static")
-        app.state.model.workspaces.get_consent_pause = AsyncMock(
-            return_value=time.time() + 600
+        # (the pause is an interactive-mode affordance only). The row
+        # carries a LIVE pause window alongside the static mode.
+        app = self._paused_app(
+            egress_mode="static", request=request(), has_decider=True
         )
         coord = ConsentCoordinator(app)
         fut = await coord.hold(FULL_WS, "1.2.3.4", 443)
@@ -847,12 +1014,7 @@ class TestConsentCoordinatorHoldPaused:
         # and walks away -- the window keeps auto-allowing (the mode is
         # still interactive) instead of flipping every off-list
         # destination to static denials.
-        import time
-
-        app = _app(request=request(), has_decider=False)
-        app.state.model.workspaces.get_consent_pause = AsyncMock(
-            return_value=time.time() + 600
-        )
+        app = self._paused_app(request=request(), has_decider=False)
         coord = ConsentCoordinator(app)
         fut = await coord.hold(FULL_WS, "1.2.3.4", 443)
         assert fut.result()["reason"] == "paused"
@@ -862,8 +1024,11 @@ class TestConsentCoordinatorHoldPaused:
         # A pause whose window elapsed is not paused -> the normal interactive
         # gate applies (here: a decider is present -> hold).
         app = _app(request=request())
-        app.state.model.workspaces.get_consent_pause = AsyncMock(
-            return_value=1.0  # past
+        app.state.model.workspaces.get_workspace = AsyncMock(
+            return_value={
+                "egress_mode": "interactive",
+                "consent_paused_until": 1.0,  # past
+            }
         )
         coord = ConsentCoordinator(app)
         fut = await coord.hold(FULL_WS, "1.2.3.4", 443)
@@ -875,12 +1040,7 @@ class TestConsentCoordinatorHoldPaused:
     async def test_paused_db_error_fail_closes_to_deny(self):
         # A model failure in the pause path must not strand the hold -- the
         # outer guard fail-closes to deny.
-        import time
-
-        app = _app(request=request())
-        app.state.model.workspaces.get_consent_pause = AsyncMock(
-            return_value=time.time() + 600
-        )
+        app = self._paused_app(request=request())
         app.state.model.egress_consent.active_verdict_for = AsyncMock(
             side_effect=RuntimeError("db gone")
         )
@@ -951,6 +1111,34 @@ class TestConsentCoordinatorResolve:
         # timeout cancelled -> the row was NOT expired
         app.state.model.egress_consent.expire_pending.assert_not_awaited()
         assert fut.result()["decision"] == "allow"
+
+    async def test_resolve_awaits_cancelled_timeout_task(self):
+        # #3083: resolve cancels AND awaits the hold's timeout task before
+        # moving on -- here the task already started and is parked in its
+        # sleep, so the cancel lands inside its except arm (normal return).
+        app = _app(request=request(), decide_row=request())
+        coord = ConsentCoordinator(app)
+        await coord.hold(FULL_WS, "1.2.3.4", 443)
+        await asyncio.sleep(0)  # let the timeout task take its first step
+        task = coord._holds["rid-1"]["task"]
+        await coord.resolve("rid-1", "allowed", "a@x")
+        assert task.done()
+        assert not task.cancelled()  # its except-CancelledError arm returned
+
+    async def test_resolve_awaits_task_cancelled_before_it_started(self):
+        # The timeout task never started (hold() ran without yielding to the
+        # loop); the cancel kills the coroutine before its body engages, the
+        # task ends CANCELLED, and resolve must swallow the CancelledError
+        # from awaiting it (the arm of _cancel_hold_task's except).
+        app = _app(request=request(), decide_row=request())
+        coord = ConsentCoordinator(app)
+        await coord.hold(FULL_WS, "1.2.3.4", 443)
+        task = coord._holds["rid-1"]["task"]
+        assert not task.done()
+        verdict = await coord.resolve("rid-1", "allowed", "a@x")
+        assert verdict["decision"] == "allow"
+        assert task.done()
+        assert task.cancelled()
 
     async def test_resolve_fail_closes_when_decide_raises(self):
         # decide() raising (DB error) must not orphan the Future -- the hold's
@@ -1356,6 +1544,33 @@ class TestConsentCoordinatorStop:
         }
         assert expired == {"r1", "r2"}
 
+    async def test_stop_awaits_cancelled_timeout_tasks(self):
+        # #3083: stop() cancels AND awaits each hold's timeout task, so no
+        # pending task outlives the coordinator (no "Task was destroyed but
+        # it is pending" noise when the loop closes right after).
+        app = _app(request=request())
+        coord = ConsentCoordinator(app)
+        await coord.hold(FULL_WS, "1.2.3.4", 443)
+        task = coord._holds["rid-1"]["task"]
+        await coord.stop()
+        assert task.done()  # cancelled AND reaped before stop returned
+
+    async def test_stop_awaits_task_cancelled_before_it_started(self):
+        # The timeout task never got a first step (hold() ran without
+        # yielding); cancelling it kills the coroutine before its body's
+        # except-CancelledError engages, so the task ends CANCELLED -- the
+        # await must swallow that, and the hold still fail-closes.
+        app = _app(request=request())
+        coord = ConsentCoordinator(app)
+        await coord.hold(FULL_WS, "1.2.3.4", 443)
+        task = coord._holds["rid-1"]["task"]
+        await coord.stop()
+        assert task.done()
+        assert task.cancelled()
+        app.state.model.egress_consent.expire_pending.assert_awaited_once_with(
+            "rid-1"
+        )
+
     async def test_stop_is_idempotent(self):
         app = _app(request=request())
         coord = ConsentCoordinator(app)
@@ -1671,6 +1886,72 @@ class TestEgressSidecarWS:
         await handler
         assert ws.sent == []  # relay cancelled before it could send
         assert not fut.done()  # the coordinator's hold Future is untouched
+
+
+class TestConsentRevokeIntegration3083:
+    """Real DB + real model: the #3083 revoke nits end-to-end."""
+
+    async def _interactive_ws(self, app_state, user, name):
+        from klangk.model.workspaces import EGRESS_MODE_INTERACTIVE
+
+        _wire_coordinator_extras(app_state)
+        return await app_state.state.model.workspaces.create_workspace(
+            user["id"], name, egress_mode=EGRESS_MODE_INTERACTIVE
+        )
+
+    async def test_shared_forever_entry_survives_one_revoke(
+        self, app_state, user
+    ):
+        # #3083: two forever allows for one host:port share a single
+        # allowed_domains entry. Revoking one verdict keeps the entry (the
+        # survivor still needs it); revoking the survivor retracts it.
+        ws = await self._interactive_ws(app_state, user, "shared-forever")
+        ec = app_state.state.model.egress_consent
+        coord = ConsentCoordinator(app_state)
+        ids = []
+        for _ in range(2):
+            # hold -> resolve `forever` (the path that persists the entry)
+            await coord.hold(ws["id"], "shared.example.com", 443)
+            req_id = next(iter(coord._holds))
+            verdict = await coord.resolve(
+                req_id, "allowed", user["id"], duration="forever"
+            )
+            assert verdict["decision"] == "allow"
+            ids.append(req_id)
+        row = await app_state.state.model.workspaces.get_workspace(ws["id"])
+        assert row["allowed_domains"] == ["shared.example.com:443"]
+        # revoke ONE of the two -> the shared entry must survive
+        assert await coord.revoke(ids[0], user["id"]) is True
+        row = await app_state.state.model.workspaces.get_workspace(ws["id"])
+        assert row["allowed_domains"] == ["shared.example.com:443"]
+        active = await ec.list_active(ws["id"])
+        assert [r["id"] for r in active] == [ids[1]]
+        # revoke the survivor -> now the entry is retracted
+        assert await coord.revoke(ids[1], user["id"]) is True
+        row = await app_state.state.model.workspaces.get_workspace(ws["id"])
+        assert row["allowed_domains"] == []
+        assert await ec.list_active(ws["id"]) == []
+
+    async def test_concurrent_duplicate_revokes_both_ack_success(
+        self, app_state, user
+    ):
+        # #3083: two deciders revoke the same verdict concurrently: both
+        # revokes ack success (the loser's is idempotent), never a
+        # misleading "revoke failed -- still in effect".
+        ws = await self._interactive_ws(app_state, user, "dup-revoke")
+        ec = app_state.state.model.egress_consent
+        coord = ConsentCoordinator(app_state)
+        await coord.hold(ws["id"], "dup.example.com", 443)
+        req_id = next(iter(coord._holds))
+        await coord.resolve(req_id, "allowed", user["id"], "tilrestart")
+        results = await asyncio.gather(
+            coord.revoke(req_id, user["id"]),
+            coord.revoke(req_id, user["id"]),
+        )
+        assert results == [True, True]
+        fresh = await ec.get_request(req_id)
+        assert fresh["decision"] == "revoked"
+        assert await ec.list_active(ws["id"]) == []
 
 
 # --- pause integration: real model round-trip (#2332) ------------------------


### PR DESCRIPTION
Drive-by fixes for the five consent/ nits from the bug sweep. Full suite
passes at 100% branch coverage; xenon A-rank maintained.

1. **Cancelled timeout tasks never awaited.** `stop()` and `resolve()` now
   cancel *and* await each hold's timeout task (`_cancel_hold_task`), so a
   loop closing at shutdown can no longer emit "Task was destroyed but it
   is pending" noise. The await swallows the task-that-never-started case
   (its body's `except CancelledError` never engaged).

2. **Three sequential DB reads per blocked SYN.** `hold()` now fetches the
   workspace row once and serves all three gates from it: `_ws_is_allow`,
   `_ws_is_paused` (new `consent_paused_until` column surfaced on the
   full-row shape), and `_ws_is_interactive` (decider check is in-memory).
   The now-unused `workspace_is_interactive` predicate (`consent/egress.py`)
   and the coordinator's `_is_allow`/`_is_paused`/`is_interactive` are
   removed along with their export.

3. **Concurrent duplicate revokes produce a misleading ack.** Both race
   windows are now idempotent successes: a row that already reads
   `revoked` at the first read (`_already_revoked_in_scope` — the winner
   already dropped the rule, so no second drop is sent), and a lost
   `UPDATE` (`_row_revoked` re-reads; already-revoked → success). The
   losing decider's TUI no longer flashes "revoke failed — still in
   effect" while the rule is actually gone.

4. **Revoking one of two identical `forever` verdicts retracts the shared
   durable entry.** Retraction now checks `list_active` for another
   in-effect `forever` verdict mapping to the same entry
   (`_forever_entry_still_shared`, case-insensitive) and keeps it while a
   survivor exists. Entry building is unified in one `_forever_entry()`
   used by both the persist and retract sides.

5. **`egress_consent_rate_limit: 0` denied everything.** 0 now disables
   the pending cap (unlimited), matching the retention knobs; documented
   in the settings comment and the changelog.

Tests: unit coverage for every new branch (shared-entry survivor matrix,
both revoke race windows, cancel-await arms, single-read hold, rate_limit
0/>0), plus real-DB integration tests for the shared forever entry and
the concurrent duplicate revoke.


Fixes #3083
