### PR TITLE
Make monitor hook spawn failures fatal instead of retrying forever (#3092)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -1978,6 +1978,13 @@ git-credential` (#1700).** `pig-latin` removed; `word-count` dormant.
 
 ### Fixed
 
+- **`klangk monitor` hook spawn failures are now fatal (#3092).** A
+  `--` command whose binary could not be spawned (missing or not
+  executable) used to be misclassified as a network error, making the
+  monitor reconnect with backoff forever. It now prints the spawn
+  error and exits nonzero; socket-level errors still reconnect as
+  before.
+
 - **Workspace name minimum length is enforced (#3110).** The API now
   rejects empty and whitespace-only workspace names on create, rename,
   duplicate, and import (422 on the JSON bodies, 400 on the import

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -1979,11 +1979,11 @@ git-credential` (#1700).** `pig-latin` removed; `word-count` dormant.
 ### Fixed
 
 - **`klangk monitor` hook spawn failures are now fatal (#3092).** A
-  `--` command whose binary could not be spawned (missing or not
-  executable) used to be misclassified as a network error, making the
-  monitor reconnect with backoff forever. It now prints the spawn
-  error and exits nonzero; socket-level errors still reconnect as
-  before.
+  `--` command that could not be spawned (missing binary, bad path
+  component, not executable) used to be misclassified as a network
+  error, making the monitor reconnect with backoff forever. It now
+  prints the spawn error and exits nonzero; socket-level errors still
+  reconnect as before.
 
 - **Workspace name minimum length is enforced (#3110).** The API now
   rejects empty and whitespace-only workspace names on create, rename,

--- a/docs/features/health-check.md
+++ b/docs/features/health-check.md
@@ -213,8 +213,9 @@ exponential backoff — and refreshes its login token on auth failures,
 so it survives server restarts and token expiry as a long-running
 daemon. Bound it with `--max-reconnects N`, or disable reconnect with
 `--no-reconnect`. A `--` command that cannot be spawned (missing
-binary, not executable) is not retried: the monitor prints the spawn
-error and exits nonzero. See `klangk monitor --help`.
+binary, bad path component, not executable) is not retried: the
+monitor prints the spawn error and exits nonzero. See `klangk
+monitor --help`.
 
 ## Setting the health check
 

--- a/docs/features/health-check.md
+++ b/docs/features/health-check.md
@@ -212,7 +212,9 @@ filters it out — drop the filter to observe it.
 exponential backoff — and refreshes its login token on auth failures,
 so it survives server restarts and token expiry as a long-running
 daemon. Bound it with `--max-reconnects N`, or disable reconnect with
-`--no-reconnect`. See `klangk monitor --help`.
+`--no-reconnect`. A `--` command that cannot be spawned (missing
+binary, not executable) is not retried: the monitor prints the spawn
+error and exits nonzero. See `klangk monitor --help`.
 
 ## Setting the health check
 

--- a/src/klangk/klangk/cli/main.py
+++ b/src/klangk/klangk/cli/main.py
@@ -135,6 +135,7 @@ from .shellcmd import (  # noqa: F401
 )
 from .monitor import (  # noqa: F401
     dispatch_monitor_event,
+    HookCommandError,
     monitor_backoff,
     monitor_connection,
     monitor,

--- a/src/klangk/klangk/cli/monitor.py
+++ b/src/klangk/klangk/cli/monitor.py
@@ -54,6 +54,17 @@ def health_event_env(msg: dict) -> dict[str, str]:
     return env
 
 
+class HookCommandError(Exception):
+    """The hook command could not be spawned (missing binary, etc.).
+
+    Deliberately not an ``OSError`` subclass: the monitor's reconnect
+    handler treats ``OSError`` as a transient network failure, which
+    would make a permanently broken hook command retry forever (#3092).
+    Socket-level ``OSError`` — including a missing UDS socket file while
+    the server restarts — keeps reconnecting as before.
+    """
+
+
 def dispatch_monitor_event(msg: dict, command: list[str]) -> None:
     """Act on one server event.
 
@@ -78,8 +89,15 @@ def dispatch_monitor_event(msg: dict, command: list[str]) -> None:
         env["KLANGK_WORKSPACE_ID"] = str(wid)
     if msg.get("type") == "service_health":
         env.update(health_event_env(msg))
-    # FileNotFoundError (missing binary) propagates to the caller.
-    subprocess.run(command, input=payload.encode(), env=env, check=False)
+    # Spawn failures are permanent configuration errors, not transient
+    # network trouble — wrap them so the reconnect loop lets them end
+    # the run instead of retrying forever (#3092).
+    try:
+        subprocess.run(command, input=payload.encode(), env=env, check=False)
+    except (FileNotFoundError, PermissionError) as exc:
+        raise HookCommandError(
+            f"cannot run hook command {command[0]!r}: {exc}"
+        ) from exc
 
 
 async def monitor_connection(
@@ -214,6 +232,10 @@ async def monitor_run(
     to refresh the JWT via the server's refresh endpoint before
     reconnecting; if refresh fails it keeps retrying with the current
     token so the monitor self-heals once the server/token recovers.
+
+    A hook command that cannot be spawned raises
+    :class:`HookCommandError`, which propagates out of this loop
+    (retrying a permanently broken command would loop forever).
     """
     current_token = token
     context.err.print(
@@ -343,7 +365,9 @@ def monitor(
     The monitor reconnects automatically (by default forever, with
     capped exponential backoff) and refreshes its JWT on auth failures,
     so it survives server restarts and token expiry. Use
-    ``--max-reconnects`` or ``--no-reconnect`` to bound it.
+    ``--max-reconnects`` or ``--no-reconnect`` to bound it. A hook
+    command that cannot be spawned (missing binary, not executable) is
+    fatal: the monitor exits nonzero instead of retrying forever.
 
     \b
     Examples:
@@ -385,6 +409,11 @@ def monitor(
         # A rejection during the very first connect (before the loop's
         # reconnect path is established).
         context.err.print(f"[red]Connection rejected: {e}[/red]")
+        raise typer.Exit(code=1) from None
+    except HookCommandError as e:
+        # A hook command that cannot start is a permanent configuration
+        # error — surface it and stop (#3092).
+        context.err.print(f"[red]{e}[/red]")
         raise typer.Exit(code=1) from None
     except KeyboardInterrupt:
         context.err.print("[dim]Stopped.[/dim]")

--- a/src/klangk/klangk/cli/monitor.py
+++ b/src/klangk/klangk/cli/monitor.py
@@ -93,8 +93,9 @@ def dispatch_monitor_event(msg: dict, command: list[str]) -> None:
     # network trouble — wrap every OSError from the run so the reconnect
     # loop lets it end the run instead of retrying forever (#3092).
     # CPython already swallows BrokenPipeError on the input write, so
-    # what reaches here is a failed spawn (missing binary, bad path
-    # component, not executable).
+    # this is almost always a failed spawn (missing binary, bad path
+    # component, not executable); rare resource-exhaustion OSErrors
+    # (EMFILE/ENOMEM) surface here too rather than retrying silently.
     try:
         subprocess.run(command, input=payload.encode(), env=env, check=False)
     except OSError as exc:

--- a/src/klangk/klangk/cli/monitor.py
+++ b/src/klangk/klangk/cli/monitor.py
@@ -90,11 +90,14 @@ def dispatch_monitor_event(msg: dict, command: list[str]) -> None:
     if msg.get("type") == "service_health":
         env.update(health_event_env(msg))
     # Spawn failures are permanent configuration errors, not transient
-    # network trouble — wrap them so the reconnect loop lets them end
-    # the run instead of retrying forever (#3092).
+    # network trouble — wrap every OSError from the run so the reconnect
+    # loop lets it end the run instead of retrying forever (#3092).
+    # CPython already swallows BrokenPipeError on the input write, so
+    # what reaches here is a failed spawn (missing binary, bad path
+    # component, not executable).
     try:
         subprocess.run(command, input=payload.encode(), env=env, check=False)
-    except (FileNotFoundError, PermissionError) as exc:
+    except OSError as exc:
         raise HookCommandError(
             f"cannot run hook command {command[0]!r}: {exc}"
         ) from exc
@@ -366,8 +369,9 @@ def monitor(
     capped exponential backoff) and refreshes its JWT on auth failures,
     so it survives server restarts and token expiry. Use
     ``--max-reconnects`` or ``--no-reconnect`` to bound it. A hook
-    command that cannot be spawned (missing binary, not executable) is
-    fatal: the monitor exits nonzero instead of retrying forever.
+    command that cannot be spawned (missing binary, bad path
+    component, not executable) is fatal: the monitor exits nonzero
+    instead of retrying forever.
 
     \b
     Examples:

--- a/src/klangk/klangkc-tests/tests/test_cli.py
+++ b/src/klangk/klangkc-tests/tests/test_cli.py
@@ -4575,6 +4575,46 @@ class TestMonitor:
                 )
 
     @pytest.mark.asyncio
+    async def test_uds_enoent_reconnects(self):
+        # The load-bearing composition (#3092's fix direction): a
+        # FileNotFoundError from the UDS socket connect (server down,
+        # socket file absent) must stay a reconnectable network error —
+        # only hook spawn failures are fatal. Unstubbed chain: the real
+        # monitor_connection hits the real ws_connect UDS path.
+        from klangk.cli import main as main_mod
+
+        sleeps = []
+
+        async def fake_sleep(delay):
+            sleeps.append(delay)
+
+        async def fail_connect(*a, **kw):
+            pytest.fail("UDS ENOENT must fail before websockets.connect")
+
+        with (
+            patch("klangk.cli.main.websockets.connect", fail_connect),
+            patch.object(main_mod.asyncio, "sleep", fake_sleep),
+            patch.object(
+                klangk.cli.monitor, "monitor_backoff", lambda a, m: 0.0
+            ),
+        ):
+            with pytest.raises(typer.Exit) as exc_info:
+                await main_mod.monitor_run(
+                    "/nonexistent/klangk.sock",
+                    "tok",
+                    1024,
+                    command=["true"],
+                    types=[],
+                    workspaces=[],
+                    max_reconnects=1,
+                    max_delay=1.0,
+                )
+        # Gave up via the reconnect budget — the ENOENT was treated as
+        # transient, not propagated as a fatal hook error.
+        assert exc_info.value.exit_code == 1
+        assert len(sleeps) == 1
+
+    @pytest.mark.asyncio
     async def test_reconnects_after_disconnect(self):
         # Two clean closes → monitor_connection called twice, with a
         # backoff sleep in between.

--- a/src/klangk/klangkc-tests/tests/test_cli.py
+++ b/src/klangk/klangkc-tests/tests/test_cli.py
@@ -4463,10 +4463,16 @@ class TestMonitor:
         assert env["KLANGK_HEALTH_SEQ"] == "7"
 
     @pytest.mark.asyncio
-    async def test_command_not_found_propagates(self, monkeypatch):
-        # A missing command binary propagates FileNotFoundError out of
-        # the single-connection loop (the runner turns it into an exit).
-        from klangk.cli.main import monitor_connection
+    @pytest.mark.parametrize(
+        "spawn_error", [FileNotFoundError, PermissionError]
+    )
+    async def test_command_spawn_failure_raises_hook_error(
+        self, monkeypatch, spawn_error
+    ):
+        # A hook command that cannot be spawned raises HookCommandError
+        # (not a bare OSError) out of the single-connection loop, so the
+        # reconnect handler treats it as fatal (#3092).
+        from klangk.cli.main import HookCommandError, monitor_connection
 
         event = {
             "type": "service_health",
@@ -4480,9 +4486,9 @@ class TestMonitor:
         ):
             monkeypatch.setattr(
                 "klangk.cli.main.subprocess.run",
-                MagicMock(side_effect=FileNotFoundError()),
+                MagicMock(side_effect=spawn_error()),
             )
-            with pytest.raises(FileNotFoundError):
+            with pytest.raises(HookCommandError) as exc_info:
                 await monitor_connection(
                     "http://x",
                     "tok",
@@ -4491,6 +4497,41 @@ class TestMonitor:
                     types=[],
                     workspaces=[],
                 )
+        assert isinstance(exc_info.value.__cause__, spawn_error)
+        assert "nope" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_hook_error_ends_reconnect_loop(self):
+        # A spawn failure is not a network error: monitor_run must let
+        # HookCommandError fly out instead of reconnecting forever (#3092).
+        from klangk.cli import main as main_mod
+        from klangk.cli.main import HookCommandError
+
+        calls = {"conn": 0}
+
+        async def fake_conn(*args, **kwargs):
+            calls["conn"] += 1
+            raise HookCommandError("cannot run hook command 'nope'")
+
+        async def fake_sleep(delay):
+            pytest.fail("a broken hook command must not trigger backoff")
+
+        with (
+            patch.object(klangk.cli.monitor, "monitor_connection", fake_conn),
+            patch.object(main_mod.asyncio, "sleep", fake_sleep),
+        ):
+            with pytest.raises(HookCommandError):
+                await main_mod.monitor_run(
+                    "http://x",
+                    "tok",
+                    1024,
+                    command=["nope"],
+                    types=[],
+                    workspaces=[],
+                    max_reconnects=None,
+                    max_delay=1.0,
+                )
+        assert calls["conn"] == 1
 
     @pytest.mark.asyncio
     async def test_reconnects_after_disconnect(self):

--- a/src/klangk/klangkc-tests/tests/test_cli.py
+++ b/src/klangk/klangkc-tests/tests/test_cli.py
@@ -4464,7 +4464,8 @@ class TestMonitor:
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize(
-        "spawn_error", [FileNotFoundError, PermissionError]
+        "spawn_error",
+        [FileNotFoundError, PermissionError, NotADirectoryError],
     )
     async def test_command_spawn_failure_raises_hook_error(
         self, monkeypatch, spawn_error
@@ -4532,6 +4533,46 @@ class TestMonitor:
                     max_delay=1.0,
                 )
         assert calls["conn"] == 1
+
+    @pytest.mark.asyncio
+    async def test_spawn_failure_is_fatal_end_to_end(self, monkeypatch):
+        # Real dispatch chain, no monitor_connection stub: a spawn
+        # failure inside dispatch_monitor_event must fly out of
+        # monitor_run's reconnect loop without a retry or backoff sleep
+        # (#3092) — pins the wrap and the loop's except tuple together.
+        from klangk.cli import main as main_mod
+        from klangk.cli.main import HookCommandError
+
+        event = json.dumps({"type": "service_health", "healthy": True})
+        conn = _FakeMonitorConn([event])
+
+        async def fake_sleep(delay):
+            pytest.fail("a broken hook command must not trigger backoff")
+
+        with (
+            patch(
+                "klangk.cli.main.websockets.connect",
+                return_value=_FakeMonitorCM(conn),
+            ),
+            patch.object(main_mod.asyncio, "sleep", fake_sleep),
+        ):
+            monkeypatch.setattr(
+                "klangk.cli.main.subprocess.run",
+                MagicMock(
+                    side_effect=NotADirectoryError(20, "Not a directory")
+                ),
+            )
+            with pytest.raises(HookCommandError):
+                await main_mod.monitor_run(
+                    "http://x",
+                    "tok",
+                    1024,
+                    command=["/etc/passwd/nope"],
+                    types=[],
+                    workspaces=[],
+                    max_reconnects=None,
+                    max_delay=1.0,
+                )
 
     @pytest.mark.asyncio
     async def test_reconnects_after_disconnect(self):

--- a/src/klangk/klangkc-tests/tests/test_cli_main.py
+++ b/src/klangk/klangkc-tests/tests/test_cli_main.py
@@ -6318,6 +6318,26 @@ class TestMonitorCommand:
             assert result.exit_code == 1
             assert "Connection rejected" in result.output
 
+    def test_monitor_hook_command_error_exits(self, logged_in_cfg):
+        from klangk.cli import main
+        from klangk.cli.monitor import HookCommandError
+
+        async def _hook_err(*a, **kw):
+            raise HookCommandError(
+                "cannot run hook command 'nonexistent-hook':"
+                " [Errno 2] No such file or directory: 'nonexistent-hook'"
+            )
+
+        with patch.object(klangk.cli.monitor, "monitor_run", new=_hook_err):
+            from typer.testing import CliRunner
+
+            runner = CliRunner()
+            result = runner.invoke(
+                main.app, ["monitor", "--", "nonexistent-hook"]
+            )
+            assert result.exit_code == 1
+            assert "cannot run hook command" in result.output
+
     def test_monitor_keyboard_interrupt_stops_cleanly(self, logged_in_cfg):
         from klangk.cli import main
 


### PR DESCRIPTION
## Summary

`klangk monitor -- <cmd>` ran the hook command via `subprocess.run` inside the
reconnect loop's `try`. `monitor_run`'s handler catches `OSError` as a transient
network error, and `FileNotFoundError` is an `OSError` subclass — so a
permanently missing hook binary was classified as
`network error: [Errno 2] ...` and the monitor reconnected with backoff forever
(the default `max_reconnects` is unbounded), never surfacing the real problem
(#3092).

The reconnect loop's `OSError` catch is load-bearing for the UDS transport:
`ws_connect`'s UDS path raises `FileNotFoundError` (ENOENT) from
`sock.connect(uds_path)` while the server is down, and that must keep
reconnecting. So the fix is scoped to the dispatch site, per the issue's fix
direction:

- `dispatch_monitor_event` now wraps the `subprocess.run` call's
  `OSError` in a new non-`OSError` `HookCommandError`, chained via
  `from exc` — covering the full spawn-failure taxonomy (missing binary,
  `NotADirectoryError` on a bad path component, `PermissionError` on a
  non-executable). CPython already swallows `BrokenPipeError` on the
  input write, so what escapes is a failed spawn.
- The reconnect loop never matches it (it isn't an `OSError`), so it propagates
  out of `monitor_run`; the `monitor` command prints the spawn error and exits
  nonzero.
- Socket-level `OSError`s — including a missing UDS socket file while the
  server restarts — keep reconnecting exactly as before.

## Tests

- Dispatch level: parametrized `FileNotFoundError` / `PermissionError` /
  `NotADirectoryError` all raise `HookCommandError` with the command
  name and the chained cause.
- End-to-end: a real spawn failure driven through the unstubbed
  dispatch → `monitor_connection` → `monitor_run` chain exits without a
  retry or backoff sleep.
- Loop level: `monitor_run` propagates `HookCommandError` after exactly one
  connection attempt with no backoff sleep (fails against the pre-fix code,
  which would have looped forever).
- CLI level: `klangk monitor -- nonexistent-hook` exits 1 and prints the spawn
  error.

Closes #3092.
