### PR TITLE
Document literal sandbox copy destinations (#3118)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -1618,12 +1618,12 @@ stop)`) and a `server: stop at 23:00 (in 1h 12m)` status line in the
 - **`klangk sandbox` `copy:` destinations are literal container paths
   (#3118).** Only a leading `~` is special (it expands to
   `/home/{handle}`); no other shell expansion happens — a destination
-  like `~other/file` or `$HOME/file` is written as a literal filename.
-  Before the #3093 quoting fix the container's `sh` accidentally
-  expanded such destinations; that behavior was never documented and
-  is now the removed side of the fix. Spell out the destination path
-  you want. See
-  [Sandbox](https://klangk.github.io/klangk/features/sandbox/).
+  like `~other/file` or `$HOME/file` is written as a literal filename,
+  and a relative destination resolves against the container user's
+  home, not `mount-at`. Previously such destinations were expanded by
+  accident (unquoted interpolation let the container's `sh` interpret
+  them); spell out the destination path you want. See
+  [Sandbox](https://mcdonc.github.io/klangk/features/sandbox/).
 
 - **`KLANGKD_EGRESS_CONSENT_RATE_LIMIT=0`** now means unlimited (#3083).
   Previously `0` denied every interactive consent hold (the pending cap

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -1615,6 +1615,16 @@ stop)`) and a `server: stop at 23:00 (in 1h 12m)` status line in the
 
 ### Changed
 
+- **`klangk sandbox` `copy:` destinations are literal container paths
+  (#3118).** Only a leading `~` is special (it expands to
+  `/home/{handle}`); no other shell expansion happens — a destination
+  like `~other/file` or `$HOME/file` is written as a literal filename.
+  Before the #3093 quoting fix the container's `sh` accidentally
+  expanded such destinations; that behavior was never documented and
+  is now the removed side of the fix. Spell out the destination path
+  you want. See
+  [Sandbox](https://klangk.github.io/klangk/features/sandbox/).
+
 - **`KLANGKD_EGRESS_CONSENT_RATE_LIMIT=0`** now means unlimited (#3083).
   Previously `0` denied every interactive consent hold (the pending cap
   compared `>= 0`); it now disables the per-workspace pending cap, matching

--- a/docs/features/sandbox.md
+++ b/docs/features/sandbox.md
@@ -108,10 +108,12 @@ enabled on the server (the ceiling).
 
 > **`~` and the home layout:** In `mount-at`, `copy` destinations,
 > and `mounts` destinations, `~` always expands to `/home/{handle}` —
-> your home under the per-handle layout. On a **shared-home**
-> workspace (the default) your `$HOME` is `/home/klangk`, so a `~`
-> destination mounts outside your home; use an explicit absolute
-> path (e.g. `mount-at: /home/klangk/work`) there.
+> your home under the per-handle layout — and only a leading `~` is
+> special: `~user`-style tildes and `$VAR` references are never
+> expanded anywhere. On a **shared-home** workspace (the default)
+> your `$HOME` is `/home/klangk`, so a `~` destination mounts outside
+> your home; use an explicit absolute path (e.g.
+> `mount-at: /home/klangk/work`) there.
 
 ### `copy`
 
@@ -132,9 +134,12 @@ home; tilde on the right expands to the container user's home
 
 Destinations are **literal** container paths: apart from the leading
 `~` above, nothing is shell-expanded. A destination like `~other/file`
-or `$HOME/file` is written as a file literally named `~other/file` /
-`$HOME/file` — `$HOME` refers to neither the container's nor the host's
-home directory. Spell out the path you want instead.
+or `$HOME/file` is taken literally — the copy lands in a directory
+with that literal name, not in another user's home or the container's
+`$HOME`. A relative destination (no `~` or `/` prefix) is resolved by
+the container's shell against the exec working directory — the
+container user's home — **not** against `mount-at` (unlike `mounts`
+destinations). Spell out the path you want.
 
 Copies happen once during workspace creation, after the default home
 skeleton is populated but before the setup script runs. The copied

--- a/docs/features/sandbox.md
+++ b/docs/features/sandbox.md
@@ -130,6 +130,12 @@ the left expands to the host user's
 home; tilde on the right expands to the container user's home
 (`/home/{handle}` — see the `~` note above).
 
+Destinations are **literal** container paths: apart from the leading
+`~` above, nothing is shell-expanded. A destination like `~other/file`
+or `$HOME/file` is written as a file literally named `~other/file` /
+`$HOME/file` — `$HOME` refers to neither the container's nor the host's
+home directory. Spell out the path you want instead.
+
 Copies happen once during workspace creation, after the default home
 skeleton is populated but before the setup script runs. The copied
 files become independent of the host originals — changes inside the

--- a/src/klangk/klangk/cli/sandbox.py
+++ b/src/klangk/klangk/cli/sandbox.py
@@ -110,6 +110,12 @@ def expand_container_path(
     - Absolute paths pass through unchanged
     - Relative paths are resolved against *mount_at* (which must
       already be expanded)
+
+    #3118: only the leading ``~`` is special. Any other shell-like
+    syntax — ``~user`` tildes, ``$VAR`` references — passes through
+    literally, and callers quote the result (#3093), so no
+    container-side expansion happens either: sandbox destinations
+    are literal container paths by design.
     """
     if path.startswith("~/"):
         return f"/home/{handle}/{path[2:]}"
@@ -220,7 +226,13 @@ def build_copy_pairs(
     sandbox_root: Path,
     handle: str,
 ) -> list[tuple[str, str]]:
-    """Return ``(host_path, container_path)`` pairs from the copy list."""
+    """Return ``(host_path, container_path)`` pairs from the copy list.
+
+    #3118: destinations are literal container paths — only a leading
+    ``~`` expands (via expand_container_path). A ``~user`` or ``$VAR``
+    destination passes through literally; copy_sandbox_files quotes it
+    (#3093), so the container writes it as a literal filename.
+    """
     pairs = []
     for spec in config.copy:
         src_part, dest_part = parse_copy_spec(spec)

--- a/src/klangk/klangk/cli/sandbox.py
+++ b/src/klangk/klangk/cli/sandbox.py
@@ -113,9 +113,9 @@ def expand_container_path(
 
     #3118: only the leading ``~`` is special. Any other shell-like
     syntax — ``~user`` tildes, ``$VAR`` references — passes through
-    literally, and callers quote the result (#3093), so no
-    container-side expansion happens either: sandbox destinations
-    are literal container paths by design.
+    literally; the copy path quotes the result (#3093), so no
+    container-side expansion happens there either: sandbox copy
+    destinations are literal container paths by design.
     """
     if path.startswith("~/"):
         return f"/home/{handle}/{path[2:]}"
@@ -231,7 +231,10 @@ def build_copy_pairs(
     #3118: destinations are literal container paths — only a leading
     ``~`` expands (via expand_container_path). A ``~user`` or ``$VAR``
     destination passes through literally; copy_sandbox_files quotes it
-    (#3093), so the container writes it as a literal filename.
+    (#3093), so the container writes it as a literal filename. A
+    relative destination likewise passes through unresolved — the
+    container's shell runs it against the exec working directory (the
+    container user's home), not against ``mount_at``.
     """
     pairs = []
     for spec in config.copy:

--- a/src/klangk/klangkc-tests/tests/test_cli_main.py
+++ b/src/klangk/klangkc-tests/tests/test_cli_main.py
@@ -6133,6 +6133,45 @@ class TestSandboxSetupOnly:
         assert proc.returncode == 0, proc.stderr
         assert dest.read_bytes() == b"data"
 
+    async def test_copy_dest_shell_syntax_is_literal(self, tmp_path):
+        """#3118: a `~user`/`$VAR` copy destination is written literally
+        — proven by executing the generated command under a real sh and
+        checking where the file lands. (Before #3093 the unquoted
+        interpolation let the container's sh expand such destinations.)"""
+        import subprocess
+        from pathlib import Path
+
+        from klangk.cli.main import sandbox_setup
+        from klangk.cli.sandbox import SandboxConfig
+
+        (tmp_path / "cfg.txt").write_text("data")
+        config = SandboxConfig(copy=["cfg.txt:$HOME/klangk-3118-lit"])
+
+        ws = AsyncMock()
+        exec_calls = []
+
+        async def fake_exec(ws, cmd, stdin=None, stdout=None, timeout=None):
+            exec_calls.append((cmd, stdin))
+            return 0
+
+        with patch("klangk.cli.sandboxcmd.exec_on_ws", fake_exec):
+            await sandbox_setup(ws, config, tmp_path, "admin")
+
+        ((cmd, stdin),) = exec_calls
+        assert cmd[:2] == ["sh", "-c"]
+        proc = subprocess.run(
+            cmd,
+            input=stdin.getvalue(),
+            capture_output=True,
+            timeout=30,
+            cwd=tmp_path,
+        )
+        assert proc.returncode == 0, proc.stderr
+        # The copy lands under a directory literally named "$HOME" in
+        # the exec working directory — not under the real $HOME.
+        assert (tmp_path / "$HOME" / "klangk-3118-lit").read_bytes() == b"data"
+        assert not (Path.home() / "klangk-3118-lit").exists()
+
     async def test_setup_quotes_mount_and_script(self, tmp_path):
         """#3093: mount-at and setup paths containing spaces or single
         quotes must round-trip — proven by executing the generated

--- a/src/klangk/klangkc-tests/tests/test_sandbox.py
+++ b/src/klangk/klangkc-tests/tests/test_sandbox.py
@@ -172,6 +172,17 @@ class TestExpandContainerPath:
             == "/home/admin/project/subdir"
         )
 
+    def test_other_user_tilde_is_literal(self):
+        # #3118: only the leading ~/ is special — ~other is not
+        # expanded (neither host-side nor, since #3093 quotes the
+        # destination, container-side).
+        assert expand_container_path("~other/file", "admin") == "~other/file"
+
+    def test_env_var_is_literal(self):
+        # #3118: $HOME (or any $VAR) in a destination is a literal
+        # filename, not a container environment reference.
+        assert expand_container_path("$HOME/file", "admin") == "$HOME/file"
+
 
 class TestBuildAllMounts:
     def test_implicit_sandbox_root(self, sandbox_root):
@@ -257,6 +268,13 @@ class TestBuildCopyPairs:
         config = SandboxConfig(copy=["notes.txt:~/notes.txt:ro"])
         with pytest.raises(ValueError, match="Invalid copy spec"):
             build_copy_pairs(config, sandbox_root, "admin")
+
+    def test_dest_shell_syntax_is_literal(self, sandbox_root):
+        # #3118: the old accidental container-sh expansion of
+        # destinations (~other, $HOME) is gone — quoted and literal.
+        config = SandboxConfig(copy=["~/.gitconfig:$HOME/.gitconfig"])
+        pairs = build_copy_pairs(config, sandbox_root, "admin")
+        assert pairs[0][1] == "$HOME/.gitconfig"
 
 
 class TestExpandSpec:


### PR DESCRIPTION
Closes #3118.

## What

Decides and documents the semantics of `.klangk-sandbox.yaml` `copy:`
destinations after #3093/#3109 made them shell-quoted: they are
**literal container paths** — option 1 of the issue.

- Only a leading `~` / `~/` is special (expanded host-side to
  `/home/{handle}` by `expand_container_path`); absolute paths pass
  through; everything else is literal.
- `~other/file` or `$HOME/file` destinations are written as literal
  filenames — no tilde, parameter, or any other shell expansion happens
  host-side, and the `shlex.quote` from #3093 means the container's
  `sh` performs none either.

## Why option 1 (not deliberate expansion)

Option 2 — expanding `~user` and env vars host-side — cannot be done
correctly: the client has no knowledge of the container's `$HOME` or
other users' homes (`~other` requires the container's `/etc/passwd`),
and the *host's* `$HOME` is the wrong home. The old expansion was an
accident of unquoted interpolation, never documented; literal is
predictable and honest about what the client can know.

## Changes

- `docs/features/sandbox.md` — new paragraph in the `copy:` section
  stating the literal semantics.
- `src/klangk/klangk/cli/sandbox.py` — `expand_container_path` and
  `build_copy_pairs` docstrings now state the decision.
- `src/klangk/klangkc-tests/tests/test_sandbox.py` — tests pinning
  that `~other/…` and `$HOME/…` destinations stay literal through both
  the helper and `build_copy_pairs`.
- `docs/changes.md` — Changed entry (the behavior delta the #3109
  adversarial review flagged as missing from the changelog).
