### PR TITLE
Bound the auth email-cooldown rate-limit state (#3113)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -256,6 +256,15 @@ operators or integrators to act when upgrading.
 
 ### Security
 
+- **Bounded rate-limit state for the email cooldowns (#3113).** The
+  per-address cooldown dicts behind
+  `POST /api/v1/auth/forgot-password` and
+  `POST /api/v1/auth/resend-verification` are now capped at 10,000
+  hashed keys, shed oldest-first, and sweep expired entries only when
+  recording. An unauthenticated flood of unique addresses can no longer
+  grow process memory or per-request CPU without bound, and no raw
+  email strings are retained.
+
 - **Forgot-password no longer leaks account existence via SMTP
   failures or response timing (#3114).** `POST
 /api/v1/auth/forgot-password` now answers `"sent"` immediately and

--- a/src/klangk/klangk/api/__init__.py
+++ b/src/klangk/klangk/api/__init__.py
@@ -66,9 +66,11 @@ from . import (
     workspaces as _workspace_routes,
 )
 from .auth import (
+    RATE_LIMIT_MAX_ENTRIES,
     RESET_COOLDOWN_SECONDS,
     RESEND_COOLDOWN_SECONDS,
     prune_timestamps,
+    rate_limit_key,
     reset_timestamps,
     resend_timestamps,
 )
@@ -390,8 +392,10 @@ __all__ = (
     "wshandler",
     # auth rate-limit state (see test_api.py)
     "prune_timestamps",
+    "rate_limit_key",
     "resend_timestamps",
     "reset_timestamps",
     "RESEND_COOLDOWN_SECONDS",
     "RESET_COOLDOWN_SECONDS",
+    "RATE_LIMIT_MAX_ENTRIES",
 )

--- a/src/klangk/klangk/api/auth.py
+++ b/src/klangk/klangk/api/auth.py
@@ -1,6 +1,7 @@
 """Authentication routes: register/verify/login/logout, password and email/handle changes, resend-verification, forgot/reset-password, refresh, accept-invite, the proxy auth_request workspace-token validator, and the OIDC login/callback flows (merged from the former oidc_auth submodule)."""
 
 import asyncio
+import hashlib
 import json
 import logging
 import secrets
@@ -214,16 +215,52 @@ def prune_timestamps(
 ) -> None:
     """Evict rate-limit entries older than their cooldown window.
 
-    The resend/reset rate-limit dicts are keyed by email and gain an
-    entry on every request. Without eviction they grow without bound
-    and retain raw email addresses (PII) for the process lifetime,
-    long past the short cooldown window they're needed for. Opportunistically
-    sweeping expired entries on each access bounds both size and retention.
+    The resend/reset rate-limit dicts gain an entry on every recording
+    request, each stamped with the then-current monotonic clock, so
+    insertion order tracks timestamp order (a monotonic clock never
+    steps backwards) and expired entries form a prefix of
+    the dict. Evicting from the head costs O(entries dropped) instead
+    of the O(size) full scan the unauthenticated forgot-password path
+    used to pay on every request (#3113) — a flood of unique fresh
+    addresses could not be bounded by a full scan anyway. Keys are
+    hashes (see :func:`rate_limit_key`), so nothing retained past the
+    window is raw email (PII).
     """
     cutoff = now - cooldown_seconds
-    expired = [email for email, ts in timestamps.items() if ts < cutoff]
-    for email in expired:
-        del timestamps[email]
+    while timestamps:
+        oldest = next(iter(timestamps))
+        if timestamps[oldest] >= cutoff:
+            break
+        del timestamps[oldest]
+
+
+# Upper bound on tracked rate-limit keys per dict. Legitimate traffic
+# stays far below it (distinct addresses within one cooldown window);
+# a flood of unique submitted strings stops growing the dict at the
+# cap, degrading the window to the most recent entries instead of
+# exhausting memory and CPU (#3113).
+RATE_LIMIT_MAX_ENTRIES = 10_000
+
+
+# Per-process random key for rate_limit_key: the dicts are process-local
+# and never persisted, so the key needs no stability beyond the process.
+_RATE_LIMIT_HASH_KEY = secrets.token_bytes(32)
+
+
+def rate_limit_key(email: str) -> str:
+    """Fixed-width rate-limit key for *email*.
+
+    The forgot-password path accepts any submitted string without
+    validation (unknown addresses must behave identically to known
+    ones, #3100), so raw keys would retain attacker-chosen,
+    effectively unbounded-length email strings for the cooldown
+    window. The keyed hash bounds per-entry bytes, is not invertible
+    by dictionary/rainbow attack over a known-user domain, and cannot
+    be correlated across process restarts (#3113).
+    """
+    return hashlib.blake2b(
+        email.encode("utf-8"), key=_RATE_LIMIT_HASH_KEY, digest_size=16
+    ).hexdigest()
 
 
 resend_timestamps: dict[str, float] = {}
@@ -232,14 +269,21 @@ RESEND_COOLDOWN_SECONDS = 60
 
 def _rate_limited(timestamps: dict, cooldown: float, email: str) -> bool:
     """True when *email* hit its per-address cooldown window; otherwise
-    records this attempt. Bounds both size and retention of the window
-    (stale entries are pruned on each call)."""
-    now = time.time()
-    prune_timestamps(timestamps, cooldown, now)
-    last = timestamps.get(email, 0)
+    records this attempt. Bounded regardless of request rate (#3113):
+    the check is one dict hit, expired entries are swept only when
+    recording, and a full dict sheds its oldest entry before inserting
+    — under a unique-address flood the window degrades to the most
+    recent ``RATE_LIMIT_MAX_ENTRIES`` addresses instead of growing
+    without bound."""
+    now = time.monotonic()
+    key = rate_limit_key(email)
+    last = timestamps.get(key, 0)
     if now - last < cooldown:
         return True
-    timestamps[email] = now
+    prune_timestamps(timestamps, cooldown, now)
+    while len(timestamps) >= RATE_LIMIT_MAX_ENTRIES:
+        del timestamps[next(iter(timestamps))]
+    timestamps[key] = now
     return False
 
 

--- a/src/klangk/klangkd-tests/tests/test_api.py
+++ b/src/klangk/klangkd-tests/tests/test_api.py
@@ -1310,7 +1310,9 @@ class TestResendVerification:
 
     async def test_resend_rate_limited(self, client, db, app_state):
         # Clear stale rate limit state from parallel test workers
-        api.resend_timestamps.pop("unverified@example.com", None)
+        api.resend_timestamps.pop(
+            api.rate_limit_key("unverified@example.com"), None
+        )
         await self._create_unverified_user(app_state)
         with patch.object(
             emailsvc_mod.EmailService,
@@ -1333,7 +1335,9 @@ class TestResendVerification:
                 },
             )
         assert resp2.status_code == 429
-        api.resend_timestamps.pop("unverified@example.com", None)
+        api.resend_timestamps.pop(
+            api.rate_limit_key("unverified@example.com"), None
+        )
 
     async def test_resend_prunes_expired_entries(self, client, db, app_state):
         # Stale rate-limit state from parallel test workers
@@ -1355,12 +1359,13 @@ class TestResendVerification:
             # Backdate the entry past the cooldown window.
             import time
 
-            api.resend_timestamps["unverified@example.com"] = (
-                time.time() - api.RESEND_COOLDOWN_SECONDS - 1
+            key = api.rate_limit_key("unverified@example.com")
+            api.resend_timestamps[key] = (
+                time.monotonic() - api.RESEND_COOLDOWN_SECONDS - 1
             )
             # Also seed an unrelated expired address to confirm it is evicted.
-            api.resend_timestamps["stale@example.com"] = (
-                time.time() - api.RESEND_COOLDOWN_SECONDS - 1
+            api.resend_timestamps[api.rate_limit_key("stale@example.com")] = (
+                time.monotonic() - api.RESEND_COOLDOWN_SECONDS - 1
             )
             resp2 = await client.post(
                 "/api/v1/auth/resend-verification",
@@ -1372,7 +1377,10 @@ class TestResendVerification:
         # Expired entry no longer rate-limits, and unrelated stale entry
         # was swept on access.
         assert resp2.status_code == 200
-        assert "stale@example.com" not in api.resend_timestamps
+        assert (
+            api.rate_limit_key("stale@example.com")
+            not in api.resend_timestamps
+        )
         api.resend_timestamps.clear()
 
 
@@ -1444,7 +1452,9 @@ class TestResendVerificationLockout:
             await self._post(client, "unverified@example.com", "wrong")
         info = await attempts.get_login_attempt_info("unverified@example.com")
         assert info["attempt_count"] == 2
-        api.resend_timestamps.pop("unverified@example.com", None)
+        api.resend_timestamps.pop(
+            api.rate_limit_key("unverified@example.com"), None
+        )
         with patch.object(
             emailsvc_mod.EmailService,
             "send_verification_email",
@@ -1458,7 +1468,9 @@ class TestResendVerificationLockout:
             await attempts.get_login_attempt_info("unverified@example.com")
             is None
         )
-        api.resend_timestamps.pop("unverified@example.com", None)
+        api.resend_timestamps.pop(
+            api.rate_limit_key("unverified@example.com"), None
+        )
 
     async def test_window_reset_not_lockout(self, client, db, app_state):
         """A near-threshold count whose first failure predates the window
@@ -1518,7 +1530,9 @@ class TestForgotPassword:
         token = reset_url.split("token=")[1]
         decoded = app_state.state.auth.decode_password_reset_token(token)
         assert decoded == user["id"]
-        api.reset_timestamps.pop("forgot@example.com", None)
+        api.reset_timestamps.pop(
+            api.rate_limit_key("forgot@example.com"), None
+        )
 
     async def test_forgot_unknown_email_still_returns_sent(self, client, db):
         resp = await client.post(
@@ -1527,7 +1541,9 @@ class TestForgotPassword:
         )
         assert resp.status_code == 200
         assert resp.json()["status"] == "sent"
-        api.reset_timestamps.pop("nobody@example.com", None)
+        api.reset_timestamps.pop(
+            api.rate_limit_key("nobody@example.com"), None
+        )
 
     async def test_forgot_disabled_user_no_email_still_sent(
         self, client, app, db, app_state
@@ -1549,7 +1565,9 @@ class TestForgotPassword:
         assert resp.status_code == 200
         assert resp.json()["status"] == "sent"
         mock_send.assert_not_awaited()
-        api.reset_timestamps.pop("forgot@example.com", None)
+        api.reset_timestamps.pop(
+            api.rate_limit_key("forgot@example.com"), None
+        )
 
     async def test_forgot_smtp_failure_answers_sent_and_logs(
         self, client, db, app_state, caplog
@@ -1578,7 +1596,9 @@ class TestForgotPassword:
             "Failed to send password reset email" in r.message
             for r in caplog.records
         )
-        api.reset_timestamps.pop("forgot@example.com", None)
+        api.reset_timestamps.pop(
+            api.rate_limit_key("forgot@example.com"), None
+        )
 
     async def test_forgot_non_send_paths_mint_token(
         self, client, db, app, app_state
@@ -1610,8 +1630,12 @@ class TestForgotPassword:
         dummy_subject, real_subject = (c.args[0] for c in mint.call_args_list)
         assert real_subject == u["id"]
         assert dummy_subject != u["id"]
-        api.reset_timestamps.pop("nobody@example.com", None)
-        api.reset_timestamps.pop("forgot@example.com", None)
+        api.reset_timestamps.pop(
+            api.rate_limit_key("nobody@example.com"), None
+        )
+        api.reset_timestamps.pop(
+            api.rate_limit_key("forgot@example.com"), None
+        )
 
     async def test_forgot_rate_limited(self, client, db, app_state):
         await self._create_user(app_state)
@@ -1629,7 +1653,9 @@ class TestForgotPassword:
                 json={"email": "forgot@example.com"},
             )
         assert resp2.status_code == 429
-        api.reset_timestamps.pop("forgot@example.com", None)
+        api.reset_timestamps.pop(
+            api.rate_limit_key("forgot@example.com"), None
+        )
 
     async def test_forgot_rate_limited_unknown_email(self, client, db):
         """#3100: the cooldown must not be an account-existence oracle —
@@ -1646,7 +1672,9 @@ class TestForgotPassword:
         assert resp1.status_code == 200
         assert resp1.json()["status"] == "sent"
         assert resp2.status_code == 429
-        api.reset_timestamps.pop("ghost-forgot@example.com", None)
+        api.reset_timestamps.pop(
+            api.rate_limit_key("ghost-forgot@example.com"), None
+        )
 
     async def test_forgot_rate_limited_disabled_user(
         self, client, app, db, app_state
@@ -1673,7 +1701,9 @@ class TestForgotPassword:
         assert resp1.json()["status"] == "sent"
         assert resp2.status_code == 429
         mock_send.assert_not_awaited()
-        api.reset_timestamps.pop("forgot@example.com", None)
+        api.reset_timestamps.pop(
+            api.rate_limit_key("forgot@example.com"), None
+        )
 
     async def test_forgot_prunes_expired_entries(self, client, db, app_state):
         api.reset_timestamps.clear()
@@ -1691,18 +1721,113 @@ class TestForgotPassword:
             # Backdate the entry and seed an unrelated expired address.
             import time
 
-            api.reset_timestamps["forgot@example.com"] = (
-                time.time() - api.RESET_COOLDOWN_SECONDS - 1
+            api.reset_timestamps[api.rate_limit_key("forgot@example.com")] = (
+                time.monotonic() - api.RESET_COOLDOWN_SECONDS - 1
             )
-            api.reset_timestamps["stale@example.com"] = (
-                time.time() - api.RESET_COOLDOWN_SECONDS - 1
+            api.reset_timestamps[api.rate_limit_key("stale@example.com")] = (
+                time.monotonic() - api.RESET_COOLDOWN_SECONDS - 1
             )
             resp2 = await client.post(
                 "/api/v1/auth/forgot-password",
                 json={"email": "forgot@example.com"},
             )
         assert resp2.status_code == 200
-        assert "stale@example.com" not in api.reset_timestamps
+        assert (
+            api.rate_limit_key("stale@example.com") not in api.reset_timestamps
+        )
+        api.reset_timestamps.clear()
+
+    async def test_forgot_flood_caps_dict_size(self, client, db, monkeypatch):
+        """#3113: a flood of unique unknown addresses cannot grow the
+        dict past the cap (oldest entries are shed instead), and every
+        flood response stays identical to a known-address one — no
+        existence oracle under pressure. An over-full dict (seeded past
+        a shrunk cap) is likewise driven back under the cap in one
+        request."""
+        import sys
+        import time
+
+        monkeypatch.setattr(
+            sys.modules["klangk.api.auth"], "RATE_LIMIT_MAX_ENTRIES", 5
+        )
+        api.reset_timestamps.clear()
+        for i in range(25):
+            resp = await client.post(
+                "/api/v1/auth/forgot-password",
+                json={"email": f"flood-{i}@example.com"},
+            )
+            assert resp.status_code == 200
+            assert resp.json()["status"] == "sent"
+        assert len(api.reset_timestamps) <= 5
+        for i in range(7):
+            api.reset_timestamps[
+                api.rate_limit_key(f"seed-{i}@example.com")
+            ] = time.monotonic()
+        resp = await client.post(
+            "/api/v1/auth/forgot-password",
+            json={"email": "after@example.com"},
+        )
+        assert resp.status_code == 200
+        assert len(api.reset_timestamps) <= 5
+        api.reset_timestamps.clear()
+
+    async def test_forgot_rate_limit_keys_hold_no_raw_email(
+        self, client, db, app_state
+    ):
+        """#3113: the dict is keyed by fixed-width hashes, so no raw
+        (possibly attacker-chosen, arbitrarily long) address is
+        retained past the request."""
+        await self._create_user(app_state)
+        with patch.object(
+            emailsvc_mod.EmailService,
+            "send_password_reset_email",
+            new_callable=AsyncMock,
+        ):
+            await client.post(
+                "/api/v1/auth/forgot-password",
+                json={"email": "forgot@example.com"},
+            )
+        assert api.rate_limit_key("forgot@example.com") in api.reset_timestamps
+        assert all("@" not in key for key in api.reset_timestamps)
+        assert all(len(key) == 32 for key in api.reset_timestamps)
+        api.reset_timestamps.clear()
+
+    async def test_forgot_limited_while_dict_near_full(
+        self, client, db, app_state, monkeypatch
+    ):
+        """#3113: the cooldown check is unaffected by a dict at the
+        cap — a recorded address still 429s while junk entries fill the
+        dict around it. Its protection lasts while fewer than
+        RATE_LIMIT_MAX_ENTRIES newer entries arrive (the window is the
+        most recent cap entries), not indefinitely."""
+        import sys
+
+        monkeypatch.setattr(
+            sys.modules["klangk.api.auth"], "RATE_LIMIT_MAX_ENTRIES", 5
+        )
+        await self._create_user(app_state)
+        with patch.object(
+            emailsvc_mod.EmailService,
+            "send_password_reset_email",
+            new_callable=AsyncMock,
+        ):
+            resp1 = await client.post(
+                "/api/v1/auth/forgot-password",
+                json={"email": "forgot@example.com"},
+            )
+            assert resp1.status_code == 200
+            # Junk entries fill the dict to the cap without evicting
+            # the recorded address.
+            for i in range(4):
+                await client.post(
+                    "/api/v1/auth/forgot-password",
+                    json={"email": f"junk-{i}@example.com"},
+                )
+            resp2 = await client.post(
+                "/api/v1/auth/forgot-password",
+                json={"email": "forgot@example.com"},
+            )
+        assert resp2.status_code == 429
         api.reset_timestamps.clear()
 
 

--- a/src/klangk/klangkd-tests/tests/test_api_package.py
+++ b/src/klangk/klangkd-tests/tests/test_api_package.py
@@ -164,8 +164,10 @@ class TestPackagePublicSurface:
             "resend_timestamps",
             "reset_timestamps",
             "prune_timestamps",
+            "rate_limit_key",
             "RESEND_COOLDOWN_SECONDS",
             "RESET_COOLDOWN_SECONDS",
+            "RATE_LIMIT_MAX_ENTRIES",
         ],
     )
     def test_auth_rate_limit_globals_reexported(self, attr):


### PR DESCRIPTION
## Summary

Follow-up to #3108 (found by its adversarial review). Moving the
forgot-password cooldown before the account lookup made every submitted
string write an entry into the module-level `reset_timestamps` dict, giving
an unauthenticated caller an unbounded write surface: steady-state size of
R×60 entries under a flood of unique addresses, an O(n) full-dict scan on
*every* request (O(R²) aggregate), and retention of attacker-chosen,
arbitrarily long raw strings (PII) for the window.

The limiter state is now bounded end-to-end (`_rate_limited` /
`prune_timestamps` in `api/auth.py`), for both `reset_timestamps` and
`resend_timestamps`:

- **Keyed, hashed keys** (`rate_limit_key`): blake2b-128 keyed with a
  per-process random key — fixed 32-byte hex keys bound per-entry bytes,
  are not invertible by dictionary/rainbow attack, cannot be correlated
  across restarts, and hold no raw email past the window.
- **Prefix eviction**: entries are appended one per request with the
  then-current **monotonic** clock, so insertion order tracks timestamp
  order and expired entries form a prefix of the dict. `prune_timestamps`
  evicts from the head — O(entries dropped) instead of the old O(size) full
  scan — and only runs on the recording path; the limited path is a single
  dict hit.
- **Cap with oldest-first shedding** (`RATE_LIMIT_MAX_ENTRIES = 10_000`): a
  full dict sheds its oldest entry before inserting, so size and per-request
  cost stay bounded regardless of request rate. Under a unique-address
  flood the window degrades to the most recent 10k addresses — a recorded
  address stays protected while fewer than 10k newer entries arrive.
  Evict-oldest rather than stop-recording, which would leave *every* new
  address unlimited while junk fills the cap.

No oracle reintroduced: unknown, disabled, and enabled addresses are keyed
identically and answer the same under cap pressure (pinned by tests).

Not addressed, deliberately: the per-process note in the issue. klangkd is
single-process by construction (one uvicorn server, no `workers=` config,
pidfile guard refuses concurrent instances), so there is no N× multiplier
in any shipped deployment; keying the cooldown in the DB would instead
write attacker-controlled keys to disk on an unauthenticated path.

## Testing

- Full Python suite the CI way (`-n auto`, branch coverage):
  6757 passed, 100% coverage maintained.
- New tests: flood-of-unique-addresses caps dict size with identical 200
  responses; over-full dict driven back under the cap in one request;
  recorded address still 429s with the dict at the cap; keys hold no raw
  email (fixed-width hashes).
- Updated the existing dict-manipulating tests (incl. #3108's) to the
  hashed-key surface; `rate_limit_key` / `RATE_LIMIT_MAX_ENTRIES` re-exported
  as `api.` names for that legacy test surface.
- Fresh-eyes adversarial review ran on this branch (recorded under
  `~/.pi/agent/reviews/`); its one substantive finding — `time.monotonic()`
  instead of `time.time()` so the head-prefix ordering invariant is immune
  to clock steps — is folded in, along with keying the hash.

Closes #3113.
