### PR TITLE
Enforce minimum workspace name length on create and rename (#3110)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -1978,6 +1978,15 @@ git-credential` (#1700).** `pig-latin` removed; `word-count` dormant.
 
 ### Fixed
 
+- **Workspace name minimum length is enforced (#3110).** The API now
+  rejects empty and whitespace-only workspace names on create, rename,
+  duplicate, and import (422 on the JSON bodies, 400 on the import
+  archive/request name). Previously `"name": ""` was silently accepted
+  on create and rename; `klangk edit` already rejected blank `--name`
+  client-side (#3103), and this closes the remaining surfaces (web
+  frontend, TUI, direct API callers). Existing blank-named rows, if any,
+  are unaffected — renaming away from one remains possible.
+
 - **Exec-stdin failures surface as the command's exit status (#3124).** A
   container-side command that exits before consuming piped stdin (a file
   upload racing a dying container) no longer raises an unhandled

--- a/src/klangk/klangk/api/workspaces.py
+++ b/src/klangk/klangk/api/workspaces.py
@@ -21,7 +21,7 @@ from fastapi import (
 from fastapi.responses import (
     StreamingResponse,
 )
-from pydantic import BaseModel
+from pydantic import AfterValidator, BaseModel
 from sqlalchemy.exc import IntegrityError as SAIntegrityError
 
 from .. import (
@@ -286,6 +286,22 @@ async def list_shared_workspaces(
     )
 
 
+def _validate_workspace_name(value: str) -> str:
+    """#3110: a workspace name must carry at least one
+    non-whitespace character.
+
+    ``min_length=1`` alone would accept ``" "``; this keeps every
+    surface (web frontend, TUI, API callers) consistent with the
+    `klangk edit` command's blank-``--name`` rejection (PR #3103).
+    """
+    if not value.strip():
+        raise ValueError("Workspace name cannot be empty or only whitespace")
+    return value
+
+
+WorkspaceName = Annotated[str, AfterValidator(_validate_workspace_name)]
+
+
 class WorkspaceBodyFields(BaseModel):
     """The optional workspace fields shared verbatim by the create
     (POST) and update (PUT) bodies.
@@ -308,7 +324,7 @@ class WorkspaceBodyFields(BaseModel):
 
 
 class CreateWorkspaceRequest(WorkspaceBodyFields):
-    name: str
+    name: WorkspaceName
     auto_start: bool = False
     egress_mode: Literal["static", "interactive", "allow"] = (
         EGRESS_MODE_DEFAULT
@@ -508,7 +524,7 @@ async def _eager_start(app, body, ws, actor_id: str | None) -> None:
 
 
 class UpdateWorkspaceRequest(WorkspaceBodyFields):
-    name: str | None = None
+    name: WorkspaceName | None = None
     auto_start: bool | None = None
     # egress_mode (like allowed_domains) is enforced by the network
     # sidecar at container start, so a change here takes effect on the
@@ -764,7 +780,7 @@ async def update_workspace_settings(
 
 
 class DuplicateWorkspaceRequest(BaseModel):
-    name: str
+    name: WorkspaceName
 
 
 @router.post("/workspaces/{workspace_id}/duplicate")
@@ -1334,12 +1350,13 @@ async def _read_archive_metadata(archive_path: str) -> dict:
 
 def _archive_ws_name(metadata: dict, name: str | None) -> str:
     """The workspace name: an explicit request name wins, else the
-    archive's."""
+    archive's. Empty, blank, or non-string candidates are a 400
+    (#3110)."""
     ws_name = name or metadata.get("name")
-    if not ws_name:
+    if not isinstance(ws_name, str) or not ws_name.strip():
         raise HTTPException(
             status_code=400,
-            detail="No workspace name in archive or request",
+            detail=("No usable workspace name in archive or request"),
         )
     return ws_name
 

--- a/src/klangk/klangkd-tests/tests/test_api.py
+++ b/src/klangk/klangkd-tests/tests/test_api.py
@@ -2483,6 +2483,20 @@ class TestWorkspaceRoutes:
         assert resp.status_code == 409
         assert "already exists" in resp.json()["detail"]
 
+    async def test_create_rejects_blank_name(self, client, user):
+        # #3110: the request models enforce the name minimum centrally —
+        # empty AND whitespace-only names are 422s on every surface, not
+        # just the CLI's client-side guard (PR #3103).
+        headers = await _auth_headers(client)
+        for bad in ("", "   "):
+            resp = await client.post(
+                "/api/v1/workspaces",
+                headers=headers,
+                json={"name": bad},
+            )
+            assert resp.status_code == 422
+            assert "cannot be empty" in str(resp.json()["detail"])
+
     async def test_create_with_disallowed_image(self, client, user):
         headers = await _auth_headers(client)
         resp = await client.post(
@@ -3978,6 +3992,27 @@ class TestWorkspaceRoutes:
         assert resp.status_code == 400
         assert resp.json()["detail"] == "No fields to update"
 
+    async def test_rename_rejects_blank_name(self, client, user):
+        # #3110: PUT renames share the create-side name minimum.
+        headers = await _auth_headers(client)
+        resp = await client.post(
+            "/api/v1/workspaces",
+            json={"name": "blank-rename"},
+            headers=headers,
+        )
+        ws_id = resp.json()["id"]
+        for bad in ("", " \t "):
+            resp = await client.put(
+                f"/api/v1/workspaces/{ws_id}",
+                json={"name": bad},
+                headers=headers,
+            )
+            assert resp.status_code == 422
+        # The stored name is untouched.
+        resp = await client.get("/api/v1/workspaces", headers=headers)
+        by_name = {w["name"]: w for w in resp.json()}
+        assert "blank-rename" in by_name
+
     async def test_create_workspace_with_settings(self, client, user):
         headers = await _auth_headers(client)
         resp = await client.post(
@@ -4805,6 +4840,24 @@ class TestWorkspaceRoutes:
         )
         assert resp.status_code == 409
         assert "already exists" in resp.json()["detail"]
+
+    async def test_duplicate_rejects_blank_name(self, client, user):
+        # #3110: the duplicate create shares the name minimum.
+        headers = await _auth_headers(client)
+        ws_id = (
+            await client.post(
+                "/api/v1/workspaces",
+                json={"name": "blank-dup-src"},
+                headers=headers,
+            )
+        ).json()["id"]
+        for bad in ("", "   "):
+            resp = await client.post(
+                f"/api/v1/workspaces/{ws_id}/duplicate",
+                json={"name": bad},
+                headers=headers,
+            )
+            assert resp.status_code == 422
 
     async def test_duplicate_workspace_creates_role_groups(
         self, client, user, app_state
@@ -11527,6 +11580,53 @@ class TestWorkspaceExportImport:
         assert resp.status_code == 200
         assert resp.json()["name"] == "from-archive"
 
+    async def test_import_rejects_blank_name(self, client, admin_user, user):
+        # #3110: the import choke point shares the name minimum — a blank
+        # request name (even over a good archive name) and a blank
+        # workspace.json name are both 400s. Name resolution precedes the
+        # provenance check, so no instance_id games needed.
+        import io
+        import json
+        import tarfile
+
+        buf = io.BytesIO()
+        with tarfile.open(fileobj=buf, mode="w:gz") as tar:
+            meta = json.dumps(self._meta(name="from-archive")).encode()
+            info = tarfile.TarInfo(name="workspace.json")
+            info.size = len(meta)
+            tar.addfile(info, io.BytesIO(meta))
+        archive = buf.getvalue()
+        headers = await self._user_headers(client)
+
+        # Blank explicit request name wins over the archive's good name.
+        resp = await client.post(
+            "/api/v1/workspaces/import",
+            headers=headers,
+            params={"name": "   "},
+            files={"file": ("archive.tar.gz", archive, "application/gzip")},
+        )
+        assert resp.status_code == 400
+        assert (
+            resp.json()["detail"]
+            == "No usable workspace name in archive or request"
+        )
+
+        # Blank archive name with no request override.
+        buf = io.BytesIO()
+        with tarfile.open(fileobj=buf, mode="w:gz") as tar:
+            meta = json.dumps(self._meta(name=" \t")).encode()
+            info = tarfile.TarInfo(name="workspace.json")
+            info.size = len(meta)
+            tar.addfile(info, io.BytesIO(meta))
+        resp = await client.post(
+            "/api/v1/workspaces/import",
+            headers=headers,
+            files={
+                "file": ("archive.tar.gz", buf.getvalue(), "application/gzip")
+            },
+        )
+        assert resp.status_code == 400
+
     async def test_import_follows_deploy_default(
         self, client, admin_user, user
     ):
@@ -12144,7 +12244,7 @@ class TestWorkspaceExportImport:
             },
         )
         assert resp.status_code == 400
-        assert "No workspace name" in resp.json()["detail"]
+        assert "No usable workspace name" in resp.json()["detail"]
 
     async def test_import_disallowed_image_falls_back(self, client, user):
         """Archive with disallowed image falls back to default."""


### PR DESCRIPTION
Closes #3110.

## Summary

The server accepted an empty workspace name on both create and rename — the
request models carried `name: str` / `name: str | None` with no minimum, the
model layer only guards duplicates, and the schema's `NOT NULL` doesn't reject
`''`. The CLI already rejects blank `--name` client-side (#3103); this adds the
central server-side guard so every surface (web frontend, TUI, direct API
callers) is covered:

- **`WorkspaceName`** — a strip-aware Pydantic `AfterValidator`
  (`_validate_workspace_name` in `src/klangk/klangk/api/workspaces.py`) applied
  to `CreateWorkspaceRequest.name`, `UpdateWorkspaceRequest.name`, and
  `DuplicateWorkspaceRequest.name`. Empty **and** whitespace-only names now
  422 (a bare `min_length=1` would still accept `" "`).
- **Import choke point** — `_archive_ws_name` now rejects a blank or
  non-string resolved name (request query name or archive
  `workspace.json` name) with the existing 400.
- Explicit `{"name": null}` on PUT still returns the friendlier
  `_reject_null_fields` 400; absence stays legal.
- Existing blank-named rows, if any, are unaffected — renaming away from one
  remains possible (decided against an upgrade normalization; validation is
  enough going forward).

## Tests

Four new tests in `src/klangk/klangkd-tests/tests/test_api.py`
(`test_*_rejects_blank_name` for create / rename / duplicate / import),
covering the 422/400 paths and that a rejected rename leaves the stored name
untouched. Full suite: 6792 passed, 100% branch coverage maintained; xenon
rank A maintained.

## Changelog

`docs/changes.md` entry under `[Unreleased]` → `Fixed`.
