### PR TITLE
Fix CLI edit rename+restart crash, name mangling, timeout tracebacks (#3091)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -1964,8 +1964,9 @@ git-credential` (#1700).** `pig-latin` removed; `word-count` dormant.
   running workspace renamed by the same edit (`klangk edit my-ws --name
 new-ws …` then answering `y` to the restart prompt) crashed with an
   uncaught `WorkspaceNotFoundError` traceback before the restart could
-  fire. The restart now targets the workspace id, and the
-  confirmation echoes show the new name.
+  fire. The restart now targets the workspace id, the confirmation
+  echoes show the new name, and an empty `--name` is rejected instead
+  of silently renaming the workspace to the empty string.
 
 - **Consent-popup socket names mangled digits (#3091).** A typo in the
   workspace-id sanitizer's character class (`0189` instead of the range

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -1960,6 +1960,24 @@ git-credential` (#1700).** `pig-latin` removed; `word-count` dormant.
   Future (deny) and expires the row before letting the cancellation
   propagate.
 
+- **`klangk edit` restart-after-rename crash (#3091).** Restarting a
+  running workspace renamed by the same edit (`klangk edit my-ws --name
+new-ws …` then answering `y` to the restart prompt) crashed with an
+  uncaught `WorkspaceNotFoundError` traceback before the restart could
+  fire. The restart now targets the workspace id, and the
+  confirmation echoes show the new name.
+
+- **Consent-popup socket names mangled digits (#3091).** A typo in the
+  workspace-id sanitizer's character class (`0189` instead of the range
+  `0-9`) replaced digits 2–7 with `-` in the tmux socket and session
+  names, mangling nearly every workspace's consent-popup socket and
+  letting distinct ids collide on one socket.
+
+- **`klangk shell` / `klangk sandbox` timeout tracebacks (#3091).** A
+  container that never reaches the ready state within the wait budget
+  now surfaces a one-line timeout message and a nonzero exit instead
+  of a raw `TimeoutError` traceback.
+
 - **`egress_request` frames now carry one request shape on every delivery
   path (#3082).** A live hold fanned out to deciders carried a request dict
   without `duration`/`revoked_at`/`revoked_by`, while a connect-time replay

--- a/src/klangk/klangk/cli/edit.py
+++ b/src/klangk/klangk/cli/edit.py
@@ -554,7 +554,10 @@ def apply_edit(client, ws, body: dict, restart: bool) -> None:
         context.err.print("[red]Workspace not found[/red]")
         raise typer.Exit(code=1)
     resp.raise_for_status()
-    typer.echo(f"Updated workspace {ws.name}")
+    # The server renamed it when body carries "name" — echo (and restart
+    # by id) against the new name; ws.name is the stale pre-edit value.
+    current_name = body.get("name") or ws.name
+    typer.echo(f"Updated workspace {current_name}")
 
     if restart:
         context.err.print(
@@ -563,8 +566,8 @@ def apply_edit(client, ws, body: dict, restart: bool) -> None:
         )
         answer = input("Restart now? [y/N] ").strip().lower()
         if answer in ("y", "yes"):
-            client.restart_workspace(ws.name)
-            typer.echo(f"Restarted workspace {ws.name}")
+            client.restart_workspace_by_id(ws.id)
+            typer.echo(f"Restarted workspace {current_name}")
 
 
 @context.app.command()

--- a/src/klangk/klangk/cli/edit.py
+++ b/src/klangk/klangk/cli/edit.py
@@ -616,6 +616,12 @@ def edit(
     Without flags, interactively prompts for each field.
     Press Enter to keep the current value.
     """
+    if name is not None and not name.strip():
+        # The server has no min-length on the rename field, so an empty
+        # --name would otherwise rename to "" while the echoes still show
+        # the old name (review of #3091).
+        context.err.print("[red]New name cannot be empty[/red]")
+        raise typer.Exit(code=1)
     context.require_auth()
     client = context.client()
     ws = context.resolve_or_exit(client, workspace)

--- a/src/klangk/klangk/cli/sandboxcmd.py
+++ b/src/klangk/klangk/cli/sandboxcmd.py
@@ -207,6 +207,9 @@ def run_sandbox_setup(
     except ConnectionError as e:
         context.err.print(f"[red]{e}[/red]")
         raise typer.Exit(code=1) from None
+    except asyncio.TimeoutError as e:
+        context.err.print(f"[red]{context.timeout_detail(e)}[/red]")
+        raise typer.Exit(code=1) from None
 
 
 def load_config_or_exit(sandbox_root: Path):

--- a/src/klangk/klangk/cli/shell_popup.py
+++ b/src/klangk/klangk/cli/shell_popup.py
@@ -107,7 +107,7 @@ def tmux_usable(version: tuple[int, int] | None) -> bool:
 
 def _sanitize(name: str) -> str:
     """Make a tmux-safe session-name fragment (no ``.`` or ``:``)."""
-    return re.sub(r"[^A-Za-z0189_-]", "-", name)[:24] or "ws"
+    return re.sub(r"[^A-Za-z0-9_-]", "-", name)[:24] or "ws"
 
 
 def socket_path(workspace_id: str) -> str:

--- a/src/klangk/klangk/cli/shellcmd.py
+++ b/src/klangk/klangk/cli/shellcmd.py
@@ -239,6 +239,40 @@ def shell_rejected(e: websockets.InvalidStatus) -> None:
     raise typer.Exit(code=1) from None
 
 
+def attach_shell(server_spec, token, ws, window, forward_agent) -> None:
+    """Run the PTY shell session, surfacing failures as a clean exit.
+
+    A handshake rejection, a dropped connection, or a container that
+    never becomes ready within the wait budget (#3091) each print a
+    one-line message and exit nonzero instead of a raw traceback — the
+    same presentation ``context.run_ws_command`` gives the exec and
+    terminal-share commands (#2876).
+    """
+    try:
+        asyncio.run(
+            ws_shell(
+                server_spec,
+                token,
+                ws.id,
+                window=window,
+                forward_agent=forward_agent,
+                max_size=context.ws_max_size(),
+            )
+        )
+    except websockets.InvalidStatus as e:
+        shell_rejected(e)
+    except ConnectionError as e:
+        reset_terminal()
+        drain_stdin()
+        context.err.print(f"[red]{e}[/red]")
+        raise typer.Exit(code=1) from None
+    except asyncio.TimeoutError as e:
+        reset_terminal()
+        drain_stdin()
+        context.err.print(f"[red]{context.timeout_detail(e)}[/red]")
+        raise typer.Exit(code=1) from None
+
+
 @context.app.command()
 def shell(
     workspace: str | None = typer.Argument(
@@ -297,22 +331,5 @@ def shell(
         # is not interactive-egress, or the member may not decide egress
         # (#2976: spectator-profile members never spawn a decider).
         raise typer.Exit(code=run_consent_popup(ws, terminal, forward_agent))
-    try:
-        asyncio.run(
-            ws_shell(
-                context.server_url(),
-                token,
-                ws.id,
-                window=terminal,
-                forward_agent=forward_agent,
-                max_size=context.ws_max_size(),
-            )
-        )
-        context.err.print(f"Disconnected from [bold]{ws.name}[/bold].")
-    except websockets.InvalidStatus as e:
-        shell_rejected(e)
-    except ConnectionError as e:
-        reset_terminal()
-        drain_stdin()
-        context.err.print(f"[red]{e}[/red]")
-        raise typer.Exit(code=1) from None
+    attach_shell(context.server_url(), token, ws, terminal, forward_agent)
+    context.err.print(f"Disconnected from [bold]{ws.name}[/bold].")

--- a/src/klangk/klangkc-tests/tests/test_cli.py
+++ b/src/klangk/klangkc-tests/tests/test_cli.py
@@ -6054,7 +6054,8 @@ class TestSandboxCommandGuards:
             "sandbox_setup_only",
             MagicMock(side_effect=asyncio_mod.TimeoutError()),
         )
-        monkeypatch.setattr(sandboxcmd.context, "err", MagicMock())
+        err = MagicMock()
+        monkeypatch.setattr(sandboxcmd.context, "err", err)
         with pytest.raises(typer.Exit) as exc_info:
             sandboxcmd.run_sandbox_setup(
                 "http://s",
@@ -6067,6 +6068,8 @@ class TestSandboxCommandGuards:
                 MagicMock(),
             )
         assert exc_info.value.exit_code == 1
+        # A one-line message was printed (not a traceback).
+        assert "Timed out" in str(err.print.call_args_list)
 
     def test_mark_setup_state_warns_on_failure(self):
         from klangk.cli.sandboxcmd import mark_setup_state

--- a/src/klangk/klangkc-tests/tests/test_cli.py
+++ b/src/klangk/klangkc-tests/tests/test_cli.py
@@ -6041,6 +6041,33 @@ class TestSandboxCommandGuards:
                 MagicMock(),
             )
 
+    def test_run_sandbox_setup_timeout_exits(self, monkeypatch):
+        """#3091: a container that never becomes ready exits with a one-line
+        message, not a raw asyncio.TimeoutError traceback."""
+        import asyncio as asyncio_mod
+
+        from klangk.cli import sandboxcmd
+
+        monkeypatch.setattr(sandboxcmd.context, "ws_max_size", lambda: 2**20)
+        monkeypatch.setattr(
+            sandboxcmd,
+            "sandbox_setup_only",
+            MagicMock(side_effect=asyncio_mod.TimeoutError()),
+        )
+        monkeypatch.setattr(sandboxcmd.context, "err", MagicMock())
+        with pytest.raises(typer.Exit) as exc_info:
+            sandboxcmd.run_sandbox_setup(
+                "http://s",
+                "tok",
+                "ws",
+                "ws-id",
+                MagicMock(),
+                Path("/tmp"),
+                "handle",
+                MagicMock(),
+            )
+        assert exc_info.value.exit_code == 1
+
     def test_mark_setup_state_warns_on_failure(self):
         from klangk.cli.sandboxcmd import mark_setup_state
 

--- a/src/klangk/klangkc-tests/tests/test_cli_integration.py
+++ b/src/klangk/klangkc-tests/tests/test_cli_integration.py
@@ -1620,6 +1620,21 @@ class TestShellConnectionError:
             shell(workspace="ws", terminal="x")
         assert exc_info.value.exit_code == 1
 
+    def test_shell_catches_container_timeout(self, monkeypatch):
+        """#3091: a container that never becomes ready exits with a one-line
+        message, not a raw asyncio.TimeoutError traceback."""
+        import asyncio as asyncio_mod
+
+        from klangk.cli.main import shell
+
+        self._shell_with_side_effect(monkeypatch, asyncio_mod.TimeoutError())
+
+        import typer
+
+        with pytest.raises(typer.Exit) as exc_info:
+            shell(workspace="ws", terminal="x")
+        assert exc_info.value.exit_code == 1
+
 
 class TestSSHAgentForwarding:
     @pytest.mark.filterwarnings("ignore::RuntimeWarning")

--- a/src/klangk/klangkc-tests/tests/test_cli_integration.py
+++ b/src/klangk/klangkc-tests/tests/test_cli_integration.py
@@ -1628,12 +1628,24 @@ class TestShellConnectionError:
         from klangk.cli.main import shell
 
         self._shell_with_side_effect(monkeypatch, asyncio_mod.TimeoutError())
+        err = MagicMock()
+        monkeypatch.setattr("klangk.cli.context.err", err)
+        # The cleanup pair runs through shellcmd's own imported bindings.
+        reset = MagicMock()
+        drain = MagicMock()
+        monkeypatch.setattr("klangk.cli.shellcmd.reset_terminal", reset)
+        monkeypatch.setattr("klangk.cli.shellcmd.drain_stdin", drain)
 
         import typer
 
         with pytest.raises(typer.Exit) as exc_info:
             shell(workspace="ws", terminal="x")
         assert exc_info.value.exit_code == 1
+        # A one-line message was printed (not a traceback) …
+        assert "Timed out" in str(err.print.call_args_list)
+        # … and the terminal was restored before exiting.
+        reset.assert_called_once()
+        drain.assert_called_once()
 
 
 class TestSSHAgentForwarding:

--- a/src/klangk/klangkc-tests/tests/test_cli_main.py
+++ b/src/klangk/klangkc-tests/tests/test_cli_main.py
@@ -4083,6 +4083,26 @@ class TestMainCLI:
         client.restart_workspace_by_id.assert_called_once_with(ws.id)
         client.restart_workspace.assert_not_called()
 
+    def test_edit_rejects_empty_new_name(self, logged_in_cfg, monkeypatch):
+        """--name '' (or whitespace) is refused before any request: the
+        server would otherwise accept a zero-length rename while the CLI
+        echoes keep the old name (review of #3091)."""
+        from klangk.cli import main
+
+        client = MagicMock()
+        with patch.object(context_mod, "client", return_value=client):
+            from typer.testing import CliRunner
+
+            runner = CliRunner()
+            result = runner.invoke(
+                main.app,
+                ["edit", "my-ws", "--name", ""],
+            )
+            assert result.exit_code == 1
+            assert "cannot be empty" in result.output
+
+        client.put.assert_not_called()
+
     def test_edit_no_restart_when_stopped(self, logged_in_cfg, monkeypatch):
         """Stopped ws + create-time field → no restart prompt."""
         from klangk.cli import main

--- a/src/klangk/klangkc-tests/tests/test_cli_main.py
+++ b/src/klangk/klangkc-tests/tests/test_cli_main.py
@@ -3923,7 +3923,7 @@ class TestMainCLI:
                 # The restart offer fired (its warning goes to stderr).
                 assert answers and "restart now?" in answers[0].lower()
 
-        client.restart_workspace.assert_not_called()  # declined
+        client.restart_workspace_by_id.assert_not_called()  # declined
 
     def test_edit_sudo_lockdown_on_absent_bag_no_prompt(
         self, logged_in_cfg, monkeypatch
@@ -4014,7 +4014,7 @@ class TestMainCLI:
                 assert result.exit_code == 0
                 assert "Updated" in result.stdout
 
-        client.restart_workspace.assert_not_called()
+        client.restart_workspace_by_id.assert_not_called()
 
     def test_edit_restart_needed_accept(self, logged_in_cfg, monkeypatch):
         """Running ws + create-time field → warn, user accepts restart."""
@@ -4042,7 +4042,46 @@ class TestMainCLI:
                 assert result.exit_code == 0
                 assert "Restarted" in result.stdout
 
-        client.restart_workspace.assert_called_once_with("my-ws")
+        client.restart_workspace_by_id.assert_called_once_with(ws.id)
+
+    def test_edit_rename_restart_targets_id(self, logged_in_cfg, monkeypatch):
+        """#3091: restarting a workspace renamed by the same edit must go
+        by id — the old name no longer resolves after the rename."""
+        from klangk.cli import main
+
+        ws = Workspace(
+            id="ws1" + "0" * 52,
+            name="my-ws",
+            created_at="2025-01-01T00:00:00Z",
+            running=True,
+        )
+        client = MagicMock()
+        client.resolve_workspace.return_value = ws
+        client.put.return_value = MagicMock(status_code=200)
+
+        with patch.object(context_mod, "client", return_value=client):
+            with patch("builtins.input", return_value="y"):
+                from typer.testing import CliRunner
+
+                runner = CliRunner()
+                result = runner.invoke(
+                    main.app,
+                    [
+                        "edit",
+                        "my-ws",
+                        "--name",
+                        "new-ws",
+                        "--image",
+                        "new-img",
+                    ],
+                )
+                assert result.exit_code == 0
+                # The echoes carry the new name, not the stale pre-edit one.
+                assert "Updated workspace new-ws" in result.stdout
+                assert "Restarted workspace new-ws" in result.stdout
+
+        client.restart_workspace_by_id.assert_called_once_with(ws.id)
+        client.restart_workspace.assert_not_called()
 
     def test_edit_no_restart_when_stopped(self, logged_in_cfg, monkeypatch):
         """Stopped ws + create-time field → no restart prompt."""
@@ -4069,7 +4108,7 @@ class TestMainCLI:
             assert result.exit_code == 0
             assert "Restart" not in result.stdout
 
-        client.restart_workspace.assert_not_called()
+        client.restart_workspace_by_id.assert_not_called()
 
     def test_edit_no_restart_for_name(self, logged_in_cfg, monkeypatch):
         """Running ws + non-create-time field (name) → no restart prompt."""
@@ -4096,7 +4135,7 @@ class TestMainCLI:
             assert result.exit_code == 0
             assert "Restart" not in result.stdout
 
-        client.restart_workspace.assert_not_called()
+        client.restart_workspace_by_id.assert_not_called()
 
     def test_dup_workspace(self, logged_in_cfg, monkeypatch):
         from klangk.cli import main

--- a/src/klangk/klangkc-tests/tests/test_shell_popup.py
+++ b/src/klangk/klangkc-tests/tests/test_shell_popup.py
@@ -109,6 +109,13 @@ class TestNaming:
         p = sp.socket_path("w.s:i")
         assert ":" not in p and "w.s:i.sock" not in p
 
+    def test_socket_path_keeps_digits(self):
+        """#3091: the sanitizer's character class is the range 0-9, not the
+        literal set "0189" — digits 2-7 must survive, or nearly every
+        uuid-hex workspace id gets mangled (and ids can collide)."""
+        assert sp._sanitize("abc123def456") == "abc123def456"
+        assert sp.socket_path("e7c2b6a4").endswith("e7c2b6a4.sock")
+
     def test_session_names_prefixed_and_safe(self):
         outer = sp.outer_session_name("wsid")
         hidden = sp.hidden_session_name("wsid")


### PR DESCRIPTION
Closes #3091.

## Summary

Three CLI fixes from the `cli/` sweep:

- **`klangk edit` restart-after-rename crash.** `apply_edit` restarted via the stale pre-edit name, so accepting the restart prompt after a `--name` rename raised an uncaught `WorkspaceNotFoundError` traceback and the restart never fired. It now restarts by id (`restart_workspace_by_id`), and the "Updated/Restarted workspace" echoes carry the new name.
- **`_sanitize` digit mangling.** The consent-popup name sanitizer's character class was `[^A-Za-z0189_-]` — the literal set `{0,1,8,9}`, not the range `0-9` — so digits 2–7 became `-` in the tmux socket/session names of nearly every workspace (ids are uuid hex), and distinct ids could collide on one popup socket after mangling + truncation.
- **`shell` / sandbox-setup timeout tracebacks.** Neither `klangk shell` nor `run_sandbox_setup` caught `asyncio.TimeoutError`, so a container that never reached `container_ready` within the 60 s budget surfaced as a raw traceback. Both now print a one-line message and exit 1 — the same presentation `context.run_ws_command` gives the exec/terminal-share paths (#2876). The shell attach's error handling moved into a new `attach_shell` helper (the `shell` command was already at the xenon-A complexity limit).

## Tests

- `test_edit_rename_restart_targets_id` — rename + restart-accept restarts by id and echoes the new name; existing edit tests now assert the by-id call.
- `test_socket_path_keeps_digits` — digits 2–7 survive sanitization.
- `test_shell_catches_container_timeout`, `test_run_sandbox_setup_timeout_exits` — `TimeoutError` becomes `typer.Exit(1)`.

Full suite: `python -m pytest src/klangk/klangkd-tests/tests src/klangk/klangkc-tests/tests -n auto` — 6691 passed, 100% branch coverage; xenon A gate green.
