### PR TITLE
Reject sandbox copy specs with extra colon segments (#3119)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -1978,6 +1978,12 @@ git-credential` (#1700).** `pig-latin` removed; `word-count` dormant.
 
 ### Fixed
 
+- **Sandbox `copy` specs with extra colon segments are rejected (#3119).**
+  A `.klangk-sandbox.yaml` `copy:` entry like `notes.txt:~/notes.txt:ro`
+  used to silently drop the trailing `:ro` and copy anyway; it now fails
+  config load with an `Invalid sandbox config` error. Copy specs are
+  strictly `source:dest` — they take no mount-style `:options` segment.
+
 - **`klangk monitor` hook spawn failures are now fatal (#3092).** A
   `--` command that could not be spawned (missing binary, bad path
   component, not executable) used to be misclassified as a network

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -1982,7 +1982,8 @@ git-credential` (#1700).** `pig-latin` removed; `word-count` dormant.
   A `.klangk-sandbox.yaml` `copy:` entry like `notes.txt:~/notes.txt:ro`
   used to silently drop the trailing `:ro` and copy anyway; it now fails
   config load with an `Invalid sandbox config` error. Copy specs are
-  strictly `source:dest` — they take no mount-style `:options` segment.
+  strictly `source:dest` — no mount-style `:options` segment, both
+  halves non-empty, string entries only.
 
 - **`klangk monitor` hook spawn failures are now fatal (#3092).** A
   `--` command that could not be spawned (missing binary, bad path

--- a/docs/features/sandbox.md
+++ b/docs/features/sandbox.md
@@ -121,10 +121,13 @@ copy:
   - ~/.zshrc:~/.zshrc
 ```
 
-Files copied from the host into the container home directory. Uses the
-same `source:destination` format as mounts. Tilde on the left expands
-to the host user's home; tilde on the right expands to the container
-user's home (`/home/{handle}` — see the `~` note above).
+Files copied from the host into the container home directory. Uses
+`source:destination`, but — unlike `mounts` — takes **no options
+segment**: exactly one colon. A spec like `notes.txt:~/notes.txt:ro`
+is a config error (the load fails with `Invalid sandbox config`),
+not a read-only copy. Tilde on the left expands to the host user's
+home; tilde on the right expands to the container user's home
+(`/home/{handle}` — see the `~` note above).
 
 Copies happen once during workspace creation, after the default home
 skeleton is populated but before the setup script runs. The copied

--- a/docs/features/sandbox.md
+++ b/docs/features/sandbox.md
@@ -123,9 +123,10 @@ copy:
 
 Files copied from the host into the container home directory. Uses
 `source:destination`, but — unlike `mounts` — takes **no options
-segment**: exactly one colon. A spec like `notes.txt:~/notes.txt:ro`
-is a config error (the load fails with `Invalid sandbox config`),
-not a read-only copy. Tilde on the left expands to the host user's
+segment**: exactly one colon, and both halves must be non-empty. A
+spec like `notes.txt:~/notes.txt:ro` is a config error (the load
+fails with `Invalid sandbox config`), not a read-only copy. Tilde on
+the left expands to the host user's
 home; tilde on the right expands to the container user's home
 (`/home/{handle}` — see the `~` note above).
 

--- a/src/klangk/klangk/cli/sandbox.py
+++ b/src/klangk/klangk/cli/sandbox.py
@@ -185,11 +185,13 @@ def build_all_mounts(
 def parse_copy_spec(spec: str) -> tuple[str, str]:
     """Split a copy spec into ``(source, dest)``.
 
-    Copy specs are strictly ``source:dest`` — exactly one colon. A
-    spec with no colon, or with extra colon-separated segments (a
-    mount-style ``:ro`` option, say), is rejected: copy specs take
-    no options segment, and silently dropping the extra segments
-    would hide the mistake (#3119).
+    Copy specs are strictly ``source:dest`` — exactly one colon,
+    both halves non-empty. A spec with no colon, with extra
+    colon-separated segments (a mount-style ``:ro`` option, say),
+    or with an empty half is rejected: copy specs take no options
+    segment, a path containing a colon cannot be expressed, and
+    silently dropping or defaulting the bad parts would hide the
+    mistake (#3119).
     """
     src, sep, dest = spec.partition(":")
     if not sep or ":" in dest:
@@ -197,12 +199,19 @@ def parse_copy_spec(spec: str) -> tuple[str, str]:
             f"Invalid copy spec: {spec!r} (need source:dest with"
             " exactly one colon; copy specs take no options)"
         )
+    if not src or not dest:
+        raise ValueError(
+            f"Invalid copy spec: {spec!r} (source and destination"
+            " must both be non-empty)"
+        )
     return src, dest
 
 
 def validate_copy_specs(specs: list[str]) -> None:
     """Raise ``ValueError`` on any malformed copy spec (#3119)."""
     for spec in specs:
+        if not isinstance(spec, str):
+            raise ValueError(f"Invalid copy spec: {spec!r} (must be a string)")
         parse_copy_spec(spec)
 
 

--- a/src/klangk/klangk/cli/sandbox.py
+++ b/src/klangk/klangk/cli/sandbox.py
@@ -63,6 +63,12 @@ def load_sandbox_config(sandbox_root: Path) -> SandboxConfig:
     workspace = raw.get("workspace") or {}
     sandbox = raw.get("sandbox") or {}
 
+    copy_specs = list_field(raw, "copy")
+    # Reject malformed copy specs up front so they surface as config
+    # errors (via load_config_or_exit) instead of being silently
+    # mangled at setup time (#3119).
+    validate_copy_specs(copy_specs)
+
     return SandboxConfig(
         image=workspace.get("image"),
         service_command=workspace.get(
@@ -77,7 +83,7 @@ def load_sandbox_config(sandbox_root: Path) -> SandboxConfig:
         mount_at=sandbox.get("mount-at", sandbox.get("mount_at", "~/work")),
         setup=sandbox.get("setup"),
         setup_timeout=parse_setup_timeout(sandbox),
-        copy=list_field(raw, "copy"),
+        copy=copy_specs,
         mounts=list_field(raw, "mounts"),
         volumes=list_field(raw, "volumes"),
     )
@@ -176,6 +182,30 @@ def build_all_mounts(
     return mounts
 
 
+def parse_copy_spec(spec: str) -> tuple[str, str]:
+    """Split a copy spec into ``(source, dest)``.
+
+    Copy specs are strictly ``source:dest`` — exactly one colon. A
+    spec with no colon, or with extra colon-separated segments (a
+    mount-style ``:ro`` option, say), is rejected: copy specs take
+    no options segment, and silently dropping the extra segments
+    would hide the mistake (#3119).
+    """
+    src, sep, dest = spec.partition(":")
+    if not sep or ":" in dest:
+        raise ValueError(
+            f"Invalid copy spec: {spec!r} (need source:dest with"
+            " exactly one colon; copy specs take no options)"
+        )
+    return src, dest
+
+
+def validate_copy_specs(specs: list[str]) -> None:
+    """Raise ``ValueError`` on any malformed copy spec (#3119)."""
+    for spec in specs:
+        parse_copy_spec(spec)
+
+
 def build_copy_pairs(
     config: SandboxConfig,
     sandbox_root: Path,
@@ -184,11 +214,9 @@ def build_copy_pairs(
     """Return ``(host_path, container_path)`` pairs from the copy list."""
     pairs = []
     for spec in config.copy:
-        parts = spec.split(":")
-        if len(parts) < 2:
-            raise ValueError(f"Invalid copy spec: {spec!r} (need source:dest)")
-        src = expand_host_path(parts[0], sandbox_root)
-        dest = expand_container_path(parts[1], handle)
+        src_part, dest_part = parse_copy_spec(spec)
+        src = expand_host_path(src_part, sandbox_root)
+        dest = expand_container_path(dest_part, handle)
         pairs.append((src, dest))
     return pairs
 

--- a/src/klangk/klangkc-tests/tests/test_sandbox.py
+++ b/src/klangk/klangkc-tests/tests/test_sandbox.py
@@ -12,6 +12,7 @@ from klangk.cli.sandbox import (
     load_sandbox_config,
     parse_copy_spec,
     resolve_setup_command,
+    validate_copy_specs,
 )
 
 
@@ -120,6 +121,19 @@ class TestLoadSandboxConfig:
         with pytest.raises(ValueError, match="Invalid copy spec"):
             load_sandbox_config(sandbox_root)
 
+    def test_copy_spec_empty_source_rejected_at_load(self, sandbox_root):
+        """An empty source resolves to the sandbox root dir (#3119)."""
+        _write_config(sandbox_root, {"copy": [":~/notes.txt"]})
+        with pytest.raises(ValueError, match="Invalid copy spec"):
+            load_sandbox_config(sandbox_root)
+
+    def test_copy_spec_non_string_rejected_at_load(self, sandbox_root):
+        """A YAML int/null entry must fail as a config error, not a
+        traceback (fresh-eyes review of #3119)."""
+        _write_config(sandbox_root, {"copy": [42]})
+        with pytest.raises(ValueError, match="Invalid copy spec"):
+            load_sandbox_config(sandbox_root)
+
 
 class TestExpandHostPath:
     def test_absolute(self, tmp_path):
@@ -200,6 +214,27 @@ class TestParseCopySpec:
     def test_extra_segment_raises(self):
         with pytest.raises(ValueError, match="Invalid copy spec"):
             parse_copy_spec("a.txt:b.txt:ro")
+
+    def test_empty_source_raises(self):
+        with pytest.raises(ValueError, match="non-empty"):
+            parse_copy_spec(":dest")
+
+    def test_empty_dest_raises(self):
+        with pytest.raises(ValueError, match="non-empty"):
+            parse_copy_spec("src:")
+
+    def test_both_empty_raises(self):
+        with pytest.raises(ValueError, match="non-empty"):
+            parse_copy_spec(":")
+
+
+class TestValidateCopySpecs:
+    def test_non_string_raises(self):
+        with pytest.raises(ValueError, match="must be a string"):
+            validate_copy_specs([42])
+
+    def test_valid_specs_pass(self):
+        validate_copy_specs(["a:b", "~/.gitconfig:~/.gitconfig"])
 
 
 class TestBuildCopyPairs:

--- a/src/klangk/klangkc-tests/tests/test_sandbox.py
+++ b/src/klangk/klangkc-tests/tests/test_sandbox.py
@@ -10,6 +10,7 @@ from klangk.cli.sandbox import (
     expand_container_path,
     expand_host_path,
     load_sandbox_config,
+    parse_copy_spec,
     resolve_setup_command,
 )
 
@@ -108,6 +109,17 @@ class TestLoadSandboxConfig:
         with pytest.raises(ValueError, match="Invalid sandbox config"):
             load_sandbox_config(sandbox_root)
 
+    def test_copy_spec_no_colon_rejected_at_load(self, sandbox_root):
+        _write_config(sandbox_root, {"copy": ["notes.txt"]})
+        with pytest.raises(ValueError, match="Invalid copy spec"):
+            load_sandbox_config(sandbox_root)
+
+    def test_copy_spec_extra_segment_rejected_at_load(self, sandbox_root):
+        """A mount-style :ro suffix must not be silently dropped (#3119)."""
+        _write_config(sandbox_root, {"copy": ["notes.txt:~/notes.txt:ro"]})
+        with pytest.raises(ValueError, match="Invalid copy spec"):
+            load_sandbox_config(sandbox_root)
+
 
 class TestExpandHostPath:
     def test_absolute(self, tmp_path):
@@ -177,6 +189,19 @@ class TestBuildAllMounts:
         assert "/data:/home/admin/project/subdir" in mounts
 
 
+class TestParseCopySpec:
+    def test_simple(self):
+        assert parse_copy_spec("a.txt:b.txt") == ("a.txt", "b.txt")
+
+    def test_no_colon_raises(self):
+        with pytest.raises(ValueError, match="Invalid copy spec"):
+            parse_copy_spec("no-colon")
+
+    def test_extra_segment_raises(self):
+        with pytest.raises(ValueError, match="Invalid copy spec"):
+            parse_copy_spec("a.txt:b.txt:ro")
+
+
 class TestBuildCopyPairs:
     def test_basic(self, sandbox_root):
         config = SandboxConfig(copy=["~/.gitconfig:~/.gitconfig"])
@@ -189,6 +214,12 @@ class TestBuildCopyPairs:
 
     def test_invalid_spec_raises(self, sandbox_root):
         config = SandboxConfig(copy=["no-colon"])
+        with pytest.raises(ValueError, match="Invalid copy spec"):
+            build_copy_pairs(config, sandbox_root, "admin")
+
+    def test_extra_segment_raises(self, sandbox_root):
+        """Direct construction bypasses load-time validation (#3119)."""
+        config = SandboxConfig(copy=["notes.txt:~/notes.txt:ro"])
         with pytest.raises(ValueError, match="Invalid copy spec"):
             build_copy_pairs(config, sandbox_root, "admin")
 


### PR DESCRIPTION
## Summary

`build_copy_pairs` split each `copy:` spec on `:` and used only `parts[0]` and
`parts[1]`, silently dropping any further segments: `copy:
["notes.txt:~/notes.txt:ro"]` copied to `~/notes.txt` with the `:ro` vanishing
— inconsistent with `_expand_spec` (mounts/volumes), which re-joins extra
segments as options, so a user assuming mount-spec syntax got silently wrong
behavior.

Fixes #3119 using the issue's option 1 (reject):

- **`parse_copy_spec`** (`cli/sandbox.py`) splits strictly on the first colon
  and rejects specs with zero or extra colons (`"no-colon"`, `"a:b:ro"`)
  with `ValueError: Invalid copy spec: ... (need source:dest with exactly one
  colon; copy specs take no options)`.
- **`load_sandbox_config`** validates the `copy` list up front
  (`validate_copy_specs`), so `load_config_or_exit` surfaces the error as
  `Invalid sandbox config: ...` and exits before any workspace is created
  (previously the silent mangling happened mid-setup, after creation).
- **`build_copy_pairs`** parses via the same helper, so directly-constructed
  `SandboxConfig`s stay guarded.
- Docs (`docs/features/sandbox.md`): the copy section no longer claims "same
  format as mounts" — it now states exactly one colon, no options segment,
  and that `notes.txt:~/notes.txt:ro` is a config error.
- Changelog entry under `[Unreleased]` → Fixed.

Note: a host source path containing a `:` was already inexpressible (the
first colon terminated the source); it is now rejected loudly rather than
silently copying to a truncated destination.

## Testing

- New tests in `klangkc-tests/tests/test_sandbox.py`: both failure modes
  (no colon / extra segments) at both levels (config load, direct
  `build_copy_pairs` / `parse_copy_spec`), plus the happy path.
- Full Python suite CI-style: 6821 passed, 100% branch coverage.
- `pre-commit run xenon --all-files` passes.

## Review

A fresh-eyes adversarial review ran before this PR was opened; its findings
(empty copy-spec halves and non-string entries crashing with tracebacks
instead of clean config errors) were addressed in the second commit. Known
out-of-scope follow-up it flagged: `mounts`/`volumes` specs with no colon
still surface only at `build_all_mounts` time, not config load.
