### PR TITLE
Fix api/ hardening gaps: registration TOCTOU, atomic member share, export truncation (#3101)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -1966,6 +1966,29 @@ git-credential` (#1700).** `pig-latin` removed; `word-count` dormant.
   word-split it. `setup:` was never documented to accept shell syntax,
   so a script path is all it passes now.
 
+- **Concurrent duplicate registrations and invite accepts return a
+  clean 4xx (#3101).** The production email-verification `register`
+  path and `accept-invite` only pre-checked for an existing account
+  before inserting, so two racing requests made the loser hit a 500;
+  they now catch the lost race and return the same 400 as the
+  pre-check.
+- **One pending invitation per email (#3101).** `POST /invitations`
+  now enforces a single pending invitation per address (partial
+  unique index, migration 0028 revokes any duplicate pending rows
+  created by the old race; history is kept), so concurrent sends can
+  no longer mint two pending invitations.
+- **Workspace member/group share is atomic and duplicate-safe
+  (#3101).** Sharing a workspace with a user or group writes the whole
+  permission block in one transaction: a failure no longer leaves a
+  partial share, concurrent shares no longer collide on positions, and
+  re-sharing an already-shared principal is rejected with 409 instead
+  of stacking a duplicate block.
+- **Export no longer hides a tar failure behind a 200 (#3101).** A
+  missing `tar` binary fails the export with a clean 500, and a tar
+  that dies mid-run aborts the download (logged at ERROR with tar's
+  stderr) instead of delivering a truncated archive; the CLI removes
+  the partial file and reports the interrupted transfer.
+
 - **Cancellation during a consent verdict no longer hangs the egress
   relay** (#3089). A decider disconnect or backend shutdown landing while
   the verdict's DB write was in flight escaped as a `CancelledError`

--- a/src/klangk/klangk/api/admin.py
+++ b/src/klangk/klangk/api/admin.py
@@ -12,6 +12,7 @@ from fastapi import (
     Request,
 )
 from pydantic import BaseModel
+from sqlalchemy.exc import IntegrityError as SAIntegrityError
 
 from .. import (
     acl,
@@ -65,6 +66,25 @@ def _validate_root_acl(entries, resource: str) -> None:
         )
 
 
+async def create_invitation_or_race_400(app, req, admin) -> dict:
+    """Create the invitation row, mapping a lost race to a 400.
+
+    The pending pre-check in ``send_invitation`` is not atomic with the
+    insert, so a concurrent send that wins the partial unique index
+    (m0028) must surface as the same 400 the pre-check returns — and
+    only one pending invitation survives (#3101).
+    """
+    try:
+        return await app.state.model.invitations.create_invitation(
+            req.email, admin["id"]
+        )
+    except SAIntegrityError:
+        raise HTTPException(
+            status_code=400,
+            detail="A pending invitation already exists for this email",
+        ) from None
+
+
 @router.post("/invitations")
 async def send_invitation(
     req: SendInviteRequest,
@@ -95,9 +115,7 @@ async def send_invitation(
             detail="A pending invitation already exists for this email",
         )
 
-    invitation = await app.state.model.invitations.create_invitation(
-        req.email, admin["id"]
-    )
+    invitation = await create_invitation_or_race_400(app, req, admin)
     token = app.state.auth.create_invitation_token(invitation["id"], req.email)
 
     hostname, proto, base_path = request.app.state.util.derive_hosting_info(

--- a/src/klangk/klangk/api/auth.py
+++ b/src/klangk/klangk/api/auth.py
@@ -22,6 +22,7 @@ from fastapi.security import HTTPAuthorizationCredentials
 
 import httpx
 from pydantic import BaseModel
+from sqlalchemy.exc import IntegrityError as SAIntegrityError
 
 from .. import (
     auth,
@@ -147,9 +148,7 @@ async def register(
     # Insert user and send email in a transaction — if the email fails,
     # the user insert is rolled back so they can try again.
     async with app.state.model.transaction() as db:
-        await app.state.model.users.insert_unverified_user(
-            db, user_id, req.email, password_hash
-        )
+        await insert_user_or_race_400(app, db, user_id, req, password_hash)
         logger.info("User inserted (uncommitted): %s", req.email)
         await send_email(
             app.state.email.send_verification_email(
@@ -161,6 +160,27 @@ async def register(
         logger.info("Verification email sent, committing user: %s", req.email)
 
     return {"status": "pending_verification", "email": req.email}
+
+
+async def insert_user_or_race_400(
+    app, db, user_id, req, password_hash
+) -> None:
+    """Insert the unverified user row, mapping a lost race to a 400.
+
+    The duplicate-email pre-check in ``register`` is not atomic with
+    the INSERT, so a concurrent registration that wins the UNIQUE
+    constraint must surface as the same opaque 400 the pre-check
+    returns — no enumeration, no 500 (#3101; production-path twin of
+    the #877 fix).
+    """
+    try:
+        await app.state.model.users.insert_unverified_user(
+            db, user_id, req.email, password_hash
+        )
+    except SAIntegrityError:
+        raise HTTPException(
+            status_code=400, detail="Registration failed"
+        ) from None
 
 
 @router.get("/auth/verify")
@@ -659,6 +679,28 @@ class AcceptInviteRequest(BaseModel):
     password: str
 
 
+async def create_invited_user(
+    request: Request, email: str, password: str
+) -> dict:
+    """Create the verified account for an accepted invitation.
+
+    The duplicate-email pre-check in the caller is not atomic with the
+    INSERT, so a concurrent accept (or registration) that wins the
+    UNIQUE constraint must surface as the same 400 the pre-check
+    returns, not an unhandled 500 (#3101).
+    """
+    password_hash = await asyncio.to_thread(auth.hash_password, password)
+    try:
+        return await request.app.state.model.users.create_user(
+            email, password_hash, verified=True
+        )
+    except SAIntegrityError:
+        raise HTTPException(
+            status_code=400,
+            detail="An account with this email already exists",
+        ) from None
+
+
 @router.post("/auth/accept-invite")
 async def accept_invite(req: AcceptInviteRequest, request: Request):
     """Accept an invitation and create a verified account."""
@@ -685,10 +727,7 @@ async def accept_invite(req: AcceptInviteRequest, request: Request):
             status_code=400, detail="An account with this email already exists"
         )
 
-    password_hash = await asyncio.to_thread(auth.hash_password, req.password)
-    user = await request.app.state.model.users.create_user(
-        email, password_hash, verified=True
-    )
+    user = await create_invited_user(request, email, req.password)
     await request.app.state.model.invitations.mark_invitation_accepted(
         invitation_id
     )

--- a/src/klangk/klangk/api/workspaces.py
+++ b/src/klangk/klangk/api/workspaces.py
@@ -45,7 +45,6 @@ from ..workspace_settings import (
 )
 from .common import get_app_dep
 from ..model import (
-    ACTION_ALLOW,
     EGRESS_MODE_DEFAULT,
     EGRESS_MODES,
     PRINCIPAL_GROUP,
@@ -1119,6 +1118,16 @@ async def export_workspace(
     """
     workspace = await _exportable_workspace(app, workspace_id, user["id"])
 
+    # Pre-flight before the response starts (#3101): once the first
+    # chunk goes out the status line is already 200, so a tar binary
+    # that cannot even start must fail here as a clean 500 instead of
+    # an empty 200 body.
+    if shutil.which("tar") is None:
+        raise HTTPException(
+            status_code=500,
+            detail="Export failed: the tar binary is not available",
+        )
+
     home_dir = app.state.workspaces.home_path(workspace_id)
     ws_name = workspace["name"]
 
@@ -1144,11 +1153,19 @@ async def export_workspace(
                 "-", tmpdir, home_dir
             )
 
-            proc = await asyncio.create_subprocess_exec(
-                *tar_args,
-                stdout=asyncio.subprocess.PIPE,
-                stderr=asyncio.subprocess.DEVNULL,
-            )
+            # stderr goes to a temp file, not DEVNULL: on a tar failure
+            # the reason must reach the log, and a pipe would risk
+            # deadlocking on a stderr flood (#3101).
+            stderr_file = tempfile.TemporaryFile()
+            try:
+                proc = await asyncio.create_subprocess_exec(
+                    *tar_args,
+                    stdout=asyncio.subprocess.PIPE,
+                    stderr=stderr_file,
+                )
+            except BaseException:
+                stderr_file.close()
+                raise
             try:
                 while True:
                     chunk = await proc.stdout.read(_CHUNK_SIZE)
@@ -1156,10 +1173,30 @@ async def export_workspace(
                         break
                     yield chunk
                 await proc.wait()
+                if proc.returncode != 0:
+                    # The status line is already sent, so the body can
+                    # only be aborted — raise so the transfer breaks
+                    # mid-stream instead of delivering a clean 200 with
+                    # a truncated archive the user later fails to
+                    # import (#3101).
+                    stderr_file.seek(0)
+                    stderr_text = stderr_file.read(2000).decode(
+                        errors="replace"
+                    )
+                    logger.error(
+                        "Workspace export tar failed (rc=%s) for %s: %s",
+                        proc.returncode,
+                        workspace_id,
+                        stderr_text,
+                    )
+                    raise RuntimeError(
+                        f"Export tar failed with rc={proc.returncode}"
+                    )
             finally:
                 if proc.returncode is None:
                     proc.kill()
                     await proc.wait()
+                stderr_file.close()
         finally:
             shutil.rmtree(tmpdir, ignore_errors=True)
 
@@ -1513,6 +1550,31 @@ class AddMemberRequest(BaseModel):
     email: str
 
 
+# What a simple share grants (#3101): one block appended atomically by
+# the model layer. ``join-workspace`` is the connect gate (#2975) and
+# ``monitor-workspace`` keeps health/status frames flowing (#2783).
+MEMBER_SHARE_PERMISSIONS = (
+    "view",
+    "monitor-workspace",
+    "join-workspace",
+    "terminal",
+    "files-view",
+    "files-download",
+    "files-write",
+)
+
+# Group shares mirror the member block minus the monitor grant the
+# role-group layout never carried.
+GROUP_SHARE_PERMISSIONS = (
+    "view",
+    "join-workspace",
+    "terminal",
+    "files-view",
+    "files-download",
+    "files-write",
+)
+
+
 @router.post("/workspaces/{workspace_id}/members")
 async def add_workspace_member(
     workspace_id: str,
@@ -1529,34 +1591,20 @@ async def add_workspace_member(
         raise HTTPException(
             status_code=400, detail="Cannot share with yourself"
         )
-    # Add ACL entries granting the target user view+monitor+join+
-    # terminal+files(+dl/ul) on this workspace, packed at the next available
-    # positions. ``join-workspace`` is the connect gate (#2975) — it rides
-    # along with ``terminal`` so a shared member keeps the ability to open
-    # the workspace at all; ``monitor`` rides along too (#2783) so the
-    # member keeps receiving health/status frames — either can also be
-    # granted alone for monitoring-only members.
-    resource = f"/workspaces/{workspace_id}"
-    existing = await app.state.model.acl.get_acl_entries(resource)
-    next_pos = max((e["position"] for e in existing), default=-1) + 1
-    for perm in (
-        "view",
-        "monitor-workspace",
-        "join-workspace",
-        "terminal",
-        "files-view",
-        "files-download",
-        "files-write",
-    ):
-        await app.state.model.acl.add_acl_entry(
-            resource,
-            next_pos,
-            ACTION_ALLOW,
-            perm,
-            PRINCIPAL_USER,
-            user_id=target["id"],
+    # Append the member's whole permission block in one transaction —
+    # positions allocated inside it, duplicates detected instead of
+    # stacking a second block (#3101).
+    shared = await app.state.model.acl.add_principal_entries(
+        f"/workspaces/{workspace_id}",
+        list(MEMBER_SHARE_PERMISSIONS),
+        PRINCIPAL_USER,
+        user_id=target["id"],
+    )
+    if not shared:
+        raise HTTPException(
+            status_code=409,
+            detail="This user already has access to the workspace",
         )
-        next_pos += 1
     app.state.sockets.notify_user_workspaces_changed(user["id"])
     app.state.sockets.notify_user_workspaces_changed(target["id"])
     return {
@@ -1834,26 +1882,16 @@ async def add_workspace_group(
     group = await app.state.model.users.get_group_by_id(body.group_id)
     if group is None:
         raise HTTPException(status_code=404, detail="Group not found")
-    resource = f"/workspaces/{workspace_id}"
-    existing = await app.state.model.acl.get_acl_entries(resource)
-    max_pos = max((e["position"] for e in existing), default=-1)
-    for i, perm in enumerate(
-        [
-            "view",
-            "join-workspace",
-            "terminal",
-            "files-view",
-            "files-download",
-            "files-write",
-        ]
-    ):
-        await app.state.model.acl.add_acl_entry(
-            resource,
-            max_pos + 1 + i,
-            ACTION_ALLOW,
-            perm,
-            PRINCIPAL_GROUP,
-            group_id=body.group_id,
+    shared = await app.state.model.acl.add_principal_entries(
+        f"/workspaces/{workspace_id}",
+        list(GROUP_SHARE_PERMISSIONS),
+        PRINCIPAL_GROUP,
+        group_id=body.group_id,
+    )
+    if not shared:
+        raise HTTPException(
+            status_code=409,
+            detail="This group already has access to the workspace",
         )
     return {"status": "shared", "group_id": group["id"], "name": group["name"]}
 

--- a/src/klangk/klangk/cli/workspaces.py
+++ b/src/klangk/klangk/cli/workspaces.py
@@ -521,6 +521,17 @@ def export_workspace(
                 progress.update(task_id, total=final, completed=final)
     except httpx.HTTPStatusError as e:
         export_error(e)
+    except httpx.RequestError:
+        # A mid-body abort (server-side tar failure breaks the stream
+        # instead of shipping a truncated 200, #3101) lands here —
+        # remove the partial archive rather than leave a file that
+        # only fails confusingly at import time.
+        out_path.unlink(missing_ok=True)
+        context.err.print(
+            "[red]Export failed:[/red] transfer interrupted —"
+            " the archive was not completed"
+        )
+        raise typer.Exit(code=1) from None
     _out = Console()
     _out.print(f"Exported [bold]{name}[/bold] → {out_path}")
 

--- a/src/klangk/klangk/model/acl.py
+++ b/src/klangk/klangk/model/acl.py
@@ -95,6 +95,26 @@ def _reject_agent_principal(entry: dict) -> None:
         )
 
 
+def next_position(entries: list[dict]) -> int:
+    """One past the resource's current highest ACE position."""
+    return max((e["position"] for e in entries), default=-1) + 1
+
+
+def is_principal_entry(
+    entry: dict, principal_type: int, user_id, group_id
+) -> bool:
+    """True when *entry* grants to the given principal.
+
+    The ids are compared as exact values (``None`` matches ``None``);
+    ``row_to_acl_entry`` always materializes both columns.
+    """
+    return (
+        entry["principal_type"] == principal_type
+        and entry["user_id"] == user_id
+        and entry["group_id"] == group_id
+    )
+
+
 class ACLModel(Submodel):
     """ACL data access, through ``app_state.db``.
 
@@ -182,6 +202,91 @@ class ACLModel(Submodel):
             (resource,),
         )
         return [row_to_acl_entry(row) for row in rows]
+
+    async def _select_acl_entries(self, db, resource: str) -> list[dict]:
+        """Read a resource's entries on the passed connection.
+
+        The share helper reads inside its ``write_transaction`` so the
+        duplicate check and position allocation see the same locked
+        snapshot the writes land on (#3101).
+        """
+        cursor = await db.execute(
+            "SELECT id, resource, position, action, principal_type,"
+            " user_id, group_id, system_principal, permission"
+            " FROM acl_entries WHERE resource = ?"
+            " ORDER BY position",
+            (resource,),
+        )
+        return [row_to_acl_entry(row) for row in await cursor.fetchall()]
+
+    async def add_principal_entries(
+        self,
+        resource: str,
+        permissions: list[str],
+        principal_type: int,
+        user_id: str | None = None,
+        group_id: str | None = None,
+    ) -> bool:
+        """Append a principal's permission block atomically (#3101).
+
+        The duplicate check, the position allocation, and every insert
+        run in one ``write_transaction`` (write lock held throughout),
+        so a failure anywhere rolls the whole block back — no partial
+        share with ``view`` but not ``files-*`` — and concurrent shares
+        serialize instead of computing overlapping positions or
+        stacking duplicate blocks. Returns True when the block was
+        added, False when the principal already holds entries on the
+        resource.
+
+        Raises the same guards as :meth:`add_acl_entry`
+        (:class:`AgentPrincipalError`, :class:`WorkspaceRoleScopeError`).
+        """
+        template = {
+            "action": ACTION_ALLOW,
+            "principal_type": principal_type,
+            "user_id": user_id,
+            "group_id": group_id,
+            "system_principal": None,
+        }
+        _reject_agent_principal(template)
+        async with self.app.state.db.write_transaction() as db:
+            entries = await self._load_locked_entries(
+                db, resource, principal_type, user_id, group_id
+            )
+            if entries is None:
+                return False
+            base = next_position(entries)
+            for i, permission in enumerate(permissions):
+                await self._insert_acl_entry(
+                    db,
+                    resource,
+                    {
+                        **template,
+                        "position": base + i,
+                        "permission": permission,
+                    },
+                )
+        return True
+
+    async def _load_locked_entries(
+        self, db, resource: str, principal_type: int, user_id, group_id
+    ) -> list[dict] | None:
+        """Scope-check the principal, then read the locked entry list.
+
+        Returns ``None`` when the principal already holds entries on
+        the resource (duplicate share) — the caller must not append a
+        second block. Runs on the caller's ``write_transaction``
+        connection so the answer matches the snapshot the writes land
+        on.
+        """
+        if principal_type == PRINCIPAL_GROUP and group_id is not None:
+            await self._check_role_group_scope(db, resource, group_id)
+        entries = await self._select_acl_entries(db, resource)
+        duplicate = any(
+            is_principal_entry(e, principal_type, user_id, group_id)
+            for e in entries
+        )
+        return None if duplicate else entries
 
     async def get_acl_entries_map(
         self,

--- a/src/klangk/klangk/model/db.py
+++ b/src/klangk/klangk/model/db.py
@@ -208,6 +208,32 @@ class DB:
         finally:
             await db.close()
 
+    @asynccontextmanager
+    async def write_transaction(self):
+        """Context manager like :meth:`transaction`, but the write lock
+        is taken up front (``BEGIN IMMEDIATE``).
+
+        A plain :meth:`transaction` only starts the driver transaction
+        at the first DML statement, so decision-then-write helpers that
+        SELECT first compute on a pre-lock snapshot: two concurrent
+        writers can both pass a duplicate check or both allocate the
+        same positions, and the loser's write silently clobbers the
+        winner's. Here the lock precedes every read, so reads see all
+        committed data and concurrent writers serialize behind this
+        transaction (#3101). The migration runner uses the same
+        explicit-``BEGIN`` posture for the same reason.
+        """
+        db = await self.get_db()
+        try:
+            await db.execute("BEGIN IMMEDIATE")
+            yield db
+            await db.commit()
+        except BaseException:
+            await db.rollback()
+            raise
+        finally:
+            await db.close()
+
     async def fetchone(self, query: str, params: tuple = ()) -> Row | None:
         """Run a single-row SELECT and return the row, or ``None``."""
         async with self.transaction() as db:

--- a/src/klangk/klangk/model/migrations/__init__.py
+++ b/src/klangk/klangk/model/migrations/__init__.py
@@ -75,6 +75,7 @@ from klangk.model.migrations import m0024_join_workspace_permission
 from klangk.model.migrations import m0025_drop_dead_images_deny_row
 from klangk.model.migrations import m0026_volumes_admin_surface
 from klangk.model.migrations import m0027_retire_admin_marker
+from klangk.model.migrations import m0028_invitations_pending_unique
 from klangk.model.migrations.base import Migration
 
 __all__ = ["MIGRATIONS", "Migration", "run_migrations"]
@@ -110,6 +111,7 @@ MIGRATIONS: list[Migration] = [
     m0025_drop_dead_images_deny_row.migration,
     m0026_volumes_admin_surface.migration,
     m0027_retire_admin_marker.migration,
+    m0028_invitations_pending_unique.migration,
 ]
 
 

--- a/src/klangk/klangk/model/migrations/m0028_invitations_pending_unique.py
+++ b/src/klangk/klangk/model/migrations/m0028_invitations_pending_unique.py
@@ -1,0 +1,50 @@
+"""Migration 0028: one pending invitation per email (#3101).
+
+The send-invitation route pre-checks ``get_pending_invitation_by_email``
+and then inserts — not atomic, so two concurrent sends for the same
+address both passed the pre-check and minted two pending invitations
+(the route's 400 never fired). Fresh databases get the partial unique
+index ``idx_invitations_pending_dedup`` from the baseline schema; this
+migration backfills it onto deployed databases.
+
+First it collapses any duplicate pending rows the race already created:
+per email, the oldest pending invitation (by ``created_at``, id as
+tiebreak) survives and the younger duplicates are flipped to
+``revoked`` — the same terminal state an admin revoke produces, keeping
+the audit trail while freeing the email's single pending slot. Accepted
+and revoked history is untouched (the index covers only ``pending``).
+
+Idempotent by construction: with at most one pending row per email the
+UPDATE matches nothing, and the index uses IF NOT EXISTS.
+"""
+
+from klangk.model.migrations.base import Migration
+
+
+async def apply(db) -> None:
+    await db.execute(
+        """
+        UPDATE invitations SET status = 'revoked'
+        WHERE status = 'pending' AND id NOT IN (
+            SELECT id FROM (
+                SELECT id, ROW_NUMBER() OVER (
+                    PARTITION BY email
+                    ORDER BY created_at, id
+                ) AS rn
+                FROM invitations
+                WHERE status = 'pending'
+            ) WHERE rn = 1
+        )
+        """
+    )
+    await db.execute(
+        "CREATE UNIQUE INDEX IF NOT EXISTS idx_invitations_pending_dedup"
+        " ON invitations(email) WHERE status = 'pending'"
+    )
+
+
+migration = Migration(
+    id=28,
+    name="0028_invitations_pending_unique",
+    apply=apply,
+)

--- a/src/klangk/klangk/model/schema.py
+++ b/src/klangk/klangk/model/schema.py
@@ -384,6 +384,16 @@ async def init_core_tables(db) -> None:
             accepted_at TEXT
         )
     """)
+    # One pending invitation per email (#3101): the get-pending
+    # pre-check in the send-invitation route is not atomic with the
+    # insert, so two concurrent sends used to mint two pending rows.
+    # The partial index (accepted/revoked history stays unlimited)
+    # makes the loser's insert fail at the storage layer; migration
+    # 0028 backfills this on deployed databases.
+    await db.execute(
+        "CREATE UNIQUE INDEX IF NOT EXISTS idx_invitations_pending_dedup"
+        " ON invitations(email) WHERE status = 'pending'"
+    )
 
 
 def _shared_ec_columns(ec_old_cols: set[str]) -> list[str]:

--- a/src/klangk/klangkc-tests/tests/test_cli_main.py
+++ b/src/klangk/klangkc-tests/tests/test_cli_main.py
@@ -5048,6 +5048,32 @@ class TestExportImportCLI:
         with pytest.raises(typer.Exit):
             main.export_workspace(name="err-ws", output=tmp_path / "o.tar.gz")
 
+    def test_export_transfer_interrupted(
+        self, logged_in_cfg, monkeypatch, tmp_path, capsys
+    ):
+        """A mid-body abort (server-side tar failure, #3101) exits 1,
+        reports the interrupted transfer, and removes the partial
+        archive instead of leaving a file that only fails at import
+        time."""
+        from klangk.cli import main
+
+        ws = Workspace(id="ws-x-id", name="x-ws", created_at="2025-01-01")
+        out = tmp_path / "x.tar.gz"
+
+        def partial_then_abort(ws_id, out_path, on_progress=None):
+            out_path.write_bytes(b"partial archive")
+            raise httpx.RemoteProtocolError("peer closed connection")
+
+        client = MagicMock()
+        client.resolve_workspace.return_value = ws
+        client.export_workspace.side_effect = partial_then_abort
+        monkeypatch.setattr(context_mod, "client", lambda: client)
+
+        with pytest.raises(typer.Exit):
+            main.export_workspace(name="x-ws", output=out)
+        assert not out.exists()
+        assert "interrupted" in capsys.readouterr().err
+
     def test_export_http_error_403(self, logged_in_cfg, monkeypatch, tmp_path):
         """#2707: the export-permission denial gets a specific message."""
         from klangk.cli import main

--- a/src/klangk/klangkd-tests/tests/test_api.py
+++ b/src/klangk/klangkd-tests/tests/test_api.py
@@ -12,6 +12,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 from fastapi import FastAPI
 import httpx
 from httpx import AsyncClient, ASGITransport
+from sqlalchemy.exc import IntegrityError as SAIntegrityError
 
 from klangk import (
     api,
@@ -852,6 +853,36 @@ class TestAuthRoutes:
             headers={"Authorization": f"Bearer {token}"},
         )
         assert resp.status_code == 400
+
+    async def test_register_race_integrity_error(self, client, app, db):
+        """The production email-verification path must catch a lost
+        duplicate-email race: same opaque 400 as the pre-check, no 500,
+        and no verification email sent (#3101)."""
+        with (
+            patch.object(
+                app.state.model.users,
+                "insert_unverified_user",
+                side_effect=SAIntegrityError(
+                    "statement", {}, Exception("UNIQUE constraint failed")
+                ),
+            ),
+            patch.object(
+                emailsvc_mod.EmailService,
+                "send_verification_email",
+                new_callable=AsyncMock,
+            ) as mock_send,
+        ):
+            resp = await client.post(
+                "/api/v1/auth/register",
+                json={"email": "race@example.com", "password": "newpass1"},
+            )
+        assert resp.status_code == 400
+        assert resp.json()["detail"] == "Registration failed"
+        mock_send.assert_not_called()
+        assert (
+            await app.state.model.users.get_user_by_email("race@example.com")
+            is None
+        )
 
     async def test_verify_email(self, client, db, app_state):
         """Verify endpoint marks user as verified."""
@@ -4837,6 +4868,43 @@ class TestWorkspaceSharingRoutes:
             "view",
         ]
 
+    async def test_add_member_duplicate_rejected(
+        self, client, user, app_state
+    ):
+        """Re-sharing an already-shared member is a 409, not a second
+        stacked block (#3101)."""
+        headers = await _auth_headers(client)
+        other = await self._create_other_user(app_state)
+        resp = await client.post(
+            "/api/v1/workspaces", headers=headers, json={"name": "share-ws"}
+        )
+        ws_id = resp.json()["id"]
+        assert (
+            await client.post(
+                f"/api/v1/workspaces/{ws_id}/members",
+                headers=headers,
+                json={"email": "other@example.com"},
+            )
+        ).status_code == 200
+
+        resp = await client.post(
+            f"/api/v1/workspaces/{ws_id}/members",
+            headers=headers,
+            json={"email": "other@example.com"},
+        )
+        assert resp.status_code == 409
+        assert "already has access" in resp.json()["detail"]
+        entries = await app_state.state.model.acl.get_acl_entries(
+            f"/workspaces/{ws_id}"
+        )
+        member_entries = [
+            e
+            for e in entries
+            if e["principal_type"] == model.PRINCIPAL_USER
+            and e["user_id"] == other["id"]
+        ]
+        assert len(member_entries) == 7  # one block, not two
+
     async def test_add_member_notifies_owner_and_target(
         self, client, app, user, sockets, app_state
     ):
@@ -6147,6 +6215,45 @@ class TestWorkspaceGroupSharing:
             "view",
         ]
 
+    async def test_share_with_group_duplicate_rejected(
+        self, client, user, app_state
+    ):
+        """Re-sharing an already-shared group is a 409, not a second
+        stacked block (#3101)."""
+        headers = await _auth_headers(client)
+        resp = await client.post(
+            "/api/v1/workspaces",
+            headers=headers,
+            json={"name": "group-dup-ws"},
+        )
+        ws_id = resp.json()["id"]
+        group = await app_state.state.model.users.create_group("dup-devs")
+
+        assert (
+            await client.post(
+                f"/api/v1/workspaces/{ws_id}/groups",
+                headers=headers,
+                json={"group_id": group["id"]},
+            )
+        ).status_code == 200
+        resp = await client.post(
+            f"/api/v1/workspaces/{ws_id}/groups",
+            headers=headers,
+            json={"group_id": group["id"]},
+        )
+        assert resp.status_code == 409
+        assert "already has access" in resp.json()["detail"]
+        entries = await app_state.state.model.acl.get_acl_entries(
+            f"/workspaces/{ws_id}"
+        )
+        group_entries = [
+            e
+            for e in entries
+            if e["principal_type"] == model.PRINCIPAL_GROUP
+            and e["group_id"] == group["id"]
+        ]
+        assert len(group_entries) == 6  # one block, not two
+
     async def test_remove_group(self, client, user, app_state):
         headers = await _auth_headers(client)
         resp = await client.post(
@@ -6219,7 +6326,10 @@ class TestWorkspaceGroupSharing:
         assert resp.status_code == 400
         assert "grantable only" in resp.json()["detail"]
 
-        # Its own workspace's role group stays grantable.
+        # Its own workspace's role group stays grantable in principle —
+        # but it already holds the seeded owner grants on that
+        # workspace, so the share is a detected duplicate (409, #3101),
+        # never a second stacked block.
         owners_a = await app_state.state.model.users.get_group_by_name(
             f"owners-{ws_a}"
         )
@@ -6228,7 +6338,18 @@ class TestWorkspaceGroupSharing:
             headers=headers,
             json={"group_id": owners_a["id"]},
         )
-        assert resp.status_code == 200
+        assert resp.status_code == 409
+        assert "already has access" in resp.json()["detail"]
+        entries = await app_state.state.model.acl.get_acl_entries(
+            f"/workspaces/{ws_a}"
+        )
+        owners_entries = [
+            e
+            for e in entries
+            if e["principal_type"] == model.PRINCIPAL_GROUP
+            and e["group_id"] == owners_a["id"]
+        ]
+        assert len(owners_entries) == 1  # the seeded wildcard, not a stack
 
     async def test_replace_acl_rejects_other_workspaces_role_group(
         self, client, user, app_state
@@ -10621,6 +10742,89 @@ class TestWorkspaceExportImport:
             assert metadata["name"] == "export-test"
             assert "instance_id" in metadata
 
+    async def test_export_missing_tar_binary_is_clean_500(
+        self, client, admin_user, user, app
+    ):
+        """A tar that cannot start fails before the response begins —
+        a clean 500, not an empty 200 body (#3101)."""
+        headers = await self._user_headers(client)
+        resp = await client.post(
+            "/api/v1/workspaces", headers=headers, json={"name": "no-tar"}
+        )
+        ws = resp.json()
+        with patch("shutil.which", return_value=None):
+            resp = await client.get(
+                f"/api/v1/workspaces/{ws['id']}/export", headers=headers
+            )
+        assert resp.status_code == 500
+        assert "tar binary" in resp.json()["detail"]
+
+    async def test_export_tar_failure_aborts_body(
+        self, client, admin_user, user, app, caplog
+    ):
+        """A tar that fails mid-run must not deliver a clean 200 with a
+        truncated archive: the stream aborts and the failure is logged
+        at ERROR with tar's stderr (#3101)."""
+        import logging
+
+        headers = await self._user_headers(client)
+        resp = await client.post(
+            "/api/v1/workspaces",
+            headers=headers,
+            json={"name": "bad-tar"},
+        )
+        ws = resp.json()
+        home = app.state.workspaces.home_path(ws["id"])
+        home.mkdir(parents=True, exist_ok=True)
+        (home / "data.txt").write_text("x" * 4096)
+
+        real_args = app.state.workspaces.build_export_tar_args
+
+        def broken_args(output, tmpdir, home_dir):
+            # Real archive args plus a member that cannot exist: tar
+            # streams the valid members, then exits nonzero.
+            return real_args(output, tmpdir, home_dir) + [
+                "/nonexistent-member-xyz"
+            ]
+
+        caplog.set_level(logging.ERROR, logger="klangk.api.workspaces")
+        with patch.object(
+            app.state.workspaces, "build_export_tar_args", broken_args
+        ):
+            with pytest.raises(RuntimeError, match="Export tar failed"):
+                await client.get(
+                    f"/api/v1/workspaces/{ws['id']}/export", headers=headers
+                )
+        assert any(
+            "export tar failed" in r.message.lower() for r in caplog.records
+        )
+
+    async def test_export_subprocess_spawn_failure_aborts_body(
+        self, client, admin_user, user, app
+    ):
+        """A spawn failure after the pre-flight (e.g. the binary
+        vanished) aborts the stream too, without leaking the stderr
+        temp file (#3101)."""
+        headers = await self._user_headers(client)
+        resp = await client.post(
+            "/api/v1/workspaces",
+            headers=headers,
+            json={"name": "spawn-fail"},
+        )
+        ws = resp.json()
+
+        async def no_exec(*args, **kwargs):
+            raise FileNotFoundError("tar vanished")
+
+        with patch(
+            "klangk.api.workspaces.asyncio.create_subprocess_exec",
+            no_exec,
+        ):
+            with pytest.raises(FileNotFoundError):
+                await client.get(
+                    f"/api/v1/workspaces/{ws['id']}/export", headers=headers
+                )
+
     async def test_export_requires_permission(
         self, client, admin_user, user, app_state
     ):
@@ -12279,6 +12483,40 @@ class TestInvitations:
         assert resp.status_code == 400
         assert "pending invitation" in resp.json()["detail"]
 
+    async def test_send_invitation_race_integrity_error(
+        self, client, app, admin_user, app_state
+    ):
+        """A concurrent send that wins the pending-invitation race (the
+        m0028 partial unique index is the backstop) gets the pre-check's
+        400, and only one invitation row exists (#3101)."""
+        headers = await self._admin_headers(client)
+        with (
+            patch.object(
+                app.state.model.invitations,
+                "create_invitation",
+                side_effect=SAIntegrityError(
+                    "statement", {}, Exception("UNIQUE constraint failed")
+                ),
+            ),
+            patch.object(
+                emailsvc_mod.EmailService,
+                "send_invitation_email",
+                new_callable=AsyncMock,
+            ) as mock_send,
+        ):
+            resp = await client.post(
+                "/api/v1/invitations",
+                headers=headers,
+                json={"email": "inv-race@example.com"},
+            )
+        assert resp.status_code == 400
+        assert "pending invitation" in resp.json()["detail"]
+        mock_send.assert_not_called()
+        result = await app.state.model.invitations.list_invitations(
+            q="inv-race"
+        )
+        assert result["total"] == 0
+
     async def test_send_invitation_invalid_email(self, client, admin_user):
         headers = await self._admin_headers(client)
         resp = await client.post(
@@ -12763,6 +13001,42 @@ class TestInvitations:
         )
         assert resp.status_code == 400
         assert "already exists" in resp.json()["detail"]
+
+    async def test_accept_invite_race_integrity_error(
+        self, client, app, admin_user, app_state
+    ):
+        """A concurrent accept/registration that wins the UNIQUE
+        constraint surfaces as the pre-check's 400, not a 500 (#3101)."""
+        headers = await self._admin_headers(client)
+        with patch.object(
+            emailsvc_mod.EmailService,
+            "send_invitation_email",
+            new_callable=AsyncMock,
+        ):
+            create_resp = await client.post(
+                "/api/v1/invitations",
+                headers=headers,
+                json={"email": "ace-race@example.com"},
+            )
+        inv_id = create_resp.json()["id"]
+        token = _auth().create_invitation_token(inv_id, "ace-race@example.com")
+
+        with patch.object(
+            app.state.model.users,
+            "create_user",
+            side_effect=SAIntegrityError(
+                "statement", {}, Exception("UNIQUE constraint failed")
+            ),
+        ):
+            resp = await client.post(
+                "/api/v1/auth/accept-invite",
+                json={"token": token, "password": "newpassword"},
+            )
+        assert resp.status_code == 400
+        assert "already exists" in resp.json()["detail"]
+        # The invitation is still pending — nothing was consumed.
+        invitation = await app.state.model.invitations.get_invitation(inv_id)
+        assert invitation["status"] == "pending"
 
     async def test_accept_invite_wrong_purpose_token(self, client, db):
         # Use a verification token (wrong purpose)

--- a/src/klangk/klangkd-tests/tests/test_migrations.py
+++ b/src/klangk/klangkd-tests/tests/test_migrations.py
@@ -88,6 +88,7 @@ class TestRunner:
             (25, "0025_drop_dead_images_deny_row"),
             (26, "0026_volumes_admin_surface"),
             (27, "0027_retire_admin_marker"),
+            (28, "0028_invitations_pending_unique"),
         ]
         async with aiosqlite.connect(str(app_state.state.db.db_path)) as db:
             assert await _recorded(db) == expected
@@ -181,6 +182,7 @@ class TestRunner:
                 (25, "0025_drop_dead_images_deny_row"),
                 (26, "0026_volumes_admin_surface"),
                 (27, "0027_retire_admin_marker"),
+                (28, "0028_invitations_pending_unique"),
             ]
 
     async def test_m0008_agent_identity_and_human_collision(
@@ -3026,5 +3028,102 @@ class TestM0027RetireAdminMarker:
             await m0027_retire_admin_marker.migration.apply(db)
             cursor = await db.execute("SELECT COUNT(*) FROM acl_entries")
             assert (await cursor.fetchone())[0] == 0
+        finally:
+            await db.__aexit__(None, None, None)
+
+
+class TestM0028InvitationsPendingUnique:
+    """m0028 collapses duplicate pending invitations (the pre-#3101 race
+    residue) and backfills the one-pending-per-email partial index."""
+
+    async def _db(self, tmp_path):
+        db = aiosqlite.connect(str(tmp_path / "m0028.db"))
+        db = await db.__aenter__()
+        await db.execute(
+            "CREATE TABLE invitations ("
+            " id TEXT PRIMARY KEY, email TEXT NOT NULL,"
+            " invited_by TEXT NOT NULL,"
+            " status TEXT NOT NULL DEFAULT 'pending',"
+            " created_at TEXT NOT NULL DEFAULT (datetime('now')),"
+            " accepted_at TEXT)"
+        )
+        return db
+
+    async def _insert(
+        self, db, id, email, status, created_at, invited_by="inviter"
+    ):
+        await db.execute(
+            "INSERT INTO invitations (id, email, invited_by, status,"
+            " created_at) VALUES (?, ?, ?, ?, ?)",
+            (id, email, invited_by, status, created_at),
+        )
+
+    async def _statuses(self, db, email) -> list[tuple]:
+        cursor = await db.execute(
+            "SELECT id, status FROM invitations WHERE email = ?"
+            " ORDER BY created_at, id",
+            (email,),
+        )
+        return list(await cursor.fetchall())
+
+    async def test_dedupes_and_creates_index(self, tmp_path):
+        from klangk.model.migrations import m0028_invitations_pending_unique
+
+        db = await self._db(tmp_path)
+        try:
+            # Race residue: two pendings for one email (oldest first).
+            await self._insert(db, "old", "a@b.com", "pending", "2026-01-01")
+            await self._insert(db, "new", "a@b.com", "pending", "2026-01-02")
+            # History for the same email must survive untouched.
+            await self._insert(db, "acc", "a@b.com", "accepted", "2025-12-01")
+            await self._insert(db, "rev", "a@b.com", "revoked", "2025-12-02")
+            # Another email's pending is unaffected.
+            await self._insert(db, "b1", "b@b.com", "pending", "2026-01-03")
+            await db.commit()
+
+            await m0028_invitations_pending_unique.migration.apply(db)
+
+            assert await self._statuses(db, "a@b.com") == [
+                ("acc", "accepted"),
+                ("rev", "revoked"),
+                ("old", "pending"),
+                ("new", "revoked"),
+            ]
+            assert await self._statuses(db, "b@b.com") == [("b1", "pending")]
+
+            # The index now forbids a second pending for one email.
+            with pytest.raises(Exception) as exc_info:
+                await self._insert(db, "again", "a@b.com", "pending", "x")
+            assert "UNIQUE" in str(exc_info.value)
+
+            # Idempotent: a re-run changes nothing and raises not.
+            await m0028_invitations_pending_unique.migration.apply(db)
+            assert await self._statuses(db, "a@b.com") == [
+                ("acc", "accepted"),
+                ("rev", "revoked"),
+                ("old", "pending"),
+                ("new", "revoked"),
+            ]
+        finally:
+            await db.__aexit__(None, None, None)
+
+    async def test_no_duplicates_is_noop(self, tmp_path):
+        from klangk.model.migrations import m0028_invitations_pending_unique
+
+        db = await self._db(tmp_path)
+        try:
+            await self._insert(db, "solo", "c@b.com", "pending", "2026-01-01")
+            await db.commit()
+            await m0028_invitations_pending_unique.migration.apply(db)
+            assert await self._statuses(db, "c@b.com") == [("solo", "pending")]
+            # An empty pending set is fine too.
+            await db.execute(
+                "UPDATE invitations SET status = 'accepted' WHERE id = 'solo'"
+            )
+            await db.commit()
+            await m0028_invitations_pending_unique.migration.apply(db)
+            assert await self._statuses(db, "c@b.com") == [
+                ("solo", "accepted")
+            ]
         finally:
             await db.__aexit__(None, None, None)

--- a/src/klangk/klangkd-tests/tests/test_model.py
+++ b/src/klangk/klangkd-tests/tests/test_model.py
@@ -1036,6 +1036,191 @@ class TestWorkspaceSharing:
         assert result["next_offset"] is None
 
 
+class TestAddPrincipalEntries:
+    """The atomic member/group share block (#3101).
+
+    add_principal_entries appends a principal's permission block in one
+    write_transaction: duplicate detection, position allocation, and
+    every insert share a single locked snapshot.
+    """
+
+    PERMS = ["view", "join-workspace", "terminal"]
+
+    async def test_user_block_appended_after_existing(
+        self, workspace, user, app_state
+    ):
+        other = await app_state.state.model.users.create_user(
+            "block@example.com", "hash"
+        )
+        resource = f"/workspaces/{workspace['id']}"
+        await app_state.state.model.acl.add_acl_entry(
+            resource,
+            0,
+            model.ACTION_ALLOW,
+            "view",
+            model.PRINCIPAL_USER,
+            user_id=user["id"],
+        )
+
+        assert await app_state.state.model.acl.add_principal_entries(
+            resource, self.PERMS, model.PRINCIPAL_USER, user_id=other["id"]
+        )
+        entries = await app_state.state.model.acl.get_acl_entries(resource)
+        added = [e for e in entries if e["user_id"] == other["id"]]
+        assert [e["permission"] for e in added] == self.PERMS
+        assert [e["position"] for e in added] == [
+            1,
+            2,
+            3,
+        ]
+
+    async def test_duplicate_returns_false_adds_nothing(
+        self, workspace, user, app_state
+    ):
+        other = await app_state.state.model.users.create_user(
+            "dup@example.com", "hash"
+        )
+        resource = f"/workspaces/{workspace['id']}"
+        m = app_state.state.model.acl
+        assert await m.add_principal_entries(
+            resource, self.PERMS, model.PRINCIPAL_USER, user_id=other["id"]
+        )
+        before = await m.get_acl_entries(resource)
+
+        assert not await m.add_principal_entries(
+            resource, self.PERMS, model.PRINCIPAL_USER, user_id=other["id"]
+        )
+
+        assert await m.get_acl_entries(resource) == before
+
+    async def test_mid_block_failure_rolls_back(
+        self, workspace, user, app_state
+    ):
+        """A failure partway through the block leaves no partial share."""
+        from unittest.mock import patch
+
+        other = await app_state.state.model.users.create_user(
+            "partial@example.com", "hash"
+        )
+        resource = f"/workspaces/{workspace['id']}"
+        m = app_state.state.model.acl
+        before = await m.get_acl_entries(resource)
+        original = type(m)._insert_acl_entry
+        calls = []
+
+        async def flaky(self, db, res, entry):
+            calls.append(entry["permission"])
+            if len(calls) == 3:
+                raise RuntimeError("boom mid-block")
+            return await original(self, db, res, entry)
+
+        with patch.object(type(m), "_insert_acl_entry", flaky):
+            with pytest.raises(RuntimeError, match="boom mid-block"):
+                await m.add_principal_entries(
+                    resource,
+                    self.PERMS,
+                    model.PRINCIPAL_USER,
+                    user_id=other["id"],
+                )
+        assert len(calls) == 3  # the third insert is the one that failed
+        assert await m.get_acl_entries(resource) == before
+
+    async def test_role_group_scope_guard_blocks_first(
+        self, workspace, user, app_state
+    ):
+        """The #2750 scope guard fires inside the same transaction, so a
+        cross-workspace role-group share writes nothing."""
+        from klangk.model.users import WorkspaceRoleScopeError
+
+        ws_b = await app_state.state.model.workspaces.create_workspace(
+            user["id"], "scope-guard-b"
+        )
+        owners_b = await app_state.state.model.users.create_group(
+            f"owners-{ws_b['id']}", source=model.GROUP_SOURCE_WORKSPACE_ROLE
+        )
+        resource = f"/workspaces/{workspace['id']}"
+        m = app_state.state.model.acl
+        before = await m.get_acl_entries(resource)
+
+        with pytest.raises(WorkspaceRoleScopeError):
+            await m.add_principal_entries(
+                resource,
+                self.PERMS,
+                model.PRINCIPAL_GROUP,
+                group_id=owners_b["id"],
+            )
+        assert await m.get_acl_entries(resource) == before
+
+    async def test_agent_principal_rejected(self, workspace, user, app_state):
+        from klangk.model.users import AgentPrincipalError
+
+        resource = f"/workspaces/{workspace['id']}"
+        with pytest.raises(AgentPrincipalError):
+            await app_state.state.model.acl.add_principal_entries(
+                resource,
+                self.PERMS,
+                model.PRINCIPAL_USER,
+                user_id=model.AGENT_USER_ID,
+            )
+
+    async def test_concurrent_same_principal_one_block(
+        self, workspace, user, app_state
+    ):
+        """Two in-flight shares for the same user: the write lock
+        serializes them, one block lands, the loser is told duplicate."""
+        other = await app_state.state.model.users.create_user(
+            "racer@example.com", "hash"
+        )
+        resource = f"/workspaces/{workspace['id']}"
+        m = app_state.state.model.acl
+        results = await asyncio.gather(
+            m.add_principal_entries(
+                resource,
+                self.PERMS,
+                model.PRINCIPAL_USER,
+                user_id=other["id"],
+            ),
+            m.add_principal_entries(
+                resource,
+                self.PERMS,
+                model.PRINCIPAL_USER,
+                user_id=other["id"],
+            ),
+        )
+        assert sorted(results) == [False, True]
+        entries = await m.get_acl_entries(resource)
+        added = [e for e in entries if e["user_id"] == other["id"]]
+        assert [e["permission"] for e in added] == self.PERMS
+
+    async def test_concurrent_distinct_principals_no_overlap(
+        self, workspace, user, app_state
+    ):
+        """Two in-flight shares for different users both land with
+        disjoint positions — no lost update, no UNIQUE backstop 500."""
+        a = await app_state.state.model.users.create_user(
+            "racer-a@example.com", "hash"
+        )
+        b = await app_state.state.model.users.create_user(
+            "racer-b@example.com", "hash"
+        )
+        resource = f"/workspaces/{workspace['id']}"
+        m = app_state.state.model.acl
+        results = await asyncio.gather(
+            m.add_principal_entries(
+                resource, self.PERMS, model.PRINCIPAL_USER, user_id=a["id"]
+            ),
+            m.add_principal_entries(
+                resource, self.PERMS, model.PRINCIPAL_USER, user_id=b["id"]
+            ),
+        )
+        assert results == [True, True]
+        entries = await m.get_acl_entries(resource)
+        positions = [e["position"] for e in entries]
+        assert len(positions) == len(set(positions))
+        assert len([e for e in entries if e["user_id"] == a["id"]]) == 3
+        assert len([e for e in entries if e["user_id"] == b["id"]]) == 3
+
+
 class TestSearchUsers:
     async def test_search_by_prefix(self, user, app_state):
         await app_state.state.model.users.create_user(
@@ -1763,6 +1948,26 @@ class TestInvitations:
         assert not await app_state.state.model.invitations.revoke_invitation(
             "nonexistent"
         )
+
+    async def test_second_pending_for_same_email_rejected(
+        self, db, admin_user, app_state
+    ):
+        """The partial unique index (m0028) is the storage backstop for
+        the send route's non-atomic pending pre-check (#3101): a second
+        pending row for one email cannot exist, while history for the
+        same email stays unlimited."""
+        m = app_state.state.model.invitations
+        first = await m.create_invitation("idx@b.com", admin_user["id"])
+        with pytest.raises(sqlalchemy.exc.IntegrityError):
+            await m.create_invitation("idx@b.com", admin_user["id"])
+
+        # Freeing the pending slot (accept or revoke) re-enables a new
+        # invitation for the same email; history rows coexist.
+        assert await m.revoke_invitation(first["id"])
+        second = await m.create_invitation("idx@b.com", admin_user["id"])
+        assert await m.mark_invitation_accepted(second["id"])
+        third = await m.create_invitation("idx@b.com", admin_user["id"])
+        assert third["status"] == "pending"
 
 
 class TestOIDCUsers:


### PR DESCRIPTION
Closes #3101.

## Registration/invite TOCTOU (production paths)

- **`register` (email-verification path)** and **`accept-invite`** now catch the lost duplicate-email `UNIQUE` race (`SAIntegrityError`) and return the exact same opaque 400 as their pre-checks — no enumeration, no 500. This is the production-path twin of the #877 fix, which only covered the test-mode path.
- **`send_invitation`**: `invitations` gains a partial unique index `(email) WHERE status = 'pending'` — schema baseline plus **migration 0028**, which first collapses any duplicate pending rows the old race already minted (oldest pending survives, younger duplicates flip to `revoked`; accepted/revoked history untouched). The route maps the lost race to the pre-check's 400, so concurrent sends yield exactly one pending invitation.

## Atomic member/group share

`add_workspace_member` / `add_workspace_group` no longer issue 6–7 separate one-transaction `add_acl_entry` calls computed from a pre-read snapshot. New model-layer helper `ACLModel.add_principal_entries` appends the principal's whole permission block under one **`BEGIN IMMEDIATE`** transaction (new `DB.write_transaction` context manager):

- a mid-block failure (scope guard, DB error) rolls the whole share back — no partial `view`-without-`files-*` grants;
- concurrent shares serialize behind the write lock instead of computing overlapping positions (verified by real `asyncio.gather` concurrency tests);
- a repeated share is detected and rejected with **409** instead of stacking a duplicate block (the agent-principal and role-group-scope guards are preserved inside the transaction).

## Export no longer hides a tar failure behind a 200

- Pre-flight `shutil.which("tar")` → clean **500** before the response starts.
- After the drain, `proc.returncode != 0` → **ERROR log** including tar's stderr (captured to a temp file — `DEVNULL` before) and the stream **aborts mid-body**, so the client sees a broken transfer rather than a clean 200 with a truncated archive.
- The `klangk export` CLI command catches `httpx.RequestError`, removes the partial archive, and reports the interrupted transfer.

## Tests

Model (atomicity, duplicates, scope/agent guards, true-concurrency serialization, index semantics), API (race injections via `SAIntegrityError`, duplicate-share 409s, export failure modes), migration 0028 (dedupe + index, idempotency), CLI (interrupted transfer). Full suite green with 100% branch coverage; xenon rank A maintained.
