### PR TITLE
Retry wedged podman logs/inspect probes in sidecar readiness (#3120)

### DIFF
--- a/src/klangk/klangkd-tests/e2e-tests/test_network_sidecar_e2e.py
+++ b/src/klangk/klangkd-tests/e2e-tests/test_network_sidecar_e2e.py
@@ -387,20 +387,37 @@ def _logs_snapshot(name):
     ~80 reattaches over 40s, line present in the failure-time snapshot).
     Every probe cycle therefore starts from a snapshot; the follow only
     adds NEW output on top (#3062).
+
+    Returns ``(text, stalled)``. The snapshot itself can wedge on the
+    runners (#3120: a 20 s hang, SIGKILL, and the TimeoutExpired errored
+    the fixture before any retry logic could run); the short 5 s timeout
+    plus the catch turns a wedge into "no data this cycle" so the caller
+    retries within its own deadline.
     """
-    return podman("logs", name, check=False, timeout=20).stdout
+    try:
+        return podman("logs", name, check=False, timeout=5).stdout, False
+    except subprocess.TimeoutExpired:
+        return "", True
 
 
 def _container_state(name):
-    """``<status> <exitcode>`` for container *name* via podman inspect."""
-    return podman(
-        "inspect",
-        "-f",
-        "{{.State.Status}} {{.State.ExitCode}}",
-        name,
-        check=False,
-        timeout=20,
-    ).stdout.strip()
+    """``<status> <exitcode>`` for container *name* via podman inspect.
+
+    A wedged probe (#3120 — same runner-side podman stall class) yields
+    ``""``: an unknown state the caller treats as still-running and
+    re-probes within its deadline.
+    """
+    try:
+        return podman(
+            "inspect",
+            "-f",
+            "{{.State.Status}} {{.State.ExitCode}}",
+            name,
+            check=False,
+            timeout=5,
+        ).stdout.strip()
+    except subprocess.TimeoutExpired:
+        return ""
 
 
 def _follow_once(name, needle, deadline):
@@ -449,16 +466,25 @@ def _follow_logs_until(name, needle, timeout, what):
     poll interval. Best case (needle already printed) costs a single CLI
     call; a podman whose follow works costs snapshot + one long-lived
     follow; a podman whose follow is inert degrades to the old 0.5s poll
-    cadence — never worse than the poller this replaces (#3062).
+    cadence — never worse than the poller this replaces (#3062). A wedged
+    snapshot or state probe counts as no data and is retried inside the
+    same deadline (#3120) — a stalled ``podman logs`` costs one 5 s cycle,
+    not a fixture ERROR.
     """
     encoded = needle.encode()
     deadline = time.monotonic() + timeout
+    snapshot = ""
+    stalls = 0
     while True:
-        snapshot = _logs_snapshot(name)
-        if encoded in snapshot.encode(errors="replace"):
+        text, stalled = _logs_snapshot(name)
+        if stalled:
+            stalls += 1
+        else:
+            snapshot = text
+        if encoded in text.encode(errors="replace"):
             return
         if time.monotonic() >= deadline:
-            pytest.fail(f"{what} within {timeout}s\nlogs:\n{snapshot}")
+            pytest.fail(_deadline_msg(what, timeout, snapshot, stalls))
         followed = _follow_once(name, encoded, deadline)
         if encoded in followed:
             return
@@ -470,8 +496,19 @@ def _follow_logs_until(name, needle, timeout, what):
                 f"logs:\n{snapshot}"
             )
         if time.monotonic() >= deadline:
-            pytest.fail(f"{what} within {timeout}s\nlogs:\n{snapshot}")
+            pytest.fail(_deadline_msg(what, timeout, snapshot, stalls))
         time.sleep(0.5)
+
+
+def _deadline_msg(what, timeout, snapshot, stalls):
+    """Deadline-exceeded failure message for ``_follow_logs_until``.
+
+    Notes how many ``podman logs`` snapshots wedged (#3120) so the report
+    distinguishes "container never logged the needle" from "podman itself
+    stalled" — the SIGKILLed process leaves nothing else to go on.
+    """
+    note = f" (podman logs snapshots stalled {stalls}x)" if stalls else ""
+    return f"{what} within {timeout}s{note}\nlogs:\n{snapshot}"
 
 
 def _wait_ready(name, timeout=40):

--- a/src/klangk/klangkd-tests/e2e-tests/test_network_sidecar_e2e.py
+++ b/src/klangk/klangkd-tests/e2e-tests/test_network_sidecar_e2e.py
@@ -366,10 +366,18 @@ def _free_port():
 
 
 def _reap_follow(follow):
-    """Kill a ``podman logs --follow`` helper and close its pipe."""
+    """Kill a ``podman logs --follow`` helper and close its pipe.
+
+    ``wait`` is bounded: an unkillable (D-state) podman — the plausible
+    mechanism behind the runner-side stall class (#2616/#3064/#3120) — is
+    abandoned rather than hung on; pytest-timeout stays the backstop.
+    """
     if follow.poll() is None:
         follow.kill()
-    follow.wait()
+    try:
+        follow.wait(timeout=5)
+    except subprocess.TimeoutExpired:
+        pass
     if follow.stdout is not None:
         try:
             follow.stdout.close()
@@ -401,11 +409,13 @@ def _logs_snapshot(name):
 
 
 def _container_state(name):
-    """``<status> <exitcode>`` for container *name* via podman inspect.
+    """``(state, stalled)`` for container *name* via podman inspect.
 
-    A wedged probe (#3120 — same runner-side podman stall class) yields
-    ``""``: an unknown state the caller treats as still-running and
-    re-probes within its deadline.
+    ``state`` is ``"<status> <exitcode>"``. A wedged probe (#3120 — same
+    runner-side podman stall class) yields ``("", True)``: an unknown
+    state the caller treats as still-running and re-probes within its
+    deadline. A failed inspect on a vanished container also reports a
+    ``""`` state (with ``False``) — read neither as a specific status.
     """
     try:
         return podman(
@@ -415,9 +425,9 @@ def _container_state(name):
             name,
             check=False,
             timeout=5,
-        ).stdout.strip()
+        ).stdout.strip(), False
     except subprocess.TimeoutExpired:
-        return ""
+        return "", True
 
 
 def _follow_once(name, needle, deadline):
@@ -468,8 +478,8 @@ def _follow_logs_until(name, needle, timeout, what):
     follow; a podman whose follow is inert degrades to the old 0.5s poll
     cadence — never worse than the poller this replaces (#3062). A wedged
     snapshot or state probe counts as no data and is retried inside the
-    same deadline (#3120) — a stalled ``podman logs`` costs one 5 s cycle,
-    not a fixture ERROR.
+    same deadline (#3120) — each wedged call costs its 5 s timeout, not a
+    fixture ERROR.
     """
     encoded = needle.encode()
     deadline = time.monotonic() + timeout
@@ -488,7 +498,9 @@ def _follow_logs_until(name, needle, timeout, what):
         followed = _follow_once(name, encoded, deadline)
         if encoded in followed:
             return
-        state = _container_state(name)
+        state, state_stalled = _container_state(name)
+        if state_stalled:
+            stalls += 1
         if "exited" in state or "stopped" in state:
             pytest.fail(
                 f"{what}: container exited before the expected log line. "
@@ -503,11 +515,11 @@ def _follow_logs_until(name, needle, timeout, what):
 def _deadline_msg(what, timeout, snapshot, stalls):
     """Deadline-exceeded failure message for ``_follow_logs_until``.
 
-    Notes how many ``podman logs`` snapshots wedged (#3120) so the report
+    Notes how many ``podman logs``/``inspect`` probes wedged (#3120) so the report
     distinguishes "container never logged the needle" from "podman itself
     stalled" — the SIGKILLed process leaves nothing else to go on.
     """
-    note = f" (podman logs snapshots stalled {stalls}x)" if stalls else ""
+    note = f" (podman probes stalled {stalls}x)" if stalls else ""
     return f"{what} within {timeout}s{note}\nlogs:\n{snapshot}"
 
 

--- a/src/klangk/klangkd-tests/tests/test_network_sidecar_probe.py
+++ b/src/klangk/klangkd-tests/tests/test_network_sidecar_probe.py
@@ -59,7 +59,16 @@ class TestSnapshotStallContract:
     def test_container_state_wedge_yields_unknown(self, monkeypatch):
         mod = load_probe_module(monkeypatch)
         monkeypatch.setattr(mod, "podman", _wedge)
-        assert mod._container_state("nc") == ""
+        assert mod._container_state("nc") == ("", True)
+
+    def test_deadline_msg_counts_wedged_probes(self, monkeypatch):
+        mod = load_probe_module(monkeypatch)
+        assert mod._deadline_msg("not ready", 40, "log line", 2) == (
+            "not ready within 40s (podman probes stalled 2x)\nlogs:\nlog line"
+        )
+        assert mod._deadline_msg("not ready", 40, "log line", 0) == (
+            "not ready within 40s\nlogs:\nlog line"
+        )
 
 
 class TestFollowLogsUntil:
@@ -138,3 +147,56 @@ class TestFollowLogsUntil:
         monkeypatch.setattr(mod, "_follow_once", lambda *args: b"")
         with pytest.raises(Failed, match="container exited"):
             mod._follow_logs_until("nc", "dns-proxy listening", 5, "not ready")
+
+
+class StubFollow:
+    """Just enough Popen surface for ``_reap_follow`` (stdout is self)."""
+
+    def __init__(self, unkillable=False):
+        self.unkillable = unkillable
+        self.returncode = None
+        self.killed = False
+        self.closed = False
+
+    def poll(self):
+        return self.returncode
+
+    def kill(self):
+        self.killed = True
+        if not self.unkillable:
+            self.returncode = -9
+
+    def wait(self, timeout=None):
+        if self.unkillable:
+            raise subprocess.TimeoutExpired(["podman", "logs"], timeout)
+        return self.returncode
+
+    def close(self):
+        self.closed = True
+
+    @property
+    def stdout(self):
+        return self
+
+
+class TestReapFollow:
+    def test_already_exited_follow_is_just_closed(self, monkeypatch):
+        mod = load_probe_module(monkeypatch)
+        stub = StubFollow()
+        stub.returncode = 0
+        mod._reap_follow(stub)
+        assert not stub.killed and stub.closed
+
+    def test_reap_kills_and_closes(self, monkeypatch):
+        mod = load_probe_module(monkeypatch)
+        stub = StubFollow()
+        mod._reap_follow(stub)
+        assert stub.killed and stub.returncode == -9 and stub.closed
+
+    def test_reap_abandons_unkillable_follow(self, monkeypatch):
+        # D-state podman: kill lands, wait never completes — reap must
+        # still close the pipe and return instead of hanging on it.
+        mod = load_probe_module(monkeypatch)
+        stub = StubFollow(unkillable=True)
+        mod._reap_follow(stub)
+        assert stub.killed and stub.closed

--- a/src/klangk/klangkd-tests/tests/test_network_sidecar_probe.py
+++ b/src/klangk/klangkd-tests/tests/test_network_sidecar_probe.py
@@ -1,0 +1,140 @@
+"""Unit tests for the sidecar readiness probe's stall handling (#3120).
+
+``_follow_logs_until`` (``test_network_sidecar_e2e.py``) drives sidecar
+readiness via snapshot-then-follow (#3062). On the CI runners the one-shot
+``podman logs`` snapshot itself can wedge (20 s hang, SIGKILL) — the
+resulting ``subprocess.TimeoutExpired`` used to escape every safety net
+(deadline, stopped-container fast-fail, degrade-to-poll) and ERROR the
+fixture. The probe now treats a wedged snapshot or state probe as "no data
+this cycle" and retries within its deadline. These tests exercise that
+logic hermetically by scripting the module's ``podman`` helper; real podman
+is the e2e suite's job.
+"""
+
+import importlib.util
+import os
+import subprocess
+import sys
+
+import pytest
+
+# pytest 9 dropped the top-level ``pytest.Failed`` name; the class stays
+# reachable as the exception owned by the ``pytest.fail`` factory.
+Failed = pytest.fail.Exception
+
+_E2E_FILE = os.path.realpath(
+    os.path.join(
+        os.path.dirname(__file__),
+        "..",
+        "e2e-tests",
+        "test_network_sidecar_e2e.py",
+    )
+)
+
+
+def load_probe_module(monkeypatch):
+    """Import the e2e module under a throwaway name (cf. test_e2e_imports)."""
+    monkeypatch.syspath_prepend(os.path.dirname(_E2E_FILE))
+    spec = importlib.util.spec_from_file_location("netsc_e2e_probe", _E2E_FILE)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    try:
+        spec.loader.exec_module(module)
+    finally:
+        sys.modules.pop(spec.name, None)
+    return module
+
+
+def _wedge(*args, check=True, timeout=120):
+    """A podman call that hangs until the subprocess timeout kills it."""
+    raise subprocess.TimeoutExpired(["podman", *args], timeout)
+
+
+class TestSnapshotStallContract:
+    def test_logs_snapshot_wedge_yields_no_data_and_flag(self, monkeypatch):
+        mod = load_probe_module(monkeypatch)
+        monkeypatch.setattr(mod, "podman", _wedge)
+        assert mod._logs_snapshot("nc") == ("", True)
+
+    def test_container_state_wedge_yields_unknown(self, monkeypatch):
+        mod = load_probe_module(monkeypatch)
+        monkeypatch.setattr(mod, "podman", _wedge)
+        assert mod._container_state("nc") == ""
+
+
+class TestFollowLogsUntil:
+    def test_needle_in_history_never_follows(self, monkeypatch):
+        mod = load_probe_module(monkeypatch)
+
+        def fake_podman(*args, check=True, timeout=120):
+            stdout = (
+                "dns-proxy listening\n" if args[0] == "logs" else "running 0"
+            )
+            return subprocess.CompletedProcess(
+                args, 0, stdout=stdout, stderr=""
+            )
+
+        monkeypatch.setattr(mod, "podman", fake_podman)
+
+        def fail_follow(*args):
+            raise AssertionError(
+                "follow must not run when the snapshot already has the needle"
+            )
+
+        monkeypatch.setattr(mod, "_follow_once", fail_follow)
+        mod._follow_logs_until("nc", "dns-proxy listening", 5, "not ready")
+
+    def test_wedged_snapshot_and_probe_are_retried_not_raised(
+        self, monkeypatch
+    ):
+        # #3120 regression: the first logs AND inspect calls wedge; the
+        # probe must ride it out and find the needle on the next cycle.
+        mod = load_probe_module(monkeypatch)
+        calls = []
+
+        def fake_podman(*args, check=True, timeout=120):
+            calls.append(args[0])
+            if calls.count(args[0]) == 1:
+                raise subprocess.TimeoutExpired(["podman", *args], timeout)
+            stdout = (
+                "dns-proxy listening\n" if args[0] == "logs" else "running 0"
+            )
+            return subprocess.CompletedProcess(
+                args, 0, stdout=stdout, stderr=""
+            )
+
+        monkeypatch.setattr(mod, "podman", fake_podman)
+        monkeypatch.setattr(mod, "_follow_once", lambda *args: b"")
+        mod._follow_logs_until("nc", "dns-proxy listening", 10, "not ready")
+        assert calls.count("logs") == 2  # one wedge cycle, then success
+
+    def test_persistent_wedge_fails_within_deadline_with_stall_note(
+        self, monkeypatch
+    ):
+        mod = load_probe_module(monkeypatch)
+
+        def fake_podman(*args, check=True, timeout=120):
+            if args[0] == "logs":
+                raise subprocess.TimeoutExpired(["podman", *args], timeout)
+            return subprocess.CompletedProcess(
+                args, 0, stdout="running 0", stderr=""
+            )
+
+        monkeypatch.setattr(mod, "podman", fake_podman)
+        monkeypatch.setattr(mod, "_follow_once", lambda *args: b"")
+        with pytest.raises(Failed, match=r"stalled 1x"):
+            mod._follow_logs_until("nc", "dns-proxy listening", 0, "not ready")
+
+    def test_exited_container_still_fails_fast(self, monkeypatch):
+        mod = load_probe_module(monkeypatch)
+
+        def fake_podman(*args, check=True, timeout=120):
+            stdout = "" if args[0] == "logs" else "exited 1"
+            return subprocess.CompletedProcess(
+                args, 0, stdout=stdout, stderr=""
+            )
+
+        monkeypatch.setattr(mod, "podman", fake_podman)
+        monkeypatch.setattr(mod, "_follow_once", lambda *args: b"")
+        with pytest.raises(Failed, match="container exited"):
+            mod._follow_logs_until("nc", "dns-proxy listening", 5, "not ready")


### PR DESCRIPTION
## Summary

Backend-E2E flake fix for #3120: the setup of `test_direct_upstream_exfil_is_blocked` errored because a one-shot `podman logs` snapshot on the freshly booted network sidecar hung for its full 20 s timeout, and the `subprocess.TimeoutExpired` propagated straight out of `_follow_logs_until` — bypassing the 40 s readiness deadline, the stopped-container fast-fail, and the degrade-to-poll path (#3062/#3063).

Changes to the readiness probe in `test_network_sidecar_e2e.py`:

- `_logs_snapshot` now runs with a 5 s timeout and catches the wedge, returning `(text, stalled)`; a stall means "no data this cycle", so the loop retries inside its existing deadline instead of erroring the fixture.
- `_container_state` (same runner-side podman stall class — #2616, #3064) catches its wedge the same way and yields an unknown state, which the caller treats as still-running.
- Deadline failures note how many snapshots stalled (`podman logs snapshots stalled Nx`), so the next occurrence distinguishes "container never logged the needle" from "podman itself wedged" — the SIGKILLed process leaves nothing else to go on.
- Failure reports keep the last successful snapshot rather than an empty one from a stalled cycle.

New hermetic unit tests (`tests/test_network_sidecar_probe.py`) script the module's `podman` helper to cover: wedge-retry-then-success, persistent wedge failing within the deadline with the stall note, exited-container fast-fail, and needle-in-history needing no follow.

## Test plan

- [x] `test_network_sidecar_probe.py` + `test_e2e_imports.py` pass
- [x] `test-push` gate green (full Python unit suite, 6730 passed)
- [ ] `test-backend-e2e` in CI (not run locally per repo policy)
