### PR TITLE
Guard blank workspace name in settings panel saves (#3130)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -1984,7 +1984,7 @@ git-credential` (#1700).** `pig-latin` removed; `word-count` dormant.
   saving until a name was re-entered. The blank name is now rejected
   inline on the field (same message as the server's rule, #3110), and
   validation-style API errors render their actual message instead of a
-  bare status code.
+  bare status code (save banner and ownership-transfer snackbar).
 
 - **Sandbox `copy` specs with extra colon segments are rejected (#3119).**
   A `.klangk-sandbox.yaml` `copy:` entry like `notes.txt:~/notes.txt:ro`

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -1978,6 +1978,14 @@ git-credential` (#1700).** `pig-latin` removed; `word-count` dormant.
 
 ### Fixed
 
+- **Workspace settings panel name validation (#3130).** Clearing the
+  _Name_ field and tapping _Save_ used to fail the whole panel update
+  with an opaque `Failed: Error: 422`, blocking every other field from
+  saving until a name was re-entered. The blank name is now rejected
+  inline on the field (same message as the server's rule, #3110), and
+  validation-style API errors render their actual message instead of a
+  bare status code.
+
 - **Sandbox `copy` specs with extra colon segments are rejected (#3119).**
   A `.klangk-sandbox.yaml` `copy:` entry like `notes.txt:~/notes.txt:ro`
   used to silently drop the trailing `:ro` and copy anyway; it now fails

--- a/src/frontend/lib/workspace/workspace_settings_panel.dart
+++ b/src/frontend/lib/workspace/workspace_settings_panel.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:convert';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:http/http.dart' as http;
 import 'package:provider/provider.dart';
 import '../auth/auth_service.dart';
 import '../theme/colors.dart';
@@ -175,14 +176,7 @@ class WorkspaceSettingsPanelState extends State<WorkspaceSettingsPanel> {
         if (mounted) setState(() => _saveMessage = null);
       });
     } else {
-      String detail;
-      try {
-        detail = (jsonDecode(resp.body) as Map)['detail'] ?? resp.body;
-      } catch (e) {
-        debugPrint('[WorkspaceSettingsPanel] parse error detail failed: $e');
-        detail = 'Error: ${resp.statusCode}';
-      }
-      setState(() => _saveMessage = 'Failed: $detail');
+      setState(() => _saveMessage = 'Failed: ${_apiErrorDetail(resp)}');
     }
   }
 
@@ -218,6 +212,34 @@ class WorkspaceSettingsPanelState extends State<WorkspaceSettingsPanel> {
       canRestart: widget.canRestart,
       onRestart: _restartNow,
     );
+  }
+}
+
+/// Extract a human-readable message from an API error body (#3130).
+///
+/// Most error routes send ``{"detail": "<string>"}``, but FastAPI/
+/// Pydantic validation failures (422) put a *list* of error objects under
+/// ``detail`` (each with ``loc``/``msg``) — surface the first message,
+/// minus Pydantic's ``Value error, `` prefix, instead of tripping the old
+/// string cast and degrading to a bare ``Error: 422``.
+String _apiErrorDetail(http.Response resp) {
+  try {
+    final decoded = jsonDecode(resp.body);
+    if (decoded is Map) {
+      final detail = decoded['detail'];
+      if (detail is String) return detail;
+      if (detail is List && detail.isNotEmpty && detail.first is Map) {
+        final msg = (detail.first as Map)['msg'];
+        if (msg is String) {
+          return msg.replaceFirst('Value error, ', '');
+        }
+      }
+      return resp.body;
+    }
+    return resp.body;
+  } catch (e) {
+    debugPrint('[WorkspaceSettingsPanel] parse error detail failed: $e');
+    return 'Error: ${resp.statusCode}';
   }
 }
 
@@ -399,6 +421,9 @@ class _SettingsFormState extends State<_SettingsForm> {
   String? _envError;
   String? _allowedDomainsError;
   String? _rejectedDomainsError;
+  // #3130: inline validation on the Name field, set when a save is
+  // attempted with a blank name and cleared as soon as the user edits.
+  String? _nameError;
   bool _saving = false;
   bool _exporting = false;
 
@@ -596,7 +621,20 @@ class _SettingsFormState extends State<_SettingsForm> {
   }
 
   Future<void> _save() async {
-    setState(() => _saving = true);
+    final name = _nameCtrl.text.trim();
+    // #3130: guard the rename client-side with the same rule the server
+    // enforces (#3110) — a blank name must fail visibly on the field
+    // instead of 422-ing the whole panel PUT and blocking every other
+    // field from saving.
+    if (name.isEmpty) {
+      setState(() =>
+          _nameError = 'Workspace name cannot be empty or only whitespace');
+      return;
+    }
+    setState(() {
+      _saving = true;
+      _nameError = null;
+    });
     final formSettings = _collectSettings();
     // PUT settings is a full-replace bag, so seed from the existing bag
     // unconditionally — API-only keys the form does not represent (e.g.
@@ -616,7 +654,7 @@ class _SettingsFormState extends State<_SettingsForm> {
     // remains the ceiling).
     if (widget.sudoAvailable) settings['allow_sudo'] = _sudoEnabled;
     await widget.onSave({
-      'name': _nameCtrl.text.trim(),
+      'name': name,
       'image': _selectedImage,
       'service_command':
           _cmdCtrl.text.trim().isEmpty ? null : _cmdCtrl.text.trim(),
@@ -844,7 +882,11 @@ class _SettingsFormState extends State<_SettingsForm> {
             labelStyle: labelStyle,
             floatingLabelBehavior: FloatingLabelBehavior.always,
             border: const OutlineInputBorder(),
+            errorText: _nameError,
           ),
+          onChanged: (_) {
+            if (_nameError != null) setState(() => _nameError = null);
+          },
         ),
         const SizedBox(height: 16),
         if (widget.allowedImages.isNotEmpty)

--- a/src/frontend/lib/workspace/workspace_settings_panel.dart
+++ b/src/frontend/lib/workspace/workspace_settings_panel.dart
@@ -215,6 +215,14 @@ class WorkspaceSettingsPanelState extends State<WorkspaceSettingsPanel> {
   }
 }
 
+/// Pydantic v2 renders an AfterValidator's message as
+/// ``"Value error, <original>"`` — strip that prefix so the banner shows
+/// the message the validator actually raised.
+String _stripPydanticPrefix(String msg) {
+  const prefix = 'Value error, ';
+  return msg.startsWith(prefix) ? msg.substring(prefix.length) : msg;
+}
+
 /// Extract a human-readable message from an API error body (#3130).
 ///
 /// Most error routes send ``{"detail": "<string>"}``, but FastAPI/
@@ -231,7 +239,7 @@ String _apiErrorDetail(http.Response resp) {
       if (detail is List && detail.isNotEmpty && detail.first is Map) {
         final msg = (detail.first as Map)['msg'];
         if (msg is String) {
-          return msg.replaceFirst('Value error, ', '');
+          return _stripPydanticPrefix(msg);
         }
       }
       return resp.body;
@@ -635,45 +643,50 @@ class _SettingsFormState extends State<_SettingsForm> {
       _saving = true;
       _nameError = null;
     });
-    final formSettings = _collectSettings();
-    // PUT settings is a full-replace bag, so seed from the existing bag
-    // unconditionally — API-only keys the form does not represent (e.g.
-    // bridge_timeout) and toggle-gated keys (nix, allow_sudo) whose
-    // toggles are hidden on this deploy must survive the save instead of
-    // being silently wiped (#2017 review).
-    final bag = (widget.workspace['settings'] as Map<String, dynamic>?) ??
-        const <String, dynamic>{};
-    final Map<String, dynamic> settings = {...bag, ...formSettings};
-    // #2233: emit an explicit nix value (true or false) whenever the
-    // toggle is shown — including false, to actually turn the mount off
-    // (omitting the key leaves the stale bag untouched).
-    if (widget.nixAvailable) settings['nix'] = _nixEnabled;
-    // #2017: same for the sudo posture — an explicit value whenever the
-    // toggle is shown, so a check-to-revert actually clears a stored
-    // lock-down. True follows the deploy posture (the server setting
-    // remains the ceiling).
-    if (widget.sudoAvailable) settings['allow_sudo'] = _sudoEnabled;
-    await widget.onSave({
-      'name': name,
-      'image': _selectedImage,
-      'service_command':
-          _cmdCtrl.text.trim().isEmpty ? null : _cmdCtrl.text.trim(),
-      'health_check': _healthCheckCtrl.text.trim().isEmpty
-          ? null
-          : _healthCheckCtrl.text.trim(),
-      'mounts': _mounts.isNotEmpty ? _mounts : null,
-      'env': _envVars.isNotEmpty ? _envVars : null,
-      'allowed_domains': _allowedDomains.isNotEmpty ? _allowedDomains : null,
-      'rejected_domains': _rejectedDomains.isNotEmpty ? _rejectedDomains : null,
-      'egress_mode': _egressMode,
-      'per_handle_home': _perHandleHome,
-      // #2768: full-replace — an emptied field clears the override back
-      // to the deploy default. Display-time only (no restart needed).
-      'classification_banner': _classificationBannerCtrl.text.trim(),
-      if (widget.allowAutostart) 'auto_start': _autoStart,
-      if (settings.isNotEmpty) 'settings': settings,
-    });
-    if (mounted) setState(() => _saving = false);
+    try {
+      final formSettings = _collectSettings();
+      // PUT settings is a full-replace bag, so seed from the existing bag
+      // unconditionally — API-only keys the form does not represent (e.g.
+      // bridge_timeout) and toggle-gated keys (nix, allow_sudo) whose
+      // toggles are hidden on this deploy must survive the save instead
+      // of being silently wiped (#2017 review).
+      final bag = (widget.workspace['settings'] as Map<String, dynamic>?) ??
+          const <String, dynamic>{};
+      final Map<String, dynamic> settings = {...bag, ...formSettings};
+      // #2233: emit an explicit nix value (true or false) whenever the
+      // toggle is shown — including false, to actually turn the mount off
+      // (omitting the key leaves the stale bag untouched).
+      if (widget.nixAvailable) settings['nix'] = _nixEnabled;
+      // #2017: same for the sudo posture — an explicit value whenever the
+      // toggle is shown, so a check-to-revert actually clears a stored
+      // lock-down. True follows the deploy posture (the server setting
+      // remains the ceiling).
+      if (widget.sudoAvailable) settings['allow_sudo'] = _sudoEnabled;
+      await widget.onSave({
+        'name': name,
+        'image': _selectedImage,
+        'service_command':
+            _cmdCtrl.text.trim().isEmpty ? null : _cmdCtrl.text.trim(),
+        'health_check': _healthCheckCtrl.text.trim().isEmpty
+            ? null
+            : _healthCheckCtrl.text.trim(),
+        'mounts': _mounts.isNotEmpty ? _mounts : null,
+        'env': _envVars.isNotEmpty ? _envVars : null,
+        'allowed_domains': _allowedDomains.isNotEmpty ? _allowedDomains : null,
+        'rejected_domains':
+            _rejectedDomains.isNotEmpty ? _rejectedDomains : null,
+        'egress_mode': _egressMode,
+        'per_handle_home': _perHandleHome,
+        // #2768: full-replace — an emptied field clears the override back
+        // to the deploy default. Display-time only (no restart needed).
+        'classification_banner': _classificationBannerCtrl.text.trim(),
+        if (widget.allowAutostart) 'auto_start': _autoStart,
+        if (settings.isNotEmpty) 'settings': settings,
+      });
+    } finally {
+      // A network exception must not leave Save permanently disabled.
+      if (mounted) setState(() => _saving = false);
+    }
   }
 
   void _tryAddMount() {
@@ -1614,15 +1627,11 @@ class _SettingsFormState extends State<_SettingsForm> {
         SnackBar(content: Text('Workspace transferred to $email')),
       );
     } else {
-      String detail;
-      try {
-        detail = (jsonDecode(resp.body) as Map)['detail'] ?? resp.body;
-      } catch (e) {
-        debugPrint('[WorkspaceSettingsPanel] parse transfer error: $e');
-        detail = 'Error: ${resp.statusCode}';
-      }
+      // #3130: reuse the list-aware parser — a Pydantic 422 detail is a
+      // list of error objects, which the old string cast turned into a
+      // bare "Error: <code>".
       ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text('Transfer failed: $detail')),
+        SnackBar(content: Text('Transfer failed: ${_apiErrorDetail(resp)}')),
       );
     }
   }

--- a/src/frontend/test/workspace_settings_panel_test.dart
+++ b/src/frontend/test/workspace_settings_panel_test.dart
@@ -59,7 +59,7 @@ const _workspace = {
 /// the defaults serve the workspace list, images, and a 200 PUT on save.
 http.Client _client({
   Map<String, dynamic>? workspace,
-  Map<String, dynamic>? saveResponse,
+  Object? saveResponse,
   int saveStatus = 200,
   int exportStatus = 200,
   bool imagesFail = false,
@@ -72,6 +72,7 @@ http.Client _client({
   List<String>? stopRecorder,
   int stopStatus = 200,
   bool stopThrows = false,
+  List<String>? putRecorder,
 }) {
   final ws = (workspace ?? _workspace);
   return MockClient((request) async {
@@ -103,6 +104,7 @@ http.Client _client({
       );
     }
     if (p == '/api/v1/workspaces/$_wsId' && request.method == 'PUT') {
+      putRecorder?.add(p);
       return http.Response(
         jsonEncode(saveResponse ?? {'status': 'updated'}),
         saveStatus,
@@ -1371,33 +1373,8 @@ void main() {
     testWidgets(
         'a cleared Name blocks the save inline and sends no PUT (#3130)',
         (tester) async {
-      var puts = 0;
-      testAuthHttpClientOverride = MockClient((request) async {
-        final p = request.url.path;
-        if (p == '/api/v1/config') {
-          return http.Response(jsonEncode({}), 200);
-        }
-        if (p == '/api/v1/workspaces') {
-          return http.Response(jsonEncode([_workspace]), 200);
-        }
-        if (p == '/api/v1/workspaces/shared') {
-          return http.Response(jsonEncode([]), 200);
-        }
-        if (p == '/api/v1/images') {
-          return http.Response(
-            jsonEncode({
-              'default': 'klangk-pi',
-              'allowed': ['klangk-pi'],
-            }),
-            200,
-          );
-        }
-        if (p == '/api/v1/workspaces/$_wsId' && request.method == 'PUT') {
-          puts++;
-          return http.Response(jsonEncode({'status': 'updated'}), 200);
-        }
-        return http.Response('not found', 404);
-      });
+      final puts = <String>[];
+      testAuthHttpClientOverride = _client(putRecorder: puts);
       await tester.pumpWidget(_buildPanel());
       await tester.pumpAndSettle();
 
@@ -1420,7 +1397,7 @@ void main() {
         tester.widget<TextField>(nameField).decoration?.errorText,
         'Workspace name cannot be empty or only whitespace',
       );
-      expect(puts, 0);
+      expect(puts, isEmpty);
       expect(find.textContaining('Failed'), findsNothing);
 
       // Typing a name clears the error; the save then goes through.
@@ -1435,7 +1412,7 @@ void main() {
       await tester.pump();
       await tester.pump(const Duration(milliseconds: 100));
 
-      expect(puts, 1);
+      expect(puts, hasLength(1));
       expect(find.text('Settings saved'), findsOneWidget);
       await tester.pump(const Duration(seconds: 2));
       await tester.pumpAndSettle();
@@ -1475,6 +1452,47 @@ void main() {
       );
       // The raw Pydantic prefix is stripped.
       expect(find.textContaining('Value error'), findsNothing);
+      await tester.pumpAndSettle();
+    });
+
+    testWidgets(
+        'a map body with an unusable detail falls back to the raw body '
+        '(#3130)', (tester) async {
+      // detail is neither a string nor a list of error objects — the
+      // banner shows the raw body instead of a bare status code.
+      testAuthHttpClientOverride = _client(
+        saveStatus: 400,
+        saveResponse: {'detail': 42},
+      );
+      await tester.pumpWidget(_buildPanel());
+      await tester.pumpAndSettle();
+
+      await _scrollToAndTap(tester, find.text('Save'));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 100));
+
+      expect(find.textContaining('Failed'), findsOneWidget);
+      expect(find.textContaining('{"detail":42}'), findsOneWidget);
+      await tester.pumpAndSettle();
+    });
+
+    testWidgets('a non-map JSON body falls back to the raw body (#3130)',
+        (tester) async {
+      // A JSON string root parses fine but carries no detail key — the
+      // banner shows the raw body.
+      testAuthHttpClientOverride = _client(
+        saveStatus: 502,
+        saveResponse: 'plain gateway error',
+      );
+      await tester.pumpWidget(_buildPanel());
+      await tester.pumpAndSettle();
+
+      await _scrollToAndTap(tester, find.text('Save'));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 100));
+
+      expect(find.textContaining('Failed'), findsOneWidget);
+      expect(find.textContaining('plain gateway error'), findsOneWidget);
       await tester.pumpAndSettle();
     });
 
@@ -2591,6 +2609,52 @@ void main() {
         find.textContaining('Transfer failed'),
         findsOneWidget,
       );
+    });
+
+    testWidgets('transfer failure with a list detail renders its msg (#3130)',
+        (tester) async {
+      // A Pydantic 422 detail list must render the message, not degrade
+      // to a bare status code off a string-cast TypeError.
+      testAuthHttpClientOverride = _client(
+        searchResults: [
+          {'id': 'u2', 'email': 'target@test.com', 'handle': 'target'},
+        ],
+        transferStatus: 422,
+        transferResponse: {
+          'detail': [
+            {
+              'type': 'value_error',
+              'loc': ['body', 'email'],
+              'msg': 'Value error, not a valid email',
+              'input': 'target',
+            }
+          ]
+        },
+      );
+      await tester.pumpWidget(_buildPanel());
+      await tester.pumpAndSettle();
+
+      await _scrollToAndTap(
+        tester,
+        find.widgetWithText(OutlinedButton, 'Transfer Ownership'),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.enterText(find.byType(TextField).last, 'target');
+      await tester.pump(const Duration(milliseconds: 400));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('target@test.com'));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('Transfer'));
+      await tester.pumpAndSettle();
+
+      expect(
+        find.textContaining('Transfer failed: not a valid email'),
+        findsOneWidget,
+      );
+      expect(find.textContaining('Value error'), findsNothing);
     });
 
     testWidgets('transfer failure with non-JSON body shows status code',

--- a/src/frontend/test/workspace_settings_panel_test.dart
+++ b/src/frontend/test/workspace_settings_panel_test.dart
@@ -59,7 +59,7 @@ const _workspace = {
 /// the defaults serve the workspace list, images, and a 200 PUT on save.
 http.Client _client({
   Map<String, dynamic>? workspace,
-  Map<String, String>? saveResponse,
+  Map<String, dynamic>? saveResponse,
   int saveStatus = 200,
   int exportStatus = 200,
   bool imagesFail = false,
@@ -1365,6 +1365,116 @@ void main() {
       expect(find.textContaining('Failed'), findsOneWidget);
       expect(find.textContaining('bad mounts'), findsOneWidget);
       // Drain the 2s auto-clear timer (see save-success test).
+      await tester.pumpAndSettle();
+    });
+
+    testWidgets(
+        'a cleared Name blocks the save inline and sends no PUT (#3130)',
+        (tester) async {
+      var puts = 0;
+      testAuthHttpClientOverride = MockClient((request) async {
+        final p = request.url.path;
+        if (p == '/api/v1/config') {
+          return http.Response(jsonEncode({}), 200);
+        }
+        if (p == '/api/v1/workspaces') {
+          return http.Response(jsonEncode([_workspace]), 200);
+        }
+        if (p == '/api/v1/workspaces/shared') {
+          return http.Response(jsonEncode([]), 200);
+        }
+        if (p == '/api/v1/images') {
+          return http.Response(
+            jsonEncode({
+              'default': 'klangk-pi',
+              'allowed': ['klangk-pi'],
+            }),
+            200,
+          );
+        }
+        if (p == '/api/v1/workspaces/$_wsId' && request.method == 'PUT') {
+          puts++;
+          return http.Response(jsonEncode({'status': 'updated'}), 200);
+        }
+        return http.Response('not found', 404);
+      });
+      await tester.pumpWidget(_buildPanel());
+      await tester.pumpAndSettle();
+
+      // Clear the Name field and try to save.
+      final nameField = find.byWidgetPredicate(
+        (w) => w is TextField && w.decoration?.labelText == 'Name',
+      );
+      await tester.enterText(nameField, '');
+      // Unfocus so the focused field's keep-visible doesn't fight the
+      // scroll-to-Save below (settle its animated scroll fully).
+      FocusManager.instance.primaryFocus?.unfocus();
+      await tester.pumpAndSettle();
+      await _scrollToAndTap(tester, find.text('Save'));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 100));
+
+      // The guard fired: inline validation on the field, no PUT sent, no
+      // blanket failure banner.
+      expect(
+        tester.widget<TextField>(nameField).decoration?.errorText,
+        'Workspace name cannot be empty or only whitespace',
+      );
+      expect(puts, 0);
+      expect(find.textContaining('Failed'), findsNothing);
+
+      // Typing a name clears the error; the save then goes through.
+      await tester.enterText(nameField, 'renamed-ws');
+      FocusManager.instance.primaryFocus?.unfocus();
+      await tester.pumpAndSettle();
+      expect(
+        tester.widget<TextField>(nameField).decoration?.errorText,
+        isNull,
+      );
+      await _scrollToAndTap(tester, find.text('Save'));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 100));
+
+      expect(puts, 1);
+      expect(find.text('Settings saved'), findsOneWidget);
+      await tester.pump(const Duration(seconds: 2));
+      await tester.pumpAndSettle();
+    });
+
+    testWidgets(
+        'save failure renders a 422 detail list instead of a bare code '
+        '(#3130)', (tester) async {
+      // FastAPI/Pydantic validation errors put a list of error objects
+      // under detail — the message must surface the first msg (minus
+      // Pydantic's "Value error, " prefix), not degrade to "Error: 422".
+      testAuthHttpClientOverride = _client(
+        saveStatus: 422,
+        saveResponse: <String, dynamic>{
+          'detail': [
+            {
+              'type': 'value_error',
+              'loc': ['body', 'name'],
+              'msg': 'Value error, Workspace name cannot be empty or only '
+                  'whitespace',
+              'input': '',
+            }
+          ]
+        },
+      );
+      await tester.pumpWidget(_buildPanel());
+      await tester.pumpAndSettle();
+
+      await _scrollToAndTap(tester, find.text('Save'));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 100));
+
+      expect(find.textContaining('Failed'), findsOneWidget);
+      expect(
+        find.textContaining('Workspace name cannot be empty'),
+        findsOneWidget,
+      );
+      // The raw Pydantic prefix is stripped.
+      expect(find.textContaining('Value error'), findsNothing);
       await tester.pumpAndSettle();
     });
 


### PR DESCRIPTION
## Summary

Fixes #3130.

Two gaps in the workspace settings panel that made a cleared _Name_ field block
every save on the panel with an opaque `Failed: Error: 422`:

- **No client-side guard on the Name field.** The panel's single PUT built
  `'name': _nameCtrl.text.trim()` unconditionally, so a blank name hit the
  server's Pydantic minimum-length validator (#3110) and failed the whole panel
  update — no other field could be saved until a name was re-typed. `_save()`
  now rejects a blank name with inline validation on the field (the same
  "Workspace name cannot be empty or only whitespace" message the server
  enforces) and sends no request; editing the field clears the error, matching
  the create dialog's guard pattern.
- **422 error bodies are list-shaped, the parser assumed a string.** The old
  `detail = (jsonDecode(resp.body) as Map)['detail']` threw a `TypeError` on
  FastAPI/Pydantic validation bodies (`detail` is a list of error objects),
  which the catch degraded to the generic `Failed: Error: 422`. The new
  `_apiErrorDetail()` renders the first error object's `msg` (with Pydantic's
  `Value error, ` prefix stripped via an anchored check), passes string details
  through unchanged, and keeps the raw-body / status-code fallbacks for
  unparsable bodies. Both call sites in the panel use it: the save banner and
  the ownership-transfer snackbar (which carried the same latent cast bug).

Also from the fresh-eyes review: `_save()` wraps the PUT in `try/finally` so a
network exception can no longer leave the Save button permanently disabled.

## Testing

Widget tests in `test/workspace_settings_panel_test.dart`:

- a cleared name blocks the save inline, sends **no** PUT, shows no failure
  banner — then typing a name clears the error and the save goes through;
- a 422 with a list-shaped `detail` renders the first `msg` (prefix stripped)
  instead of a bare code, for both the save banner and the transfer snackbar;
- both `_apiErrorDetail` fallback shapes (map body with an unusable `detail`,
  non-map JSON root) render the raw body — the panel file stays at 100% line
  coverage.

Full frontend suite: `flutter test --coverage` — 1209 passing.
