### PR TITLE
Fix three TUI bugs: rename+restart, consent picker flash, edit-form Enter (#3096)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -1990,7 +1990,9 @@ new-ws …` then answering `y` to the restart prompt) crashed with an
   workspace (#3096).** Accepting the post-save restart prompt on a
   renamed workspace called `restart` with the pre-rename name, which
   missed and left the workspace running the old configuration ("Saved,
-  but restart failed"). The restart now targets the post-save name.
+  but restart failed"). The restart now targets the workspace by id, so
+  it resolves after a rename and cannot hit a different workspace that
+  happens to share the name.
 
 - **`klangk consent-decide`: picking a duration while disconnected no
   longer strands the picker (#3096).** Submitting a duration from the

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -1986,6 +1986,24 @@ new-ws …` then answering `y` to the restart prompt) crashed with an
   now surfaces a one-line timeout message and a nonzero exit instead
   of a raw `TimeoutError` traceback.
 
+- **TUI edit form: rename + "Restart now" now restarts the renamed
+  workspace (#3096).** Accepting the post-save restart prompt on a
+  renamed workspace called `restart` with the pre-rename name, which
+  missed and left the workspace running the old configuration ("Saved,
+  but restart failed"). The restart now targets the post-save name.
+
+- **`klangk consent-decide`: picking a duration while disconnected no
+  longer strands the picker (#3096).** Submitting a duration from the
+  picker with the socket down flashed to the picker screen (which has no
+  status bar), raising before the modal dismissed — Enter then did
+  nothing and only Esc closed the picker. The flash now lands on the
+  queue screen's status line and the modal dismisses normally.
+
+- **TUI edit form: Enter in the /tmp size field now submits (#3096).**
+  The edit form's Enter-submit id list omitted the /tmp size input, so
+  pressing Enter there was a no-op (the create form already submitted).
+  Enter now saves the form from that field as well.
+
 - **`egress_request` frames now carry one request shape on every delivery
   path (#3082).** A live hold fanned out to deciders carried a request dict
   without `duration`/`revoked_at`/`revoked_by`, while a connect-time replay

--- a/src/klangk/klangk/cli/tui/consent.py
+++ b/src/klangk/klangk/cli/tui/consent.py
@@ -1300,15 +1300,16 @@ class ConsentDeciderApp(App):
         """
         self._flash_msg = f" [red]![/red] {escape(message)}"
         self._flash_until = time.time() + ttl
-        # Query the ACTIVE screen (App.query_one searches the app's default
-        # screen, not a pushed one): the main queue's ``#status`` or the rules
-        # screen's ``#rules-status`` (a revoke can be issued / its ack can
-        # arrive while either is up).
-        screen = self.screen
-        target = (
-            "#rules-status" if isinstance(screen, RulesScreen) else "#status"
-        )
-        screen.query_one(target, Static).update(self._flash_msg)
+        # The rules screen owns its own status bar (a revoke can be issued
+        # / its ack can arrive while it is up); otherwise query app-level so
+        # the message lands on the main queue's ``#status`` even when a
+        # modal — the duration picker — is the active screen (#3096).
+        if isinstance(self.screen, RulesScreen):
+            self.screen.query_one("#rules-status", Static).update(
+                self._flash_msg
+            )
+        else:
+            self.query_one("#status", Static).update(self._flash_msg)
 
     # -- actions -----------------------------------------------------------
 

--- a/src/klangk/klangk/cli/tui/screens/workspace_form.py
+++ b/src/klangk/klangk/cli/tui/screens/workspace_form.py
@@ -142,6 +142,21 @@ _EDITOR_INPUT_HANDLERS = {
     "reject_input": "_add_rejected_domain",
 }
 
+# Enter in any of these scalar inputs submits the form. Shared by the
+# create and edit forms — the two lists drifted once already (the edit
+# form lost tmp_size, #3096), so keep one literal.
+_SCALAR_SUBMIT_IDS = (
+    "name",
+    "command",
+    "health_check",
+    "classification_banner",
+    "idle_timeout",
+    "cpu_limit",
+    "memory_limit",
+    "pids_limit",
+    "tmp_size",
+)
+
 
 def compose_general_pane(
     image_select, *, name="", auto_start=False, nix=False, allow_sudo=False
@@ -1135,17 +1150,7 @@ class CreateWorkspaceScreen(WorkspaceFormMixin, TabSkipMixin, StatusScreen):
     def on_input_submitted(self, event: Input.Submitted) -> None:
         self.handle_form_input_submitted(
             event,
-            submit_ids=(
-                "name",
-                "command",
-                "health_check",
-                "classification_banner",
-                "idle_timeout",
-                "cpu_limit",
-                "memory_limit",
-                "pids_limit",
-                "tmp_size",
-            ),
+            submit_ids=_SCALAR_SUBMIT_IDS,
             submit=self._create,
         )
 
@@ -1722,13 +1727,13 @@ class EditWorkspaceScreen(WorkspaceFormMixin, TabSkipMixin, StatusScreen):
         if self in self.app.screen_stack:
             self.dismiss(result)
 
-    def prompt_restart_after_save(self, ws_name, dismiss_name) -> None:
+    def prompt_restart_after_save(self, ws_id, dismiss_name) -> None:
         """Ask whether to restart the running container to apply the save."""
 
         def _after(restart: bool) -> None:
             if restart:
                 self.run_worker(
-                    self._do_restart_after_save(ws_name, dismiss_name),
+                    self._do_restart_after_save(ws_id, dismiss_name),
                     exit_on_error=False,
                 )
             else:
@@ -1760,16 +1765,18 @@ class EditWorkspaceScreen(WorkspaceFormMixin, TabSkipMixin, StatusScreen):
             self.msg(f"Failed to save: {exc}", error=True)
             return
         if restart_needed:
-            # The PUT above already applied the rename, so the restart must
-            # target the post-save name (#3096).
-            self.prompt_restart_after_save(name, name)
+            # Restart by id: the PUT above may have renamed the workspace,
+            # and names are only unique per owner — a shared workspace
+            # renamed onto another visible workspace's name would otherwise
+            # restart the wrong container (#3096).
+            self.prompt_restart_after_save(ws.id, name)
         else:
             self._safe_dismiss(name)
 
-    async def _do_restart_after_save(self, ws_name, dismiss_name) -> None:
+    async def _do_restart_after_save(self, ws_id, dismiss_name) -> None:
         try:
             await asyncio.to_thread(
-                self.app.tui_state.restart_workspace, ws_name
+                self.app.tui_state.restart_workspace_by_id, ws_id
             )
         except Exception as exc:
             self.msg(f"Saved, but restart failed: {exc}", error=True)
@@ -1789,17 +1796,7 @@ class EditWorkspaceScreen(WorkspaceFormMixin, TabSkipMixin, StatusScreen):
     def on_input_submitted(self, event: Input.Submitted) -> None:
         self.handle_form_input_submitted(
             event,
-            submit_ids=(
-                "name",
-                "command",
-                "health_check",
-                "classification_banner",
-                "idle_timeout",
-                "cpu_limit",
-                "memory_limit",
-                "pids_limit",
-                "tmp_size",
-            ),
+            submit_ids=_SCALAR_SUBMIT_IDS,
             submit=self.save,
         )
 

--- a/src/klangk/klangk/cli/tui/screens/workspace_form.py
+++ b/src/klangk/klangk/cli/tui/screens/workspace_form.py
@@ -1760,7 +1760,9 @@ class EditWorkspaceScreen(WorkspaceFormMixin, TabSkipMixin, StatusScreen):
             self.msg(f"Failed to save: {exc}", error=True)
             return
         if restart_needed:
-            self.prompt_restart_after_save(ws.name, name)
+            # The PUT above already applied the rename, so the restart must
+            # target the post-save name (#3096).
+            self.prompt_restart_after_save(name, name)
         else:
             self._safe_dismiss(name)
 
@@ -1796,6 +1798,7 @@ class EditWorkspaceScreen(WorkspaceFormMixin, TabSkipMixin, StatusScreen):
                 "cpu_limit",
                 "memory_limit",
                 "pids_limit",
+                "tmp_size",
             ),
             submit=self.save,
         )

--- a/src/klangk/klangk/cli/tui/state.py
+++ b/src/klangk/klangk/cli/tui/state.py
@@ -334,6 +334,13 @@ class TuiState:
     def restart_workspace(self, name: str) -> None:
         self.client().restart_workspace(name)
 
+    def restart_workspace_by_id(self, workspace_id: str) -> None:
+        """Restart by id — unambiguous even when the workspace was just
+        renamed, or when a shared workspace shares a name with another
+        workspace visible to this user (names are unique per owner, not
+        globally) (#3096)."""
+        self.client().restart_workspace_by_id(workspace_id)
+
     def stop_workspace(self, name: str) -> None:
         self.client().stop_workspace(name)
 

--- a/src/klangk/klangkc-tests/tests/test_consent_decide.py
+++ b/src/klangk/klangkc-tests/tests/test_consent_decide.py
@@ -967,6 +967,28 @@ class TestAppActions:
             # The modal is gone after submit.
             assert not isinstance(app.screen, tui_consent.DurationPickerScreen)
 
+    async def test_picker_enter_disconnected_flashes_and_dismisses(self):
+        # Disconnected + a duration picked from the picker must flash on
+        # the queue screen's status bar (not query the picker for #status)
+        # and still dismiss the modal (#3096).
+        app = _make_app()
+        async with app.run_test() as pilot:
+            ws = FakeWS([])
+            app._ws = ws
+            app.controller.apply_frame(_req_frame("r1", host="a.com"))
+            app._refresh()
+            await pilot.pause()
+            await pilot.press("A")
+            await pilot.pause()
+            assert isinstance(app.screen, tui_consent.DurationPickerScreen)
+            app._ws = None  # the socket dropped while the picker was open
+            await pilot.press("enter")
+            await pilot.pause()
+            # The modal dismissed despite the flash on the disconnected path.
+            assert not isinstance(app.screen, tui_consent.DurationPickerScreen)
+            status = app.query_one("#status", Static)
+            assert "reconnecting" in str(status.content)
+
     async def test_D_opens_picker_enter_sends_picked_duration(self):
         app = _make_app()
         async with app.run_test() as pilot:

--- a/src/klangk/klangkc-tests/tests/test_consent_decide.py
+++ b/src/klangk/klangkc-tests/tests/test_consent_decide.py
@@ -987,7 +987,10 @@ class TestAppActions:
             # The modal dismissed despite the flash on the disconnected path.
             assert not isinstance(app.screen, tui_consent.DurationPickerScreen)
             status = app.query_one("#status", Static)
-            assert "reconnecting" in str(status.content)
+            # "disconnected" only appears in the FLASH text — the plain
+            # disconnected status line says "reconnecting" without it —
+            # so this discriminates the flash from the idle status line.
+            assert "disconnected" in str(status.content)
 
     async def test_D_opens_picker_enter_sends_picked_duration(self):
         app = _make_app()

--- a/src/klangk/klangkc-tests/tests/test_tui.py
+++ b/src/klangk/klangkc-tests/tests/test_tui.py
@@ -173,6 +173,7 @@ def _authed_state(**extra):
         current_user_id=lambda: None,
         close_terminal=_async_empty,
         restart_workspace=lambda n: None,
+        restart_workspace_by_id=lambda n: None,
         # Stubbed so MainScreen.do_create doesn't make a real (timing-out)
         # HTTP call for the allowed-domains list (#1989).
         default_allowed_domains=lambda: [],
@@ -196,6 +197,7 @@ def _ws(owned=None, shared=None, **extra):
         current_user_id=lambda: None,
         close_terminal=_async_empty,
         restart_workspace=lambda n: None,
+        restart_workspace_by_id=lambda n: None,
         # Stubbed so MainScreen.do_create doesn't make a real (timing-out)
         # HTTP call for the allowed-domains list (#1989).
         default_allowed_domains=lambda: [],
@@ -2724,11 +2726,13 @@ def test_tui_state_workspace_methods(monkeypatch, redirect_xdg):
     assert st.list_shared_workspaces()[0].name == "b"
     assert st.find_workspace("a").name == "a"
     st.restart_workspace("a")
+    st.restart_workspace_by_id("id-a")
     st.stop_workspace("a")
     st.start_workspace("a")
     st.delete_workspace("a")
     assert st.duplicate_workspace("a", "c") == {"id": "3", "name": "c"}
     fake.restart_workspace.assert_called_once_with("a")
+    fake.restart_workspace_by_id.assert_called_once_with("id-a")
     fake.stop_workspace.assert_called_once_with("a")
     fake.start_workspace.assert_called_once_with("a")
     fake.delete_workspace.assert_called_once_with("a")
@@ -9626,7 +9630,8 @@ def _edit_state(ws, *, update=None, restart=None, **extra):
         list_images=lambda: {"default": "base", "allowed": ["base", "py:3"]},
         allow_autostart=lambda: True,
         update_workspace=update or (lambda *a, **k: None),
-        restart_workspace=restart or (lambda *a, **k: None),
+        # The edit form restarts by id (#3096).
+        restart_workspace_by_id=restart or (lambda *a, **k: None),
     )
     base.update(extra)
     return _ws(**base)
@@ -10631,9 +10636,10 @@ async def test_edit_screen_restart_declined(monkeypatch):
         assert not isinstance(app.screen, EditWorkspaceScreen)
 
 
-async def test_edit_screen_rename_restart_uses_new_name(monkeypatch):
-    # The PUT applies the rename, so the post-save restart prompt must
-    # target the NEW name, not the workspace object's stale one (#3096).
+async def test_edit_screen_rename_restart_targets_id(monkeypatch):
+    # The PUT applies the rename, so the post-save restart must target the
+    # workspace id — the stale name would miss, and even the NEW name is
+    # ambiguous (names are unique per owner, not globally) (#3096).
     async def noop(*a, **k):
         return None
 
@@ -10655,7 +10661,7 @@ async def test_edit_screen_rename_restart_uses_new_name(monkeypatch):
         app.screen.dismiss(True)
         await pilot.pause()
         await app.workers.wait_for_complete()
-        assert restarted == [("newname",)]
+        assert restarted == [("id-oldname",)]
 
 
 async def test_edit_screen_enter_in_tmp_size_submits(monkeypatch):

--- a/src/klangk/klangkc-tests/tests/test_tui.py
+++ b/src/klangk/klangkc-tests/tests/test_tui.py
@@ -10631,6 +10631,59 @@ async def test_edit_screen_restart_declined(monkeypatch):
         assert not isinstance(app.screen, EditWorkspaceScreen)
 
 
+async def test_edit_screen_rename_restart_uses_new_name(monkeypatch):
+    # The PUT applies the rename, so the post-save restart prompt must
+    # target the NEW name, not the workspace object's stale one (#3096).
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr_main, "listen_for_status", noop)
+    restarted = []
+    ws = _wsobj("oldname", image="base", running=True)
+    app = KlangkApp(
+        _edit_state(ws, restart=lambda *a, **k: restarted.append(a))
+    )
+    async with app.run_test() as pilot:
+        _edit_screen(app, ws)
+        await pilot.pause()
+        es = app.screen
+        es.query_one("#name", Input).value = "newname"
+        es.query_one("#image", Select).value = "py:3"  # create-time change
+        es.save()
+        await app.workers.wait_for_complete()
+        assert isinstance(app.screen, ConfirmScreen)  # restart offered
+        app.screen.dismiss(True)
+        await pilot.pause()
+        await app.workers.wait_for_complete()
+        assert restarted == [("newname",)]
+
+
+async def test_edit_screen_enter_in_tmp_size_submits(monkeypatch):
+    # Enter in the /tmp size input submits the edit form (the edit form's
+    # submit_ids omitted tmp_size) (#3096).
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr_main, "listen_for_status", noop)
+    updated = []
+    ws = _wsobj("alpha", image="base")
+    app = KlangkApp(_edit_state(ws, update=lambda *a, **k: updated.append(k)))
+    async with app.run_test(size=(140, 40)) as pilot:
+        _edit_screen(app, ws)
+        await pilot.pause()
+        es = app.screen
+        tmp = es.query_one("#tmp_size", Input)
+        tmp.value = "2"
+        es.set_focus(tmp)
+        await pilot.pause()
+        await pilot.press("enter")
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        # The form submitted: update_workspace ran and the screen dismissed.
+        assert updated and updated[0].get("name") == "alpha"
+        assert not isinstance(app.screen, EditWorkspaceScreen)
+
+
 async def test_edit_screen_restart_failure(monkeypatch):
     async def noop(*a, **k):
         return None


### PR DESCRIPTION
## Summary

Fixes the three confirmed bugs from the `cli/tui` audit (#3096):

1. **Edit form: rename + "Restart now" restarted under the stale old name.**
   `do_save` passed `ws.name` (pre-rename) to `prompt_restart_after_save`, so
   the post-save restart resolved the old name, missed, and left the workspace
   running the old configuration ("Saved, but restart failed"). The restart now
   targets the workspace **by id** (`TuiState.restart_workspace_by_id`,
   forwarded to the existing `client.restart_workspace_by_id`) — resolving after
   a rename and immune to the name-collision hazard (names are unique per
   owner, not globally; `resolve_workspace` takes the first name match across
   owned+shared lists).
2. **`klangk consent-decide`: duration picker stranded when disconnected.**
   `flash()` queried the *active* screen for `#status`; with
   `DurationPickerScreen` active that raises `NoMatches` out of
   `on_option_list_option_selected` before `dismiss(None)` — Enter did nothing,
   only Esc closed the picker, and `_send_verdict`'s failure flash died
   silently in its task. The non-rules path now queries app-level so the
   message lands on the queue screen's status line; the picker dismisses.
3. **Edit form: Enter in the `/tmp size` field didn't submit.** The edit
   form's `submit_ids` omitted `"tmp_size"` (the create form includes it).
   Added — and the create/edit `submit_ids` are now one shared
   `_SCALAR_SUBMIT_IDS` constant, since the bug was drift between the two
   duplicate literals.

## Testing

- Regression tests: picker-submit-while-disconnected (dismisses; the status
  assertion pins the *flash* text — "disconnected" appears only in flash
  messages, the plain disconnected line says "reconnecting"),
  rename+restart targets the workspace id, Enter in `/tmp size` submits the
  edit form, and a forward test for the new `restart_workspace_by_id` state
  wrapper.
- Full Python suite CI-style:
  `pytest src/klangk/klangkd-tests/tests src/klangk/klangkc-tests/tests -n auto`
  → 6690 passed, 100% branch coverage.
- `pre-commit run xenon --all-files` → Passed.

## Review round

Addressed all findings from the adversarial review run: the restart is now
id-based (the "important" finding), `submit_ids` deduped, and the picker
test's status assertion strengthened to discriminate flash vs plain status
(the two nits).

Closes #3096
