### PR TITLE
Degrade gracefully on corrupt klangk-state.yaml (#3111)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -1985,6 +1985,15 @@ git-credential` (#1700).** `pig-latin` removed; `word-count` dormant.
   prints the spawn error and exits nonzero; socket-level errors still
   reconnect as before.
 
+- **Corrupt `klangk-state.yaml` no longer bricks the CLI (#3111).** A
+  state file that is valid YAML but not a mapping, or not valid YAML at
+  all, is now treated as an empty state — commands run unauthenticated
+  and `klangk login` works as the repair flow instead of crashing with
+  `AttributeError`/`yaml.YAMLError`. An unparseable `klangk.yaml` gets
+  the same treatment (empty config + a one-line warning). The state
+  file is also written atomically now, so an interrupted save (crash,
+  kill, full disk) can no longer leave it truncated in the first place.
+
 - **Workspace name minimum length is enforced (#3110).** The API now
   rejects empty and whitespace-only workspace names on create, rename,
   duplicate, and import (422 on the JSON bodies, 400 on the import

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -1986,13 +1986,14 @@ git-credential` (#1700).** `pig-latin` removed; `word-count` dormant.
   reconnect as before.
 
 - **Corrupt `klangk-state.yaml` no longer bricks the CLI (#3111).** A
-  state file that is valid YAML but not a mapping, or not valid YAML at
-  all, is now treated as an empty state — commands run unauthenticated
-  and `klangk login` works as the repair flow instead of crashing with
-  `AttributeError`/`yaml.YAMLError`. An unparseable `klangk.yaml` gets
-  the same treatment (empty config + a one-line warning). The state
-  file is also written atomically now, so an interrupted save (crash,
-  kill, full disk) can no longer leave it truncated in the first place.
+  state or config file that is not a mapping, not parseable, or not
+  valid UTF-8 now degrades to an empty document (with a one-line
+  warning) instead of crashing every command — `klangk login` works as
+  the repair flow. The state file and the managed `klangk.yaml` writes
+  are atomic now, so an interrupted write can no longer leave a
+  truncated file; and an add-server that would rewrite an unparseable
+  `klangk.yaml` is refused with a clear message instead of silently
+  discarding its contents.
 
 - **Workspace name minimum length is enforced (#3110).** The API now
   rejects empty and whitespace-only workspace names on create, rename,

--- a/src/klangk/klangk/cli/config.py
+++ b/src/klangk/klangk/cli/config.py
@@ -14,8 +14,11 @@ user tokens, the server's is GB-scale DBs + UDS). See #1646.
 from __future__ import annotations
 
 
+import contextlib
+import logging
 import os
 import shlex
+import tempfile
 import yaml
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -288,12 +291,35 @@ def load_yaml_config() -> dict:
     mapping (a stray list, a bare string) must not crash every CLI
     command with ``AttributeError`` — it degrades to an empty config
     (#3094), the same degrade-not-crash rule as a bad
-    ``terminal-open-cmd`` (#2685).
+    ``terminal-open-cmd`` (#2685). An *unparseable* document (YAML
+    syntax error) degrades the same way, with a one-line warning so the
+    user learns the file was ignored (#3111).
     """
     if not CONFIG_PATH.exists():
         return {}
-    data = yaml.safe_load(CONFIG_PATH.read_text())
+    data = _safe_load_yaml(CONFIG_PATH)
     return data if isinstance(data, dict) else {}
+
+
+def _safe_load_yaml(path: Path):
+    """``yaml.safe_load`` for a user-facing file (None on parse error).
+
+    A YAML syntax error must not crash every CLI command with a raw
+    ``yaml.YAMLError`` traceback (#3111) — it degrades to an empty
+    document (None, which the callers coerce to ``{}``), with a
+    one-line warning routed through the logging last-resort handler
+    (stderr) so the user learns the file was ignored.
+    """
+    try:
+        return yaml.safe_load(path.read_text())
+    except yaml.YAMLError as exc:
+        detail = " ".join(str(exc).split())
+        logging.getLogger(__name__).warning(
+            "%s: YAML parse error ignored, treating as empty: %s",
+            path.name,
+            detail,
+        )
+        return None
 
 
 def add_server_to_config(
@@ -392,6 +418,42 @@ def remove_server_from_config(alias: str) -> bool:
     return True
 
 
+def load_yaml_state() -> dict:
+    """The parsed klangk-state.yaml (empty when absent or not a mapping).
+
+    klangk-state.yaml is written by ``CLIState.save()`` and never
+    hand-edited — but corruption is realistic (an interrupted write, a
+    stray edit): a document that is valid YAML but not a mapping, or
+    not valid YAML at all, must not crash every CLI command — it
+    degrades to an empty state so commands run unauthenticated and
+    ``klangk login`` works as the repair flow (#3111).
+    """
+    if not STATE_PATH.exists():
+        return {}
+    data = _safe_load_yaml(STATE_PATH)
+    return data if isinstance(data, dict) else {}
+
+
+def _atomic_write(path: Path, content: str) -> None:
+    """Atomically replace *path* with *content* (mode 0600).
+
+    Writes to a temp file in the same directory, then ``os.replace`` —
+    an interrupted write (crash, kill, full disk) can only lose the
+    temp file, never leave a truncated state file behind (#3111).
+    """
+    path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+    fd, tmp = tempfile.mkstemp(dir=path.parent, prefix=path.name)
+    try:
+        with os.fdopen(fd, "w") as out:
+            out.write(content)
+        os.chmod(tmp, 0o600)
+        os.replace(tmp, path)
+    except BaseException:
+        with contextlib.suppress(OSError):
+            os.unlink(tmp)
+        raise
+
+
 @dataclass
 class UserEntry:
     """Per-user credentials within a server in klangk-state.yaml."""
@@ -455,17 +517,13 @@ class CLIState:
 
     @classmethod
     def load(cls) -> CLIState:
-        if not STATE_PATH.exists():
-            return cls()
-        text = STATE_PATH.read_text()
-        data = yaml.safe_load(text) or {}
+        data = load_yaml_state()
         return cls(
             active_server=data.get("active-server"),
             servers=parse_server_states(data),
         )
 
     def save(self) -> None:
-        STATE_PATH.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
         data: dict = {}
         if self.active_server is not None:
             data["active-server"] = self.active_server
@@ -473,9 +531,7 @@ class CLIState:
             server_data = server_state_data(ss)
             if server_data:
                 data[url] = server_data
-        content = yaml.dump(data, default_flow_style=False)
-        STATE_PATH.write_text(content)
-        os.chmod(STATE_PATH, 0o600)
+        _atomic_write(STATE_PATH, yaml.dump(data, default_flow_style=False))
 
     def get_token(self, server_url: str) -> str | None:
         """Return the token for the active user on a server."""

--- a/src/klangk/klangk/cli/config.py
+++ b/src/klangk/klangk/cli/config.py
@@ -252,8 +252,7 @@ def ensure_config() -> None:
         "# See docs/features/ssh-agent-forwarding.md.\n"
         "forward-agent: true\n\n"
     )
-    CONFIG_PATH.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
-    CONFIG_PATH.write_text(header + "servers: {}\n")
+    _write_config_text(header + "servers: {}\n")
 
 
 def seed_config(server_url: str, user: str | None = None) -> None:
@@ -280,8 +279,7 @@ def seed_config(server_url: str, user: str | None = None) -> None:
         "# See docs/features/ssh-agent-forwarding.md.\n"
         "forward-agent: true\n\n"
     )
-    CONFIG_PATH.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
-    CONFIG_PATH.write_text(header + servers_yaml)
+    _write_config_text(header + servers_yaml)
 
 
 def load_yaml_config() -> dict:
@@ -292,33 +290,68 @@ def load_yaml_config() -> dict:
     command with ``AttributeError`` — it degrades to an empty config
     (#3094), the same degrade-not-crash rule as a bad
     ``terminal-open-cmd`` (#2685). An *unparseable* document (YAML
-    syntax error) degrades the same way, with a one-line warning so the
-    user learns the file was ignored (#3111).
+    syntax error, non-UTF-8 bytes) degrades the same way, with a
+    one-line warning so the user learns the file was ignored (#3111).
+    """
+    data, _ok = _load_config_doc()
+    return data
+
+
+def _load_config_doc() -> tuple[dict, bool]:
+    """The parsed klangk.yaml plus whether the on-disk file was usable.
+
+    The bool is False only when the file exists but could not be parsed
+    (syntax error, non-UTF-8 bytes). Read-only callers ignore it and
+    degrade to ``{}``; the config *writers* use it to refuse rewriting
+    a file whose content may still be hand-repairable — a ``{}`` read
+    followed by a write would discard it silently (#3111). A document
+    that parses but is not a mapping carries no recoverable content,
+    so writers may normalize it by rewriting (#3094).
     """
     if not CONFIG_PATH.exists():
-        return {}
+        return {}, True
     data = _safe_load_yaml(CONFIG_PATH)
-    return data if isinstance(data, dict) else {}
+    if data is None:
+        return {}, False
+    if isinstance(data, dict):
+        return data, True
+    _warn_corrupt(CONFIG_PATH, "document is not a mapping")
+    return {}, True
+
+
+_CORRUPT_WARNED: set[Path] = set()
+
+
+def _warn_corrupt(path: Path, reason: str) -> None:
+    """One flattened warning line, once per file per process.
+
+    Routed through the logging last-resort handler (stderr; the CLI
+    never configures logging). Once-per-process because the TUI
+    reloads klangk.yaml on every ``cfg()`` call — per-call warnings
+    would spam the terminal (#3111).
+    """
+    if path in _CORRUPT_WARNED:
+        return
+    _CORRUPT_WARNED.add(path)
+    logging.getLogger(__name__).warning(
+        "%s: %s — treating as empty", path.name, reason
+    )
 
 
 def _safe_load_yaml(path: Path):
-    """``yaml.safe_load`` for a user-facing file (None on parse error).
+    """``yaml.safe_load`` for a user-facing file (None on parse failure).
 
-    A YAML syntax error must not crash every CLI command with a raw
-    ``yaml.YAMLError`` traceback (#3111) — it degrades to an empty
-    document (None, which the callers coerce to ``{}``), with a
-    one-line warning routed through the logging last-resort handler
-    (stderr) so the user learns the file was ignored.
+    Any parse failure must not crash every CLI command with a raw
+    traceback (#3111) — a YAML syntax error *or* bytes that are not
+    UTF-8 (a torn multi-byte sequence where an interrupted write
+    truncated the file). It degrades to an empty document (None, which
+    the callers coerce to ``{}``) with a one-line warning.
     """
     try:
         return yaml.safe_load(path.read_text())
-    except yaml.YAMLError as exc:
+    except (yaml.YAMLError, UnicodeDecodeError) as exc:
         detail = " ".join(str(exc).split())
-        logging.getLogger(__name__).warning(
-            "%s: YAML parse error ignored, treating as empty: %s",
-            path.name,
-            detail,
-        )
+        _warn_corrupt(path, f"parse error ignored ({detail})")
         return None
 
 
@@ -333,11 +366,18 @@ def add_server_to_config(
     remains user-owned; this is the one managed write, used only by the
     TUI's add-server flow.
 
-    Raises ``AliasConflictError`` if *alias* already exists — callers
-    must catch the error and surface it to the user (#1763).
+    Raises ``AliasConflictError`` if *alias* already exists, and
+    ``ConfigUnreadableError`` when klangk.yaml exists but can't be
+    parsed — rewriting from the degraded empty config would discard
+    the (potentially hand-repairable) file. Callers must catch both
+    and surface the error to the user (#1763, #3111).
     """
-    CONFIG_PATH.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
-    data = load_yaml_config()
+    data, ok = _load_config_doc()
+    if not ok:
+        raise ConfigUnreadableError(
+            "klangk.yaml is unreadable (corrupt or not valid YAML) — "
+            "fix or remove it, then retry."
+        )
     servers = data.get("servers") or {}
     if alias in servers:
         raise AliasConflictError(f"Alias '{alias}' already exists.")
@@ -346,11 +386,20 @@ def add_server_to_config(
         entry["user"] = user
     servers[alias] = entry
     data["servers"] = servers
-    CONFIG_PATH.write_text(yaml.dump(data, default_flow_style=False))
+    _write_config_text(yaml.dump(data, default_flow_style=False))
 
 
 class AliasConflictError(Exception):
     """Raised when renaming a server alias to one that already exists."""
+
+
+class ConfigUnreadableError(Exception):
+    """Raised when klangk.yaml exists but cannot be parsed into a mapping.
+
+    Managed writes refuse to proceed in that case: the file's content
+    may be hand-repairable, and rewriting from the degraded empty
+    config would silently discard it (#3111).
+    """
 
 
 def check_alias_renaming(
@@ -380,13 +429,15 @@ def update_server_in_config(
     """Update an existing server entry in klangk.yaml.
 
     If *old_alias* differs from *new_alias* the entry is renamed.
-    Returns True if the alias was found and updated, False otherwise.
+    Returns True if the alias was found and updated, False otherwise
+    (also when klangk.yaml can't be parsed — an unreadable file is
+    left untouched rather than rewritten from an empty config, #3111).
     Raises ``AliasConflictError`` if *new_alias* already exists under
     a different key.
     """
-    if not CONFIG_PATH.exists():
+    data, ok = _load_config_doc()
+    if not ok:
         return False
-    data = load_yaml_config()
     servers = data.get("servers") or {}
     if old_alias not in servers:
         return False
@@ -396,25 +447,28 @@ def update_server_in_config(
         del servers[old_alias]
     servers[new_alias] = entry
     data["servers"] = servers
-    CONFIG_PATH.write_text(yaml.dump(data, default_flow_style=False))
+    _write_config_text(yaml.dump(data, default_flow_style=False))
     return True
 
 
 def remove_server_from_config(alias: str) -> bool:
     """Remove a named server entry from klangk.yaml.
 
-    Returns True if the alias was present and removed, False otherwise.
-    The counterpart to ``add_server_to_config`` (TUI delete-server flow).
+    Returns True if the alias was present and removed, False otherwise
+    (also when klangk.yaml can't be parsed — an unreadable file is
+    left untouched rather than rewritten from an empty config, #3111).
+    The counterpart to ``add_server_to_config`` (TUI delete-server
+    flow).
     """
-    if not CONFIG_PATH.exists():
+    data, ok = _load_config_doc()
+    if not ok:
         return False
-    data = load_yaml_config()
     servers = data.get("servers") or {}
     if alias not in servers:
         return False
     del servers[alias]
     data["servers"] = servers
-    CONFIG_PATH.write_text(yaml.dump(data, default_flow_style=False))
+    _write_config_text(yaml.dump(data, default_flow_style=False))
     return True
 
 
@@ -424,34 +478,62 @@ def load_yaml_state() -> dict:
     klangk-state.yaml is written by ``CLIState.save()`` and never
     hand-edited — but corruption is realistic (an interrupted write, a
     stray edit): a document that is valid YAML but not a mapping, or
-    not valid YAML at all, must not crash every CLI command — it
-    degrades to an empty state so commands run unauthenticated and
-    ``klangk login`` works as the repair flow (#3111).
+    not parseable at all (syntax error, non-UTF-8 bytes), must not
+    crash every CLI command — it degrades to an empty state so
+    commands run unauthenticated and ``klangk login`` works as the
+    repair flow (#3111).
     """
     if not STATE_PATH.exists():
         return {}
     data = _safe_load_yaml(STATE_PATH)
-    return data if isinstance(data, dict) else {}
+    if data is None:
+        return {}
+    if isinstance(data, dict):
+        return data
+    _warn_corrupt(STATE_PATH, "document is not a mapping")
+    return {}
 
 
-def _atomic_write(path: Path, content: str) -> None:
-    """Atomically replace *path* with *content* (mode 0600).
+def _atomic_write(path: Path, content: str, mode: int) -> None:
+    """Atomically replace *path* with *content* (permission *mode*).
 
     Writes to a temp file in the same directory, then ``os.replace`` —
-    an interrupted write (crash, kill, full disk) can only lose the
-    temp file, never leave a truncated state file behind (#3111).
+    an interrupted write (process crash, kill, full disk) can only lose
+    the temp file, never leave a truncated target behind (#3111).
     """
     path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
     fd, tmp = tempfile.mkstemp(dir=path.parent, prefix=path.name)
     try:
         with os.fdopen(fd, "w") as out:
             out.write(content)
-        os.chmod(tmp, 0o600)
+        os.chmod(tmp, mode)
         os.replace(tmp, path)
     except BaseException:
         with contextlib.suppress(OSError):
             os.unlink(tmp)
         raise
+
+
+def _existing_mode(path: Path, default: int) -> int:
+    """The file's permission bits, or *default* when it doesn't exist.
+
+    klangk.yaml is user-owned: a managed write preserves whatever mode
+    the user chose instead of forcing one (#3111 review).
+    """
+    try:
+        return path.stat().st_mode & 0o777
+    except OSError:
+        return default
+
+
+def _write_config_text(text: str) -> None:
+    """Atomically write klangk.yaml, preserving an existing file's mode.
+
+    The config-file counterpart of ``CLIState.save()``'s atomic write:
+    an interrupted managed write must not truncate the user's config
+    (#3111 review).
+    """
+    _atomic_write(CONFIG_PATH, text, _existing_mode(CONFIG_PATH, 0o644))
 
 
 @dataclass
@@ -531,7 +613,11 @@ class CLIState:
             server_data = server_state_data(ss)
             if server_data:
                 data[url] = server_data
-        _atomic_write(STATE_PATH, yaml.dump(data, default_flow_style=False))
+        _atomic_write(
+            STATE_PATH,
+            yaml.dump(data, default_flow_style=False),
+            0o600,
+        )
 
     def get_token(self, server_url: str) -> str | None:
         """Return the token for the active user on a server."""

--- a/src/klangk/klangk/cli/tui/screens/login.py
+++ b/src/klangk/klangk/cli/tui/screens/login.py
@@ -21,7 +21,7 @@ from textual.widgets import (
 )
 
 from ..state import LoginError
-from ...config import AliasConflictError
+from ...config import AliasConflictError, ConfigUnreadableError
 from ...transport import is_valid_server_spec
 from .base import (
     ConfirmScreen,
@@ -227,7 +227,7 @@ class LoginScreen(SpatialNavScreen, StatusScreen):
                         alias,
                         raw,
                     )
-                except AliasConflictError as exc:
+                except (AliasConflictError, ConfigUnreadableError) as exc:
                     self._set_message(str(exc), error=True)
                     return
         else:

--- a/src/klangk/klangk/cli/tui/screens/server.py
+++ b/src/klangk/klangk/cli/tui/screens/server.py
@@ -20,7 +20,7 @@ from textual.widgets import (
     Static,
 )
 
-from ...config import AliasConflictError
+from ...config import AliasConflictError, ConfigUnreadableError
 from ...transport import is_valid_server_spec
 from .base import (
     ConfirmScreen,
@@ -224,6 +224,10 @@ class AddServerScreen(StatusScreen):
                     style="red",
                 )
             )
+            return
+        except ConfigUnreadableError as exc:
+            msg = self.query_one("#add_msg", Static)
+            msg.update(Text(str(exc), style="red"))
             return
         self.app.server_changed()
 

--- a/src/klangk/klangkc-tests/tests/test_cli.py
+++ b/src/klangk/klangkc-tests/tests/test_cli.py
@@ -162,6 +162,21 @@ class TestCLIConfig:
         assert cfg.forward_agent is None
         assert "parse error" in caplog.text
 
+    def test_load_non_utf8_yaml_degrades_to_empty(
+        self, tmp_path, monkeypatch, caplog
+    ):
+        """Non-UTF-8 bytes (a torn multi-byte sequence where an
+        interrupted write truncated the file) must not crash every CLI
+        command with a raw UnicodeDecodeError traceback either (#3111)."""
+        config_path = tmp_path / "klangk.yaml"
+        config_path.write_bytes(b"forward-agent: \xff\xfe\ntok")
+        monkeypatch.setattr("klangk.cli.config.CONFIG_PATH", config_path)
+        with caplog.at_level("WARNING"):
+            cfg = CLIConfig.load()
+        assert cfg.servers == {}
+        assert cfg.forward_agent is None
+        assert "parse error" in caplog.text
+
     def test_resolve_server_alias(self):
         cfg = CLIConfig(
             servers={
@@ -510,6 +525,21 @@ class TestCLIState:
         assert state.servers == {}
         assert "parse error" in caplog.text
 
+    def test_load_non_utf8_state_degrades_to_empty(
+        self, tmp_path, monkeypatch, caplog
+    ):
+        """Non-UTF-8 bytes in the state file must not brick the CLI with
+        a raw UnicodeDecodeError traceback — it degrades to an empty
+        state so klangk login works as the repair flow (#3111)."""
+        state_path = tmp_path / "klangk-state.yaml"
+        state_path.write_bytes(b"active-server: http://\xff\xfe\n")
+        monkeypatch.setattr("klangk.cli.config.STATE_PATH", state_path)
+        with caplog.at_level("WARNING"):
+            state = CLIState.load()
+        assert state.active_server is None
+        assert state.servers == {}
+        assert "parse error" in caplog.text
+
     def test_load_skips_non_dict_values(self, tmp_path, monkeypatch):
         state_path = tmp_path / "klangk-state.yaml"
         state_path.write_text(
@@ -739,9 +769,9 @@ class TestAuth:
 
     def test_login_recovers_from_corrupt_state(self, tmp_path, monkeypatch):
         """klangk login is the repair flow for a corrupt klangk-state.yaml
-        — it must not crash with AttributeError/YAMLError on a non-mapping
-        or unparseable document, and must overwrite it with valid state
-        (#3111)."""
+        — it must not crash with AttributeError/YAMLError/
+        UnicodeDecodeError on a non-mapping, unparseable, or non-UTF-8
+        document, and must overwrite it with valid state (#3111)."""
         state_path = tmp_path / "klangk-state.yaml"
         monkeypatch.setattr("klangk.cli.config.STATE_PATH", state_path)
         mock_resp = MagicMock()
@@ -749,8 +779,16 @@ class TestAuth:
         mock_resp.json.return_value = {"access_token": "jwt-fixed"}
         from klangk.cli import auth
 
-        for bad in ("- oops\n", "active-server: [unclosed\n"):
-            state_path.write_text(bad)
+        corruptions = (
+            "- oops\n",
+            "active-server: [unclosed\n",
+            b"active-server: http://\xff\xfe\n",
+        )
+        for bad in corruptions:
+            if isinstance(bad, bytes):
+                state_path.write_bytes(bad)
+            else:
+                state_path.write_text(bad)
             with patch(
                 "klangk.cli.transport.httpx.request", return_value=mock_resp
             ):

--- a/src/klangk/klangkc-tests/tests/test_cli.py
+++ b/src/klangk/klangkc-tests/tests/test_cli.py
@@ -147,6 +147,21 @@ class TestCLIConfig:
         monkeypatch.setattr("klangk.cli.config.CONFIG_PATH", config_path)
         assert load_yaml_config() == {}
 
+    def test_load_unparseable_yaml_degrades_to_empty(
+        self, tmp_path, monkeypatch, caplog
+    ):
+        """A YAML syntax error (not just a non-mapping document) must
+        not crash every CLI command with a raw yaml.YAMLError traceback
+        — it degrades to an empty config with a one-line warning (#3111)."""
+        config_path = tmp_path / "klangk.yaml"
+        config_path.write_text("servers: [unclosed\n")
+        monkeypatch.setattr("klangk.cli.config.CONFIG_PATH", config_path)
+        with caplog.at_level("WARNING"):
+            cfg = CLIConfig.load()
+        assert cfg.servers == {}
+        assert cfg.forward_agent is None
+        assert "parse error" in caplog.text
+
     def test_resolve_server_alias(self):
         cfg = CLIConfig(
             servers={
@@ -465,6 +480,36 @@ class TestCLIState:
         assert state.active_server is None
         assert state.servers == {}
 
+    def test_load_non_mapping_yaml_degrades_to_empty(
+        self, tmp_path, monkeypatch
+    ):
+        """A valid-YAML-but-not-a-mapping state document must not brick
+        every CLI command (klangk login included) with AttributeError —
+        it degrades to an empty state so the user can re-login (#3111)."""
+        for bad in ("- oops\n", "just a string\n", "42\n"):
+            state_path = tmp_path / "klangk-state.yaml"
+            state_path.write_text(bad)
+            monkeypatch.setattr("klangk.cli.config.STATE_PATH", state_path)
+            state = CLIState.load()
+            assert state.active_server is None
+            assert state.servers == {}
+
+    def test_load_unparseable_yaml_degrades_to_empty(
+        self, tmp_path, monkeypatch, caplog
+    ):
+        """A YAML syntax error in the state file must not brick the CLI
+        either — it degrades to an empty state (one-line warning) so
+        commands run unauthenticated and klangk login works as the
+        repair flow (#3111)."""
+        state_path = tmp_path / "klangk-state.yaml"
+        state_path.write_text("active-server: [unclosed\n")
+        monkeypatch.setattr("klangk.cli.config.STATE_PATH", state_path)
+        with caplog.at_level("WARNING"):
+            state = CLIState.load()
+        assert state.active_server is None
+        assert state.servers == {}
+        assert "parse error" in caplog.text
+
     def test_load_skips_non_dict_values(self, tmp_path, monkeypatch):
         state_path = tmp_path / "klangk-state.yaml"
         state_path.write_text(
@@ -491,6 +536,41 @@ class TestCLIState:
         assert loaded.active_server == "http://test:8995"
         assert loaded.get_token("http://test:8995") == "tok"
         assert loaded.get_email("http://test:8995") == "a@b.com"
+
+    def test_save_is_atomic_keeps_old_file_on_failure(
+        self, tmp_path, monkeypatch
+    ):
+        """An interrupted save (crash, kill, full disk) must never
+        truncate the existing state file — only the temp file is lost
+        (#3111)."""
+        import yaml
+
+        state_path = tmp_path / "klangk-state.yaml"
+        state_path.write_text("active-server: http://old:8995\n")
+        monkeypatch.setattr("klangk.cli.config.STATE_PATH", state_path)
+
+        def failing_replace(src, dst):
+            raise OSError("disk full")
+
+        monkeypatch.setattr("klangk.cli.config.os.replace", failing_replace)
+        state = CLIState()
+        state.set_credentials("http://new:8995", "u@t.com", "tok")
+        with pytest.raises(OSError):
+            state.save()
+        data = yaml.safe_load(state_path.read_text())
+        assert data["active-server"] == "http://old:8995"
+        # No temp file lingers next to the state file.
+        assert list(state_path.parent.iterdir()) == [state_path]
+
+    def test_save_leaves_no_temp_file(self, tmp_path, monkeypatch):
+        """A successful save replaces the file via rename — no temp
+        residue in the state dir (#3111)."""
+        state_path = tmp_path / "klangk-state.yaml"
+        monkeypatch.setattr("klangk.cli.config.STATE_PATH", state_path)
+        state = CLIState()
+        state.set_credentials("http://test:8995", "u@t.com", "tok")
+        state.save()
+        assert list(state_path.parent.iterdir()) == [state_path]
 
     def test_save_creates_parent_dirs(self, tmp_path, monkeypatch):
         state_path = tmp_path / "sub" / "dir" / "klangk-state.yaml"
@@ -656,6 +736,32 @@ class TestAuth:
         assert state.get_token("http://localhost:8995") == "jwt123"
         assert state.get_email("http://localhost:8995") == "u@test.com"
         assert state.active_server == "http://localhost:8995"
+
+    def test_login_recovers_from_corrupt_state(self, tmp_path, monkeypatch):
+        """klangk login is the repair flow for a corrupt klangk-state.yaml
+        — it must not crash with AttributeError/YAMLError on a non-mapping
+        or unparseable document, and must overwrite it with valid state
+        (#3111)."""
+        state_path = tmp_path / "klangk-state.yaml"
+        monkeypatch.setattr("klangk.cli.config.STATE_PATH", state_path)
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = {"access_token": "jwt-fixed"}
+        from klangk.cli import auth
+
+        for bad in ("- oops\n", "active-server: [unclosed\n"):
+            state_path.write_text(bad)
+            with patch(
+                "klangk.cli.transport.httpx.request", return_value=mock_resp
+            ):
+                with patch(
+                    "klangk.cli.auth.Prompt.ask",
+                    side_effect=["u@test.com", "pass123"],
+                ):
+                    auth.login("http://localhost:8995")
+            state = CLIState.load()
+            assert state.get_token("http://localhost:8995") == "jwt-fixed"
+            assert state.active_server == "http://localhost:8995"
 
     def test_login_with_user_flag(self, tmp_path, monkeypatch):
         state_path = tmp_path / "klangk-state.yaml"

--- a/src/klangk/klangkc-tests/tests/test_tui.py
+++ b/src/klangk/klangkc-tests/tests/test_tui.py
@@ -49,6 +49,7 @@ from klangk.cli.config import (
     AliasConflictError,
     CLIConfig,
     CLIState,
+    ConfigUnreadableError,
     ServerEntry,
     add_server_to_config,
     remove_server_from_config,
@@ -379,6 +380,37 @@ def test_config_flows_survive_non_mapping_file(redirect_xdg):
     assert update_server_in_config("a", "a", "https://a.example") is False
     add_server_to_config("a", "https://a.example")
     assert CLIConfig.load().servers["a"].url == "https://a.example"
+
+
+def test_add_server_refuses_unparseable_config(redirect_xdg):
+    """An unparseable klangk.yaml may hold hand-repairable content —
+    add must refuse instead of rewriting the whole file from the
+    degraded empty config (#3111)."""
+    cpath, _ = redirect_xdg
+    cpath.write_text("servers: [unclosed\n")
+    with pytest.raises(ConfigUnreadableError, match="unreadable"):
+        add_server_to_config("a", "https://a.example")
+    assert cpath.read_text() == "servers: [unclosed\n"
+
+
+def test_update_remove_noop_on_unparseable_config(redirect_xdg):
+    """update/remove on an unparseable klangk.yaml leave the file
+    untouched (False), not rewritten from an empty config (#3111)."""
+    cpath, _ = redirect_xdg
+    cpath.write_bytes(b"servers: [x, \xff\n")
+    assert update_server_in_config("a", "a", "https://a.example") is False
+    assert remove_server_from_config("a") is False
+    assert cpath.read_bytes() == b"servers: [x, \xff\n"
+
+
+def test_managed_config_write_preserves_mode(redirect_xdg):
+    """A managed klangk.yaml write keeps the file's existing mode
+    instead of forcing one (#3111 review)."""
+    cpath, _ = redirect_xdg
+    add_server_to_config("a", "https://a.example")
+    cpath.chmod(0o600)
+    assert update_server_in_config("a", "a", "https://a2.example") is True
+    assert oct(cpath.stat().st_mode & 0o777) == oct(0o600)
 
 
 def test_update_server_in_config(redirect_xdg):
@@ -11477,6 +11509,38 @@ async def test_login_choose_server_duplicate_alias(monkeypatch):
         assert "already exists" in rendered
 
 
+async def test_login_choose_server_unreadable_config(monkeypatch):
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr_main, "listen_for_status", noop)
+
+    def _raise_unreadable(alias, url, user=None):
+        raise ConfigUnreadableError(
+            "klangk.yaml is unreadable (corrupt or not valid YAML) — "
+            "fix or remove it, then retry."
+        )
+
+    st = _st(
+        current_url=lambda: None,
+        known_servers=lambda: [],
+        default_uds=lambda: None,
+        cfg=lambda: CLIConfig(),
+        auth_mode=lambda: "password",
+        email=lambda: None,
+        token=lambda: None,
+        is_authenticated=lambda: False,
+        add_server=_raise_unreadable,
+    )
+    app = KlangkApp(st)
+    async with app.run_test() as _pilot:
+        login = app.screen
+        login._choose_server("https://dup.example")
+        await app.workers.wait_for_complete()
+        rendered = str(login.query_one("#message").render()).lower()
+        assert "unreadable" in rendered
+
+
 async def test_login_url_switches_to_existing_alias(monkeypatch):
     """Entering a URL whose derived alias already exists switches to it (#1849)."""
 
@@ -11589,6 +11653,33 @@ async def test_add_server_rejects_duplicate_alias_screen(monkeypatch):
         await app.workers.wait_for_complete()
         rendered = str(s.query_one("#add_msg").render()).lower()
         assert "already exists" in rendered
+
+
+async def test_add_server_unreadable_config_screen(monkeypatch):
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr_main, "listen_for_status", noop)
+
+    def _raise_unreadable(alias, url, user=None):
+        raise ConfigUnreadableError(
+            "klangk.yaml is unreadable (corrupt or not valid YAML) — "
+            "fix or remove it, then retry."
+        )
+
+    st = _authed_state(add_server=_raise_unreadable)
+    app = KlangkApp(st)
+    async with app.run_test() as pilot:
+        app.push_screen(AddServerScreen())
+        await pilot.pause()
+        s = app.screen
+        s.query_one("#alias", Input).value = "prod"
+        s.query_one("#url", Input).value = "https://prod.example"
+        s._add()
+        await app.workers.wait_for_complete()
+        rendered = str(s.query_one("#add_msg").render()).lower()
+        assert "unreadable" in rendered
+        assert "fix or remove" in rendered
 
 
 async def test_confirm_screen(monkeypatch):


### PR DESCRIPTION
## Summary

Fixes #3111.

A `klangk-state.yaml` that is valid YAML but not a mapping (a stray list, a
bare string, a number) crashed **every** CLI command — including
`klangk login`, the natural repair flow — with
`AttributeError: 'list' object has no attribute 'get'`. The state file is
written by the CLI itself, and `CLIState.save()` used a non-atomic
`write_text`, so an interrupted write (crash, kill, full disk) could
produce exactly that kind of corruption with no user error at all.

## Changes

- **`CLIState.load()` now goes through `load_yaml_state()`**, the state-file
  counterpart of `load_yaml_config()` (#3094): a document that is valid YAML
  but not a mapping degrades to an empty state, so commands run
  unauthenticated and `klangk login` works as the repair flow.
- **Every parse failure degrades** (both `klangk.yaml` and
  `klangk-state.yaml`), via a shared `_safe_load_yaml()` reader: a YAML
  syntax error *or* non-UTF-8 bytes (a torn multi-byte sequence at a
  truncation point) degrade to an empty document plus a one-line warning —
  once per file per process, so the TUI's per-reload config reads can't
  spam. Previously an unparseable `klangk.yaml` crashed every command with
  a raw `yaml.YAMLError` traceback. A non-mapping document warns too,
  instead of degrading silently.
- **Writes are atomic**: `CLIState.save()` and the managed `klangk.yaml`
  writers (ensure/seed/add/update/remove) write to a `mkstemp` temp file
  in the same directory, then `os.replace` — an interrupted write can only
  lose the temp file, never leave a truncated target. Managed `klangk.yaml`
  writes preserve the file's existing mode; the state file stays `0600`.
- **No silent config wipe**: `add_server_to_config()` refuses to rewrite an
  unparseable `klangk.yaml` (`ConfigUnreadableError`, surfaced in both TUI
  add-server screens — update/remove leave the file untouched) instead of
  rewriting it from the degraded empty config. A document that parses but
  isn't a mapping is still normalized by the rewrite (#3094 behavior,
  preserved and tested).

## Verification

- New unit tests: non-mapping / unparseable / non-UTF-8 documents degrade to
  empty with the warning (config, state, and the `login()` recovery flow —
  the issue's exact repro); a failing `os.replace` leaves the old state file
  byte-identical with no temp residue; add/update/remove refuse (file
  untouched) on an unparseable config; a managed write preserves the
  existing mode; both TUI screens surface `ConfigUnreadableError`.
- Full suite green the CI way (`-n auto`, 100% branch coverage), xenon rank
  A, all pre-commit hooks.
- Manual before/after with the real binary: pre-fix, `klangk ls` with
  `- oops` in the state file crashes with the `AttributeError` traceback;
  post-fix it prints `No server configured — run klangk login … first` and
  exits 1, and corrupt files additionally print the one-line
  `… parse error ignored (…) — treating as empty` warning.

## Changelog

`docs/changes.md` entry added under `[Unreleased] → Fixed`.
