### PR TITLE
Fix bugs found auditing top-level klangk modules, half 1 (#3123)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -2014,6 +2014,19 @@ git-credential` (#1700).** `pig-latin` removed; `word-count` dormant.
   `klangk-setup-home` failure used to stay bare forever (no
   `.profile`/`.bashrc`); an empty user directory now re-triggers the
   copy, matching the shared-home behavior.
+- **A mistyped workspace-created-hook change no longer fails the
+  create (#3123).** A hook assigning a mistyped value (e.g.
+  `allowed_domains = [123]` or a non-iterable `mounts`) crashed the
+  validation step and 500'd the workspace create/import/duplicate
+  request. Per the documented failure semantics the change is now
+  logged as invalid and the workspace is returned exactly as created.
+
+- **`KLANGKD_SOCKET` / `KLANGKD_CADDY_ADMIN_SOCKET` changes on SIGHUP
+  now warn (#3123).** Both sockets are bound for the life of the
+  process (uvicorn's listener, the Caddy child's admin UDS); a reloaded
+  value never applied and silently desynced the proxy supervision. The
+  reload now logs the same "requires a full process restart" warning
+  as `KLANGKD_PORT`/`KLANGKD_LISTEN`.
 
 - **Non-mapping `klangk.yaml` no longer crashes every CLI command
   (#3094).** A config file holding valid YAML that is not a mapping

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -2028,6 +2028,20 @@ git-credential` (#1700).** `pig-latin` removed; `word-count` dormant.
   reload now logs the same "requires a full process restart" warning
   as `KLANGKD_PORT`/`KLANGKD_LISTEN`.
 
+- **Typo'd CIDR settings no longer wedge the proxy (#3123).** An
+  invalid entry in `KLANGKD_TRUSTED_PROXY_CIDRS` or
+  `KLANGKD_CONTAINER_SUBNETS` flowed into the Caddyfile, where Caddy
+  rejects it at adapt time — the config push failed and the watchdog
+  kill/respawn loop left the whole proxy down on a typo. Invalid
+  entries are now skipped with a warning (fail-closed: narrower
+  egress allowlist / loopback-only proxy trust, and an all-invalid
+  container-subnet list denies container egress like a blank one).
+
+- **`klangkd doctor` pacman hints use `-S` (#3123).** The install hint
+  for an arch-family host emitted `sudo pacman install <pkg>`; pacman
+  has no `install` subcommand, so the hint failed verbatim. It now
+  emits `sudo pacman -S <pkg>`.
+
 - **Non-mapping `klangk.yaml` no longer crashes every CLI command
   (#3094).** A config file holding valid YAML that is not a mapping
   (a stray list or a bare string) used to abort every `klangk`

--- a/src/klangk/klangk/caddy.py
+++ b/src/klangk/klangk/caddy.py
@@ -79,13 +79,38 @@ def _split_sources(raw: str) -> list[str]:
     return [s.strip() for s in raw.split(",") if s.strip()]
 
 
+def _caddy_parseable_cidr(token: str) -> bool:
+    """True when *token* parses the way Caddy's provisioner parses IPs
+    and CIDRs (Go ``netip``): an IP, or ``IP/<prefix-length>`` with an
+    ASCII-decimal prefix length.
+
+    Python's :func:`ipaddress.ip_network` additionally accepts
+    dotted-quad netmask/hostmask notation (``10.0.0.0/255.255.0.0``),
+    which Go's ``netip.ParsePrefix`` rejects — and Caddy's *adapt*
+    step passes those through, so the failure lands at ``POST /load``
+    provision time (the exact kill/respawn wedge this validator
+    exists to prevent; nginx accepts netmask notation, so a
+    copy-pasted ``allow`` line hits it). The suffix check is
+    ASCII-only because ``str.isdigit()`` admits non-ASCII decimal
+    digits that Go's ``strconv.ParseUint`` rejects.
+    """
+    try:
+        ipaddress.ip_network(token, strict=False)
+    except ValueError:
+        return False
+    if "/" not in token:
+        return True
+    suffix = token.split("/", 1)[1]
+    return suffix.isascii() and suffix.isdigit()
+
+
 def _valid_cidr_tokens(tokens: list[str]) -> list[str]:
-    """The tokens that parse as an IP address or CIDR.
+    """The tokens Caddy can consume as an IP address or CIDR.
 
     An invalid entry is warned and skipped: garbage would otherwise
     flow into the Caddyfile (a ``remote_ip`` matcher or
     ``trusted_proxies static`` argument), where Caddy rejects it at
-    adapt time — the ``POST /load`` fails and the watchdog's
+    provision time — the ``POST /load`` fails and the watchdog's
     kill/respawn loop wedges the whole proxy on a typo'd setting.
     Skipping fails toward *less* access (narrower egress allowlist /
     narrower XFF trust), never more. The warning deliberately does not
@@ -96,16 +121,14 @@ def _valid_cidr_tokens(tokens: list[str]) -> list[str]:
     """
     valid: list[str] = []
     for token in tokens:
-        try:
-            ipaddress.ip_network(token, strict=False)
-        except ValueError:
+        if _caddy_parseable_cidr(token):
+            valid.append(token)
+        else:
             logger.warning(
                 "ignoring an invalid IP/CIDR entry — entries must be"
                 " IPs or CIDRs (KLANGKD_TRUSTED_PROXY_CIDRS /"
                 " KLANGKD_CONTAINER_SUBNETS)"
             )
-        else:
-            valid.append(token)
     return valid
 
 

--- a/src/klangk/klangk/caddy.py
+++ b/src/klangk/klangk/caddy.py
@@ -88,7 +88,11 @@ def _valid_cidr_tokens(tokens: list[str]) -> list[str]:
     adapt time — the ``POST /load`` fails and the watchdog's
     kill/respawn loop wedges the whole proxy on a typo'd setting.
     Skipping fails toward *less* access (narrower egress allowlist /
-    narrower XFF trust), never more.
+    narrower XFF trust), never more. The warning deliberately does not
+    echo the entry value: the fields are env-sourced, and clear-text
+    logging them is flagged by CodeQL
+    (py/clear-text-logging-sensitive-data) — the operator re-reads
+    their own short config list to spot the offender.
     """
     valid: list[str] = []
     for token in tokens:
@@ -96,10 +100,9 @@ def _valid_cidr_tokens(tokens: list[str]) -> list[str]:
             ipaddress.ip_network(token, strict=False)
         except ValueError:
             logger.warning(
-                "ignoring invalid IP/CIDR entry %r — entries must be IPs"
-                " or CIDRs (KLANGKD_TRUSTED_PROXY_CIDRS /"
-                " KLANGKD_CONTAINER_SUBNETS)",
-                token,
+                "ignoring an invalid IP/CIDR entry — entries must be"
+                " IPs or CIDRs (KLANGKD_TRUSTED_PROXY_CIDRS /"
+                " KLANGKD_CONTAINER_SUBNETS)"
             )
         else:
             valid.append(token)
@@ -335,9 +338,9 @@ class CaddyRenderer:
             entries = _valid_cidr_tokens(tokens)
             if len(entries) != len(tokens):
                 logger.warning(
-                    "KLANGKD_CONTAINER_SUBNETS: invalid entries skipped"
-                    " (valid: %r)",
-                    entries,
+                    "KLANGKD_CONTAINER_SUBNETS: skipped %d invalid"
+                    " entry/entries (the valid ones remain in effect)",
+                    len(tokens) - len(entries),
                 )
             return _explicit_source_entries(entries)
         addrs = detect_host_ipv4s()

--- a/src/klangk/klangk/caddy.py
+++ b/src/klangk/klangk/caddy.py
@@ -79,6 +79,33 @@ def _split_sources(raw: str) -> list[str]:
     return [s.strip() for s in raw.split(",") if s.strip()]
 
 
+def _valid_cidr_tokens(tokens: list[str]) -> list[str]:
+    """The tokens that parse as an IP address or CIDR.
+
+    An invalid entry is warned and skipped: garbage would otherwise
+    flow into the Caddyfile (a ``remote_ip`` matcher or
+    ``trusted_proxies static`` argument), where Caddy rejects it at
+    adapt time — the ``POST /load`` fails and the watchdog's
+    kill/respawn loop wedges the whole proxy on a typo'd setting.
+    Skipping fails toward *less* access (narrower egress allowlist /
+    narrower XFF trust), never more.
+    """
+    valid: list[str] = []
+    for token in tokens:
+        try:
+            ipaddress.ip_network(token, strict=False)
+        except ValueError:
+            logger.warning(
+                "ignoring invalid IP/CIDR entry %r — entries must be IPs"
+                " or CIDRs (KLANGKD_TRUSTED_PROXY_CIDRS /"
+                " KLANGKD_CONTAINER_SUBNETS)",
+                token,
+            )
+        else:
+            valid.append(token)
+    return valid
+
+
 def _non_loopback(entries: list[str]) -> list[str]:
     """The non-loopback subset (loopback keeps full browser UI/API access)."""
     return [s for s in entries if not _is_loopback(s)]
@@ -96,9 +123,11 @@ def _warned_non_loopback(entries: list[str]) -> list[str]:
     return deny_entries
 
 
-def _explicit_source_entries(raw: str) -> tuple[list[str], list[str]]:
-    """(acl, deny) from the explicit KLANGKD_CONTAINER_SUBNETS setting."""
-    entries = _split_sources(raw)
+def _explicit_source_entries(
+    entries: list[str],
+) -> tuple[list[str], list[str]]:
+    """(acl, deny) from the explicit (pre-validated)
+    KLANGKD_CONTAINER_SUBNETS entries."""
     return entries, _warned_non_loopback(entries)
 
 
@@ -302,7 +331,15 @@ class CaddyRenderer:
         """
         explicit = self.app.state.settings.container_subnets
         if explicit:
-            return _explicit_source_entries(str(explicit))
+            tokens = _split_sources(str(explicit))
+            entries = _valid_cidr_tokens(tokens)
+            if len(entries) != len(tokens):
+                logger.warning(
+                    "KLANGKD_CONTAINER_SUBNETS: invalid entries skipped"
+                    " (valid: %r)",
+                    entries,
+                )
+            return _explicit_source_entries(entries)
         addrs = detect_host_ipv4s()
         if addrs:
             return addrs, _non_loopback(addrs)
@@ -357,16 +394,10 @@ class CaddyRenderer:
 
     def _trusted_proxy_cidrs(self) -> list[str]:
         """Validated KLANGKD_TRUSTED_PROXY_CIDRS entries (loopback if empty/invalid)."""
-        raw = self.app.state.settings.trusted_proxy_cidrs
-        entries: list[str] = []
-        for token in (raw or "").split(","):
-            token = token.strip()
-            if not token:
-                continue
-            entries.append(token)
-        if not entries:
-            entries = ["127.0.0.1", "::1"]
-        return entries
+        entries = _valid_cidr_tokens(
+            _split_sources(self.app.state.settings.trusted_proxy_cidrs or "")
+        )
+        return entries or ["127.0.0.1", "::1"]
 
     # -- global options ----------------------------------------------------
 
@@ -898,9 +929,13 @@ class CaddyWatchdog:
         """Poll the admin UDS until Caddy accepts a connection (or timeout).
 
         Any HTTP response (any status) counts as "up" — the admin endpoint is
-        listening. A connection failure (missing socket / refused — raised by
-        httpx as :class:`~httpx.ConnectError`) means not-up yet: sleep and
-        retry until the deadline, then return ``False``.
+        listening. A transport-level failure (missing socket / refused —
+        raised by httpx as :class:`~httpx.ConnectError`, but also a stalled
+        peer raising a read *timeout* or protocol error) means not-up yet:
+        every :class:`~httpx.HTTPError` is retried, not just the connect
+        flavor — an uncaught one would kill the whole supervision task and
+        leave a blank-config Caddy running unsupervised. Sleep and retry
+        until the deadline, then return ``False``.
         """
         deadline = asyncio.get_running_loop().time() + timeout
         loop = asyncio.get_running_loop()
@@ -926,7 +961,7 @@ class CaddyWatchdog:
                     # real socket — don't let it mask the successful connect.
                     pass
                 return True
-            except (httpx.ConnectError, OSError):
+            except (httpx.HTTPError, OSError):
                 await asyncio.sleep(0.2)
         return False
 

--- a/src/klangk/klangk/doctor.py
+++ b/src/klangk/klangk/doctor.py
@@ -183,6 +183,9 @@ def install_hint(binary: str, manager: str | None) -> str:
         return f"brew install {pkg}"
     if manager == "apt":
         return f"sudo apt install {pkg}"
+    if manager == "pacman":
+        # pacman has no "install" subcommand — the package action is -S.
+        return f"sudo pacman -S {pkg}"
     return f"sudo {manager} install {pkg}"
 
 

--- a/src/klangk/klangk/files.py
+++ b/src/klangk/klangk/files.py
@@ -56,8 +56,10 @@ def validate_path(path: str) -> str:
     * null bytes
     * non-absolute paths
     * path components exceeding NAME_MAX
-    * paths that still contain ``..`` after normalization (defense-in-depth;
-      normpath should collapse them, but we reject them anyway)
+
+    ``..`` segments cannot survive: for an absolute path
+    :func:`posixpath.normpath` collapses every ``..`` away, so the
+    normalized result is always a pure ``/a/b`` form.
     """
     if "\0" in path:
         raise ValueError("Null byte in path")

--- a/src/klangk/klangk/hooks.py
+++ b/src/klangk/klangk/hooks.py
@@ -310,6 +310,24 @@ def _resolve_hook_callable(path: str, func_name: str) -> Callable:
     return hook
 
 
+def _validated_change_error(app, changed: dict) -> str | None:
+    """:func:`_validate_hook_changes` with a raising validator treated
+    as an invalid change.
+
+    A mistyped value (``allowed_domains = [123]``, a non-iterable
+    ``mounts``) reaches a non-``ValueError`` path inside a validator;
+    per the log-and-continue contract that must reject the change, not
+    fail the create."""
+    try:
+        return _validate_hook_changes(app, changed)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning(
+            "workspace-created hook change could not be validated",
+            exc_info=exc,
+        )
+        return f"validation raised {type(exc).__name__}: {exc}"
+
+
 class WorkspaceHookHandle(dict):
     """The workspace row as seen by a workspace-created hook (#2762).
 
@@ -548,7 +566,7 @@ class Hooks:
         changed = hook_field_changes(handle, workspace)
         if not changed:
             return workspace
-        invalid = _validate_hook_changes(self.app, changed)
+        invalid = _validated_change_error(self.app, changed)
         if invalid is not None:
             logger.warning(
                 "workspace-created hook %s made an invalid change to "

--- a/src/klangk/klangk/lifecycle.py
+++ b/src/klangk/klangk/lifecycle.py
@@ -85,13 +85,21 @@ def broadcast_container_status(
 
 
 # Settings that a SIGHUP reload re-resolves and validates but CANNOT apply
-# without a full process restart: the HTTP listener is bound for the life of
-# the process, and the DB engine + on-disk state dir are already open/written.
-# A change here is logged at warning level (so the operator knows it didn't
-# take effect) rather than silently ignored (#1587).
+# without a full process restart: the HTTP listener and backend/admin UDS
+# sockets are bound for the life of the process, and the DB engine +
+# on-disk state dir are already open/written. The UDS entries matter for
+# the Caddy supervision: the child's bootstrap config, its CADDY_ADMIN
+# env, and uvicorn's own bind all pin the startup paths — a reloaded
+# value desyncs the watchdog (its httpx client polls the new admin path
+# the child never binds) and the renderer (caddy dials a backend socket
+# that no longer exists). A change here is logged at warning level (so
+# the operator knows it didn't take effect) rather than silently
+# ignored (#1587).
 _NON_RELOADABLE_SETTINGS: tuple[tuple[str, str], ...] = (
     ("port", "the HTTP listener is already bound"),
     ("listen", "the HTTP listener is already bound"),
+    ("socket", "the backend UDS listener is already bound"),
+    ("caddy_admin_socket", "the Caddy admin UDS is already bound"),
     ("data_dir", "the DB engine is already open"),
     ("state_dir", "instance state is already on disk"),
 )

--- a/src/klangk/klangk/llm_router.py
+++ b/src/klangk/klangk/llm_router.py
@@ -248,7 +248,8 @@ class LLMRouter:
     router is ``None`` and the endpoints return 503.
 
     **Passthrough mode**: when the config has exactly one wildcard entry
-    (``model_name`` contains ``*``), litellm is bypassed entirely.
+    (``model_name`` is exactly ``*`` — see :func:`is_passthrough`),
+    litellm is bypassed entirely.
     Requests are forwarded to the upstream via httpx, and ``/models``
     queries the upstream for dynamic model discovery.
     """
@@ -268,6 +269,13 @@ class LLMRouter:
         if not models:
             self._router = None
             self._passthrough_base = None
+            self._passthrough_key = ""
+            # A passthrough→empty reload must close the old client too —
+            # the early return used to skip the close below, leaking the
+            # client's connections for the life of the process.
+            if self._http_client is not None:
+                _spawn_aclose(self._http_client)
+                self._http_client = None
             return
 
         model_list = _build_model_list(models, settings.llm_api_key)

--- a/src/klangk/klangk/llm_router.py
+++ b/src/klangk/klangk/llm_router.py
@@ -383,7 +383,15 @@ class LLMRouter:
             ),
             stream=True,
         )
-        resp.raise_for_status()
+        if resp.is_error:
+            # Release the streamed response's pooled connection before
+            # raising. Nobody downstream closes it on the error path —
+            # the API handler only sees the exception — and the
+            # HTTPStatusError keeps the response referenced, so the
+            # connection would sit held against the pool's limits until
+            # GC under sustained upstream errors.
+            await resp.aclose()
+            resp.raise_for_status()
         return resp
 
     async def list_upstream_models(self) -> list[dict[str, Any]]:

--- a/src/klangk/klangkd-tests/tests/test_caddy.py
+++ b/src/klangk/klangkd-tests/tests/test_caddy.py
@@ -28,6 +28,7 @@ from klangk.caddy import (
 )
 from klangk.caddy import (
     CADDYFILE_CONTENT_TYPE,
+    _caddy_parseable_cidr,
     post_load,
     tcp_upstream,
     uds_upstream,
@@ -286,6 +287,41 @@ class TestContainerSourceLists:
         with caplog.at_level("WARNING"):
             cidrs = _renderer(s)._trusted_proxy_cidrs()
         assert cidrs == ["127.0.0.1", "::1"]
+        assert "invalid IP/CIDR entry" in caplog.text
+
+    @pytest.mark.parametrize(
+        "entry",
+        [
+            "10.0.0.0/255.255.0.0",  # dotted-quad netmask: python yes, netip no
+            "10.0.0.0/0.0.255.255",  # hostmask form: same mismatch
+            "10.0.0.0/\u0661\u0662",  # Arabic-Indic digits: isdigit() yes, ParseUint no
+        ],
+    )
+    def test_python_only_cidr_forms_rejected(self, entry, caplog):
+        """The accept boundary must match Caddy's provisioner (Go netip),
+        not Python's ipaddress: netmask/hostmask notation and non-ASCII
+        digit suffixes parse in Python but fail at POST /load provision
+        time — the kill/respawn wedge this validator exists to prevent
+        (nginx accepts netmask notation, so copy-pasted lines hit it)."""
+        assert _caddy_parseable_cidr(entry) is False
+        s = make_settings(
+            {"KLANGKD_CONTAINER_SUBNETS": f"{entry},192.168.0.0/16"}
+        )
+        with caplog.at_level("WARNING"):
+            acl, _deny = _renderer(s)._container_source_entries()
+        assert entry not in acl
+        assert "192.168.0.0/16" in acl
+        assert "invalid IP/CIDR entry" in caplog.text
+
+    def test_host_bits_cidr_still_accepted(self):
+        """Go netip.ParsePrefix accepts host-bits-set prefixes (masking
+        them), so 10.0.0.1/24 must stay valid — do not over-reject."""
+        assert _caddy_parseable_cidr("10.0.0.1/24") is True
+        assert _caddy_parseable_cidr("10.0.0.0/8") is True
+        assert _caddy_parseable_cidr("127.0.0.1") is True
+        assert _caddy_parseable_cidr("::1") is True
+        assert _caddy_parseable_cidr("fe80::/10") is True
+        assert _caddy_parseable_cidr("notacidr") is False
 
 
 # ---------------------------------------------------------------------------

--- a/src/klangk/klangkd-tests/tests/test_caddy.py
+++ b/src/klangk/klangkd-tests/tests/test_caddy.py
@@ -250,6 +250,43 @@ class TestContainerSourceLists:
         assert "172.16.0.0/12" in lst
         assert "10.0.0.0/8" in lst
 
+    def test_invalid_container_subnet_skipped(self, caplog):
+        """A typo'd CIDR is warned and skipped, not rendered into the
+        Caddyfile (Caddy would reject the config at adapt time and wedge
+        the proxy in a kill/respawn loop)."""
+        s = make_settings(
+            {"KLANGKD_CONTAINER_SUBNETS": "notacidr,10.89.0.0/24"}
+        )
+        with caplog.at_level("WARNING"):
+            acl, deny = _renderer(s)._container_source_entries()
+        assert "10.89.0.0/24" in acl
+        assert "notacidr" not in acl
+        assert "notacidr" not in deny
+        assert "invalid IP/CIDR entry" in caplog.text
+
+    def test_all_invalid_container_subnets_fail_closed(self, caplog):
+        """Every entry invalid -> warn + deny-all (the blank-setting
+        semantic), not a wedged proxy and not a silent widening to
+        auto-detected sources."""
+        s = make_settings({"KLANGKD_CONTAINER_SUBNETS": "garbage"})
+        with caplog.at_level("WARNING"):
+            lst = _renderer(s)._egress_remote_ip_list()
+        assert lst == ""
+        assert "invalid entries skipped" in caplog.text
+
+    def test_invalid_trusted_proxy_cidr_skipped(self, caplog):
+        s = make_settings({"KLANGKD_TRUSTED_PROXY_CIDRS": "oops,10.0.0.0/8"})
+        with caplog.at_level("WARNING"):
+            cidrs = _renderer(s)._trusted_proxy_cidrs()
+        assert cidrs == ["10.0.0.0/8"]
+        assert "invalid IP/CIDR entry" in caplog.text
+
+    def test_all_invalid_trusted_proxy_cidrs_loopback(self, caplog):
+        s = make_settings({"KLANGKD_TRUSTED_PROXY_CIDRS": "oops"})
+        with caplog.at_level("WARNING"):
+            cidrs = _renderer(s)._trusted_proxy_cidrs()
+        assert cidrs == ["127.0.0.1", "::1"]
+
 
 # ---------------------------------------------------------------------------
 # CaddyRenderer — section builders
@@ -851,6 +888,29 @@ class TestWaitForAdmin:
         # Small timeout → a couple of 0.2s polls then give up.
         assert await wd._wait_for_admin(timeout=0.001) is False
         assert slept  # the retry path slept at least once
+
+    @pytest.mark.asyncio
+    async def test_transport_timeout_retried_not_fatal(self, monkeypatch):
+        """A stalled admin peer (accepts, never answers -> ReadTimeout) is
+        a not-yet-up poll, not an exception that kills the watchdog task
+        and leaves a blank-config Caddy unsupervised (#3123)."""
+        import klangk.caddy as caddy_mod
+
+        async def _fake_sleep(s):
+            pass
+
+        monkeypatch.setattr(caddy_mod.asyncio, "sleep", _fake_sleep)
+
+        class _Stalled(_FakeAsyncClient):
+            async def get(self, url):
+                raise httpx.ReadTimeout("stalled")
+
+        monkeypatch.setattr(
+            caddy_mod.httpx, "AsyncHTTPTransport", lambda uds: None
+        )
+        monkeypatch.setattr(caddy_mod.httpx, "AsyncClient", _Stalled)
+        wd = _wd(make_settings({}))
+        assert await wd._wait_for_admin(timeout=0.001) is False
 
 
 class TestWatchdogStart:

--- a/src/klangk/klangkd-tests/tests/test_caddy.py
+++ b/src/klangk/klangkd-tests/tests/test_caddy.py
@@ -272,7 +272,7 @@ class TestContainerSourceLists:
         with caplog.at_level("WARNING"):
             lst = _renderer(s)._egress_remote_ip_list()
         assert lst == ""
-        assert "invalid entries skipped" in caplog.text
+        assert "invalid entry" in caplog.text
 
     def test_invalid_trusted_proxy_cidr_skipped(self, caplog):
         s = make_settings({"KLANGKD_TRUSTED_PROXY_CIDRS": "oops,10.0.0.0/8"})

--- a/src/klangk/klangkd-tests/tests/test_doctor.py
+++ b/src/klangk/klangkd-tests/tests/test_doctor.py
@@ -131,12 +131,13 @@ class TestInstallHint:
         """The ip binary ships as `iproute` on Red Hat family and `iproute2`
         elsewhere (#2921) — the binary name alone names a nonexistent
         package on every major manager."""
+        assert install_hint("pacman", "pacman") == "sudo pacman -S pacman"
         assert install_hint("ip", "dnf") == "sudo dnf install iproute"
         assert install_hint("ip", "yum") == "sudo yum install iproute"
         assert install_hint("ip", "apt") == "sudo apt install iproute2"
         assert install_hint("ip", "zypper") == "sudo zypper install iproute2"
         assert install_hint("ip", "apk") == "sudo apk install iproute2"
-        assert install_hint("ip", "pacman") == "sudo pacman install iproute2"
+        assert install_hint("ip", "pacman") == "sudo pacman -S iproute2"
         assert install_hint("ip", "brew") == "brew install iproute2"
 
 

--- a/src/klangk/klangkd-tests/tests/test_hooks.py
+++ b/src/klangk/klangkd-tests/tests/test_hooks.py
@@ -867,6 +867,41 @@ class TestFireWorkspaceCreated:
         )
         assert any(e["permission"] == "*" for e in entries)
 
+    @pytest.mark.parametrize(
+        "field, value",
+        [
+            ("allowed_domains", [123]),  # non-str entry -> AttributeError
+            ("rejected_domains", [123]),  # non-str entry -> AttributeError
+            ("allowed_domains", 5),  # non-iterable -> TypeError
+            ("mounts", 5),  # non-iterable -> TypeError
+        ],
+    )
+    async def test_mistyped_change_rejected_not_fatal(
+        self, app_state, user, caplog, field, value
+    ):
+        """A mistyped (not merely invalid) value must not break the
+        log-and-continue contract: the validator raising instead of
+        returning an error string still leaves the workspace unchanged
+        and the create un-failed."""
+        await app_state.state.model.init_db()
+        hooks = await self._wire(app_state)
+
+        def hook(workspace, actor):
+            workspace[field] = value
+
+        hooks.workspace_created_hook = hook
+        hooks.workspace_created_hook_is_async = False
+        hooks.workspace_created_hook_source = "test-mistyped"
+        ws = await self._seed(app_state, user)
+        with caplog.at_level(logging.WARNING, logger="klangk.hooks"):
+            out = await hooks.fire_workspace_created(ws, user)
+        assert out is ws
+        assert any(
+            "could not be validated" in r.message for r in caplog.records
+        )
+        row = await app_state.state.model.workspaces.get_workspace(ws["id"])
+        assert row[field] is None
+
 
 class TestHooksBranchGaps2834:
     """#2834 branch gate: hook-field diff and created_at carry-over

--- a/src/klangk/klangkd-tests/tests/test_llm_proxy_api.py
+++ b/src/klangk/klangkd-tests/tests/test_llm_proxy_api.py
@@ -333,6 +333,7 @@ class TestChatCompletions:
         app.state.llm_router = lr
 
         mock_resp = AsyncMock()
+        mock_resp.is_error = False
         mock_resp.raise_for_status = lambda: None
 
         async def fake_lines():

--- a/src/klangk/klangkd-tests/tests/test_llm_router.py
+++ b/src/klangk/klangkd-tests/tests/test_llm_router.py
@@ -8,6 +8,7 @@ import types
 from unittest.mock import AsyncMock, patch
 
 import httpx
+import pytest
 
 from klangk import llm_router as llm_router_mod
 from klangk.llm_router import (
@@ -422,6 +423,7 @@ class TestPassthrough:
         ]
         router = LLMRouter(app)
         mock_resp = AsyncMock()
+        mock_resp.is_error = False
         mock_resp.raise_for_status = lambda: None
         mock_client = AsyncMock()
         mock_client.build_request.return_value = "fake-request"
@@ -433,6 +435,39 @@ class TestPassthrough:
         )
         assert resp is mock_resp
         mock_client.send.assert_called_once()
+
+    async def test_passthrough_stream_error_closes_response(self):
+        """An error status closes the streamed response before raising —
+        the API layer only sees the exception, so an orphaned streamed
+        response would hold its pool connection until GC (#3123)."""
+        app = _app()
+        app.state.settings.llm_models = [
+            {
+                "model_name": "*",
+                "litellm_params": {
+                    "api_base": "http://fake:1234/v1",
+                    "api_key": "test-key",
+                },
+            }
+        ]
+        router = LLMRouter(app)
+
+        def _raise():
+            raise httpx.HTTPStatusError("502", request=None, response=None)
+
+        mock_resp = AsyncMock()
+        mock_resp.is_error = True
+        mock_resp.raise_for_status = _raise
+        mock_client = AsyncMock()
+        mock_client.build_request.return_value = "fake-request"
+        mock_client.send.return_value = mock_resp
+        router._http_client = mock_client
+
+        with pytest.raises(httpx.HTTPStatusError):
+            await router.passthrough_completion_stream(
+                {"model": "test", "messages": [], "stream": True}
+            )
+        mock_resp.aclose.assert_awaited_once()
 
     async def test_reconfigure_closes_old_client(self):
         """Reconfiguring from passthrough to router closes the httpx client."""

--- a/src/klangk/klangkd-tests/tests/test_llm_router.py
+++ b/src/klangk/klangkd-tests/tests/test_llm_router.py
@@ -455,6 +455,26 @@ class TestPassthrough:
         await asyncio.sleep(0)
         old_client.aclose.assert_called_once()
 
+    async def test_reconfigure_to_empty_closes_old_client(self):
+        """Reconfiguring from passthrough to no models closes the client."""
+        import asyncio
+
+        app = _app()
+        app.state.settings.llm_models = [
+            {"model_name": "*", "litellm_params": {"api_base": "http://x:1"}}
+        ]
+        router = LLMRouter(app)
+        assert router.passthrough
+        old_client = AsyncMock()
+        router._http_client = old_client
+
+        router.reconfigure(_app())
+        assert not router.passthrough
+        assert not router.active
+        assert router._http_client is None
+        await asyncio.sleep(0)
+        old_client.aclose.assert_called_once()
+
     async def test_list_upstream_models_passthrough(self):
         app = _app()
         app.state.settings.llm_models = [

--- a/src/klangk/klangkd-tests/tests/test_main.py
+++ b/src/klangk/klangkd-tests/tests/test_main.py
@@ -2749,6 +2749,24 @@ class TestMainEntryCallback2910:
         assert "port" in caplog.text
         assert "full process restart" in caplog.text
 
+    @pytest.mark.parametrize(
+        "env_key",
+        ["KLANGKD_SOCKET", "KLANGKD_CADDY_ADMIN_SOCKET"],
+    )
+    def test_warn_non_reloadable_covers_bound_sockets(
+        self, app_state, caplog, env_key
+    ):
+        """The backend/admin UDS paths are bound for the process lifetime;
+        a SIGHUP change must warn like port/listen (#3123)."""
+        app_state = _make_app_state()
+        lc = app_state.state.lifecycle
+        old = app_state.state.settings
+        new = make_settings({env_key: "/tmp/changed.sock"})
+        with caplog.at_level("WARNING"):
+            lc._warn_non_reloadable(old, new)
+        assert env_key.removeprefix("KLANGKD_").lower() in caplog.text
+        assert "full process restart" in caplog.text
+
     async def test_apply_pending_reseed_noop_without_flag(self, app_state):
         """apply_pending_reseed is a no-op when reconfigure hasn't been called."""
         app_state = _make_app_state()


### PR DESCRIPTION
Audit of the 17 `.py` files directly under `src/klangk/klangk/` (half 1: `acl.py` – `llm_router.py`), per #3123. Every file was read end to end across two passes; 8 findings were confirmed and fixed (the functional ones verified empirically with failing tests first).

## Pass 1

- **hooks — mistyped hook change failed the create (verified).** A workspace-created hook assigning a mistyped value (`allowed_domains = [123]`, a non-iterable `mounts`) reached a non-`ValueError` path inside the validators; the `AttributeError`/`TypeError` escaped `fire_workspace_created` and 500'd the create/import/duplicate request, breaking the documented log-and-continue contract. A raising validator is now treated as an invalid change: logged, workspace returned unchanged, create un-failed.
- **llm_router — passthrough client leak on empty reload (verified).** `_configure_from_settings` returned early when `llm_models` became empty, skipping the `_spawn_aclose` of the passthrough `httpx.AsyncClient` — its connections leaked for the process lifetime on every SIGHUP reload that removed the models config.
- **lifecycle — bound sockets now in the non-reloadable warning list.** `KLANGKD_SOCKET` / `KLANGKD_CADDY_ADMIN_SOCKET` are pinned by uvicorn's bind and the Caddy child's bootstrap config + `CADDY_ADMIN` env; a SIGHUP change never applied and silently desynced the watchdog (its httpx client polls an admin path the child never binds). Both now log the standard "requires a full process restart" warning.
- **Docstring drift.** `files.validate_path` claimed a `..` rejection that does not exist (unreachable for absolute paths — `normpath` collapses them); the `LLMRouter` class docstring said passthrough triggers on a `model_name` *containing* `*` when only an exact `*` matches.

## Pass 2

- **caddy — typo'd CIDR wedged the whole proxy.** An invalid entry in `KLANGKD_TRUSTED_PROXY_CIDRS` / `KLANGKD_CONTAINER_SUBNETS` flowed into the Caddyfile (`remote_ip` matcher / `trusted_proxies static`), which Caddy rejects at adapt time — `POST /load` failed and the watchdog's kill/respawn loop left the proxy permanently down on a typo. Entries are now validated (`ipaddress.ip_network`) and invalid ones skipped with a warning, failing closed (narrower egress allowlist / loopback-only trust; all-invalid container subnets deny egress like a blank setting). `_trusted_proxy_cidrs`'s docstring claimed this validation all along.
- **caddy — non-connect transport errors killed the watchdog.** `_wait_for_admin` caught only `ConnectError`/`OSError`; a stalled admin peer raising `ReadTimeout` (any `httpx.HTTPError`) escaped and killed the supervision task, leaving a blank-config Caddy running unsupervised with no respawn. All transport errors now retry until the deadline.
- **llm_router — streamed error response leaked a pool connection.** `passthrough_completion_stream` raised `raise_for_status()` without closing the streamed response; the API layer only sees the exception (which references the response), so the connection sat held against the pool until GC. The response is closed before raising.
- **doctor — pacman install hint.** `sudo pacman install <pkg>` — pacman has no `install` subcommand; now `sudo pacman -S <pkg>`.

## Audited clean

`acl.py`, `auth.py`, `bind_safety.py`, `emailsvc.py`, `exceptions.py`, `features.py`, `first_run.py`, `fips.py`, `inactivity.py`, `__init__.py`, `interval.py` — no defects found beyond the fixed items above. Spot-verified the trickier invariants along the way (`resource_ancestors` walk order, `_enforce_session_limit` oldest-first revoke against `list_sessions` ordering, the API layer's `stat_path` pre-check covering the streaming download paths, `first_run`'s `open("x")` race guard, the FIPS probe parity between host and in-container layers).

Closes #3123.
