### PR TITLE
Derive sandbox copy parents POSIX-style, not with host Path (#3117)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -1985,6 +1985,13 @@ git-credential` (#1700).** `pig-latin` removed; `word-count` dormant.
   strictly `source:dest` — no mount-style `:options` segment, both
   halves non-empty, string entries only.
 
+- **`klangk sandbox` copy destinations are now resolved POSIX-style
+  (#3117).** The `mkdir -p` parent for a `copy:` destination was derived
+  with the CLI host's path flavor, so on a Windows host a container path
+  like `/home/admin/sub dir` came out backslash-mangled and the copy
+  landed in the wrong directory inside the container. The parent is now
+  computed with POSIX semantics regardless of host platform.
+
 - **`klangk monitor` hook spawn failures are now fatal (#3092).** A
   `--` command that could not be spawned (missing binary, bad path
   component, not executable) used to be misclassified as a network

--- a/src/klangk/klangk/cli/sandboxcmd.py
+++ b/src/klangk/klangk/cli/sandboxcmd.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import asyncio
 import io
 import json
+import posixpath
 import shlex
 import sys
 from pathlib import Path
@@ -52,9 +53,12 @@ async def copy_sandbox_files(ws, config, sandbox_root, handle) -> None:
             )
             continue
         context.err.print(f"  [dim]copy:[/dim] {host_path} → {container_dest}")
-        parent = str(Path(container_dest).parent)
-        # #3093: quote the paths — a copy destination containing
-        # spaces must round-trip into the sh -c string intact.
+        # #3117: derive the parent POSIX-style — the destination is a
+        # container path, and the host ``Path`` flavor (WindowsPath on
+        # a Windows CLI host) mangles POSIX paths. #3093: quote the
+        # paths — a copy destination containing spaces must round-trip
+        # into the sh -c string intact.
+        parent = posixpath.dirname(container_dest)
         stdout_buf = io.BytesIO()
         exit_code = await exec_on_ws(
             ws,

--- a/src/klangk/klangk/cli/sandboxcmd.py
+++ b/src/klangk/klangk/cli/sandboxcmd.py
@@ -11,10 +11,9 @@ from __future__ import annotations
 import asyncio
 import io
 import json
-import posixpath
 import shlex
 import sys
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 
 import typer
 import websockets
@@ -53,12 +52,16 @@ async def copy_sandbox_files(ws, config, sandbox_root, handle) -> None:
             )
             continue
         context.err.print(f"  [dim]copy:[/dim] {host_path} → {container_dest}")
-        # #3117: derive the parent POSIX-style — the destination is a
-        # container path, and the host ``Path`` flavor (WindowsPath on
-        # a Windows CLI host) mangles POSIX paths. #3093: quote the
-        # paths — a copy destination containing spaces must round-trip
-        # into the sh -c string intact.
-        parent = posixpath.dirname(container_dest)
+        # #3117: derive the parent with PurePosixPath — the destination
+        # is a container path, and the host ``Path`` flavor
+        # (WindowsPath on a Windows CLI host) mangles POSIX paths.
+        # PurePosixPath (not posixpath.dirname) so a bare relative
+        # dest still yields ``.`` (mkdir -p .) instead of an empty
+        # string that makes mkdir fail and the && chain skip the
+        # copy. #3093: quote the paths — a copy destination
+        # containing spaces must round-trip into the sh -c string
+        # intact.
+        parent = str(PurePosixPath(container_dest).parent)
         stdout_buf = io.BytesIO()
         exit_code = await exec_on_ws(
             ws,

--- a/src/klangk/klangkc-tests/tests/test_sandbox.py
+++ b/src/klangk/klangkc-tests/tests/test_sandbox.py
@@ -1,5 +1,7 @@
 """Tests for klangk sandbox config loading and path resolution."""
 
+from unittest.mock import patch
+
 import pytest
 import yaml
 
@@ -285,3 +287,56 @@ class TestResolveSetupCommand:
         config = SandboxConfig(mount_at="~/project", setup="setup.sh")
         result = resolve_setup_command(config, "admin")
         assert result == "/home/admin/project/setup.sh"
+
+
+class TestCopySandboxFiles:
+    """copy_sandbox_files derives container parents POSIX-style (#3117).
+
+    The destination is a container (POSIX) path; the host ``Path``
+    flavor must never touch it — on a Windows CLI host
+    ``WindowsPath('/home/admin/sub dir').parent`` yields
+    backslash-flavored parents and drive-letter semantics.
+    """
+
+    async def test_parent_is_posix_with_spaces(self, tmp_path):
+        from klangk.cli import sandboxcmd
+
+        src = tmp_path / "file.txt"
+        src.write_text("data")
+        config = SandboxConfig(copy=[f"{src}:~/sub dir/file.txt"])
+        commands = []
+
+        async def fake_exec_on_ws(ws, cmd, **kwargs):
+            commands.append(cmd)
+            return 0
+
+        with patch.object(sandboxcmd, "exec_on_ws", fake_exec_on_ws):
+            await sandboxcmd.copy_sandbox_files(
+                None, config, tmp_path, "admin"
+            )
+
+        assert len(commands) == 1
+        sh_cmd = commands[0][2]
+        # Parent derived POSIX-style and both paths quoted (#3093).
+        assert "mkdir -p '/home/admin/sub dir'" in sh_cmd
+        assert "cat > '/home/admin/sub dir/file.txt'" in sh_cmd
+
+    async def test_parent_of_root_level_dest(self, tmp_path):
+        from klangk.cli import sandboxcmd
+
+        src = tmp_path / "file.txt"
+        src.write_text("data")
+        config = SandboxConfig(copy=[f"{src}:/opt/file.txt"])
+        commands = []
+
+        async def fake_exec_on_ws(ws, cmd, **kwargs):
+            commands.append(cmd)
+            return 0
+
+        with patch.object(sandboxcmd, "exec_on_ws", fake_exec_on_ws):
+            await sandboxcmd.copy_sandbox_files(
+                None, config, tmp_path, "admin"
+            )
+
+        sh_cmd = commands[0][2]
+        assert "mkdir -p /opt && cat > /opt/file.txt" in sh_cmd

--- a/src/klangk/klangkc-tests/tests/test_sandbox.py
+++ b/src/klangk/klangkc-tests/tests/test_sandbox.py
@@ -340,3 +340,27 @@ class TestCopySandboxFiles:
 
         sh_cmd = commands[0][2]
         assert "mkdir -p /opt && cat > /opt/file.txt" in sh_cmd
+
+    async def test_parent_of_relative_dest_is_dot(self, tmp_path):
+        """A bare relative dest passes through build_copy_pairs
+        unexpanded (expand_container_path gets no mount_at there), so
+        its parent must be ``.`` — an empty parent makes mkdir fail
+        and the && chain silently skip the copy (#3117 review)."""
+        from klangk.cli import sandboxcmd
+
+        src = tmp_path / "file.txt"
+        src.write_text("data")
+        config = SandboxConfig(copy=[f"{src}:file.txt"])
+        commands = []
+
+        async def fake_exec_on_ws(ws, cmd, **kwargs):
+            commands.append(cmd)
+            return 0
+
+        with patch.object(sandboxcmd, "exec_on_ws", fake_exec_on_ws):
+            await sandboxcmd.copy_sandbox_files(
+                None, config, tmp_path, "admin"
+            )
+
+        sh_cmd = commands[0][2]
+        assert "mkdir -p . && cat > file.txt" in sh_cmd


### PR DESCRIPTION
## Summary

`copy_sandbox_files` derived the `mkdir -p` parent of a sandbox `copy:`
destination with the **host** `Path` flavor. The destination is a
*container* path (always POSIX), so on a Windows CLI host
`WindowsPath('/home/admin/sub dir').parent` produced backslash-flavored
parents and drive-letter semantics — the copy landed in the wrong
directory inside the container.

The parent is now derived with `posixpath.dirname`, POSIX-style
regardless of host platform. Pre-existing (the #3093 quoting fix only
wrapped the result); found in the adversarial review of #3109.

Also grepped the whole CLI package for other host-`Path` uses on
already-expanded container paths — every other `Path(...)` call operates
on host paths only (config files, UDS sockets, export archives, the
sandbox root); the sandbox path helpers in `cli/sandbox.py` build
container paths purely by string concatenation.

## Tests

Two unit tests in `TestCopySandboxFiles` (`klangkc-tests`) mock
`exec_on_ws` and pin the generated `sh -c` string: a
`~/sub dir/file.txt` destination must produce
`mkdir -p '/home/admin/sub dir' && cat > '/home/admin/sub dir/file.txt'`
(the space makes the assertion fail if anyone reverts to host-`Path`
parent derivation on backslash-flavored hosts), and an `/opt/file.txt`
destination produces the unquoted `mkdir -p /opt && cat > /opt/file.txt`.

Closes #3117.
