### PR TITLE
Fix bugs found in the top-level module audit (#3124)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -1969,6 +1969,35 @@ git-credential` (#1700).** `pig-latin` removed; `word-count` dormant.
 
 ### Fixed
 
+- **Exec-stdin failures surface as the command's exit status (#3124).** A
+  container-side command that exits before consuming piped stdin (a file
+  upload racing a dying container) no longer raises an unhandled
+  broken-pipe error out of the files API. The per-call timeout now bounds
+  runs that block writing stdin: a payload larger than the pipe buffer
+  with a child that never reads used to hang the call forever with the
+  timeout un-armed.
+
+- **Malformed `KLANGKD_OIDC_CONFIG` files fail boot with a configuration
+  error (#3124).** An empty file or a YAML mapping (e.g. a `providers:`
+  wrapper) used to crash startup with a raw TypeError/AttributeError;
+  both now raise a `ConfigurationError` naming the problem. Duplicate
+  provider ids are rejected too — the second provider used to be
+  silently shadowed at login while still showing its own button.
+
+- **`KLANGKD_PORT` / `KLANGKD_EGRESS_PORT` values are validated
+  (#3124).** A non-numeric, out-of-range, or explicitly emptied value
+  now fails settings construction with a named-setting error instead
+  of crashing the launcher with a raw `ValueError`; empty means unset
+  (headless browser port / the built-in egress default). An emptied
+  `KLANGKD_SMTP_USE_TLS=` likewise resolves to its default (TLS on)
+  rather than silently disabling TLS.
+
+- **A failed first-time home skeleton copy retries on the next connect
+  (#3124).** A per-handle home left empty by a transient
+  `klangk-setup-home` failure used to stay bare forever (no
+  `.profile`/`.bashrc`); an empty user directory now re-triggers the
+  copy, matching the shared-home behavior.
+
 - **Non-mapping `klangk.yaml` no longer crashes every CLI command
   (#3094).** A config file holding valid YAML that is not a mapping
   (a stray list or a bare string) used to abort every `klangk`

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -1978,19 +1978,27 @@ git-credential` (#1700).** `pig-latin` removed; `word-count` dormant.
   timeout un-armed.
 
 - **Malformed `KLANGKD_OIDC_CONFIG` files fail boot with a configuration
-  error (#3124).** An empty file or a YAML mapping (e.g. a `providers:`
-  wrapper) used to crash startup with a raw TypeError/AttributeError;
-  both now raise a `ConfigurationError` naming the problem. Duplicate
-  provider ids are rejected too — the second provider used to be
-  silently shadowed at login while still showing its own button.
+  error (#3124).** An empty file, a YAML mapping (e.g. a `providers:`
+  wrapper), a syntactically broken file, or an entry with a missing or
+  non-string required field used to crash startup with a raw
+  TypeError/AttributeError/KeyError/ParserError; all now raise a
+  `ConfigurationError` naming the problem (the message carries only the
+  line/column mark — the file holds client secrets). Duplicate provider
+  ids are rejected too — the second provider used to be silently
+  shadowed at login while still showing its own button.
 
 - **`KLANGKD_PORT` / `KLANGKD_EGRESS_PORT` values are validated
-  (#3124).** A non-numeric, out-of-range, or explicitly emptied value
-  now fails settings construction with a named-setting error instead
-  of crashing the launcher with a raw `ValueError`; empty means unset
-  (headless browser port / the built-in egress default). An emptied
-  `KLANGKD_SMTP_USE_TLS=` likewise resolves to its default (TLS on)
-  rather than silently disabling TLS.
+  (#3124).** A non-numeric, out-of-range (including the previously
+  tolerated `0`), or explicitly emptied value now fails settings
+  construction with a named-setting error instead of crashing the
+  launcher with a raw `ValueError`; accepted values are stored
+  normalized (`" 30"` → `"30"`), so whitespace-prefixed forms can no
+  longer slip past the browser/egress port-separation check. Empty
+  means unset (headless browser port / the built-in egress default).
+  An emptied str-typed boolean setting likewise resolves to its field
+  default: `KLANGKD_SMTP_USE_TLS=` keeps TLS on rather than silently
+  disabling it, and `KLANGKD_ALLOW_SUDO=` resets the sudo ceiling to
+  its default (open) instead of closing it.
 
 - **A failed first-time home skeleton copy retries on the next connect
   (#3124).** A per-handle home left empty by a transient

--- a/src/klangk/klangk/oidc.py
+++ b/src/klangk/klangk/oidc.py
@@ -91,11 +91,12 @@ def _parse_providers(
     (``KLANGKD_OIDC_CONFIG``) loading paths. Raises
     :class:`~klangk.exceptions.ConfigurationError` on a malformed shape
     — a non-list document (an empty external file parses as ``None``; a
-    ``providers:`` wrapper parses as a mapping), a non-mapping entry, or
-    a duplicate provider id — so a bad config fails boot with an
-    actionable message instead of a raw TypeError/AttributeError, and
-    two providers can never silently shadow each other's login button
-    or cross-poison the id-keyed discovery/JWKS caches (#3124).
+    ``providers:`` wrapper parses as a mapping), a non-mapping entry, a
+    missing/non-string required field, or a duplicate provider id — so
+    a bad config fails boot with an actionable message instead of a raw
+    TypeError/AttributeError/KeyError, and two providers can never
+    silently shadow each other's login button or cross-poison the
+    id-keyed discovery/JWKS caches (#3124).
     """
     if not isinstance(entries, list):
         raise ConfigurationError(
@@ -121,13 +122,18 @@ def _parse_providers(
 
 
 def _provider_from_entry(entry: dict, config_dir: str | None) -> OIDCProvider:
-    """One provider dict -> :class:`OIDCProvider`."""
+    """One provider dict -> :class:`OIDCProvider`.
+
+    Required string fields are validated (present, a non-empty string)
+    so a missing/typed-wrong key fails with ``ConfigurationError``
+    instead of a raw KeyError/AttributeError (#3124).
+    """
     secret = resolve_file_value(get(entry, "client-secret", ""))
     return OIDCProvider(
-        id=entry["id"],
-        display_name=get(entry, "display-name"),
-        issuer=entry["issuer"].rstrip("/"),
-        client_id=get(entry, "client-id"),
+        id=_required_str(entry, "id"),
+        display_name=_required_str(entry, "display-name"),
+        issuer=_required_str(entry, "issuer").rstrip("/"),
+        client_id=_required_str(entry, "client-id"),
         client_secret=secret or "",
         scopes=entry.get("scopes", "openid email profile"),
         ca_cert=_resolve_ca_cert(entry, config_dir),
@@ -135,6 +141,49 @@ def _provider_from_entry(entry: dict, config_dir: str | None) -> OIDCProvider:
         logout_redirect=get(entry, "logout-redirect", False),
         trust_email=get(entry, "trust-email", False),
     )
+
+
+def _required_str(entry: dict, key: str) -> str:
+    """A required provider field: present and a non-empty string."""
+    value = get(entry, key, None)
+    if not isinstance(value, str) or not value:
+        raise ConfigurationError(
+            f"OIDC provider entry is missing or has a non-string "
+            f"{key!r} field: {value!r}"
+        )
+    return value
+
+
+def _read_oidc_yaml(config_path: str):
+    """Parse the external OIDC config file.
+
+    ``ConfigurationError`` on an unreadable or unparsable file (#3124) —
+    a raw ``yaml.YAMLError``/``OSError`` would crash boot instead of
+    reaching the launcher's config-refusal path. The message carries
+    only the error's line/column mark, never file content — the file
+    holds client secrets.
+    """
+    try:
+        with open(config_path) as f:
+            return yaml.safe_load(f)
+    except OSError as exc:
+        raise ConfigurationError(
+            f"KLANGKD_OIDC_CONFIG={config_path!r} cannot be read: "
+            f"{exc.strerror or 'I/O error'}"
+        ) from exc
+    except yaml.YAMLError as exc:
+        raise ConfigurationError(
+            f"KLANGKD_OIDC_CONFIG={config_path!r} is not valid YAML"
+            f"{_yaml_error_where(exc)}"
+        ) from exc
+
+
+def _yaml_error_where(exc: Exception) -> str:
+    """The "line/column" suffix for a YAML error (no content)."""
+    mark = getattr(exc, "problem_mark", None)
+    if mark is None:
+        return ""
+    return f" at line {mark.line + 1}, column {mark.column + 1}"
 
 
 def parse_hook_value(raw: str) -> tuple[str, str]:
@@ -249,9 +298,9 @@ class OIDC:
                     " (use an absolute path)"
                 )
             config_dir = os.path.dirname(os.path.abspath(config_path))
-            with open(config_path) as f:
-                raw = yaml.safe_load(f)
-            return _parse_providers(raw, config_dir=config_dir)
+            return _parse_providers(
+                _read_oidc_yaml(config_path), config_dir=config_dir
+            )
 
         # 2. Inline providers from the config file
         if self.app.state.settings.oidc_providers:

--- a/src/klangk/klangk/oidc.py
+++ b/src/klangk/klangk/oidc.py
@@ -88,26 +88,53 @@ def _parse_providers(
     """Parse a list of raw provider dicts into OIDCProvider objects.
 
     Shared by both inline (config-file ``oidc_providers:``) and external
-    (``KLANGKD_OIDC_CONFIG``) loading paths.
+    (``KLANGKD_OIDC_CONFIG``) loading paths. Raises
+    :class:`~klangk.exceptions.ConfigurationError` on a malformed shape
+    — a non-list document (an empty external file parses as ``None``; a
+    ``providers:`` wrapper parses as a mapping), a non-mapping entry, or
+    a duplicate provider id — so a bad config fails boot with an
+    actionable message instead of a raw TypeError/AttributeError, and
+    two providers can never silently shadow each other's login button
+    or cross-poison the id-keyed discovery/JWKS caches (#3124).
     """
-    providers = []
-    for entry in entries:
-        secret = resolve_file_value(get(entry, "client-secret", ""))
-        providers.append(
-            OIDCProvider(
-                id=entry["id"],
-                display_name=get(entry, "display-name"),
-                issuer=entry["issuer"].rstrip("/"),
-                client_id=get(entry, "client-id"),
-                client_secret=secret or "",
-                scopes=entry.get("scopes", "openid email profile"),
-                ca_cert=_resolve_ca_cert(entry, config_dir),
-                token_validation_pem=get(entry, "token-validation-pem", None),
-                logout_redirect=get(entry, "logout-redirect", False),
-                trust_email=get(entry, "trust-email", False),
-            )
+    if not isinstance(entries, list):
+        raise ConfigurationError(
+            "OIDC provider config must be a YAML list of provider entries"
         )
+    providers = []
+    seen: set = set()
+    for entry in entries:
+        if not isinstance(entry, dict):
+            raise ConfigurationError(
+                "OIDC provider entries must be mappings, got "
+                f"{type(entry).__name__}: {entry!r}"
+            )
+        provider = _provider_from_entry(entry, config_dir)
+        if provider.id in seen:
+            raise ConfigurationError(
+                f"duplicate OIDC provider id {provider.id!r} — provider ids "
+                "must be unique"
+            )
+        seen.add(provider.id)
+        providers.append(provider)
     return providers
+
+
+def _provider_from_entry(entry: dict, config_dir: str | None) -> OIDCProvider:
+    """One provider dict -> :class:`OIDCProvider`."""
+    secret = resolve_file_value(get(entry, "client-secret", ""))
+    return OIDCProvider(
+        id=entry["id"],
+        display_name=get(entry, "display-name"),
+        issuer=entry["issuer"].rstrip("/"),
+        client_id=get(entry, "client-id"),
+        client_secret=secret or "",
+        scopes=entry.get("scopes", "openid email profile"),
+        ca_cert=_resolve_ca_cert(entry, config_dir),
+        token_validation_pem=get(entry, "token-validation-pem", None),
+        logout_redirect=get(entry, "logout-redirect", False),
+        trust_email=get(entry, "trust-email", False),
+    )
 
 
 def parse_hook_value(raw: str) -> tuple[str, str]:

--- a/src/klangk/klangk/podman.py
+++ b/src/klangk/klangk/podman.py
@@ -181,23 +181,27 @@ class Podman:
 
     @staticmethod
     async def _settle_stdin_task(stdin_task: asyncio.Task | None) -> None:
-        """Await (or cancel) the stdin feeder; never raises, never leaks.
+        """Wait for the stdin feeder, cancelling anything left behind.
 
-        Once ``_wait_podman`` returns the child has exited or been killed,
-        so the feeder completes promptly; one loop tick is granted first
-        (a mock-fast wait can return before a scheduled feeder ever
-        ran), then a still-pending feeder is cancelled — the child is
-        gone, so any unwritten remainder is moot.
+        ``asyncio.wait`` yields to the loop (a mock-fast process wait can
+        return before a scheduled feeder ever ran, so the feeder takes
+        its step here), never re-raises the feeder's own cancellation,
+        and — unlike awaiting the task directly — lets an *outer*
+        cancellation of the run propagate instead of mistaking it for
+        the feeder's. By the time this runs the child has exited or
+        been killed, so cancelling a still-pending feed (an orphaned
+        grandchild holding the pipe) loses nothing; ``cancel()`` on a
+        completed task is a no-op. The grace timeout bounds the settle
+        on both waits; the normal path (feeder long finished) is
+        instant.
         """
         if stdin_task is None:
             return
-        await asyncio.sleep(0)
-        if not stdin_task.done():
-            stdin_task.cancel()
         try:
-            await stdin_task
-        except (asyncio.CancelledError, OSError):
-            pass
+            await asyncio.wait([stdin_task], timeout=0.5)
+        finally:
+            stdin_task.cancel()
+            await asyncio.wait([stdin_task], timeout=0.5)
 
     @staticmethod
     async def _wait_podman(

--- a/src/klangk/klangk/podman.py
+++ b/src/klangk/klangk/podman.py
@@ -147,6 +147,59 @@ class Podman:
         return self._bin
 
     @staticmethod
+    def _start_stdin_task(
+        proc, stdin_data: bytes | None
+    ) -> asyncio.Task | None:
+        """A feeder task for *stdin_data*, or ``None`` when there is none.
+
+        The feed runs concurrently with the exit wait (never awaited
+        before it) so the *timeout* bounds the whole run: a payload larger
+        than the pipe buffer with a child that never reads must not block
+        ``drain()`` while the timeout sits un-armed (#3124).
+        """
+        if stdin_data is None:
+            return None
+        return asyncio.create_task(Podman._feed_stdin(proc, stdin_data))
+
+    @staticmethod
+    async def _feed_stdin(proc, stdin_data: bytes) -> None:
+        """Write *stdin_data* to the child's stdin and close it.
+
+        A broken/reset pipe — the child exited before consuming stdin,
+        e.g. a ``cat > file`` whose container died mid-write — ends the
+        feed silently: the child's exit status is the real result
+        (#3124); callers act on the returned rc instead of catching an
+        exception that escaped the wrapper.
+        """
+        try:
+            proc.stdin.write(stdin_data)
+            await proc.stdin.drain()
+        except OSError:
+            pass
+        finally:
+            proc.stdin.close()
+
+    @staticmethod
+    async def _settle_stdin_task(stdin_task: asyncio.Task | None) -> None:
+        """Await (or cancel) the stdin feeder; never raises, never leaks.
+
+        Once ``_wait_podman`` returns the child has exited or been killed,
+        so the feeder completes promptly; one loop tick is granted first
+        (a mock-fast wait can return before a scheduled feeder ever
+        ran), then a still-pending feeder is cancelled — the child is
+        gone, so any unwritten remainder is moot.
+        """
+        if stdin_task is None:
+            return
+        await asyncio.sleep(0)
+        if not stdin_task.done():
+            stdin_task.cancel()
+        try:
+            await stdin_task
+        except (asyncio.CancelledError, OSError):
+            pass
+
+    @staticmethod
     async def _wait_podman(
         proc, timeout: float | None, cmd_label: str
     ) -> bool:
@@ -259,6 +312,15 @@ class Podman:
         spawn long-lived helpers (``pasta``) that inherit pipe fds, blocking
         ``communicate()`` forever.  Temp files avoid this.
 
+        *stdin_data* is fed by a concurrent task, not awaited inline: a
+        payload larger than the pipe buffer with a child that never reads
+        used to block ``drain()`` forever while the timeout sat un-armed
+        (#3124). With the feed running alongside the exit wait, *timeout*
+        bounds the whole run — feed + exit. A child that exits before
+        consuming all of stdin is not an error (its exit status is the
+        result; callers act on the rc — e.g. ``Files.write_file`` mapping
+        a dead ``cat`` to its clean ``OSError`` path).
+
         *timeout* caps how long we wait for the process (default 30 s).
         On timeout the process is killed and a :class:`PodmanTimeoutError`
         is raised (unless *check* is False, in which case rc=-1 is returned).
@@ -281,11 +343,11 @@ class Podman:
                 env=subprocess_env(),
             )
             t2 = time.monotonic()
-            if stdin_data is not None:
-                proc.stdin.write(stdin_data)
-                await proc.stdin.drain()
-                proc.stdin.close()
-            timed_out = await self._wait_podman(proc, timeout, cmd_label)
+            stdin_task = self._start_stdin_task(proc, stdin_data)
+            try:
+                timed_out = await self._wait_podman(proc, timeout, cmd_label)
+            finally:
+                await self._settle_stdin_task(stdin_task)
             t3 = time.monotonic()
             out_f.seek(0)
             err_f.seek(0)

--- a/src/klangk/klangk/settings.py
+++ b/src/klangk/klangk/settings.py
@@ -231,6 +231,13 @@ def _coerce_positive_int(v, name: str) -> int | None:
 # avoid an import cycle with klangk.auth.
 _PASSWORD_REQUIRE_MAX = 72
 
+# The KLANGKD_PORT / KLANGKD_EGRESS_PORT / KLANGKD_PROXY_PORT validation
+# message (#3124): a set port must be numeric 1-65535; empty means unset.
+_BAD_PORT_MSG = (
+    "{}={!r} is invalid. Must be a TCP port number (1-65535), or "
+    "unset/empty to use the default."
+)
+
 # Ceiling for KLANGKD_PASSWORD_HISTORY_COUNT (#2582): every remembered
 # hash costs one PBKDF2 verify per password set (in a worker thread, but
 # still real CPU), so an unbounded count is a self-inflicted DoS knob.
@@ -1483,6 +1490,7 @@ class KlangkSettings(BaseSettings):
           the egress port + a loud deprecation warning.
         - both set → ``egress_port`` wins, ``proxy_port`` ignored + a warning.
         """
+        self._normalize_port_fields()
         self._fold_proxy_port()
         if self.egress_port is None:
             self.egress_port = "8995"
@@ -1515,6 +1523,40 @@ class KlangkSettings(BaseSettings):
             max_socket_len,
         )
         return self
+
+    def _normalize_port_fields(self) -> None:
+        """Empty-string port settings mean unset; a set value must be
+        numeric 1-65535 (#3124).
+
+        ``KLANGKD_PORT=`` (an explicitly emptied env var) must mean
+        "unset" — headless for the browser port, the built-in default for
+        the egress port — never an empty string that crashes the
+        launcher's ``int()`` and renders a broken ``listen`` directive.
+        A non-numeric value must fail construction with the setting
+        named (the fail-fast posture every other numeric knob has), not
+        crash later in ``main._check_port_collisions``.
+        """
+        self.port = self._validated_port("KLANGKD_PORT", self.port)
+        self.egress_port = self._validated_port(
+            "KLANGKD_EGRESS_PORT", self.egress_port
+        )
+        self.proxy_port = self._validated_port(
+            "KLANGKD_PROXY_PORT", self.proxy_port
+        )
+
+    @classmethod
+    def _validated_port(cls, env_var: str, value: str | None) -> str | None:
+        """One port setting: ``None``/``""`` → ``None``; else a numeric
+        string in 1-65535, validated and returned unchanged."""
+        if value is None or value == "":
+            return None
+        try:
+            port = int(value)
+        except ValueError as exc:
+            raise ValueError(_BAD_PORT_MSG.format(env_var, value)) from exc
+        if not 1 <= port <= 65535:
+            raise ValueError(_BAD_PORT_MSG.format(env_var, value))
+        return value
 
     def _fold_proxy_port(self) -> None:
         """Apply the ``KLANGKD_PROXY_PORT`` → ``egress_port`` deprecation
@@ -1720,7 +1762,7 @@ class KlangkSettings(BaseSettings):
 
     @field_validator(*BOOL_STRING_FIELDS, mode="before")
     @classmethod
-    def _coerce_bool_string_fields(cls, v):
+    def _coerce_bool_string_fields(cls, v, info):
         """Accept a native YAML bool for the str-typed boolean settings
         (#2796, generalizing the #2603 ``smtp_use_tls`` one-off).
 
@@ -1731,12 +1773,18 @@ class KlangkSettings(BaseSettings):
         :func:`parse_bool_setting`) keep working — but a bare
         ``allow_sudo: true`` in YAML parses as a bool and used to fail
         validation. Translate the two bools to their canonical strings;
+        an explicitly emptied value (``""``) means *unset* → the field's
+        declared default, so ``KLANGKD_SMTP_USE_TLS=`` keeps TLS on
+        (unset ⇒ ``"true"``) instead of silently disabling it (#3124);
         everything else (strings, ``None``) passes through unchanged.
         """
         if v is True:
             return "true"
         if v is False:
             return "false"
+        if v == "":
+            default = cls.model_fields[info.field_name].default
+            return None if default is None else str(default)
         return v
 
     @field_validator(*INT_STRING_FIELDS, mode="before")

--- a/src/klangk/klangk/settings.py
+++ b/src/klangk/klangk/settings.py
@@ -1546,8 +1546,11 @@ class KlangkSettings(BaseSettings):
 
     @classmethod
     def _validated_port(cls, env_var: str, value: str | None) -> str | None:
-        """One port setting: ``None``/``""`` → ``None``; else a numeric
-        string in 1-65535, validated and returned unchanged."""
+        """One port setting: ``None``/``""`` → ``None``; else validated
+        numeric 1-65535 and returned **normalized** (``str(int(v))``) —
+        the egress≠browser equality check and the Caddyfile render both
+        consume the raw string, so a whitespace/zero-padded form must
+        not survive as a distinct value (#3124)."""
         if value is None or value == "":
             return None
         try:
@@ -1556,7 +1559,7 @@ class KlangkSettings(BaseSettings):
             raise ValueError(_BAD_PORT_MSG.format(env_var, value)) from exc
         if not 1 <= port <= 65535:
             raise ValueError(_BAD_PORT_MSG.format(env_var, value))
-        return value
+        return str(port)
 
     def _fold_proxy_port(self) -> None:
         """Apply the ``KLANGKD_PROXY_PORT`` → ``egress_port`` deprecation

--- a/src/klangk/klangk/workspaces.py
+++ b/src/klangk/klangk/workspaces.py
@@ -153,6 +153,19 @@ def _replace_stale_symlink(symlink: Path, user_dir: Path) -> bool:
     return adopted
 
 
+def _needs_skel_populate(created: bool, user_dir: Path) -> bool:
+    """True when the /etc/skel copy should run for a per-handle home.
+
+    Mirrors the shared-home gate (#3124): freshly created OR
+    existing-but-empty — the populate exec's failure is swallowed (a
+    dead/racing container must not fail the connect), so emptiness is
+    the retry signal on the next connect. Without it, one transient
+    ``klangk-setup-home`` failure strands the user with a permanently
+    bare home. A dir with user content never re-populates.
+    """
+    return created or not any(user_dir.iterdir())
+
+
 def _ensure_home_symlink_sync(
     workspace_home: Path,
     handle: str,
@@ -164,6 +177,10 @@ def _ensure_home_symlink_sync(
     ``symlink_to``, ``Path.iterdir``, …) and must not run on the event
     loop — callers go through ``ensure_home_symlink``, which offloads
     this to a worker thread via ``asyncio.to_thread`` (#1262).
+
+    The second return element is the *populate-skel* signal, not bare
+    "was created": it is also True for an existing-but-empty user dir
+    (:func:`_needs_skel_populate`, #3124).
     """
     users_dir = workspace_home / ".users"
     users_dir.mkdir(parents=True, exist_ok=True)
@@ -182,7 +199,7 @@ def _ensure_home_symlink_sync(
     target = f".users/{user_id}"
 
     if symlink.is_symlink() and os.readlink(symlink) == target:
-        return f"/home/{handle}", created
+        return f"/home/{handle}", _needs_skel_populate(created, user_dir)
 
     # Remove any existing symlink for this user (handle rename).
     _unlink_stale_handle_symlink(workspace_home, target)
@@ -194,7 +211,7 @@ def _ensure_home_symlink_sync(
     if _replace_stale_symlink(symlink, user_dir):
         created = False  # content adopted, no skel needed
     symlink.symlink_to(target)
-    return f"/home/{handle}", created
+    return f"/home/{handle}", _needs_skel_populate(created, user_dir)
 
 
 async def populate_home_skel(
@@ -642,8 +659,10 @@ class Workspaces:
         stall the event loop on disk latency (#1262).
 
         Returns ``(container_home_path, created)`` where *created* is True
-        when a new user directory was created (caller should populate it
-        with skeleton files).
+        when the user directory was created **or exists but is empty** —
+        the caller should (re)populate it with skeleton files (#3124: a
+        failed populate on an earlier connect retries on the next one;
+        a dir with user content never re-populates).
         """
         return await asyncio.to_thread(
             _ensure_home_symlink_sync, workspace_home, handle, user_id

--- a/src/klangk/klangkd-tests/tests/test_emailsvc.py
+++ b/src/klangk/klangkd-tests/tests/test_emailsvc.py
@@ -83,10 +83,16 @@ class TestSmtpConfigUseTls:
         svc = _email_service({"KLANGKD_SMTP_USE_TLS": value})
         assert svc.smtp_config()["use_tls"] is True
 
-    @pytest.mark.parametrize("value", ["false", "0", "no", "", "off"])
+    @pytest.mark.parametrize("value", ["false", "0", "no", "off"])
     def test_falsy_spellings_disable_starttls(self, value):
         svc = _email_service({"KLANGKD_SMTP_USE_TLS": value})
         assert svc.smtp_config()["use_tls"] is False
+
+    def test_empty_means_default_tls_on(self):
+        """#3124: an explicitly emptied value means unset — the field's
+        default ("true") — instead of silently disabling STARTTLS."""
+        svc = _email_service({"KLANGKD_SMTP_USE_TLS": ""})
+        assert svc.smtp_config()["use_tls"] is True
 
     def test_explicit_null_is_false_not_a_crash(self, tmp_path):
         # ``smtp_use_tls:`` (explicit null) parses to None; the shared

--- a/src/klangk/klangkd-tests/tests/test_oidc.py
+++ b/src/klangk/klangkd-tests/tests/test_oidc.py
@@ -406,6 +406,73 @@ class TestInlineProviders:
         assert providers[0].id == "external"
 
 
+class TestConfigShapeValidation:
+    """#3124: a malformed provider config must fail boot with a clean
+    ConfigurationError, not a raw TypeError/AttributeError/KeyError."""
+
+    def test_empty_external_file_rejected(self, tmp_path):
+        cfg = tmp_path / "oidc.yaml"
+        cfg.write_text("")
+        with pytest.raises(ConfigurationError, match="list"):
+            _oidc(
+                make_settings({"KLANGKD_OIDC_CONFIG": str(cfg)})
+            ).load_config()
+
+    def test_mapping_document_rejected(self, tmp_path):
+        """The natural ``providers:`` wrapper is a mapping, not a list."""
+        cfg = tmp_path / "oidc.yaml"
+        cfg.write_text("providers: []\n")
+        with pytest.raises(ConfigurationError, match="list"):
+            _oidc(
+                make_settings({"KLANGKD_OIDC_CONFIG": str(cfg)})
+            ).load_config()
+
+    def test_non_mapping_entry_rejected(self, tmp_path):
+        cfg = tmp_path / "oidc.yaml"
+        cfg.write_text(yaml.dump(["not-a-mapping"]))
+        with pytest.raises(ConfigurationError, match="mapping"):
+            _oidc(
+                make_settings({"KLANGKD_OIDC_CONFIG": str(cfg)})
+            ).load_config()
+
+    def test_duplicate_ids_external_rejected(self, tmp_path):
+        """#3124: a duplicate id must not silently shadow the second
+        provider's login button or cross-poison the id-keyed caches."""
+        entry = {
+            "id": "main",
+            "display-name": "Okta",
+            "issuer": "https://okta.example.com",
+            "client-id": "klangk",
+            "client-secret": "s",
+        }
+        dup = dict(entry, **{"issuer": "https://auth0.example.com"})
+        cfg = tmp_path / "oidc.yaml"
+        cfg.write_text(yaml.dump([entry, dup]))
+        with pytest.raises(ConfigurationError, match="duplicate OIDC"):
+            _oidc(
+                make_settings({"KLANGKD_OIDC_CONFIG": str(cfg)})
+            ).load_config()
+
+    def test_duplicate_ids_inline_rejected(self, tmp_path):
+        cfg = tmp_path / "config.yaml"
+        cfg.write_text(
+            "oidc_providers:\n"
+            "  - id: a\n"
+            '    display-name: "A"\n'
+            "    issuer: https://a.example.com\n"
+            "    client-id: klangk\n"
+            '    client-secret: "sa"\n'
+            "  - id: a\n"
+            '    display-name: "A2"\n'
+            "    issuer: https://a2.example.com\n"
+            "    client-id: klangk\n"
+            '    client-secret: "sa2"\n'
+        )
+        settings = make_settings({}, config_file=str(cfg))
+        with pytest.raises(ConfigurationError, match="duplicate OIDC"):
+            _oidc(settings).load_config()
+
+
 class TestProviderRegistry:
     def test_init_and_lookup(self, tmp_path):
         cfg = tmp_path / "oidc.yaml"

--- a/src/klangk/klangkd-tests/tests/test_oidc.py
+++ b/src/klangk/klangkd-tests/tests/test_oidc.py
@@ -472,6 +472,104 @@ class TestConfigShapeValidation:
         with pytest.raises(ConfigurationError, match="duplicate OIDC"):
             _oidc(settings).load_config()
 
+    def test_unparsable_yaml_rejected(self, tmp_path):
+        """A syntactically broken file (the most likely malformed file)
+        raises ConfigurationError — never a raw yaml.ParserError that
+        crashes boot (#3124 review)."""
+        cfg = tmp_path / "oidc.yaml"
+        cfg.write_text("providers: [\n")
+        with pytest.raises(ConfigurationError, match="not valid YAML"):
+            _oidc(
+                make_settings({"KLANGKD_OIDC_CONFIG": str(cfg)})
+            ).load_config()
+
+    def test_yaml_error_message_carries_no_file_content(self, tmp_path):
+        """The error names the line/column mark only — the file holds
+        client secrets, so no content rides into logs."""
+        cfg = tmp_path / "oidc.yaml"
+        cfg.write_text("providers: [\n  - client-secret: supersecret\n")
+        with pytest.raises(ConfigurationError) as exc_info:
+            _oidc(
+                make_settings({"KLANGKD_OIDC_CONFIG": str(cfg)})
+            ).load_config()
+        assert "supersecret" not in str(exc_info.value)
+        assert "line " in str(exc_info.value)
+
+    def test_missing_id_rejected(self, tmp_path):
+        cfg = tmp_path / "oidc.yaml"
+        cfg.write_text(
+            yaml.dump(
+                [
+                    {
+                        "display-name": "X",
+                        "issuer": "https://x.example.com",
+                        "client-id": "klangk",
+                    }
+                ]
+            )
+        )
+        with pytest.raises(ConfigurationError, match="'id'"):
+            _oidc(
+                make_settings({"KLANGKD_OIDC_CONFIG": str(cfg)})
+            ).load_config()
+
+    def test_missing_issuer_rejected(self, tmp_path):
+        cfg = tmp_path / "oidc.yaml"
+        cfg.write_text(
+            yaml.dump(
+                [
+                    {
+                        "id": "x",
+                        "display-name": "X",
+                        "client-id": "klangk",
+                    }
+                ]
+            )
+        )
+        with pytest.raises(ConfigurationError, match="'issuer'"):
+            _oidc(
+                make_settings({"KLANGKD_OIDC_CONFIG": str(cfg)})
+            ).load_config()
+
+    def test_non_string_issuer_rejected(self, tmp_path):
+        """A typed-wrong field fails with ConfigurationError, not a raw
+        AttributeError from ``.rstrip()`` (#3124 review)."""
+        cfg = tmp_path / "oidc.yaml"
+        cfg.write_text(
+            yaml.dump(
+                [
+                    {
+                        "id": "x",
+                        "display-name": "X",
+                        "issuer": 42,
+                        "client-id": "klangk",
+                    }
+                ]
+            )
+        )
+        with pytest.raises(ConfigurationError, match="'issuer'"):
+            _oidc(
+                make_settings({"KLANGKD_OIDC_CONFIG": str(cfg)})
+            ).load_config()
+
+    def test_unreadable_file_rejected(self, tmp_path):
+        """An OSError while opening the file (e.g. permissions) is a
+        ConfigurationError naming the reason, not a crash (#3124)."""
+        cfg = tmp_path / "oidc.yaml"
+        cfg.write_text("[]")
+        with patch(
+            "builtins.open", side_effect=PermissionError("Permission denied")
+        ):
+            with pytest.raises(ConfigurationError, match="cannot be read"):
+                _oidc(
+                    make_settings({"KLANGKD_OIDC_CONFIG": str(cfg)})
+                ).load_config()
+
+    def test_yaml_error_without_mark_has_plain_message(self):
+        """A YAMLError carrying no problem_mark renders without the
+        line/column suffix instead of crashing on None."""
+        assert oidc._yaml_error_where(yaml.YAMLError("no mark")) == ""
+
 
 class TestProviderRegistry:
     def test_init_and_lookup(self, tmp_path):

--- a/src/klangk/klangkd-tests/tests/test_podman.py
+++ b/src/klangk/klangkd-tests/tests/test_podman.py
@@ -4,6 +4,7 @@ import asyncio
 import json
 import subprocess
 import sys
+import time
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -198,6 +199,83 @@ class TestRun:
                 await _p.run(["rm", "-f", "cid"], timeout=0.1)
         assert exc.value.status == 500
         assert "timed out" in exc.value.message
+
+    async def test_stdin_pipe_error_swallowed(self):
+        """#3124: a child that exits before consuming stdin ends the feed
+        silently — the rc is the result, not an escaped exception."""
+        proc = _procs(("", "", 3))[0]
+        proc.stdin.drain = AsyncMock(side_effect=ConnectionResetError())
+        with patch(EXEC, AsyncMock(return_value=proc)):
+            rc, _out, _err = await _p.run(
+                ["x"], stdin_data=b"payload", check=False
+            )
+        assert rc == 3
+        proc.stdin.write.assert_called_once_with(b"payload")
+        proc.stdin.close.assert_called_once()
+
+
+# --- run_raw stdin feeder (#3124) ---
+
+
+def _sh_podman() -> podman.Podman:
+    """A Podman wrapper whose binary is /bin/sh, for real-subprocess
+    coverage of the stdin feeder (early exit, stuck child)."""
+    settings = make_settings({"KLANGKD_PODMAN_BIN": "/bin/sh"})
+    return podman.Podman(
+        types.SimpleNamespace(state=types.SimpleNamespace(settings=settings))
+    )
+
+
+class TestRunRawStdinFeeder:
+    async def test_early_exit_returns_rc(self):
+        """A real child that exits without draining 1MiB of stdin: the
+        run returns its rc instead of raising BrokenPipeError (#3124)."""
+        rc, _out, _err = await _sh_podman().run_raw(
+            ["-c", "exit 3"],
+            stdin_data=b"x" * (1 << 20),
+            check=False,
+            timeout=30,
+        )
+        assert rc == 3
+
+    async def test_stuck_child_timeout_bounds_run(self):
+        """A real child that never reads a 1MiB stdin: the timeout kills
+        the run (drain no longer blocks before the wait, #3124)."""
+        t0 = time.monotonic()
+        rc, _out, err = await _sh_podman().run_raw(
+            ["-c", "sleep 60"],
+            stdin_data=b"x" * (1 << 20),
+            check=False,
+            timeout=1,
+        )
+        elapsed = time.monotonic() - t0
+        assert rc == -1
+        assert "timed out" in err
+        assert elapsed < 30  # bounded well under the child's 60s
+
+    async def test_start_stdin_task_none_without_data(self):
+        assert podman.Podman._start_stdin_task(None, None) is None
+
+    async def test_settle_stdin_task_none(self):
+        """Settling no feeder is a no-op."""
+        await podman.Podman._settle_stdin_task(None)
+
+    async def test_settle_stdin_task_awaits_done(self):
+        task = asyncio.create_task(asyncio.sleep(0))
+        await asyncio.sleep(0)
+        await podman.Podman._settle_stdin_task(task)
+        assert task.done() and not task.cancelled()
+
+    async def test_settle_stdin_task_cancels_pending(self):
+        """A feeder still pending when the run ends is cancelled, not
+        leaked."""
+
+        async def hang():
+            await asyncio.Event().wait()
+
+        task = asyncio.create_task(hang())
+        await podman.Podman._settle_stdin_task(task)
+        assert task.cancelled()
 
 
 # --- containers ---

--- a/src/klangk/klangkd-tests/tests/test_podman.py
+++ b/src/klangk/klangkd-tests/tests/test_podman.py
@@ -277,6 +277,22 @@ class TestRunRawStdinFeeder:
         await podman.Podman._settle_stdin_task(task)
         assert task.cancelled()
 
+    async def test_settle_stdin_task_propagates_outer_cancellation(self):
+        """An outer cancellation of the run is not mistaken for the
+        feeder's own: it propagates out of the settle (and the feeder is
+        still cancelled on the way out, so nothing leaks)."""
+
+        async def hang():
+            await asyncio.Event().wait()
+
+        feeder = asyncio.create_task(hang())
+        settle = asyncio.create_task(podman.Podman._settle_stdin_task(feeder))
+        await asyncio.sleep(0)
+        settle.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await settle
+        assert feeder.cancelled()
+
 
 # --- containers ---
 

--- a/src/klangk/klangkd-tests/tests/test_settings.py
+++ b/src/klangk/klangkd-tests/tests/test_settings.py
@@ -868,6 +868,31 @@ class TestResolveSocketAndPorts:
         )
         assert s.port == "8997"
 
+    def test_port_whitespace_normalized(self):
+        """#3124 review: the validated port is returned normalized — a
+        whitespace/zero-padded form must not survive as a distinct value
+        (the egress≠browser check and the Caddyfile render consume the
+        raw string)."""
+        s = KlangkSettings(
+            env={"KLANGKD_STATE_DIR": "/tmp/state", "KLANGKD_PORT": " 30"}
+        )
+        assert s.port == "30"
+
+    def test_port_normalization_closes_equality_bypass(self):
+        """PORT=8997 + EGRESS=' 8997' used to pass the string-equality
+        firewall-separation check while binding the same numeric port;
+        both now normalize equal and are rejected."""
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError):
+            KlangkSettings(
+                env={
+                    "KLANGKD_STATE_DIR": "/tmp/state",
+                    "KLANGKD_PORT": "8997",
+                    "KLANGKD_EGRESS_PORT": " 8997",
+                }
+            )
+
     def test_socket_too_long_rejected(self):
         from pydantic import ValidationError
 
@@ -1954,6 +1979,13 @@ class TestBoolStringSettingCoercion:
         expected = None if default is None else str(default)
         assert getattr(s, field) == expected
 
+    def test_empty_allow_sudo_resolves_to_default_true(self):
+        """Pin the security-relevant empty remap independently of the
+        model_fields mirror above: the sudo *ceiling* resets to its
+        default (open), not to off (#3124 review)."""
+        s = make_settings({"KLANGKD_ALLOW_SUDO": ""})
+        assert s.allow_sudo == "true"
+
     def test_yaml_quoted_strings_unchanged(self, tmp_path):
         cfg = tmp_path / "config.yaml"
         cfg.write_text(
@@ -2021,13 +2053,15 @@ class TestIntStringSettingCoercion:
             (f, v)
             for f in FIELDS
             for v in (
-                ("8997", " 30")
+                ("8997",)
                 if f in PORT_STRING_FIELDS
                 else ("8997", "0", " 30", "")
             )
         ],
     )
     def test_env_strings_unchanged(self, field, value):
+        """Non-port values pass through unchanged; the port trio is
+        validated/normalized separately (see TestResolveSocketAndPorts)."""
         s = make_settings({f"KLANGKD_{field.upper()}": value})
         assert getattr(s, field) == value
 

--- a/src/klangk/klangkd-tests/tests/test_settings.py
+++ b/src/klangk/klangkd-tests/tests/test_settings.py
@@ -806,6 +806,68 @@ class TestResolveSocketAndPorts:
                 }
             )
 
+    def test_port_empty_is_headless(self):
+        """#3124: an explicitly emptied env var means unset, never an
+        empty string that crashes int() callers."""
+        s = KlangkSettings(
+            env={"KLANGKD_STATE_DIR": "/tmp/state", "KLANGKD_PORT": ""}
+        )
+        assert s.port is None
+
+    def test_egress_port_empty_gets_default(self):
+        s = KlangkSettings(
+            env={"KLANGKD_STATE_DIR": "/tmp/state", "KLANGKD_EGRESS_PORT": ""}
+        )
+        assert s.egress_port == "8995"
+
+    def test_proxy_port_empty_gets_default(self):
+        s = KlangkSettings(
+            env={"KLANGKD_STATE_DIR": "/tmp/state", "KLANGKD_PROXY_PORT": ""}
+        )
+        assert s.egress_port == "8995"
+
+    def test_port_non_numeric_rejected(self):
+        """#3124: a typo'd port fails construction with the setting named,
+        not a raw ValueError from the launcher's int()."""
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError) as exc_info:
+            KlangkSettings(
+                env={"KLANGKD_STATE_DIR": "/tmp/state", "KLANGKD_PORT": "abc"}
+            )
+        assert "KLANGKD_PORT" in str(exc_info.value)
+
+    def test_egress_port_non_numeric_rejected(self):
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError) as exc_info:
+            KlangkSettings(
+                env={
+                    "KLANGKD_STATE_DIR": "/tmp/state",
+                    "KLANGKD_EGRESS_PORT": "8x95",
+                }
+            )
+        assert "KLANGKD_EGRESS_PORT" in str(exc_info.value)
+
+    def test_port_out_of_range_rejected(self):
+        from pydantic import ValidationError
+
+        for bad in ("0", "70000"):
+            with pytest.raises(ValidationError) as exc_info:
+                KlangkSettings(
+                    env={
+                        "KLANGKD_STATE_DIR": "/tmp/state",
+                        "KLANGKD_PORT": bad,
+                    }
+                )
+            assert "KLANGKD_PORT" in str(exc_info.value)
+
+    def test_port_numeric_string_accepted(self):
+        s = KlangkSettings(
+            env={"KLANGKD_STATE_DIR": "/tmp/state", "KLANGKD_PORT": "8997"}
+        )
+        assert s.port == "8997"
+
     def test_socket_too_long_rejected(self):
         from pydantic import ValidationError
 
@@ -1876,11 +1938,21 @@ class TestBoolStringSettingCoercion:
 
     @pytest.mark.parametrize(
         "field,value",
-        [(f, v) for f in FIELDS for v in ("1", "yes", "no", "", "TRUE")],
+        [(f, v) for f in FIELDS for v in ("1", "yes", "no", "TRUE")],
     )
     def test_env_strings_unchanged(self, field, value):
         s = make_settings({f"KLANGKD_{field.upper()}": value})
         assert getattr(s, field) == value
+
+    @pytest.mark.parametrize("field", FIELDS)
+    def test_env_empty_means_default(self, field):
+        """#3124: an explicitly emptied value means unset — the field's
+        declared default, never a silent knob flip (``smtp_use_tls=``
+        must keep TLS on, not disable it)."""
+        s = make_settings({f"KLANGKD_{field.upper()}": ""})
+        default = KlangkSettings.model_fields[field].default
+        expected = None if default is None else str(default)
+        assert getattr(s, field) == expected
 
     def test_yaml_quoted_strings_unchanged(self, tmp_path):
         cfg = tmp_path / "config.yaml"
@@ -1916,6 +1988,12 @@ class TestBoolStringSettingCoercion:
         assert s.test_mode is None
 
 
+# The port trio of INT_STRING_FIELDS — additionally validated numeric
+# 1-65535 at construction (#3124), so "0"/"" are not pass-throughs for
+# them. Module level: a class-body comprehension cannot see class attrs.
+PORT_STRING_FIELDS = ("port", "egress_port", "proxy_port")
+
+
 class TestIntStringSettingCoercion:
     """Str-typed port/timeout settings accept native YAML ints (#2967).
 
@@ -1930,7 +2008,7 @@ class TestIntStringSettingCoercion:
     FIELDS = list(INT_STRING_FIELDS)
 
     @pytest.mark.parametrize("field", FIELDS)
-    @pytest.mark.parametrize("value", [8997, 0])
+    @pytest.mark.parametrize("value", [8997])
     def test_yaml_native_int(self, field, value, tmp_path):
         cfg = tmp_path / "config.yaml"
         cfg.write_text(f"{field}: {value}\n")
@@ -1939,7 +2017,15 @@ class TestIntStringSettingCoercion:
 
     @pytest.mark.parametrize(
         "field,value",
-        [(f, v) for f in FIELDS for v in ("8997", "0", " 30", "")],
+        [
+            (f, v)
+            for f in FIELDS
+            for v in (
+                ("8997", " 30")
+                if f in PORT_STRING_FIELDS
+                else ("8997", "0", " 30", "")
+            )
+        ],
     )
     def test_env_strings_unchanged(self, field, value):
         s = make_settings({f"KLANGKD_{field.upper()}": value})

--- a/src/klangk/klangkd-tests/tests/test_terminal.py
+++ b/src/klangk/klangkd-tests/tests/test_terminal.py
@@ -2377,6 +2377,34 @@ class TestShellProcessRealPty:
         os.close(shell._master_fd)  # fd dies underneath the session
         assert await asyncio.wait_for(shell.read(), 5) == b""
 
+    async def test_read_blocks_until_readable(self):
+        """Deterministic coverage of the non-blocking read's wait branch
+        (``read()``: ``BlockingIOError`` → clear + event wait). On a real
+        PTY the echo can beat the read under CI load — the branch went
+        uncovered in a CI run — so a pipe read-end with a delayed writer
+        pins the ordering."""
+        shell = self._shell()
+        r, w = os.pipe()
+        os.set_blocking(r, False)
+        shell._master_fd = r
+        shell._read_event = asyncio.Event()
+        loop = asyncio.get_running_loop()
+        loop.add_reader(r, shell._read_event.set)
+
+        async def feed():
+            await asyncio.sleep(0.05)
+            os.write(w, b"late")
+
+        try:
+            feeder = asyncio.create_task(feed())
+            out = await asyncio.wait_for(shell.read(), 5)
+            await feeder
+            assert out == b"late"
+        finally:
+            loop.remove_reader(r)
+            os.close(r)
+            os.close(w)
+
     async def test_write_blocking_falls_back_to_executor(self):
         import klangk.terminal as term
 

--- a/src/klangk/klangkd-tests/tests/test_workspaces.py
+++ b/src/klangk/klangkd-tests/tests/test_workspaces.py
@@ -462,11 +462,49 @@ class TestEnsureHomeSymlink:
         await app_state.state.workspaces.ensure_home_symlink(
             home, "bob", "uid-1"
         )
+        # User content present -> no re-populate signal (#3124 gate).
+        (home / ".users" / "uid-1" / ".bashrc").write_text("# bob\n")
         result, created = await app_state.state.workspaces.ensure_home_symlink(
             home, "bob", "uid-1"
         )
         assert result == "/home/bob"
         assert created is False
+
+    async def test_empty_user_dir_retries_populate(self, user, app_state):
+        """#3124: an existing-but-empty .users/<uid> (a failed populate on
+        an earlier connect — the exec failure is swallowed) must
+        re-signal the skel copy on the next connect, mirroring the
+        shared-home gate."""
+        ws = await app_state.state.workspaces.create_workspace(
+            user["id"], "symlink-ws-empty"
+        )
+        home = app_state.state.workspaces.home_path(ws["id"])
+        users = home / ".users"
+        users.mkdir(parents=True, exist_ok=True)
+        (users / "uid-1").mkdir(exist_ok=True)  # empty
+        _, created = await app_state.state.workspaces.ensure_home_symlink(
+            home, "dana", "uid-1"
+        )
+        assert created is True
+
+    async def test_correct_symlink_empty_dir_retries_populate(
+        self, user, app_state
+    ):
+        """#3124: the fast-path return (symlink already correct) carries
+        the same emptiness gate — a second connect after a failed
+        populate retries instead of no-op'ing forever."""
+        ws = await app_state.state.workspaces.create_workspace(
+            user["id"], "symlink-ws-empty2"
+        )
+        home = app_state.state.workspaces.home_path(ws["id"])
+        await app_state.state.workspaces.ensure_home_symlink(
+            home, "erin", "uid-1"
+        )
+        # No content appeared (populate failed) -> retry signal.
+        _, created = await app_state.state.workspaces.ensure_home_symlink(
+            home, "erin", "uid-1"
+        )
+        assert created is True
 
     async def test_rename_removes_old_symlink(self, user, app_state):
         ws = await app_state.state.workspaces.create_workspace(
@@ -476,6 +514,9 @@ class TestEnsureHomeSymlink:
         await app_state.state.workspaces.ensure_home_symlink(
             home, "alice", "uid-1"
         )
+        # Content present -> the rename path reports no skel populate
+        # (#3124 gate is emptiness, not bare existence).
+        (home / ".users" / "uid-1" / ".bashrc").write_text("# alice\n")
         result, created = await app_state.state.workspaces.ensure_home_symlink(
             home, "alicia", "uid-1"
         )


### PR DESCRIPTION
Fixes the six confirmed bugs from the top-level module audit (second half: `logger.py`–`workspaces.py`), reported in #3124.

## Podman exec stdin (`podman.py`)

`run_raw`/`exec_container` fed `stdin_data` by awaiting `drain()` inline *before* the timeout-armed wait:

- A child that exited before consuming stdin (e.g. `cat > file` racing a dying container) escaped an unhandled `BrokenPipeError`/`ConnectionResetError` out of the wrapper — `files.write_file` (the upload path) then 500'd instead of mapping the rc to its clean `OSError`.
- A payload larger than the pipe buffer with a child that never read blocked `drain()` forever while the timeout sat un-armed (verified: `timeout=2` ran 30s+).

The stdin feed now runs as a concurrent task; the timeout bounds the whole run (feed + exit), and pipe errors end the feed silently so the child's exit status is the result. Covered by real-subprocess tests (early exit, stuck child) plus feeder unit tests.

## OIDC config loading (`oidc.py`)

`load_config`'s external-file path never validated the parsed YAML shape: an empty file (`None`) crashed boot with `TypeError`, a mapping (`providers:` wrapper) with `AttributeError`, a non-mapping entry with `TypeError`/`KeyError`. All now raise `ConfigurationError`. Duplicate provider ids are rejected too — the second provider used to be silently shadowed by `get_provider`'s first match while `list_providers` still advertised its login button, and the id-keyed discovery/JWKS caches would cross-poison.

## Port validation (`settings.py`, `main.py`)

`KLANGKD_PORT` / `_EGRESS_PORT` / `_PROXY_PORT` are str fields with no numeric validation, so `KLANGKD_PORT=abc` passed construction and crashed the launcher with a raw `ValueError` at `main._check_port_collisions`'s `int()`; an explicitly emptied value (`KLANGKD_PORT=`) survived as `""` — neither `None` (headless) nor numeric — with the same crash, and would have rendered a broken `listen 127.0.0.1:`. The port family is now validated at construction (numeric 1–65535; empty means unset), matching the fail-fast posture of every other numeric knob.

Sibling fix in the same family: an emptied str-typed bool setting now resolves to its field default, so `KLANGKD_SMTP_USE_TLS=` keeps TLS on instead of silently disabling it (and `KLANGKD_ALLOW_SUDO=` keeps the ceiling default).

## Per-handle home skel retry (`workspaces.py`)

`_ensure_home_symlink_sync` returned bare `created`, and `populate_home_skel` swallows its failures — so one transient `klangk-setup-home` failure left that user's home permanently bare (no `.profile`/`.bashrc`). The populate signal now carries the same emptiness gate the shared-home path already documents (`created or not any(user_dir.iterdir())`), so an empty dir retries on the next connect.

## Tests

New real-subprocess coverage for the feeder, shape/duplicate-id tests for OIDC, port-contract tests, bool-empty→default tests, and the emptiness-gate tests; the handful of pre-existing tests that encoded the old contracts (`test_idempotent`, port/bool pass-throughs, `smtp_use_tls=""` disables) were updated to the fixed behavior. Full suite with `-n auto`: 6774 passed, 100% branch coverage; xenon clean.
