### PR TITLE
Degrade non-mapping klangk.yaml to empty config (#3094)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -1950,6 +1950,13 @@ git-credential` (#1700).** `pig-latin` removed; `word-count` dormant.
 
 ### Fixed
 
+- **Non-mapping `klangk.yaml` no longer crashes every CLI command
+  (#3094).** A config file holding valid YAML that is not a mapping
+  (a stray list or a bare string) used to abort every `klangk`
+  invocation with `AttributeError`. It is now treated as an empty
+  config, so commands run with defaults and a bad alias lookup misses
+  instead of crashing.
+
 - **Cancellation during a consent verdict no longer hangs the egress
   relay** (#3089). A decider disconnect or backend shutdown landing while
   the verdict's DB write was in flight escaped as a `CancelledError`

--- a/src/klangk/klangk/cli/config.py
+++ b/src/klangk/klangk/cli/config.py
@@ -180,10 +180,7 @@ class CLIConfig:
 
     @classmethod
     def load(cls) -> CLIConfig:
-        if not CONFIG_PATH.exists():
-            return cls()
-        text = CONFIG_PATH.read_text()
-        data = yaml.safe_load(text) or {}
+        data = load_yaml_config()
         return cls(
             forward_agent=data.get("forward-agent"),
             ws_max_size=data.get("ws-max-size"),
@@ -285,10 +282,18 @@ def seed_config(server_url: str, user: str | None = None) -> None:
 
 
 def load_yaml_config() -> dict:
-    """The parsed klangk.yaml (empty when the file is absent)."""
+    """The parsed klangk.yaml (empty when absent or not a mapping).
+
+    klangk.yaml is user-edited: a document that is valid YAML but not a
+    mapping (a stray list, a bare string) must not crash every CLI
+    command with ``AttributeError`` — it degrades to an empty config
+    (#3094), the same degrade-not-crash rule as a bad
+    ``terminal-open-cmd`` (#2685).
+    """
     if not CONFIG_PATH.exists():
         return {}
-    return yaml.safe_load(CONFIG_PATH.read_text()) or {}
+    data = yaml.safe_load(CONFIG_PATH.read_text())
+    return data if isinstance(data, dict) else {}
 
 
 def add_server_to_config(
@@ -377,7 +382,7 @@ def remove_server_from_config(alias: str) -> bool:
     """
     if not CONFIG_PATH.exists():
         return False
-    data = yaml.safe_load(CONFIG_PATH.read_text()) or {}
+    data = load_yaml_config()
     servers = data.get("servers") or {}
     if alias not in servers:
         return False

--- a/src/klangk/klangkc-tests/tests/test_cli.py
+++ b/src/klangk/klangkc-tests/tests/test_cli.py
@@ -25,6 +25,7 @@ from klangk.cli.config import (
     UserEntry,
     DEFAULT_WS_MAX_SIZE,
     ensure_config,
+    load_yaml_config,
     seed_config,
 )
 from klangk.cli.client import (
@@ -119,6 +120,32 @@ class TestCLIConfig:
         monkeypatch.setattr("klangk.cli.config.CONFIG_PATH", config_path)
         cfg = CLIConfig.load()
         assert cfg.servers == {}
+
+    def test_load_non_mapping_yaml_degrades_to_empty(
+        self, tmp_path, monkeypatch
+    ):
+        """A valid-YAML-but-not-a-mapping document (a stray list, a bare
+        string, a number) must not crash every CLI command with
+        AttributeError — it degrades to an empty config (#3094)."""
+        for bad in ("- oops\n", "just a string\n", "42\n"):
+            config_path = tmp_path / "klangk.yaml"
+            config_path.write_text(bad)
+            monkeypatch.setattr("klangk.cli.config.CONFIG_PATH", config_path)
+            cfg = CLIConfig.load()
+            assert cfg.servers == {}
+            assert cfg.forward_agent is None
+            assert cfg.ws_max_size is None
+            assert cfg.terminal_open_cmd is None
+
+    def test_load_yaml_config_non_mapping_returns_empty(
+        self, tmp_path, monkeypatch
+    ):
+        """load_yaml_config is the shared reader behind load(), the TUI
+        add/update/remove flows — it must coerce, not crash (#3094)."""
+        config_path = tmp_path / "klangk.yaml"
+        config_path.write_text("- a\n- b\n")
+        monkeypatch.setattr("klangk.cli.config.CONFIG_PATH", config_path)
+        assert load_yaml_config() == {}
 
     def test_resolve_server_alias(self):
         cfg = CLIConfig(

--- a/src/klangk/klangkc-tests/tests/test_tui.py
+++ b/src/klangk/klangkc-tests/tests/test_tui.py
@@ -367,6 +367,18 @@ def test_remove_server_from_config(redirect_xdg):
     assert remove_server_from_config("zzz") is False
 
 
+def test_config_flows_survive_non_mapping_file(redirect_xdg):
+    """A valid-YAML-but-not-a-mapping klangk.yaml must not crash the
+    mutation flows with AttributeError — lookups miss (False) and an
+    add rewrites the file as a mapping (#3094)."""
+    cpath, _ = redirect_xdg
+    cpath.write_text("- oops\n")
+    assert remove_server_from_config("a") is False
+    assert update_server_in_config("a", "a", "https://a.example") is False
+    add_server_to_config("a", "https://a.example")
+    assert CLIConfig.load().servers["a"].url == "https://a.example"
+
+
 def test_update_server_in_config(redirect_xdg):
     add_server_to_config("a", "https://a.example")
     assert update_server_in_config("a", "a", "https://a2.example") is True


### PR DESCRIPTION
## Summary

A `klangk.yaml` that is valid YAML but not a mapping (a stray `- item`
list, a bare string) crashed **every** CLI invocation with
`AttributeError: 'list' object has no attribute 'get'` — `CLIConfig.load()`
and `load_yaml_config()` called `.get()` on the `yaml.safe_load` result
with no shape guard (#3094).

`load_yaml_config()` is now the single guarded reader for klangk.yaml: a
non-mapping document coerces to `{}`. `CLIConfig.load()` and
`remove_server_from_config()` (the one remaining raw `safe_load` of
klangk.yaml, TUI delete-server flow) both go through it, so:

- `klangk ls` / any command runs with defaults instead of a traceback;
- TUI update/remove lookups miss (`False`) instead of crashing;
- a TUI add-server rewrites the file as a proper mapping (self-heal).

This matches the degrade-not-crash rule the codebase already applies to
a bad `terminal-open-cmd` (#2685). `sandbox.py` already isinstance-guards
its own config, and `CLIState.load`'s section parser guards its sections
(state is app-managed), so no other readers needed the guard.

## Tests

- `test_load_non_mapping_yaml_degrades_to_empty` — list / string / scalar
  documents load as an empty `CLIConfig` (the exact issue repro).
- `test_load_yaml_config_non_mapping_returns_empty` — the shared reader
  coerces.
- `test_config_flows_survive_non_mapping_file` — TUI mutation flows
  degrade; add rewrites the file as a mapping.

Full suite (CI-style): `python -m pytest src/klangk/klangkd-tests/tests
src/klangk/klangkc-tests/tests -v -n auto` — 6711 passed. Xenon gate
passed.

Fixes #3094
