### PR TITLE
Use require_auth for klangk shell and sandbox auth gating (#3090)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -1950,6 +1950,13 @@ git-credential` (#1700).** `pig-latin` removed; `word-count` dormant.
 
 ### Fixed
 
+- **`klangk shell` and `klangk sandbox` now use the standard auth gate
+  (#3090).** Both commands checked for a stored token directly, so on a
+  no-auth (`auth_modes: none`) server they refused with "Not logged in"
+  instead of auto-logging in like every other command, and with a stale
+  default UDS they suggested `klangk login` (which would fail to connect)
+  instead of reporting the unreachable socket.
+
 - **Non-mapping `klangk.yaml` no longer crashes every CLI command
   (#3094).** A config file holding valid YAML that is not a mapping
   (a stray list or a bare string) used to abort every `klangk`

--- a/src/klangk/klangk/cli/sandboxcmd.py
+++ b/src/klangk/klangk/cli/sandboxcmd.py
@@ -254,12 +254,9 @@ def sandbox(
     volumes, copies files, and runs the setup script.  Use
     ``klangk shell`` afterwards to connect.
     """
-    token = context.session_token()
-    if not token:
-        context.err.print(
-            "[red]Not logged in[/red] — run [bold]klangk login[/bold] first."
-        )
-        raise typer.Exit(code=1)
+    # require_auth (not a raw token check) so none-mode auto-login
+    # (#1374) and the stale-UDS hint (#1676) apply to sandbox too (#3090).
+    context.require_auth()
 
     sandbox_root = Path(path).resolve()
     config = load_config_or_exit(sandbox_root)
@@ -267,6 +264,7 @@ def sandbox(
     client = context.client()
     handle = client.get_handle()
     surl = context.server_url()
+    token = context.session_token()
     created = False
 
     # Check if workspace already exists.

--- a/src/klangk/klangk/cli/shellcmd.py
+++ b/src/klangk/klangk/cli/shellcmd.py
@@ -307,12 +307,10 @@ def shell(
     forward_agent, no_consent_popup = normalize_shell_flags(
         forward_agent, no_consent_popup
     )
+    # require_auth (not a raw token check) so none-mode auto-login
+    # (#1374) and the stale-UDS hint (#1676) apply to shell too (#3090).
+    context.require_auth()
     token = context.session_token()
-    if not token:
-        context.err.print(
-            "[red]Not logged in[/red] — run [bold]klangk login[/bold] first."
-        )
-        raise typer.Exit(code=1)
 
     client = context.client()
 

--- a/src/klangk/klangkc-tests/tests/test_cli.py
+++ b/src/klangk/klangkc-tests/tests/test_cli.py
@@ -6035,11 +6035,17 @@ class TestSandboxCommandGuards:
         monkeypatch.setattr(
             sandboxcmd.context,
             "require_auth",
-            MagicMock(side_effect=typer.Exit()),
+            MagicMock(side_effect=typer.Exit(code=1)),
         )
         monkeypatch.setattr(sandboxcmd.context, "err", MagicMock())
-        with pytest.raises(typer.Exit):
+        load = MagicMock()
+        monkeypatch.setattr(sandboxcmd, "load_sandbox_config", load)
+        with pytest.raises(typer.Exit) as excinfo:
             sandboxcmd.sandbox("ws", str(tmp_path))
+        assert excinfo.value.exit_code == 1
+        # Refused auth stops the command at the gate — the local
+        # config-load exit (also code 1) must not mask a missing gate.
+        load.assert_not_called()
 
     def test_sandbox_routes_auth_through_require_auth(
         self, monkeypatch, tmp_path
@@ -6057,6 +6063,38 @@ class TestSandboxCommandGuards:
         with pytest.raises(typer.Exit):
             sandboxcmd.sandbox("ws", str(tmp_path))
         guard.assert_called_once()
+
+    def test_shell_none_mode_auto_login_end_to_end(self, monkeypatch):
+        """The #3090 fix in action: fresh state, none-mode server, no
+        stored token — shell auto-logs in (#1374) and proceeds past the
+        auth gate instead of refusing with "Not logged in"."""
+        from klangk.cli import shellcmd
+        from klangk.cli.config import CLIState
+
+        state = CLIState()
+        state.active_server = "http://localhost:8995"
+        state.save()
+        monkeypatch.setattr(
+            "klangk.cli.context.fetch_config",
+            lambda _: {"auth_modes": "none", "oidc_providers": []},
+        )
+        monkeypatch.setattr(
+            "klangk.cli.context.local_login",
+            lambda url: ("admin@example.com", "jwt-auto"),
+        )
+        fake_client = MagicMock()
+        fake_client.list_workspaces.return_value = []
+        monkeypatch.setattr(shellcmd.context, "client", lambda: fake_client)
+        monkeypatch.setattr(shellcmd.context, "err", MagicMock())
+        # Real require_auth: none-mode probe -> auto-login -> token
+        # stored; the command then runs past the gate to the empty
+        # workspace list ("No workspaces found" exit, code 1).
+        with pytest.raises(typer.Exit) as excinfo:
+            shellcmd.shell(None, None, None, True)
+        assert excinfo.value.exit_code == 1
+        fake_client.list_workspaces.assert_called_once()
+        # The auto-issued token is what the command itself resolves.
+        assert shellcmd.context.session_token() == "jwt-auto"
 
     def test_run_sandbox_setup_expired_session_exits(self, monkeypatch):
         from klangk.cli import sandboxcmd

--- a/src/klangk/klangkc-tests/tests/test_cli.py
+++ b/src/klangk/klangkc-tests/tests/test_cli.py
@@ -5590,6 +5590,7 @@ class TestCliBranchGaps2834d:
         cfg = types.SimpleNamespace(image="img", mounts=[], env={}, setup=None)
         ws = types.SimpleNamespace(id="ws-exist")
         with (
+            patch("klangk.cli.context.require_auth"),
             patch("klangk.cli.context.session_token", lambda: "tok"),
             patch("klangk.cli.context.server_url", lambda: "http://t:8995"),
             patch.object(sandboxcmd, "load_sandbox_config", lambda p: cfg),
@@ -5608,17 +5609,39 @@ class TestCliBranchGaps2834d:
 
     def test_shell_bool_flag_skips_normalization(self):
         # no_consent_popup already a bool: the OptionInfo normalization
-        # arm is skipped; the run then exits cleanly without a token.
+        # arm is skipped; the run then exits at the auth gate.
         from klangk.cli import shellcmd
 
         with (
-            patch("klangk.cli.context.session_token", lambda: ""),
+            patch(
+                "klangk.cli.context.require_auth",
+                MagicMock(side_effect=typer.Exit()),
+            ),
             patch("klangk.cli.context.err", MagicMock()),
         ):
-            import typer as typer_mod
-
-            with pytest.raises(typer_mod.Exit):
+            with pytest.raises(typer.Exit):
                 shellcmd.shell("ws", None, None, True)
+
+    def test_shell_routes_auth_through_require_auth(self):
+        """shell gates via require_auth, not a raw token check (#3090):
+        none-mode auto-login (#1374) and the stale-UDS message (#1676)
+        apply to it like every other command."""
+        from klangk.cli import shellcmd
+
+        guard = MagicMock()
+        fake_client = MagicMock()
+        fake_client.list_workspaces.return_value = []
+        with (
+            patch("klangk.cli.context.require_auth", guard),
+            patch("klangk.cli.context.session_token", lambda: "tok"),
+            patch("klangk.cli.context.client", lambda: fake_client),
+            patch("klangk.cli.context.err", MagicMock()),
+        ):
+            # No workspace arg + empty list -> the interactive picker's
+            # "No workspaces found" exit, past the auth gate.
+            with pytest.raises(typer.Exit):
+                shellcmd.shell(None, None, None, True)
+        guard.assert_called_once()
 
 
 # --- No-cover audit tests (#2910) ---------------------------------------
@@ -6009,10 +6032,31 @@ class TestSandboxCommandGuards:
     def test_sandbox_without_token_exits(self, monkeypatch, tmp_path):
         from klangk.cli import sandboxcmd
 
-        monkeypatch.setattr(sandboxcmd.context, "session_token", lambda: "")
+        monkeypatch.setattr(
+            sandboxcmd.context,
+            "require_auth",
+            MagicMock(side_effect=typer.Exit()),
+        )
         monkeypatch.setattr(sandboxcmd.context, "err", MagicMock())
         with pytest.raises(typer.Exit):
             sandboxcmd.sandbox("ws", str(tmp_path))
+
+    def test_sandbox_routes_auth_through_require_auth(
+        self, monkeypatch, tmp_path
+    ):
+        """sandbox gates via require_auth, not a raw token check (#3090):
+        none-mode auto-login (#1374) and the stale-UDS message (#1676)
+        apply to it like every other command."""
+        from klangk.cli import sandboxcmd
+
+        guard = MagicMock()
+        monkeypatch.setattr(sandboxcmd.context, "require_auth", guard)
+        monkeypatch.setattr(sandboxcmd.context, "err", MagicMock())
+        # No .klangk-sandbox.yaml in tmp_path -> the config-load exit,
+        # which sits past the auth gate.
+        with pytest.raises(typer.Exit):
+            sandboxcmd.sandbox("ws", str(tmp_path))
+        guard.assert_called_once()
 
     def test_run_sandbox_setup_expired_session_exits(self, monkeypatch):
         from klangk.cli import sandboxcmd


### PR DESCRIPTION
## Summary

`klangk shell` and `klangk sandbox` gated auth with a raw
`context.session_token()` + "Not logged in" check instead of
`context.require_auth()`, losing two behaviors every other command has:

- **none-mode auto-login (#1374)** — on a fresh no-auth server
  (`auth_modes: none`) with no stored token, `klangk ls` auto-logs in and
  works, but `klangk shell <ws>` / `klangk sandbox` refused with
  "Not logged in".
- **the stale-UDS message (#1676)** — with the default UDS present but
  klangkd down, both commands said "Not logged in" (suggesting
  `klangk login`, which then fails to connect) instead of
  "Cannot connect to klangkd at <path> — is it running?".

Both now call `context.require_auth()`; `sandbox` fetches the token via
`session_token()` at its point of use (after the client/handle setup),
matching the established pairing.

## Testing

- Updated the two guard tests that exercised the old raw-token branch to
  stub `require_auth` instead.
- Added `test_shell_routes_auth_through_require_auth` and
  `test_sandbox_routes_auth_through_require_auth` asserting both commands
  pass through the shared gate.
- Full suite the CI way (xdist, branch coverage):
  `6710 passed`, 100% coverage. Xenon A-clean.
