### PR TITLE
Rate-limit forgot-password before the account lookup (#3100)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -256,6 +256,14 @@ operators or integrators to act when upgrading.
 
 ### Security
 
+- **Forgot-password rate limiter no longer leaks account existence
+  (#3100).** The 60-second per-address cooldown on
+  `POST /api/v1/auth/forgot-password` now applies before the account
+  lookup, so unknown, disabled, and enabled addresses all answer 429
+  identically on a repeated request. Previously only existing enabled
+  accounts could be rate-limited, making the cooldown an oracle for
+  both account existence and the disabled state.
+
 - **Per-frame gates on the own-terminal and ssh-agent WS commands
   (#3022).** With `join-workspace` as the connect gate (#2975), a
   join-only member could reach frames whose only protection was the

--- a/src/klangk/klangk/api/auth.py
+++ b/src/klangk/klangk/api/auth.py
@@ -292,6 +292,16 @@ async def forgot_password(
     app=Depends(get_app_dep),
 ):
     """Send a password reset email if the account exists."""
+    # Rate limit first, keyed on the submitted address only (#3100): the
+    # cooldown must not depend on whether the account exists or is
+    # disabled, or its 429 becomes an existence oracle that the
+    # ``"sent"``-for-everything posture below exists to prevent.
+    if _rate_limited(reset_timestamps, RESET_COOLDOWN_SECONDS, req.email):
+        raise HTTPException(
+            status_code=429,
+            detail="Please wait before requesting another email",
+        )
+
     user = await app.state.model.users.get_user_by_email(req.email)
     if user is None:
         # Don't reveal whether the email exists
@@ -304,13 +314,6 @@ async def forgot_password(
     # state to an anonymous caller.
     if user.get("disabled"):
         return {"status": "sent"}
-
-    # Rate limit: one reset email per address per minute
-    if _rate_limited(reset_timestamps, RESET_COOLDOWN_SECONDS, req.email):
-        raise HTTPException(
-            status_code=429,
-            detail="Please wait before requesting another email",
-        )
 
     hostname, proto, base_path = request.app.state.util.derive_hosting_info(
         request.headers, request.client.host if request.client else None

--- a/src/klangk/klangkd-tests/tests/test_api.py
+++ b/src/klangk/klangkd-tests/tests/test_api.py
@@ -1487,6 +1487,7 @@ class TestForgotPassword:
         )
         assert resp.status_code == 200
         assert resp.json()["status"] == "sent"
+        api.reset_timestamps.pop("nobody@example.com", None)
 
     async def test_forgot_disabled_user_no_email_still_sent(
         self, client, app, db, app_state
@@ -1526,6 +1527,50 @@ class TestForgotPassword:
                 json={"email": "forgot@example.com"},
             )
         assert resp2.status_code == 429
+        api.reset_timestamps.pop("forgot@example.com", None)
+
+    async def test_forgot_rate_limited_unknown_email(self, client, db):
+        """#3100: the cooldown must not be an account-existence oracle —
+        an unknown address answers 429 on the second request, exactly
+        like a known one."""
+        resp1 = await client.post(
+            "/api/v1/auth/forgot-password",
+            json={"email": "ghost-forgot@example.com"},
+        )
+        resp2 = await client.post(
+            "/api/v1/auth/forgot-password",
+            json={"email": "ghost-forgot@example.com"},
+        )
+        assert resp1.status_code == 200
+        assert resp1.json()["status"] == "sent"
+        assert resp2.status_code == 429
+        api.reset_timestamps.pop("ghost-forgot@example.com", None)
+
+    async def test_forgot_rate_limited_disabled_user(
+        self, client, app, db, app_state
+    ):
+        """#3100: a disabled account must be indistinguishable from an
+        enabled one across repeated requests — 429 on the second, no
+        email on either."""
+        u = await self._create_user(app_state)
+        await app.state.model.users.set_user_disabled(u["id"], True)
+        with patch.object(
+            emailsvc_mod.EmailService,
+            "send_password_reset_email",
+            new_callable=AsyncMock,
+        ) as mock_send:
+            resp1 = await client.post(
+                "/api/v1/auth/forgot-password",
+                json={"email": "forgot@example.com"},
+            )
+            resp2 = await client.post(
+                "/api/v1/auth/forgot-password",
+                json={"email": "forgot@example.com"},
+            )
+        assert resp1.status_code == 200
+        assert resp1.json()["status"] == "sent"
+        assert resp2.status_code == 429
+        mock_send.assert_not_awaited()
         api.reset_timestamps.pop("forgot@example.com", None)
 
     async def test_forgot_prunes_expired_entries(self, client, db, app_state):


### PR DESCRIPTION
## Summary

Moves the 60-second per-address cooldown in `POST /api/v1/auth/forgot-password` to the top of the handler, before the account lookup (#3100).

Previously the `_rate_limited` check ran only after the unknown-email and disabled-account early returns, so only an **existing, enabled** account could answer 429 — making the cooldown an oracle for both account existence and the disabled state, exactly what the `{"status": "sent"}`-for-everything posture exists to hide (#2588 kept the disabled path's response identical for this reason).

All three paths — unknown, disabled, enabled — now answer 429 identically on a repeated request. The check is keyed on the submitted address; pruning already happens inside `_rate_limited`, so placement is the only change.

## Testing

- New tests: unknown address and disabled account both answer 429 on the second rapid request (and the disabled path still sends no email).
- Full backend suite green (`6710 passed`).
