### PR TITLE
Fail-close a consent hold when resolve() is cancelled during decide() (#3089)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -1950,6 +1950,16 @@ git-credential` (#1700).** `pig-latin` removed; `word-count` dormant.
 
 ### Fixed
 
+- **Cancellation during a consent verdict no longer hangs the egress
+  relay** (#3089). A decider disconnect or backend shutdown landing while
+  the verdict's DB write was in flight escaped as a `CancelledError`
+  before the held connection's Future was resolved — with the hold popped
+  and its timeout cancelled, nothing could ever resolve it, so the
+  sidecar relay waited forever and the request row lingered pending
+  against the workspace's cap. The resolve path now fail-closes the
+  Future (deny) and expires the row before letting the cancellation
+  propagate.
+
 - **`egress_request` frames now carry one request shape on every delivery
   path (#3082).** A live hold fanned out to deciders carried a request dict
   without `duration`/`revoked_at`/`revoked_by`, while a connect-time replay

--- a/src/klangk/klangk/consent/coordinator.py
+++ b/src/klangk/klangk/consent/coordinator.py
@@ -532,10 +532,10 @@ class ConsentCoordinator:
             # rule-management view (#2335 slice A) without a reconnect.
             await self._broadcast_rules(hold["workspace_id"])
 
-    async def _pop_hold(
+    def _pop_hold(
         self, request_id: str, decider_workspace: str | None
     ) -> dict | None:
-        """Pop + reap a held request's timeout task, or None when untouchable.
+        """Pop + timeout-cancel a held request, or None when untouchable.
 
         None when the request is not currently held (already resolved, timed
         out, never held) or -- defense-in-depth -- when a workspace-scoped
@@ -544,10 +544,10 @@ class ConsentCoordinator:
         peeked) -- the hold stays for a decider actually scoped to it.
 
         The pop and the timeout-task ``cancel()`` are synchronous -- no await
-        between them (the load-bearing invariant in ``_timeout``'s docstring)
-        -- and the task is then cancelled AND awaited (#3083) so it is
-        reaped before the caller moves on (no "Task was destroyed but it is
-        pending" noise when the loop closes first).
+        between them (the load-bearing invariant in ``_timeout``'s docstring).
+        Reaping the task (cancel AND await, #3083) is the caller's job, inside
+        its own cancellation-rescued region (#3089): a cancellation landing
+        on that await must fail-close the already-popped hold, not escape.
         """
         hold = self._holds.get(request_id)
         if hold is None:
@@ -555,8 +555,73 @@ class ConsentCoordinator:
         if not _hold_in_scope(hold, decider_workspace):
             return None
         del self._holds[request_id]
-        await self._cancel_hold_task(hold["task"])
+        hold["task"].cancel()
         return hold
+
+    def _resolve_popped_fail_close(
+        self, request_id: str, hold: dict, reason: str
+    ) -> None:
+        """Synchronously fail-close an already-popped hold (#3089).
+
+        No awaits: called from a task that is being cancelled, where any
+        suspension could re-deliver cancellation before the Future is set.
+        Resolves the Future deny and tells co-deciders to drop the request;
+        the pending row is expired best-effort by the caller afterwards.
+        An already-done Future (a committed verdict landed, or a racing
+        timeout) is left untouched AND un-broadcast -- a second
+        ``egress_resolved("expired")`` after the real "allowed"/"denied"
+        frame would contradict the committed decision on the wire.
+        """
+        if hold["future"].done():
+            return
+        hold["future"].set_result(
+            {
+                "decision": VERDICT_DENY,
+                "reason": reason,
+                "duration": DURATION_ONCE,
+            }
+        )
+        self._broadcast_resolved(request_id, hold["workspace_id"], "expired")
+
+    async def _decide_or_fail_close(
+        self,
+        request_id: str,
+        decision: str,
+        decided_by: str,
+        duration: str,
+    ) -> tuple[dict, str, dict | None, dict | None, bool]:
+        """``(verdict, resolved, forever_allow_row, forever_deny_row,
+        stranded)`` for one held request's decide step.
+
+        The error arm (decide() raised a DB error) fail-closes via the
+        caller's ``_finish_resolve`` and flags ``stranded`` so the row is
+        expired afterwards (#3081). Cancellation is NOT handled here: a
+        ``CancelledError`` is not an ``Exception``, so it escapes to the
+        caller's rescue (#3089), which owns fail-closing the popped hold.
+        """
+        try:
+            row = await self.app.state.model.egress_consent.decide(
+                request_id, decision, decided_by, duration
+            )
+        except Exception:
+            # decide() failed (DB error). The hold's own timeout is already
+            # cancelled, so the Future MUST be resolved by the caller --
+            # otherwise the sidecar relay awaits it forever. Fail-close to
+            # deny + broadcast so co-deciders drop it; the row is expired
+            # best-effort AFTER the Future is resolved, so a cancellation
+            # during that expire can never hang the relay.
+            logger.exception("consent: resolve failed; fail-closing to deny")
+            return (
+                {"decision": VERDICT_DENY, "reason": "error"},
+                "expired",
+                None,
+                None,
+                True,
+            )
+        verdict, resolved, allow_row, deny_row = _build_verdict(
+            row, decision, duration
+        )
+        return verdict, resolved, allow_row, deny_row, False
 
     async def resolve(
         self,
@@ -575,47 +640,55 @@ class ConsentCoordinator:
         Returns the verdict dict relayed to the sidecar, or ``None`` if the
         request is not currently held (already resolved, timed out, never
         held) or outside the decider's workspace (``decider_workspace``).
+
+        Cancellation-safe (#3089): a ``CancelledError`` delivered anywhere
+        past the pop (reaping the timeout task, the decide() write, the
+        finish sequence, the trailing stranded expire) is rescued before
+        re-raising -- the hold's Future keeps its committed verdict if one
+        landed, else is fail-closed deny -- so the popped, timeout-less
+        hold can never be left unresolvable (the sidecar relay awaits a
+        shielded Future with no timeout of its own and would hang forever)
+        and the stranded row still gets its best-effort expire.
         """
-        hold = await self._pop_hold(request_id, decider_workspace)
+        hold = self._pop_hold(request_id, decider_workspace)
         if hold is None:
             return None
-        forever_allow_row: dict | None = None
-        forever_deny_row: dict | None = None
-        stranded = False
         try:
-            row = await self.app.state.model.egress_consent.decide(
-                request_id, decision, decided_by, duration
-            )
-        except Exception:
-            # decide() failed (DB error). The hold's own timeout is already
-            # cancelled, so we MUST resolve the Future ourselves -- otherwise
-            # the sidecar relay awaits it forever ("no hold pending forever").
-            # Fail-close to deny + broadcast so co-deciders drop it; the row
-            # is expired best-effort AFTER the Future is resolved (below), so
-            # a cancellation during that expire can never hang the relay.
-            logger.exception("consent: resolve failed; fail-closing to deny")
-            verdict = {"decision": VERDICT_DENY, "reason": "error"}
-            resolved = "expired"
-            stranded = True
-        else:
+            await self._cancel_hold_task(hold["task"])
             (
                 verdict,
                 resolved,
                 forever_allow_row,
                 forever_deny_row,
-            ) = _build_verdict(row, decision, duration)
-        await self._finish_resolve(
-            request_id,
-            hold,
-            verdict,
-            resolved,
-            forever_allow_row,
-            forever_deny_row,
-        )
-        if stranded:
-            # A hold-less pending row can never be resolved by anyone yet
-            # still occupies a pending-cap slot (#3081); best-effort expire.
+                stranded,
+            ) = await self._decide_or_fail_close(
+                request_id, decision, decided_by, duration
+            )
+            await self._finish_resolve(
+                request_id,
+                hold,
+                verdict,
+                resolved,
+                forever_allow_row,
+                forever_deny_row,
+            )
+            if stranded:
+                # A hold-less pending row can never be resolved by anyone
+                # yet still occupies a pending-cap slot (#3081);
+                # best-effort expire -- inside the rescued region so a
+                # cancellation during it cannot skip the row's expiry.
+                await self._expire_stranded(request_id)
+        except BaseException:
+            # #3089: a cancellation is NOT an Exception -- without this
+            # rescue it would escape with the hold already popped and its
+            # timeout already cancelled, so nothing could ever resolve the
+            # Future: the relay's shielded await hangs, and a rolled-back
+            # decide leaves the row pending-but-invisible (the #3081 wedge)
+            # until the startup reaper. Fail-close NOW (synchronously,
+            # done-guarded), expire the row best-effort, then propagate.
+            self._resolve_popped_fail_close(request_id, hold, "error")
             await self._expire_stranded(request_id)
+            raise
         return verdict
 
     async def _persist_forever_allow(self, row: dict) -> None:
@@ -998,8 +1071,9 @@ class ConsentCoordinator:
     async def _expire_stranded(self, request_id: str) -> None:
         """Best-effort expire of a pending row whose hold is gone (#3081).
 
-        Called only after the hold was popped (``resolve``'s decide-failure
-        arm, ``_fail_close``): a row left ``pending`` with no live hold can
+        Called only after the hold was popped (``resolve``'s error and
+        cancellation arms, ``_fail_close``): a row left ``pending`` with
+        no live hold can
         never be resolved -- ``snapshot()`` replays only rows still held,
         and a verdict for its id returns ``None`` -- yet ``count_pending``
         keeps counting it against the workspace's pending cap until the

--- a/src/klangk/klangkd-tests/tests/test_consent_coordinator.py
+++ b/src/klangk/klangkd-tests/tests/test_consent_coordinator.py
@@ -1235,6 +1235,211 @@ class TestConsentCoordinatorResolve:
         assert verdict == {"decision": "deny", "reason": "error"}
         assert fut_done_at_expire == [True]
 
+    async def test_resolve_cancelled_during_decide_fail_closes_future(self):
+        # #3089: a CancelledError delivered while decide() is in flight is
+        # not an Exception -- without the BaseException arm it would escape
+        # with the hold popped and its timeout cancelled, leaving nothing
+        # able to resolve the Future: the sidecar relay awaits it (shielded,
+        # no timeout of its own) forever. The Future must be fail-closed
+        # deny + the stranded row expired, then the cancellation re-raised.
+        app = _app(request=request())
+        entered = asyncio.Event()
+        fut_done_at_expire: list[bool] = []
+
+        async def _hanging_decide(*args):
+            entered.set()
+            await asyncio.Event().wait()  # suspend until cancelled
+
+        async def _expire(request_id):
+            fut_done_at_expire.append(fut.done())
+
+        app.state.model.egress_consent.decide = AsyncMock(
+            side_effect=_hanging_decide
+        )
+        app.state.model.egress_consent.expire_pending = AsyncMock(
+            side_effect=_expire
+        )
+        coord = ConsentCoordinator(app)
+        fut = await coord.hold(FULL_WS, "1.2.3.4", 443)
+        app.state.consent_deciders.broadcast.reset_mock()
+        task = asyncio.create_task(coord.resolve("rid-1", "allowed", "a@x"))
+        await entered.wait()  # resolve is now suspended inside decide()
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        # the Future was fail-closed BEFORE the row expire ran, and the
+        # cancellation still propagated
+        assert fut_done_at_expire == [True]
+        assert fut.result() == {
+            "decision": "deny",
+            "reason": "error",
+            "duration": "once",
+        }
+        frames = [
+            c.args[1]
+            for c in app.state.consent_deciders.broadcast.call_args_list
+        ]
+        assert {
+            "type": "egress_resolved",
+            "workspace_id": FULL_WS,
+            "request_id": "rid-1",
+            "decision": "expired",
+        } in frames
+        assert coord._holds == {}  # no orphaned hold, no unresolvable Future
+
+    async def test_resolve_cancelled_with_preset_future_skips_set_result(self):
+        # The done-guard on the cancel path: a Future already resolved (a
+        # racing timeout's set_result) keeps its first verdict; the cancel
+        # arm only broadcasts + expires, then re-raises.
+        app = _app(request=request())
+        entered = asyncio.Event()
+
+        async def _hanging_decide(*args):
+            entered.set()
+            await asyncio.Event().wait()
+
+        app.state.model.egress_consent.decide = AsyncMock(
+            side_effect=_hanging_decide
+        )
+        coord = ConsentCoordinator(app)
+        fut = await coord.hold(FULL_WS, "1.2.3.4", 443)
+        fut.set_result(
+            {"decision": "deny", "reason": "timeout", "duration": "once"}
+        )
+        task = asyncio.create_task(coord.resolve("rid-1", "allowed", "a@x"))
+        await entered.wait()
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        assert fut.result()["reason"] == "timeout"  # not clobbered
+        app.state.model.egress_consent.expire_pending.assert_awaited_once_with(
+            "rid-1"
+        )
+
+    async def test_resolve_cancelled_during_timeout_reap_fail_closes(self):
+        # #3089, the other await past the pop: a cancellation landing while
+        # the timeout task is being reaped (before decide() is even called)
+        # must also fail-close the Future -- the hold is already popped and
+        # its timeout cancelled, so nothing else could resolve it.
+        app = _app(request=request())
+        coord = ConsentCoordinator(app)
+        fut = await coord.hold(FULL_WS, "1.2.3.4", 443)
+        reaping = asyncio.Event()
+
+        async def _hanging_reap(task):
+            reaping.set()
+            await asyncio.Event().wait()
+
+        coord._cancel_hold_task = _hanging_reap
+        app.state.model.egress_consent.decide = AsyncMock(
+            side_effect=AssertionError("decide must not run")
+        )
+        task = asyncio.create_task(coord.resolve("rid-1", "allowed", "a@x"))
+        await reaping.wait()  # resolve is now suspended reaping the timeout
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        assert fut.result() == {
+            "decision": "deny",
+            "reason": "error",
+            "duration": "once",
+        }
+        app.state.model.egress_consent.decide.assert_not_awaited()
+        app.state.model.egress_consent.expire_pending.assert_awaited_once_with(
+            "rid-1"
+        )
+        assert coord._holds == {}
+
+    async def test_resolve_cancelled_at_reap_composes_guard_and_rescue(self):
+        # The real guard->rescue composition, no monkeypatch: the caller is
+        # cancelled at the reap await while the timeout task ends NOT
+        # cancelled -> the swallow-guard in _cancel_hold_task re-raises ->
+        # resolve's rescue fail-closes the popped hold.
+        import contextlib
+
+        app = _app(request=request())
+        coord = ConsentCoordinator(app)
+        fut = await coord.hold(FULL_WS, "1.2.3.4", 443)
+        orig_task = coord._holds["rid-1"]["task"]
+        completing = asyncio.Event()
+
+        async def _slow_swallowing_timeout():
+            try:
+                await asyncio.sleep(30)
+            except asyncio.CancelledError:
+                await asyncio.sleep(0)  # one more tick before completing
+                completing.set()
+                return  # ends NOT cancelled (like _timeout's except arm)
+
+        child = asyncio.create_task(_slow_swallowing_timeout())
+        await asyncio.sleep(0)  # child now parked in its sleep
+        coord._holds["rid-1"]["task"] = child
+        task = asyncio.create_task(coord.resolve("rid-1", "allowed", "a@x"))
+        # resolve popped the hold, cancelled + is reaping the swapped child
+        await completing.wait()
+        task.cancel()  # resolve is queued-to-resume: the _must_cancel path
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        assert child.done() and not child.cancelled()
+        assert fut.result() == {
+            "decision": "deny",
+            "reason": "error",
+            "duration": "once",
+        }
+        app.state.model.egress_consent.decide.assert_not_awaited()
+        app.state.model.egress_consent.expire_pending.assert_awaited_once_with(
+            "rid-1"
+        )
+        # reap the displaced original timeout task (no pending-task noise)
+        orig_task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await orig_task
+
+    async def test_resolve_cancelled_after_decide_keeps_committed_verdict(
+        self,
+    ):
+        # decide() committed (row allowed) and the cancellation lands during
+        # the finish sequence's persist await: the already-set Future keeps
+        # the REAL verdict (the relay gets the allow, not a retroactive
+        # deny), no contradictory "expired" broadcast follows the real one,
+        # and the rescue's expire is a no-op on the non-pending row.
+        row = request()
+        row["decision"] = "allowed"
+        row["duration"] = "forever"
+        app = _app(request=request(), decide_row=row)
+        coord = ConsentCoordinator(app)
+        fut = await coord.hold(FULL_WS, "1.2.3.4", 443)
+        persisting = asyncio.Event()
+
+        async def _hanging_persist(*args):
+            persisting.set()
+            await asyncio.Event().wait()
+
+        app.state.model.workspaces.add_allowed_domain = AsyncMock(
+            side_effect=_hanging_persist
+        )
+        task = asyncio.create_task(
+            coord.resolve("rid-1", "allowed", "a@x", duration="forever")
+        )
+        await persisting.wait()  # Future set; resolve suspended in persist
+        app.state.consent_deciders.broadcast.reset_mock()
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        assert fut.result()["decision"] == "allow"  # committed verdict kept
+        frames = [
+            c.args[1]
+            for c in app.state.consent_deciders.broadcast.call_args_list
+        ]
+        assert not any(
+            f.get("type") == "egress_resolved"
+            and f.get("decision") == "expired"
+            for f in frames
+        )
+        app.state.model.egress_consent.expire_pending.assert_awaited_once_with(
+            "rid-1"
+        )
+
     async def test_concurrent_resolves_first_decision_wins(self):
         # two deciders resolve the same hold concurrently: exactly one wins
         # (one decide() write), the other is a no-op (returns None).


### PR DESCRIPTION
From the #3085 review (the pre-existing happy-path window that PR's fix
didn't cover). Stacked on #3087 — review/merge that first; this branch
rebases cleanly onto main afterwards.

## The bug

In `ConsentCoordinator.resolve()`, the happy path awaits `decide()`
before `_finish_resolve`. `CancelledError` inherits `BaseException`, so
it is not caught by the `except Exception` arm: when the enclosing
decider-handler task is cancelled during that await (a decider
disconnect mid-DB-hiccup, or uvicorn closing WebSockets before lifespan
teardown at shutdown), `_finish_resolve` never runs and the hold's
Future is never resolved — with nothing left that can resolve it. The
hold was already popped from `_holds`, its timeout task already
cancelled, and `stop()` skips popped ids. The sidecar relay awaits the
Future via `asyncio.shield(future)` with no timeout of its own
(`wshandler/sidecar.py` `_relay_verdict`), so it hangs forever. The
decide transaction also rolls back on cancellation: the row stays
`pending` with no live hold — the #3081 wedge (invisible to deciders,
counted against the workspace's pending cap) until the startup reaper.

## The fix

`_decide_or_fail_close()` (the extracted decide step) gains a
`except BaseException` arm that:

1. fail-closes the Future synchronously (`_resolve_popped_fail_close`:
   deny/error/once + `egress_resolved` broadcast — no awaits, so a
   re-delivered cancellation cannot land before the Future is set);
2. expires the stranded row best-effort (`_expire_stranded`, the #3081
   retry path);
3. re-raises the cancellation.

The same extraction keeps `resolve()` at xenon rank A. `_expire_stranded`'s
docstring now names both calling arms.

## Tests

- `test_resolve_cancelled_during_decide_fail_closes_future` — drives a
  real cancellation into a task suspended inside `decide()`; asserts the
  re-raise, the deny verdict on the Future, the `egress_resolved`
  broadcast, the row expire, and (via an observing `expire_pending`
  side-effect) that the Future was resolved *before* the expire ran.
- `test_resolve_cancelled_with_preset_future_skips_set_result` — the
  done-guard: an already-resolved Future keeps its first verdict.

Full suite passes at 100% branch coverage; xenon A everywhere.

Fixes #3089
