### PR TITLE
Grant the members group create-workspace by default (#3137)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -32,6 +32,19 @@ operators or integrators to act when upgrading.
 
 ### Breaking
 
+- **Members can create workspaces by default (#3137).** The seeded
+  `create-workspace` Allow on `/workspaces` now targets the `members`
+  group (which every new user joins) in addition to `admins`, so a
+  stock multi-user deploy is self-service out of the box — bounded by
+  the admission/quota controls (`KLANGKD_ADMISSION_*`,
+  `max_running_workspaces_per_user`, `volume_quota_per_user`) and
+  `allowed_images` / `allowed_mount_roots`. **On upgrade, migration
+  m0029 appends the grant after any existing `/workspaces` rows**, so
+  existing deployments flip too; a deploy that wants the old
+  admin-only posture adds one explicit Deny for `members` (or
+  `Authenticated`) ahead of the Allow in the ACL editor. See
+  [ACL System](https://klangk.github.io/klangk/reference/acl/).
+
 - **Per-workspace sudo is now opt-in (#3046, #3047).** `KLANGKD_ALLOW_SUDO`
   no longer grants passwordless sudo by itself — it is now only the
   ceiling that permits a workspace to opt in. Sudo is on for a workspace

--- a/docs/features/authorization.md
+++ b/docs/features/authorization.md
@@ -66,30 +66,37 @@ Groups tab (create, edit, delete, member management) is gated by
 **Allow** entry for the `manage-groups` permission on the `/groups`
 resource targeting the group of your choice via the ACL editor — the
 same recipe as
-[workspace creation](#granting-workspace-creation-to-non-admin-users).
+[workspace creation](#restricting-workspace-creation).
 
 ## Default access rules
 
 On first startup, Klangk seeds these defaults:
 
 - Any logged-in user can view pages
-- Only members of the `admins` group can create workspaces, create
-  groups, or access admin functions
+- Any logged-in user can create workspaces (#3137 — every user joins
+  the `members` group, which holds the seeded `create-workspace`
+  Allow on `/workspaces`)
+- Only members of the `admins` group can create groups or access
+  admin functions
 - Unauthenticated users are denied everything
 
-## Granting workspace creation to non-admin users
+## Restricting workspace creation
 
-To let members (or another group) create workspaces:
+Workspace creation is self-service by default. To restore the
+pre-#3137 admin-only posture (or scope creation to a narrower group):
 
 1. Open the **Admin** panel and navigate to the **ACL** editor.
 2. Select the `/workspaces` resource.
-3. Add an **Allow** entry for the `create-workspace` permission, targeting the
-   `members` group (or any other group).
-4. Ensure the new entry's position is lower (checked first) than any
-   Deny entry on the same resource.
+3. Add a **Deny** entry for the `create-workspace` permission, targeting
+   the `members` group (or the **Authenticated** system principal),
+   positioned ahead of the seeded members Allow row — the ACL walk is
+   first-match-wins. To allow a narrower set instead, delete the
+   members Allow row and add an **Allow** entry targeting the group of
+   your choice.
 
 The create and import buttons in the web UI will automatically appear
-for users who gain the `create-workspace` permission.
+or disappear for users as their effective `create-workspace`
+permission changes.
 
 ## Learn more
 

--- a/docs/features/authorization.md
+++ b/docs/features/authorization.md
@@ -73,9 +73,11 @@ same recipe as
 On first startup, Klangk seeds these defaults:
 
 - Any logged-in user can view pages
-- Any logged-in user can create workspaces (#3137 — every user joins
-  the `members` group, which holds the seeded `create-workspace`
-  Allow on `/workspaces`)
+- Any logged-in user can create workspaces (#3137 — every user
+  created since #2569 joins the `members` group, which holds the
+  seeded `create-workspace` Allow on `/workspaces`; users created
+  before #2569 on an upgraded deployment never joined retroactively —
+  grant `Authenticated` instead of `members` to cover them)
 - Only members of the `admins` group can create groups or access
   admin functions
 - Unauthenticated users are denied everything

--- a/docs/reference/acl.md
+++ b/docs/reference/acl.md
@@ -35,6 +35,7 @@ Klangk uses an Access Control List (ACL) system to manage permissions. Instead o
 | `/`            | Allow  | Authenticated | `view`                   |
 | `/`            | Deny   | Everyone      | `*`                      |
 | `/workspaces`  | Allow  | group:admins  | `create-workspace`       |
+| `/workspaces`  | Allow  | group:members | `create-workspace`       |
 | `/users`       | Allow  | group:admins  | `manage-users`           |
 | `/users`       | Allow  | Authenticated | `search-users`           |
 | `/users`       | Deny   | Everyone      | `*`                      |
@@ -53,10 +54,11 @@ Klangk uses an Access Control List (ACL) system to manage permissions. Instead o
 | `/images`      | Allow  | Authenticated | `view-images`            |
 | `/images`      | Deny   | Everyone      | `*`                      |
 
-These defaults mean: any logged-in user can view pages; only members of
-the `admins` group can create workspaces or hold a `manage-*`
-permission; unauthenticated users are denied everything. There is no
-`/admin` resource — it is neither seeded nor checked by any
+These defaults mean: any logged-in user can view pages; every
+member of the `members` group (i.e. every user — see below) can
+create workspaces (#3137); only members of the `admins` group hold a
+`manage-*` permission; unauthenticated users are denied everything.
+There is no `/admin` resource — it is neither seeded nor checked by any
 endpoint; instance-admin status derives from `admins`-group membership,
 surfaced as the `is_admin` flag on `/api/v1/my-permissions`. The
 `admins` group itself cannot be renamed or deleted.
@@ -86,31 +88,42 @@ volumes back grant `manage-volumes` to `Authenticated` or a group via
 the ACL editor. No trailing Deny Everyone row is seeded on `/volumes` either,
 for the same reason.
 
-### Granting workspace creation to non-admin users
+### Workspace creation: default self-service, deny to restrict
 
-By default only administrators can create workspaces. To allow
-other users or groups to create workspaces, add an ACL entry on the
-`/workspaces` collection resource via the web UI:
+By default every authenticated member can create workspaces (#3137):
+the `members` group — which every new user joins automatically — holds
+the seeded `create-workspace` Allow on `/workspaces`. Member footprint
+is bounded by the admission and quota controls (admission memory
+margin, `max_running_workspaces_per_user`, `volume_quota_per_user`),
+and what a member-created workspace can run is constrained by
+`allowed_images` / `allowed_mount_roots` / egress filtering.
+
+A deployment that wants the pre-#3137 admin-only posture adds one
+explicit Deny via the ACL editor (first-match-wins: position it ahead
+of the members Allow):
 
 1. Navigate to **Admin → ACL** (or the Advanced ACL editor).
 2. Select the `/workspaces` resource.
-3. Add an **Allow** entry for the `create-workspace` permission, targeting either:
-   - A specific **group** (e.g., a "developers" group you've created) — all
-     members of that group can then create workspaces.
-   - The **Authenticated** system principal — restores the previous
-     behavior where any logged-in user can create workspaces.
-4. Ensure the new entry's position is lower than any Deny entry on the
-   same resource (lower position = checked first).
+3. Add a **Deny** entry for the `create-workspace` permission, targeting
+   the **`members`** group (or the **Authenticated** system principal —
+   this also covers users created outside the group), at a position
+   **lower than** the members Allow row (lower position = checked
+   first).
 
-The create button in the web UI automatically appears/disappears based
-on the user's effective `create-workspace` permission on `/workspaces`.
+Alternatively grant creation to a narrower set: delete the members
+Allow row, then add an **Allow** entry for `create-workspace` targeting
+a specific **group** (e.g. a "developers" group you've created) or the
+**Authenticated** system principal, positioned ahead of any Deny. The
+create and import buttons in the web UI automatically appear/disappear
+based on the user's effective `create-workspace` permission on
+`/workspaces`.
 
 ## Groups
 
 Groups replace the old role system. A group is a named collection of users. Two built-in groups are created automatically on first startup:
 
 - **`admins`** — the default admin user is added to it; members can create workspaces and access admin functions.
-- **`members`** — every new user (registration, invitation, OIDC first login, admin-created) is added automatically. Has no permissions by default, but deployers can grant `create-workspace` on `/workspaces` to this group to let all members create workspaces.
+- **`members`** — every new user (registration, invitation, OIDC first login, admin-created) is added automatically. Holds the seeded `create-workspace` Allow on `/workspaces` (#3137); a deploy that wants admin-only creation stages an explicit Deny ahead of it (see above).
 
 **Admin UI**: Admin > Groups tab — create/delete groups, add/remove members.
 
@@ -249,7 +262,11 @@ authenticated-user reads (pickers, share dialogs).
 
 Upgrading from an older deployment: migration 0021 inserts the six
 Allow/Deny pairs for the admins group. If you had pre-staged rows on
-one of those resources, the migration leaves it untouched.
+one of those resources, the migration leaves it untouched. Migration
+0029 appends the #3137 members `create-workspace` Allow after any
+existing `/workspaces` rows — a staged Deny keeps first-match-wins
+priority, so an admin-only deployment keeps its posture across the
+upgrade (and gains one inert Allow row).
 
 ## WebSocket gates
 

--- a/docs/reference/acl.md
+++ b/docs/reference/acl.md
@@ -264,9 +264,10 @@ Upgrading from an older deployment: migration 0021 inserts the six
 Allow/Deny pairs for the admins group. If you had pre-staged rows on
 one of those resources, the migration leaves it untouched. Migration
 0029 appends the #3137 members `create-workspace` Allow after any
-existing `/workspaces` rows — a staged Deny keeps first-match-wins
-priority, so an admin-only deployment keeps its posture across the
-upgrade (and gains one inert Allow row).
+existing `/workspaces` rows — a **stock deployment (admins Allow
+only) flips to self-service on upgrade**; a deployment with a staged
+Deny keeps first-match-wins priority, so its admin-only posture
+survives (the appended row is inert).
 
 ## WebSocket gates
 

--- a/src/klangk/klangk/lifecycle.py
+++ b/src/klangk/klangk/lifecycle.py
@@ -196,7 +196,9 @@ class Lifecycle:
         self._pending_agent_reseed = False
         await self.seed_agent_user()
 
-    async def seed_default_acls(self, admin_group_id: str) -> None:
+    async def seed_default_acls(
+        self, admin_group_id: str, members_group_id: str
+    ) -> None:
         """Seed default ACL entries if none exist yet."""
         existing = await self.app.state.model.acl.get_acl_tree_summary()
         if existing:
@@ -218,7 +220,10 @@ class Lifecycle:
             PRINCIPAL_SYSTEM,
             system_principal=SYSTEM_EVERYONE,
         )
-        # /workspaces: only admins can create (#2569)
+        # /workspaces: admins always; members too since #3137 —
+        # self-service creation is the stock posture (bounded by the
+        # admission/quota controls; an explicit Deny restores
+        # admin-only, first-match-wins).
         await self.app.state.model.acl.add_acl_entry(
             "/workspaces",
             0,
@@ -226,6 +231,14 @@ class Lifecycle:
             "create-workspace",
             PRINCIPAL_GROUP,
             group_id=admin_group_id,
+        )
+        await self.app.state.model.acl.add_acl_entry(
+            "/workspaces",
+            1,
+            ACTION_ALLOW,
+            "create-workspace",
+            PRINCIPAL_GROUP,
+            group_id=members_group_id,
         )
         # First-class resources (#2944): each governed surface is a
         # top-level tree with one flat manage-* permission — Allow for
@@ -350,10 +363,11 @@ class Lifecycle:
         """Ensure the 'members' group exists (#2569). Returns the group ID.
 
         New users (registration, invitation, OIDC first login, admin
-        create) are added to this group automatically. It gets no
-        default permissions — the ``/workspaces`` ``create`` seed goes to
-        the admin group (#2569); deployers who want all members to
-        create workspaces grant it to this group via the ACL editor.
+        create) are added to this group automatically. It holds the
+        default ``create-workspace`` grant on ``/workspaces`` (#3137) —
+        self-service creation out of the box; a deploy that wants the
+        pre-#3137 admin-only posture stages an explicit Deny (ordered
+        first-match-wins) ahead of the seeded Allow.
         """
         group = await self.app.state.model.users.get_group_by_name("members")
         if group is None:
@@ -385,7 +399,7 @@ class Lifecycle:
         admin_group_id = await self.ensure_admin_group()
         members_group_id = await self.ensure_members_group()
         self.app.state.members_group_id = members_group_id
-        await self.seed_default_acls(admin_group_id)
+        await self.seed_default_acls(admin_group_id, members_group_id)
 
         # Once an admin exists, startup must not touch users (#1622). The
         # gate is group membership, not a row id: "admins" is a group, and a

--- a/src/klangk/klangk/model/migrations/__init__.py
+++ b/src/klangk/klangk/model/migrations/__init__.py
@@ -76,6 +76,7 @@ from klangk.model.migrations import m0025_drop_dead_images_deny_row
 from klangk.model.migrations import m0026_volumes_admin_surface
 from klangk.model.migrations import m0027_retire_admin_marker
 from klangk.model.migrations import m0028_invitations_pending_unique
+from klangk.model.migrations import m0029_members_create_workspace
 from klangk.model.migrations.base import Migration
 
 __all__ = ["MIGRATIONS", "Migration", "run_migrations"]
@@ -112,6 +113,7 @@ MIGRATIONS: list[Migration] = [
     m0026_volumes_admin_surface.migration,
     m0027_retire_admin_marker.migration,
     m0028_invitations_pending_unique.migration,
+    m0029_members_create_workspace.migration,
 ]
 
 

--- a/src/klangk/klangk/model/migrations/m0029_members_create_workspace.py
+++ b/src/klangk/klangk/model/migrations/m0029_members_create_workspace.py
@@ -1,0 +1,111 @@
+"""Migration 0029: grant ``create-workspace`` to the members group (#3137).
+
+The seed used to grant ``create-workspace`` on ``/workspaces`` to the
+admins group only (#2569); a deployer who wanted self-service
+workspaces had to grant it to ``members`` by hand in the ACL editor.
+#3137 flips the default: every member can create workspaces on a stock
+deploy — bounded by the admission/quota controls (memory margin,
+per-user running-workspace and volume quotas) and by
+``allowed_images`` / ``allowed_mount_roots`` / egress filtering. A
+deploy that wants the old admin-only posture stages an explicit Deny
+on ``/workspaces`` ahead of the grant (ordered first-match-wins).
+
+This migration brings existing deployments to the new seed shape: an
+Allow ``create-workspace`` row for the ``members`` group is **appended**
+after any existing rows on ``/workspaces``. Appending — never inserting
+at a seed position — keeps every operator-staged row ahead of the new
+grant: an explicit Deny (the documented old-posture recipe) keeps
+answering first, so no deployment's posture silently loosens beyond
+what the seed itself granted. On the stock shape (Allow admins @0,
+nothing else) the append lands at position 1 — exactly the fresh-seed
+layout.
+
+The ``members`` group is created when missing (a pre-#2569 database
+that never rebooted on a #2569+ build): the boot's
+``ensure_members_group`` would create it moments later anyway, but the
+ACL row needs a group id now. Shape matches ``ensure_members_group``
+(name ``members``, description ``All regular users``, default source).
+
+A fresh database (entirely empty ``acl_entries``) is a no-op — the
+boot seeds own it (the m0021/m0023 precedent).
+
+Idempotent by construction: the insert is guarded by an existence
+check for an identical row (Allow, group:members,
+``create-workspace`` on ``/workspaces``), so a re-run inserts nothing
+— including on deployments where the operator already granted the
+permission by hand.
+"""
+
+import uuid
+
+from klangk.model.acl import ACTION_ALLOW, PRINCIPAL_GROUP
+from klangk.model.migrations.base import Migration
+
+MEMBERS_GROUP_NAME = "members"
+MEMBERS_GROUP_DESCRIPTION = "All regular users"
+RESOURCE = "/workspaces"
+PERMISSION = "create-workspace"
+
+
+async def _members_group_id(db) -> str:
+    """The ``members`` group's id, creating the group when missing."""
+    cursor = await db.execute(
+        "SELECT id FROM groups WHERE name = ?", (MEMBERS_GROUP_NAME,)
+    )
+    row = await cursor.fetchone()
+    if row is not None:
+        return row[0]
+    gid = str(uuid.uuid4())
+    await db.execute(
+        "INSERT INTO groups (id, name, description) VALUES (?, ?, ?)",
+        (gid, MEMBERS_GROUP_NAME, MEMBERS_GROUP_DESCRIPTION),
+    )
+    return gid
+
+
+async def apply(db) -> None:
+    cursor = await db.execute("SELECT COUNT(*) FROM acl_entries")
+    if (await cursor.fetchone())[0] == 0:
+        return  # fresh database — the boot seeds own it
+
+    members_id = await _members_group_id(db)
+
+    # Idempotency: an operator (or a re-run) already granted this.
+    cursor = await db.execute(
+        "SELECT 1 FROM acl_entries"
+        " WHERE resource = ? AND permission = ?"
+        " AND action = ? AND principal_type = ? AND group_id = ?",
+        (RESOURCE, PERMISSION, ACTION_ALLOW, PRINCIPAL_GROUP, members_id),
+    )
+    if await cursor.fetchone() is not None:
+        return
+
+    # Append after the last row so operator-staged rows (an explicit
+    # Deny, a scoped grant) keep first-match-wins priority.
+    cursor = await db.execute(
+        "SELECT COALESCE(MAX(position), -1) FROM acl_entries"
+        " WHERE resource = ?",
+        (RESOURCE,),
+    )
+    next_position = (await cursor.fetchone())[0] + 1
+    await db.execute(
+        "INSERT INTO acl_entries"
+        " (resource, position, action, principal_type, user_id,"
+        "  group_id, system_principal, permission)"
+        " VALUES (?, ?, ?, ?, NULL, ?, NULL, ?)",
+        (
+            RESOURCE,
+            next_position,
+            ACTION_ALLOW,
+            PRINCIPAL_GROUP,
+            members_id,
+            PERMISSION,
+        ),
+    )
+
+
+migration = Migration(
+    id=29,
+    name="0029_members_create_workspace",
+    apply=apply,
+)

--- a/src/klangk/klangk/model/migrations/m0029_members_create_workspace.py
+++ b/src/klangk/klangk/model/migrations/m0029_members_create_workspace.py
@@ -14,7 +14,7 @@ This migration brings existing deployments to the new seed shape: an
 Allow ``create-workspace`` row for the ``members`` group is **appended**
 after any existing rows on ``/workspaces``. Appending — never inserting
 at a seed position — keeps every operator-staged row ahead of the new
-grant: an explicit Deny (the documented old-posture recipe) keeps
+grant: an explicit Deny (the recommended old-posture recipe) keeps
 answering first, so no deployment's posture silently loosens beyond
 what the seed itself granted. On the stock shape (Allow admins @0,
 nothing else) the append lands at position 1 — exactly the fresh-seed
@@ -25,6 +25,12 @@ that never rebooted on a #2569+ build): the boot's
 ``ensure_members_group`` would create it moments later anyway, but the
 ACL row needs a group id now. Shape matches ``ensure_members_group``
 (name ``members``, description ``All regular users``, default source).
+
+Edge shape: a database whose ``/workspaces`` rows were deleted
+entirely (a deliberate deny-all posture) gets the Allow at position 0
+as the resource's only row — members gain creation while admins not
+in ``members`` do not. Defensible outcome of the deliberate flip on a
+pathological shape; stage a Deny to restore any stricter posture.
 
 A fresh database (entirely empty ``acl_entries``) is a no-op — the
 boot seeds own it (the m0021/m0023 precedent).

--- a/src/klangk/klangkd-tests/e2e-tests/smoketest_egress.py
+++ b/src/klangk/klangkd-tests/e2e-tests/smoketest_egress.py
@@ -1427,10 +1427,11 @@ class SmokeTest:
     async def _new_workspace(self, *args, **kwargs) -> str:
         """Create a workspace the acting identity can use.
 
-        Creation always runs as the bootstrap (admin) identity --
-        `create-workspace` is admin-gated (#2569) -- and under --as-member
-        the workspace is then shared to the member's coders role so the
-        member's decider/terminal connections on it are authorized.
+        Creation always runs as the bootstrap (admin) identity
+        (deterministic ownership for the share-based --as-member
+        wiring) -- and under --as-member the workspace is then shared
+        to the member's coders role so the member's decider/terminal
+        connections on it are authorized.
         """
         ws_id = await asyncio.to_thread(
             self._create_workspace,

--- a/src/klangk/klangkd-tests/e2e-tests/smoketest_egress.py
+++ b/src/klangk/klangkd-tests/e2e-tests/smoketest_egress.py
@@ -1320,9 +1320,11 @@ class SmokeTest:
     def _ensure_member(server: dict, admin: dict) -> None:
         """Create the plain member user for --as-member (idempotent).
 
-        The member is deliberately NOT added to any instance group: no
-        admins membership, no manage-* grants -- consent authority must
-        come from the workspace ACL alone (#2976). A 400 "already
+        The member gets no admin membership and no manage-* grants --
+        consent authority must come from the workspace ACL alone
+        (#2976). Since #2569 registration auto-joins the ``members``
+        group (instance-role, no permissions beyond the #3137
+        create-workspace seed). A 400 "already
         registered" (a rerun against the same server) is tolerated.
         """
         client = httpx.Client(

--- a/src/klangk/klangkd-tests/tests/conftest.py
+++ b/src/klangk/klangkd-tests/tests/conftest.py
@@ -199,10 +199,11 @@ async def user(app_state):
 
 @pytest.fixture
 async def ws_admin(user, admin_group, app_state):
-    """Make the standard test user an admin so it can create workspaces.
+    """Make the standard test user an admin.
 
-    Use this fixture (instead of plain ``user``) in test classes where
-    the test user needs workspace-creation permission (#2569).
+    Members can create workspaces since #3137, so plain ``user`` is
+    enough for creation; use this fixture where the test user needs
+    admin-only surfaces (manage-users, ACL editor, ...).
     """
     await app_state.state.model.users.add_user_to_group(
         user["id"], admin_group["id"]

--- a/src/klangk/klangkd-tests/tests/conftest.py
+++ b/src/klangk/klangkd-tests/tests/conftest.py
@@ -102,11 +102,9 @@ async def _seed_resource_acls(app_state):
     """
     from klangk.model.acl import (
         ACTION_ALLOW,
-        ACTION_DENY,
         PRINCIPAL_GROUP,
         PRINCIPAL_SYSTEM,
         SYSTEM_AUTHENTICATED,
-        SYSTEM_EVERYONE,
     )
 
     acl = app_state.state.model.acl
@@ -256,6 +254,9 @@ async def admin_group(app_state):
         PRINCIPAL_GROUP,
         group_id=group["id"],
     )
+    # #3137: members get create-workspace too (self-service default;
+    # inserted after the members group exists below — position 1,
+    # the fresh-seed layout).
     # First-class resource seeds (#2944), mirroring seed_default_acls.
     # /users manage-users for admins; the Deny lands at a high position
     # so _seed_resource_acls's search-users insert (position 1,
@@ -308,6 +309,16 @@ async def admin_group(app_state):
         "members", description="All regular users"
     )
     app_state.state.members_group_id = members["id"]
+    # #3137: the members group's seeded create-workspace grant
+    # (position 1, right after the admins row — the fresh-seed shape).
+    await acl.add_acl_entry(
+        "/workspaces",
+        1,
+        ACTION_ALLOW,
+        "create-workspace",
+        PRINCIPAL_GROUP,
+        group_id=members["id"],
+    )
     return group
 
 

--- a/src/klangk/klangkd-tests/tests/test_api.py
+++ b/src/klangk/klangkd-tests/tests/test_api.py
@@ -2182,8 +2182,10 @@ class TestChangeEmail:
 class TestWorkspaceRoutes:
     @pytest.fixture(autouse=True)
     async def _make_user_admin(self, ws_admin):
-        """#2569: workspace creation requires admin; make the standard
-        test user an admin so existing tests keep working."""
+        """#2569 heritage: make the standard test user an admin so the
+        class's admin-surface tests (ACL editor reads/writes, member
+        management, ...) keep working. Creation itself no longer needs
+        it (#3137)."""
 
     async def test_list_empty(self, client, user):
         headers = await _auth_headers(client)

--- a/src/klangk/klangkd-tests/tests/test_api.py
+++ b/src/klangk/klangkd-tests/tests/test_api.py
@@ -2379,10 +2379,12 @@ class TestWorkspaceRoutes:
         assert data["name"] == "test-ws"
         assert "id" in data
 
-    async def test_create_workspace_non_admin_denied(
+    async def test_create_workspace_member_allowed_by_default(
         self, client, user, app_state
     ):
-        """#2569: non-admin users cannot create workspaces."""
+        """#3137: a plain member (non-admin) can create workspaces on a
+        stock deploy — the members group holds the seeded
+        create-workspace grant."""
         from klangk.auth import hash_password
 
         pw_hash = hash_password("testpass")
@@ -2393,6 +2395,56 @@ class TestWorkspaceRoutes:
             "/api/v1/auth/login",
             json={
                 "identifier": "nonadmin@example.com",
+                "password": "testpass",
+            },
+        )
+        token = resp.json()["access_token"]
+        headers = {"Authorization": f"Bearer {token}"}
+        resp = await client.post(
+            "/api/v1/workspaces", headers=headers, json={"name": "member-ws"}
+        )
+        assert resp.status_code == 200
+        assert resp.json()["name"] == "member-ws"
+
+    async def test_create_workspace_explicit_deny_restores_admin_only(
+        self, client, user, app_state
+    ):
+        """#3137: an explicit Deny for the members group ahead of the
+        seeded Allow restores the pre-#3137 admin-only posture
+        (ordered ACL, first-match-wins)."""
+        from klangk.auth import hash_password
+        from klangk.model import (
+            ACTION_DENY,
+            PRINCIPAL_GROUP,
+        )
+
+        members = await app_state.state.model.users.get_group_by_name(
+            "members"
+        )
+        # Stage the Deny at position 1 (ahead of the seeded Allow,
+        # which shifts to position 2).
+        async with app_state.state.db.transaction() as tx:
+            await tx.execute(
+                "UPDATE acl_entries SET position = position + 1"
+                " WHERE resource = '/workspaces' AND position >= 1"
+            )
+        await app_state.state.model.acl.add_acl_entry(
+            "/workspaces",
+            1,
+            ACTION_DENY,
+            "create-workspace",
+            PRINCIPAL_GROUP,
+            group_id=members["id"],
+        )
+
+        pw_hash = hash_password("testpass")
+        await app_state.state.model.users.create_user(
+            "denied-member@example.com", pw_hash, verified=True
+        )
+        resp = await client.post(
+            "/api/v1/auth/login",
+            json={
+                "identifier": "denied-member@example.com",
                 "password": "testpass",
             },
         )

--- a/src/klangk/klangkd-tests/tests/test_main.py
+++ b/src/klangk/klangkd-tests/tests/test_main.py
@@ -241,7 +241,21 @@ class TestSeedDefaultAcls:
         Deny everyone; #2995: no /admin marker tree is seeded."""
         lifecycle = _lifecycle(make_settings({}))
         admin_group_id = await lifecycle.ensure_admin_group()
-        await lifecycle.seed_default_acls(admin_group_id)
+        members_group_id = await lifecycle.ensure_members_group()
+        await lifecycle.seed_default_acls(admin_group_id, members_group_id)
+
+        # #3137: /workspaces seeds Allow create-workspace for admins
+        # @0 AND members @1 (self-service default).
+        workspaces = await app_state.state.model.acl.get_acl_entries(
+            "/workspaces"
+        )
+        assert [
+            (e["position"], e["permission"], e["group_id"], e["action"])
+            for e in workspaces
+        ] == [
+            (0, "create-workspace", admin_group_id, model.ACTION_ALLOW),
+            (1, "create-workspace", members_group_id, model.ACTION_ALLOW),
+        ]
 
         for resource, permission in (
             # NB: /users is checked separately below — it carries the

--- a/src/klangk/klangkd-tests/tests/test_migrations.py
+++ b/src/klangk/klangkd-tests/tests/test_migrations.py
@@ -3165,7 +3165,8 @@ class TestM0029MembersCreateWorkspace:
 
     async def _seed_stock(self, db, admins_id="g-a", members_id="g-m"):
         """The stock #2569 shape: Allow create-workspace admins @0 on
-        /workspaces plus the root pair."""
+        /workspaces plus the root pair. ``members_id=None`` skips the
+        members group row (pre-#2569 database)."""
         await db.execute(
             "INSERT INTO acl_entries"
             " (resource, position, action, principal_type, group_id,"
@@ -3176,10 +3177,14 @@ class TestM0029MembersCreateWorkspace:
             (admins_id,),
         )
         await db.execute(
-            "INSERT INTO groups (id, name) VALUES (?, 'admins'),"
-            " (?, 'members')",
-            (admins_id, members_id),
+            "INSERT INTO groups (id, name) VALUES (?, 'admins')",
+            (admins_id,),
         )
+        if members_id is not None:
+            await db.execute(
+                "INSERT INTO groups (id, name) VALUES (?, 'members')",
+                (members_id,),
+            )
 
     async def test_upgraded_db_gets_the_members_grant(self, tmp_path):
         from klangk.model.migrations import m0029_members_create_workspace
@@ -3236,8 +3241,6 @@ class TestM0029MembersCreateWorkspace:
         db = await self._db(tmp_path)
         try:
             await self._seed_stock(db, members_id=None)
-            # Drop the members group the stock seed inserted.
-            await db.execute("DELETE FROM groups WHERE name = 'members'")
             await db.commit()
             await m0029_members_create_workspace.migration.apply(db)
 

--- a/src/klangk/klangkd-tests/tests/test_migrations.py
+++ b/src/klangk/klangkd-tests/tests/test_migrations.py
@@ -89,6 +89,7 @@ class TestRunner:
             (26, "0026_volumes_admin_surface"),
             (27, "0027_retire_admin_marker"),
             (28, "0028_invitations_pending_unique"),
+            (29, "0029_members_create_workspace"),
         ]
         async with aiosqlite.connect(str(app_state.state.db.db_path)) as db:
             assert await _recorded(db) == expected
@@ -183,6 +184,7 @@ class TestRunner:
                 (26, "0026_volumes_admin_surface"),
                 (27, "0027_retire_admin_marker"),
                 (28, "0028_invitations_pending_unique"),
+                (29, "0029_members_create_workspace"),
             ]
 
     async def test_m0008_agent_identity_and_human_collision(
@@ -3124,6 +3126,218 @@ class TestM0028InvitationsPendingUnique:
             await m0028_invitations_pending_unique.migration.apply(db)
             assert await self._statuses(db, "c@b.com") == [
                 ("solo", "accepted")
+            ]
+        finally:
+            await db.__aexit__(None, None, None)
+
+
+class TestM0029MembersCreateWorkspace:
+    """m0029 appends the #3137 members create-workspace grant on
+    existing deployments (Allow group:members create-workspace at the
+    end of /workspaces), creating the group when missing."""
+
+    async def _db(self, tmp_path):
+        db = aiosqlite.connect(str(tmp_path / "m0029.db"))
+        db = await db.__aenter__()
+        await db.execute(
+            "CREATE TABLE acl_entries ("
+            " id INTEGER PRIMARY KEY AUTOINCREMENT,"
+            " resource TEXT, position INTEGER, action INTEGER,"
+            " principal_type INTEGER, user_id TEXT, group_id TEXT,"
+            " system_principal INTEGER, permission TEXT,"
+            " UNIQUE(resource, position))"
+        )
+        await db.execute(
+            "CREATE TABLE groups ("
+            " id TEXT PRIMARY KEY, name TEXT UNIQUE,"
+            " description TEXT, source TEXT, created_at TEXT)"
+        )
+        return db
+
+    async def _rows(self, db, resource) -> list[tuple]:
+        cursor = await db.execute(
+            "SELECT position, action, principal_type, group_id,"
+            " system_principal, permission"
+            " FROM acl_entries WHERE resource = ? ORDER BY position",
+            (resource,),
+        )
+        return list(await cursor.fetchall())
+
+    async def _seed_stock(self, db, admins_id="g-a", members_id="g-m"):
+        """The stock #2569 shape: Allow create-workspace admins @0 on
+        /workspaces plus the root pair."""
+        await db.execute(
+            "INSERT INTO acl_entries"
+            " (resource, position, action, principal_type, group_id,"
+            "  permission)"
+            " VALUES ('/workspaces', 0, 1, 2, ?, 'create-workspace'),"
+            "        ('/', 0, 1, 0, NULL, 'view'),"
+            "        ('/', 1, 0, 0, NULL, '*')",
+            (admins_id,),
+        )
+        await db.execute(
+            "INSERT INTO groups (id, name) VALUES (?, 'admins'),"
+            " (?, 'members')",
+            (admins_id, members_id),
+        )
+
+    async def test_upgraded_db_gets_the_members_grant(self, tmp_path):
+        from klangk.model.migrations import m0029_members_create_workspace
+
+        db = await self._db(tmp_path)
+        try:
+            await self._seed_stock(db)
+            await db.commit()
+            await m0029_members_create_workspace.migration.apply(db)
+
+            # The grant lands at position 1 — the fresh-seed layout.
+            assert await self._rows(db, "/workspaces") == [
+                (
+                    0,
+                    ACTION_ALLOW,
+                    PRINCIPAL_GROUP,
+                    "g-a",
+                    None,
+                    "create-workspace",
+                ),
+                (
+                    1,
+                    ACTION_ALLOW,
+                    PRINCIPAL_GROUP,
+                    "g-m",
+                    None,
+                    "create-workspace",
+                ),
+            ]
+            # Idempotent: a re-run inserts nothing.
+            await m0029_members_create_workspace.migration.apply(db)
+            assert len(await self._rows(db, "/workspaces")) == 2
+        finally:
+            await db.__aexit__(None, None, None)
+
+    async def test_fresh_db_is_noop(self, tmp_path):
+        """An empty acl_entries table belongs to the boot seeds."""
+        from klangk.model.migrations import m0029_members_create_workspace
+
+        db = await self._db(tmp_path)
+        try:
+            await m0029_members_create_workspace.migration.apply(db)
+            cursor = await db.execute("SELECT COUNT(*) FROM acl_entries")
+            assert (await cursor.fetchone())[0] == 0
+            cursor = await db.execute("SELECT COUNT(*) FROM groups")
+            assert (await cursor.fetchone())[0] == 0
+        finally:
+            await db.__aexit__(None, None, None)
+
+    async def test_creates_missing_members_group(self, tmp_path):
+        """A pre-#2569 database with no members row gets the group."""
+        from klangk.model.migrations import m0029_members_create_workspace
+
+        db = await self._db(tmp_path)
+        try:
+            await self._seed_stock(db, members_id=None)
+            # Drop the members group the stock seed inserted.
+            await db.execute("DELETE FROM groups WHERE name = 'members'")
+            await db.commit()
+            await m0029_members_create_workspace.migration.apply(db)
+
+            cursor = await db.execute(
+                "SELECT description FROM groups WHERE name = 'members'"
+            )
+            assert await cursor.fetchone() == ("All regular users",)
+            rows = await self._rows(db, "/workspaces")
+            assert len(rows) == 2
+            assert rows[1][5] == "create-workspace"
+            # The new row points at the group that was created.
+            cursor = await db.execute(
+                "SELECT 1 FROM acl_entries e JOIN groups g"
+                " ON e.group_id = g.id WHERE g.name = 'members'"
+                " AND e.permission = 'create-workspace'"
+            )
+            assert await cursor.fetchone() is not None
+        finally:
+            await db.__aexit__(None, None, None)
+
+    async def test_operator_grant_not_duplicated(self, tmp_path):
+        """An operator who already granted members create-workspace
+        (or a re-run after a partial apply) inserts nothing."""
+        from klangk.model.migrations import m0029_members_create_workspace
+
+        db = await self._db(tmp_path)
+        try:
+            await self._seed_stock(db)
+            await db.execute(
+                "INSERT INTO acl_entries"
+                " (resource, position, action, principal_type, group_id,"
+                "  permission)"
+                " VALUES ('/workspaces', 1, 1, 2, 'g-m',"
+                "         'create-workspace')"
+            )
+            await db.commit()
+            await m0029_members_create_workspace.migration.apply(db)
+            assert len(await self._rows(db, "/workspaces")) == 2
+        finally:
+            await db.__aexit__(None, None, None)
+
+    async def test_operator_deny_stays_ahead(self, tmp_path):
+        """A staged Deny keeps first-match-wins priority: the grant
+        appends after it, never between it and the admins row."""
+        from klangk.model.migrations import m0029_members_create_workspace
+
+        db = await self._db(tmp_path)
+        try:
+            await self._seed_stock(db)
+            # The documented old-posture recipe: Deny create-workspace
+            # for members (action 0), plus a scoped Allow for another
+            # group at position 2.
+            await db.execute(
+                "INSERT INTO acl_entries"
+                " (resource, position, action, principal_type, group_id,"
+                "  permission)"
+                " VALUES ('/workspaces', 1, 0, 2, 'g-m',"
+                "         'create-workspace'),"
+                "        ('/workspaces', 2, 1, 2, 'g-x',"
+                "         'create-workspace')",
+            )
+            await db.execute(
+                "INSERT INTO groups (id, name) VALUES ('g-x', 'devs')"
+            )
+            await db.commit()
+            await m0029_members_create_workspace.migration.apply(db)
+
+            assert await self._rows(db, "/workspaces") == [
+                (
+                    0,
+                    ACTION_ALLOW,
+                    PRINCIPAL_GROUP,
+                    "g-a",
+                    None,
+                    "create-workspace",
+                ),
+                (
+                    1,
+                    ACTION_DENY,
+                    PRINCIPAL_GROUP,
+                    "g-m",
+                    None,
+                    "create-workspace",
+                ),
+                (
+                    2,
+                    ACTION_ALLOW,
+                    PRINCIPAL_GROUP,
+                    "g-x",
+                    None,
+                    "create-workspace",
+                ),
+                (
+                    3,
+                    ACTION_ALLOW,
+                    PRINCIPAL_GROUP,
+                    "g-m",
+                    None,
+                    "create-workspace",
+                ),
             ]
         finally:
             await db.__aexit__(None, None, None)


### PR DESCRIPTION
## Summary

Self-service workspace creation is now the stock posture (#3137): the boot seed
grants `create-workspace` on `/workspaces` to the **members** group (position 1,
after the admins row), and migration **m0029** appends the same grant on
existing deployments — after any staged rows, so an explicit Deny keeps
first-match-wins priority and an admin-only deployment keeps its posture across
the upgrade.

The calculus changed since #2569 made creation admin-only: admission control
(`admission_memory_enabled` + margin), `max_running_workspaces_per_user`,
`volume_quota_per_user`, container resource limits, `allowed_images`,
`allowed_mount_roots`, and egress filtering now bound what a member-created
workspace can cost and do.

### Design decisions (from the issue's open questions)

- **Migration, not fresh-installs-only.** Behavior stays version-independent:
  m0029 appends the Allow after any existing `/workspaces` rows, so operator
  rows (a staged Deny, a scoped grant) keep first-match-wins priority. A
  deployment that already granted the permission (or re-runs after a partial
  apply) is skipped — the insert is guarded by an identical-row existence
  check. On the stock shape the append lands at position 1, exactly the
  fresh-seed layout.
- **No settings knob.** A knob gating the seed would only affect fresh
  installs (the seed's empty-table gate), and a per-request knob would fork
  the ACL table's single source of truth. The ACL editor is already the
  runtime control: one Deny row for `members` (or `Authenticated`) ahead of
  the Allow restores admin-only. This mirrors the `/images`
  Allow-Authenticated precedent — a deliberate, ACL-editor-modifiable default.

## Changes

- `lifecycle.py` — `seed_default_acls` now takes the members group id and
  seeds the second `/workspaces` Allow; `ensure_members_group` docstring
  updated.
- `m0029_members_create_workspace.py` — new migration (registered in
  `MIGRATIONS`), creates the `members` group when missing (pre-#2569
  databases).
- `conftest.py` — the `admin_group` fixture mirrors the new seed row so the
  unit-test world matches a stock deploy.
- Tests — `test_create_workspace_non_admin_denied` split into
  `test_create_workspace_member_allowed_by_default` (member create → 200) and
  `test_create_workspace_explicit_deny_restores_admin_only` (Deny ahead of the
  Allow → 403); `TestSeedDefaultAcls` pins the new `/workspaces` seed shape;
  new `TestM0029` migration class (stock append, fresh-db no-op, missing-group
  creation, operator-grant dedup, operator-deny-stays-ahead).
- Docs — `docs/reference/acl.md` (default grants table, "Workspace creation:
  default self-service, deny to restrict" recipe, upgrade note),
  `docs/features/authorization.md` (default rules + restrict section),
  changelog **Breaking** entry (existing deployments flip on upgrade via
  m0029).

Frontend/CLI/TUI create surfaces needed no changes — they were already
permission-driven (`hasPermission('/workspaces', 'create-workspace')` /
plain POST), so the grant lights them up for members automatically.

Closes #3137
