### PR TITLE
Validate admin email updates, map workspace rename conflicts to 409 (#3097)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -2006,6 +2006,17 @@ new-ws …` then answering `y` to the restart prompt) crashed with an
   pressing Enter there was a no-op (the create form already submitted).
   Enter now saves the form from that field as well.
 
+- **Admin user email updates are now validated (#3097).** `PATCH
+/api/v1/users/{id}` rejects a malformed address (400 "Must be a valid
+  email address") and an address already used by another account (400
+  "Email already in use") instead of persisting invalid emails or
+  returning a 500 off the `users.email` unique constraint.
+
+- **Workspace rename conflicts now return 409 (#3097).** `PUT
+/api/v1/workspaces/{id}` renaming a workspace onto another name the
+  owner already holds returns the same 409 "A workspace named … already
+  exists" as the create, duplicate, and import paths, instead of a 500.
+
 - **`egress_request` frames now carry one request shape on every delivery
   path (#3082).** A live hold fanned out to deciders carried a request dict
   without `duration`/`revoked_at`/`revoked_by`, while a connect-time replay

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -2016,6 +2016,8 @@ new-ws …` then answering `y` to the restart prompt) crashed with an
 /api/v1/workspaces/{id}` renaming a workspace onto another name the
   owner already holds returns the same 409 "A workspace named … already
   exists" as the create, duplicate, and import paths, instead of a 500.
+  Explicitly nulling a non-nullable field (`name`, `setup_state`,
+  `egress_mode`) is now a 400 instead of a 500 or a misleading 409.
 
 - **`egress_request` frames now carry one request shape on every delivery
   path (#3082).** A live hold fanned out to deciders carried a request dict

--- a/src/klangk/klangk/api/admin.py
+++ b/src/klangk/klangk/api/admin.py
@@ -12,6 +12,7 @@ from fastapi import (
     Request,
 )
 from pydantic import BaseModel
+from sqlalchemy.exc import IntegrityError as SAIntegrityError
 
 from .. import (
     acl,
@@ -377,7 +378,14 @@ async def _update_user_email(app, user_id: str, email: str) -> None:
     existing = await app.state.model.users.get_user_by_email(email)
     if existing is not None and existing["id"] != user_id:
         raise HTTPException(status_code=400, detail="Email already in use")
-    await app.state.model.users.update_email(user_id, email)
+    try:
+        await app.state.model.users.update_email(user_id, email)
+    except SAIntegrityError:
+        # The pre-check above is not atomic with the UPDATE (#3101's
+        # TOCTOU family): a concurrent registration or change-email can
+        # claim the address in between. Map the race to the same 400 the
+        # pre-check returns instead of an unhandled 500 (#3097).
+        raise HTTPException(status_code=400, detail="Email already in use")
 
 
 async def _update_user_handle(app, user_id: str, handle: str) -> None:

--- a/src/klangk/klangk/api/admin.py
+++ b/src/klangk/klangk/api/admin.py
@@ -370,6 +370,16 @@ async def _update_user_password(app, user_id: str, password: str) -> None:
     await app.state.model.users.update_password(user_id, password_hash)
 
 
+async def _update_user_email(app, user_id: str, email: str) -> None:
+    """Apply an email change: 400 on a malformed address or one already
+    used by another account — the same checks change-email applies."""
+    auth.validate_email(email)
+    existing = await app.state.model.users.get_user_by_email(email)
+    if existing is not None and existing["id"] != user_id:
+        raise HTTPException(status_code=400, detail="Email already in use")
+    await app.state.model.users.update_email(user_id, email)
+
+
 async def _update_user_handle(app, user_id: str, handle: str) -> None:
     """Set + propagate a handle change to live WS sessions; 400 on an
     invalid handle."""
@@ -389,7 +399,7 @@ async def update_user(
 ):
     await _require_user(app, user_id)
     if req.email is not None:
-        await app.state.model.users.update_email(user_id, req.email)
+        await _update_user_email(app, user_id, req.email)
     if req.password is not None:
         await _update_user_password(app, user_id, req.password)
     if req.handle is not None:

--- a/src/klangk/klangk/api/workspaces.py
+++ b/src/klangk/klangk/api/workspaces.py
@@ -629,6 +629,25 @@ async def _apply_live_state_updates(
     await _sync_tmux_workspace_name(app, live_state, fields)
 
 
+async def _update_workspace_fields(
+    app, workspace_id: str, owner_id: str, fields: dict
+) -> bool:
+    """Apply a workspace field update; 409 when a rename collides with
+    another name the owner already holds (UNIQUE(user_id, name)) — the
+    same mapping the create, duplicate, and import paths apply."""
+    try:
+        return await app.state.model.workspaces.update_workspace(
+            workspace_id, owner_id, **fields
+        )
+    except SAIntegrityError:
+        raise HTTPException(
+            status_code=409,
+            detail=(
+                f"A workspace named {fields.get('name')!r} already exists"
+            ),
+        )
+
+
 @router.put("/workspaces/{workspace_id}")
 async def update_workspace(
     workspace_id: str,
@@ -652,8 +671,8 @@ async def update_workspace(
         _check_nix_optin(
             fields["settings"], app, previous=workspace["settings"]
         )
-    updated = await app.state.model.workspaces.update_workspace(
-        workspace_id, workspace["user_id"], **fields
+    updated = await _update_workspace_fields(
+        app, workspace_id, workspace["user_id"], fields
     )
     if not updated:
         raise HTTPException(status_code=404, detail="Workspace not found")

--- a/src/klangk/klangk/api/workspaces.py
+++ b/src/klangk/klangk/api/workspaces.py
@@ -526,6 +526,29 @@ class UpdateWorkspaceRequest(WorkspaceBodyFields):
     classification_banner: str | None = None
 
 
+# PUT-updatable columns that are NOT NULL and whose null has no
+# documented PUT meaning: an explicit null must be a 400, not a
+# constraint violation surfacing as a fabricated 409 collision
+# (#3097) or a ValueError 500 off the enum coercers. auto_start /
+# per_handle_home nulls stay legal — they coerce to 0 by design
+# (see UpdateWorkspaceRequest).
+_NOT_NULL_UPDATE_FIELDS = frozenset({"name", "setup_state", "egress_mode"})
+
+
+def _reject_null_fields(fields: dict) -> None:
+    """400 when the PUT body explicitly nulls a NOT NULL column.
+
+    ``exclude_unset=True`` keeps keys the client sent as ``null``, so
+    without this check a ``{"name": null}`` reaches the UPDATE and trips
+    the constraint — which the rename-collision mapping would then
+    misreport as "A workspace named None already exists"."""
+    for key in _NOT_NULL_UPDATE_FIELDS:
+        if key in fields and fields[key] is None:
+            raise HTTPException(
+                status_code=400, detail=f"Field '{key}' cannot be null"
+            )
+
+
 def _validate_update_fields(app, fields: dict) -> None:
     """Validate the PUT body's fields (mirrors the create API); mutates
     ``fields`` in place (normalized domain lists / settings / banner)."""
@@ -534,8 +557,9 @@ def _validate_update_fields(app, fields: dict) -> None:
 
 
 def _validate_update_core(app, fields: dict) -> None:
-    """The 400-raising checks: autostart enablement, image allow-list,
-    mount validity."""
+    """The 400-raising checks: null rejection, autostart enablement,
+    image allow-list, mount validity."""
+    _reject_null_fields(fields)
     _check_autostart(fields.get("auto_start"), app)
     if "image" in fields:
         _check_image(fields["image"], app)

--- a/src/klangk/klangkd-tests/tests/test_api.py
+++ b/src/klangk/klangkd-tests/tests/test_api.py
@@ -3318,6 +3318,31 @@ class TestWorkspaceRoutes:
         assert match[0]["name"] == "renamed"
         assert match[0]["service_command"] == "pi"
 
+    async def test_update_workspace_name_collision(self, client, user):
+        """#3097: renaming onto another name the owner holds is a 409
+        (same as create/duplicate/import), not a 500 off UNIQUE(user_id,
+        name)."""
+        headers = await _auth_headers(client)
+        for name in ("collide-a", "collide-b"):
+            resp = await client.post(
+                "/api/v1/workspaces",
+                json={"name": name},
+                headers=headers,
+            )
+            assert resp.status_code == 200
+            if name == "collide-a":
+                ws_id = resp.json()["id"]
+        resp = await client.put(
+            f"/api/v1/workspaces/{ws_id}",
+            json={"name": "collide-b"},
+            headers=headers,
+        )
+        assert resp.status_code == 409
+        assert "collide-b" in resp.json()["detail"]
+        resp = await client.get("/api/v1/workspaces", headers=headers)
+        match = [w for w in resp.json() if w["id"] == ws_id]
+        assert match[0]["name"] == "collide-a"
+
     async def test_update_workspace_egress_mode(self, client, user):
         # #2409: egress_mode is editable (PUT), taking effect on next start.
         headers = await _auth_headers(client)
@@ -9197,12 +9222,43 @@ class TestAdminEndpoints:
         headers = await self._admin_headers(client)
         resp = await client.patch(
             f"/api/v1/users/{user['id']}",
-            json={"email": "renamed"},
+            json={"email": "renamed@example.com"},
             headers=headers,
         )
         assert resp.status_code == 200
         updated = await app_state.state.model.users.get_user_by_id(user["id"])
-        assert updated["email"] == "renamed"
+        assert updated["email"] == "renamed@example.com"
+
+    async def test_update_email_invalid_rejected(
+        self, client, admin_user, user, app_state
+    ):
+        """#3097: a malformed address is rejected, not persisted."""
+        headers = await self._admin_headers(client)
+        resp = await client.patch(
+            f"/api/v1/users/{user['id']}",
+            json={"email": "not-an-email"},
+            headers=headers,
+        )
+        assert resp.status_code == 400
+        assert "valid email" in resp.json()["detail"]
+        updated = await app_state.state.model.users.get_user_by_id(user["id"])
+        assert updated["email"] == user["email"]
+
+    async def test_update_email_duplicate_rejected(
+        self, client, admin_user, user, app_state
+    ):
+        """#3097: an address owned by another account is a 400, not a
+        500 off the users.email UNIQUE constraint."""
+        headers = await self._admin_headers(client)
+        resp = await client.patch(
+            f"/api/v1/users/{user['id']}",
+            json={"email": admin_user["email"]},
+            headers=headers,
+        )
+        assert resp.status_code == 400
+        assert resp.json()["detail"] == "Email already in use"
+        updated = await app_state.state.model.users.get_user_by_id(user["id"])
+        assert updated["email"] == user["email"]
 
     async def test_update_password(self, client, admin_user, user):
         headers = await self._admin_headers(client)

--- a/src/klangk/klangkd-tests/tests/test_api.py
+++ b/src/klangk/klangkd-tests/tests/test_api.py
@@ -3343,6 +3343,59 @@ class TestWorkspaceRoutes:
         match = [w for w in resp.json() if w["id"] == ws_id]
         assert match[0]["name"] == "collide-a"
 
+    async def test_update_workspace_cross_owner_name_ok(
+        self, client, user, app_state
+    ):
+        """#3097: the name constraint is per-owner — renaming onto a name
+        a different owner holds must succeed, not 409."""
+        headers = await _auth_headers(client)
+        resp = await client.post(
+            "/api/v1/workspaces",
+            json={"name": "cross-owner"},
+            headers=headers,
+        )
+        ws_id = resp.json()["id"]
+        other = await app_state.state.model.users.create_user(
+            "crossowner@example.com", "irrelevant-hash", verified=True
+        )
+        await app_state.state.model.workspaces.create_workspace_with_acl(
+            other["id"], "cross-owner-target"
+        )
+        resp = await client.put(
+            f"/api/v1/workspaces/{ws_id}",
+            json={"name": "cross-owner-target"},
+            headers=headers,
+        )
+        assert resp.status_code == 200
+        resp = await client.get("/api/v1/workspaces", headers=headers)
+        match = [w for w in resp.json() if w["id"] == ws_id]
+        assert match[0]["name"] == "cross-owner-target"
+
+    async def test_update_workspace_null_not_null_field_rejected(
+        self, client, user, app_state
+    ):
+        """#3097: explicitly nulling a NOT NULL column is a 400 — not a
+        fabricated 409 collision (name) or a 500 (setup_state/
+        egress_mode enum coercers). auto_start/per_handle_home nulls
+        stay legal (documented coerce-to-0)."""
+        headers = await _auth_headers(client)
+        resp = await client.post(
+            "/api/v1/workspaces",
+            json={"name": "null-guard"},
+            headers=headers,
+        )
+        ws_id = resp.json()["id"]
+        for field in ("name", "setup_state", "egress_mode"):
+            resp = await client.put(
+                f"/api/v1/workspaces/{ws_id}",
+                json={field: None},
+                headers=headers,
+            )
+            assert resp.status_code == 400, field
+            assert resp.json()["detail"] == f"Field '{field}' cannot be null"
+        row = await app_state.state.model.workspaces.get_workspace(ws_id)
+        assert row["name"] == "null-guard"
+
     async def test_update_workspace_egress_mode(self, client, user):
         # #2409: egress_mode is editable (PUT), taking effect on next start.
         headers = await _auth_headers(client)
@@ -9259,6 +9312,46 @@ class TestAdminEndpoints:
         assert resp.json()["detail"] == "Email already in use"
         updated = await app_state.state.model.users.get_user_by_id(user["id"])
         assert updated["email"] == user["email"]
+
+    async def test_update_email_same_email_noop(
+        self, client, admin_user, user, app_state
+    ):
+        """#3097: patching a user with their own current email is an
+        idempotent 200, not a duplicate rejection."""
+        headers = await self._admin_headers(client)
+        resp = await client.patch(
+            f"/api/v1/users/{user['id']}",
+            json={"email": user["email"]},
+            headers=headers,
+        )
+        assert resp.status_code == 200
+        updated = await app_state.state.model.users.get_user_by_id(user["id"])
+        assert updated["email"] == user["email"]
+
+    async def test_update_email_integrity_race_guard(
+        self, client, app, admin_user, user, monkeypatch
+    ):
+        """#3097: a duplicate that slips past the pre-check (the address
+        claimed between the check and the write) is a 400, not a 500 off
+        the users.email UNIQUE constraint."""
+        from sqlalchemy.exc import IntegrityError as SAIntegrityError
+
+        async def claim_in_between(_user_id, _email):
+            raise SAIntegrityError("UPDATE users", {}, Exception("dup"))
+
+        monkeypatch.setattr(
+            app.state.model.users,
+            "update_email",
+            claim_in_between,
+        )
+        headers = await self._admin_headers(client)
+        resp = await client.patch(
+            f"/api/v1/users/{user['id']}",
+            json={"email": "claimed-in-between@example.com"},
+            headers=headers,
+        )
+        assert resp.status_code == 400
+        assert resp.json()["detail"] == "Email already in use"
 
     async def test_update_password(self, client, admin_user, user):
         headers = await self._admin_headers(client)


### PR DESCRIPTION
## Summary

Fixes #3097 — the three update-path gaps from the `api/` bug sweep:

- **`PATCH /api/v1/users/{id}` duplicate email** — the route wrote the email with no duplicate pre-check, so patching onto an address owned by another account raised `IntegrityError` off `users.email UNIQUE` → 500. Now mirrors `change-email`: `get_user_by_email` pre-check → 400 "Email already in use".
- **`PATCH /api/v1/users/{id}` invalid email** — no `auth.validate_email` on the branch; `{"email": "not-an-email"}` returned 200 and persisted. Now 400 "Must be a valid email address", matching every other email write.
- **`PUT /api/v1/workspaces/{id}` rename collision** — the only name-write without `SAIntegrityError` handling; renaming onto another name the owner holds 500ed off `UNIQUE(user_id, name)`. Now returns the same 409 "A workspace named … already exists" as create/duplicate/import (extracted `_update_workspace_fields` to keep the route at xenon rank A).

## Tests

- `test_update_email_invalid_rejected` / `test_update_email_duplicate_rejected` (assert non-persistence too)
- `test_update_workspace_name_collision` (409 + name unchanged)
- `test_update_email` updated to a valid address (it previously asserted the unvalidated-persist bug)

Full suite green: 6690 passed, 100% branch coverage (`-n auto`, CI invocation). Changelog entries added under `[Unreleased] → Fixed`.
