### PR TITLE
Publish all five images from release.yml on a tag push (#3140)

### DIFF
--- a/.github/workflows/image-host-fips.yml
+++ b/.github/workflows/image-host-fips.yml
@@ -24,6 +24,19 @@ name: FIPS Host Image Check
 
 on:
   workflow_dispatch:
+  # Release path (#3140): release.yml calls this with push-tag = the vX.Y.Z
+  # tag. There is no separate stock-host image workflow — this one builds
+  # the stock host as its layering base anyway, so the release publishes
+  # BOTH klangk-host and klangk-host-fips from here, under the immutable
+  # versioned tag only (no :latest — the floating :latest stays owned by
+  # the continuous runs above).
+  workflow_call:
+    inputs:
+      push-tag:
+        description: "Versioned tag to publish (release path); empty = <calver>-<commit> + :latest (host-fips only)"
+        required: false
+        default: ""
+        type: string
   push:
     branches: [main]
     paths:
@@ -149,16 +162,28 @@ jobs:
           echo STOCK-REFUSAL-OK
 
       # Publish (same tag convention as klangk-workspace-fips). GITHUB_TOKEN
-      # is tied to this run; the tag links the package to the repo.
-      - name: Push FIPS host image to GHCR
+      # is tied to this run; the tag links the package to the repo. The
+      # release path (#3140) publishes the stock host too (see the
+      # workflow_call note above).
+      - name: Push host images to GHCR
         run: |
           . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh
           echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
-          COMMIT=$(git rev-parse --short HEAD)
-          CALVER="$(date -u +%Y.%m.%d)"
-          VERSION="${CALVER}-${COMMIT}"
-          REPO="ghcr.io/${{ github.repository }}/klangk-host-fips"
-          docker tag klangk-host-fips:latest "$REPO:$VERSION"
-          docker tag klangk-host-fips:latest "$REPO:latest"
-          docker push "$REPO:$VERSION"
-          docker push "$REPO:latest"
+          if [ -n "${{ inputs.push-tag }}" ]; then
+            TAG="${{ inputs.push-tag }}"
+            HOST_REPO="ghcr.io/${{ github.repository }}/klangk-host"
+            docker tag klangk-host:latest "$HOST_REPO:$TAG"
+            docker push "$HOST_REPO:$TAG"
+            REPO="ghcr.io/${{ github.repository }}/klangk-host-fips"
+            docker tag klangk-host-fips:latest "$REPO:$TAG"
+            docker push "$REPO:$TAG"
+          else
+            COMMIT=$(git rev-parse --short HEAD)
+            CALVER="$(date -u +%Y.%m.%d)"
+            VERSION="${CALVER}-${COMMIT}"
+            REPO="ghcr.io/${{ github.repository }}/klangk-host-fips"
+            docker tag klangk-host-fips:latest "$REPO:$VERSION"
+            docker tag klangk-host-fips:latest "$REPO:latest"
+            docker push "$REPO:$VERSION"
+            docker push "$REPO:latest"
+          fi

--- a/.github/workflows/image-host-fips.yml
+++ b/.github/workflows/image-host-fips.yml
@@ -56,8 +56,13 @@ permissions:
   contents: read
   packages: write
 
+# Literal group prefix (not github.workflow): in a workflow_call the
+# `github` context is the CALLER's, so `github.workflow` would be "Release"
+# for every callee on a tag push — all four release.yml fan-out jobs would
+# land in one group and cancel each other (#3140). The per-file literal
+# keeps the group unique regardless of who calls this workflow.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: image-host-fips-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/image-network-sidecar.yml
+++ b/.github/workflows/image-network-sidecar.yml
@@ -1,0 +1,75 @@
+name: Build Network Sidecar Image
+
+# Build the klangk-network-sidecar container image (src/containers/network/
+# Dockerfile) and publish it to GHCR (#3140) — before this the sidecar was
+# never pullable; it existed only as the tar embedded in the host image by
+# build-host-image.sh.
+#
+# Two publish paths:
+#   - continuous (push to main / schedule-free): :<calver>-<commit>, the
+#     same tag convention as klangk-workspace.
+#   - release (workflow_call from release.yml with push-tag): the immutable
+#     :vX.Y.Z tag, built from the tagged commit.
+#
+# No :latest tag on either path (stock-image convention — see
+# building-images.md "Image Versioning"); podman-built and podman-pushed
+# like the workspace image. ONE-TIME setup: flip the new ghcr package's
+# visibility to public so anonymous pulls work (as klangk-workspace
+# already is).
+
+on:
+  workflow_dispatch:
+  workflow_call:
+    inputs:
+      push-tag:
+        description: "Versioned tag to publish (release path); empty = <calver>-<commit>"
+        required: false
+        default: ""
+        type: string
+  push:
+    branches: [main]
+    paths:
+      - "src/containers/network/**"
+      - "scripts/build-network-sidecar.sh"
+      - "src/klangksidecar/klangksidecar/**"
+      - "src/klangksidecar/pyproject.toml"
+      - ".github/workflows/image-network-sidecar.yml"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v7
+
+      # The task builds the klangksidecar wheel first (git present → real
+      # hatch-vcs version) and hands it to the image build as a named
+      # context, tagging the result klangk-network-sidecar locally.
+      - name: Build network sidecar image
+        uses: ./.github/actions/devenv-setup
+        with:
+          build-tasks: klangk:build-network-sidecar
+
+      - name: Push network sidecar image to GHCR
+        run: |
+          . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh
+          echo "${{ secrets.GITHUB_TOKEN }}" | devenv shell -- podman login ghcr.io -u ${{ github.actor }} --password-stdin
+          if [ -n "${{ inputs.push-tag }}" ]; then
+            # Release path (#3140): immutable versioned tag only.
+            VERSION="${{ inputs.push-tag }}"
+          else
+            COMMIT=$(git rev-parse --short HEAD)
+            CALVER="$(date -u +%Y.%m.%d)"
+            VERSION="${CALVER}-${COMMIT}"
+          fi
+          REPO="ghcr.io/${{ github.repository }}/klangk-network-sidecar"
+          devenv shell -- podman tag klangk-network-sidecar "$REPO:$VERSION"
+          devenv shell -- podman push "$REPO:$VERSION"

--- a/.github/workflows/image-network-sidecar.yml
+++ b/.github/workflows/image-network-sidecar.yml
@@ -35,8 +35,13 @@ on:
       - "src/klangksidecar/pyproject.toml"
       - ".github/workflows/image-network-sidecar.yml"
 
+# Literal group prefix (not github.workflow): in a workflow_call the
+# `github` context is the CALLER's, so `github.workflow` would be "Release"
+# for every callee on a tag push — all four release.yml fan-out jobs would
+# land in one group and cancel each other (#3140). The per-file literal
+# keeps the group unique regardless of who calls this workflow.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: image-network-sidecar-${{ github.ref }}
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/image-workspace-fips.yml
+++ b/.github/workflows/image-workspace-fips.yml
@@ -21,6 +21,17 @@ name: FIPS Workspace Image Check
 
 on:
   workflow_dispatch:
+  # Release path (#3140): release.yml calls this with push-tag = the vX.Y.Z
+  # tag so the release publishes klangk-workspace-fips from the tagged
+  # commit under an immutable versioned tag (no :latest — the floating
+  # :latest stays owned by the continuous runs above).
+  workflow_call:
+    inputs:
+      push-tag:
+        description: "Versioned tag to publish (release path); empty = <calver>-<commit> + :latest"
+        required: false
+        default: ""
+        type: string
   push:
     branches: [main]
     paths:
@@ -101,17 +112,24 @@ jobs:
           echo FIPS-RUNTIME-OK
           EOS
 
-      # Publish for the e2e pull path (#2631). GITHUB_TOKEN is tied to this
-      # run; the tag links the package to the repo.
+      # Publish for the e2e pull path (#2631); the release path publishes
+      # the versioned tag only (#3140). GITHUB_TOKEN is tied to this run;
+      # the tag links the package to the repo.
       - name: Push FIPS image to GHCR
         run: |
           . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh
           echo "${{ secrets.GITHUB_TOKEN }}" | devenv shell -- podman login ghcr.io -u ${{ github.actor }} --password-stdin
-          COMMIT=$(git rev-parse --short HEAD)
-          CALVER="$(date -u +%Y.%m.%d)"
-          VERSION="${CALVER}-${COMMIT}"
           REPO="ghcr.io/${{ github.repository }}/klangk-workspace-fips"
-          devenv shell -- podman tag klangk-workspace-fips:ci "$REPO:$VERSION"
-          devenv shell -- podman tag klangk-workspace-fips:ci "$REPO:latest"
-          devenv shell -- podman push "$REPO:$VERSION"
-          devenv shell -- podman push "$REPO:latest"
+          if [ -n "${{ inputs.push-tag }}" ]; then
+            VERSION="${{ inputs.push-tag }}"
+            devenv shell -- podman tag klangk-workspace-fips:ci "$REPO:$VERSION"
+            devenv shell -- podman push "$REPO:$VERSION"
+          else
+            COMMIT=$(git rev-parse --short HEAD)
+            CALVER="$(date -u +%Y.%m.%d)"
+            VERSION="${CALVER}-${COMMIT}"
+            devenv shell -- podman tag klangk-workspace-fips:ci "$REPO:$VERSION"
+            devenv shell -- podman tag klangk-workspace-fips:ci "$REPO:latest"
+            devenv shell -- podman push "$REPO:$VERSION"
+            devenv shell -- podman push "$REPO:latest"
+          fi

--- a/.github/workflows/image-workspace-fips.yml
+++ b/.github/workflows/image-workspace-fips.yml
@@ -47,8 +47,13 @@ permissions:
   contents: read
   packages: write
 
+# Literal group prefix (not github.workflow): in a workflow_call the
+# `github` context is the CALLER's, so `github.workflow` would be "Release"
+# for every callee on a tag push — all four release.yml fan-out jobs would
+# land in one group and cancel each other (#3140). The per-file literal
+# keeps the group unique regardless of who calls this workflow.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: image-workspace-fips-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/image-workspace.yml
+++ b/.github/workflows/image-workspace.yml
@@ -3,6 +3,12 @@ name: Build Workspace Image
 on:
   workflow_dispatch:
   workflow_call:
+    inputs:
+      push-tag:
+        description: "Versioned tag to publish (release path); empty = <calver>-<commit>"
+        required: false
+        default: ""
+        type: string
   push:
     branches: [main]
     paths:
@@ -32,9 +38,16 @@ jobs:
         run: |
           . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh
           echo "${{ secrets.GITHUB_TOKEN }}" | devenv shell -- podman login ghcr.io -u ${{ github.actor }} --password-stdin
-          COMMIT=$(git rev-parse --short HEAD)
-          CALVER="$(date -u +%Y.%m.%d)"
-          VERSION="${CALVER}-${COMMIT}"
+          if [ -n "${{ inputs.push-tag }}" ]; then
+            # Release path (#3140): publish under the immutable versioned
+            # tag pinned by release.yml instead of the continuous
+            # <calver>-<commit> tag.
+            VERSION="${{ inputs.push-tag }}"
+          else
+            COMMIT=$(git rev-parse --short HEAD)
+            CALVER="$(date -u +%Y.%m.%d)"
+            VERSION="${CALVER}-${COMMIT}"
+          fi
           REPO="ghcr.io/${{ github.repository }}/klangk-workspace"
           devenv shell -- podman tag klangk-workspace "$REPO:$VERSION"
           devenv shell -- podman push "$REPO:$VERSION"

--- a/.github/workflows/image-workspace.yml
+++ b/.github/workflows/image-workspace.yml
@@ -16,8 +16,13 @@ on:
       - "scripts/build-workspace-image.sh"
       - ".github/workflows/image-workspace.yml"
 
+# Literal group prefix: in a workflow_call the `github` context is the
+# CALLER's, so `github.workflow` would be "Release" for every callee on a
+# tag push — all four release.yml fan-out jobs would land in one group and
+# cancel each other (#3140). The per-file literal keeps the group unique
+# regardless of who calls this workflow.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: image-workspace-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,38 +10,71 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  build-and-release:
-    runs-on: ubuntu-latest
-    timeout-minutes: 45
+  # --- Container images (#3140) ------------------------------------------
+  #
+  # All five images publish from the tagged commit under the immutable
+  # `vX.Y.Z` tag: klangk-workspace, klangk-workspace-fips,
+  # klangk-network-sidecar, klangk-host, klangk-host-fips. release.yml
+  # owns no build steps of its own — it calls the image workflows via
+  # workflow_call with push-tag pinned to the tag, and each callee builds
+  # and publishes exactly the way its continuous runs do (host pair via
+  # docker, workspace + sidecar via podman). The four calls run in
+  # parallel on separate runners; image-host-fips.yml builds the stock
+  # host + FIPS host in one job, so the workspace + sidecar tars embedded
+  # in the host image are that job's own builds, and the FIPS host layers
+  # that same job's FIPS workspace — the auditable combination a release
+  # tag is meant to pin.
+  #
+  # Versioned tags only — the release path never retags :latest; the
+  # floating :latest tags stay owned by the continuous workflows.
+
+  sidecar-image:
     permissions:
+      contents: read
       packages: write
+    uses: ./.github/workflows/image-network-sidecar.yml
+    with:
+      push-tag: ${{ github.ref_name }}
+    secrets: inherit
+
+  workspace-image:
+    permissions:
+      contents: read
+      packages: write
+    uses: ./.github/workflows/image-workspace.yml
+    with:
+      push-tag: ${{ github.ref_name }}
+    secrets: inherit
+
+  workspace-fips-image:
+    permissions:
+      contents: read
+      packages: write
+    uses: ./.github/workflows/image-workspace-fips.yml
+    with:
+      push-tag: ${{ github.ref_name }}
+    secrets: inherit
+
+  host-images:
+    permissions:
+      contents: read
+      packages: write
+    uses: ./.github/workflows/image-host-fips.yml
+    with:
+      push-tag: ${{ github.ref_name }}
+    secrets: inherit
+
+  create-release:
+    # After all five images are published — a release tag pins the full
+    # auditable set, so the GitHub Release exists only once every image
+    # made it to GHCR.
+    needs: [sidecar-image, workspace-image, workspace-fips-image, host-images]
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
       contents: write
     steps:
       - uses: actions/checkout@v7
-
-      - uses: ./.github/actions/devenv-setup
-
-      - name: Build host image
-        run: |
-          . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh
-          devenv shell -- build-host-image
-
-      - name: Push images to GHCR
-        run: |
-          echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
-          . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh
-          VERSION="${GITHUB_REF_NAME}"
-
-          # Push host image (versioned tag only, no :latest)
-          HOST_REPO="ghcr.io/${{ github.repository }}/klangk-host"
-          docker tag klangk-host "$HOST_REPO:$VERSION"
-          docker push "$HOST_REPO:$VERSION"
-
-          # Push workspace image (versioned tag only, no :latest)
-          WS_REPO="ghcr.io/${{ github.repository }}/klangk-workspace"
-          devenv shell -- podman login ghcr.io -u ${{ github.actor }} --password-stdin <<< "${{ secrets.GITHUB_TOKEN }}"
-          devenv shell -- podman tag klangk-workspace "$WS_REPO:$VERSION"
-          devenv shell -- podman push "$WS_REPO:$VERSION"
 
       - name: Create GitHub Release
         run: |
@@ -82,8 +115,9 @@ jobs:
 
   # Build + publish the klangk wheel to PyPI via trusted publishing (OIDC,
   # no API token — same shape as the deleted cli-publish.yml pre-#1606).
-  # Runs in parallel with build-and-release — the wheel doesn't need
-  # podman/docker, and pip/uv users (the #1607 / #1645 first-run audience)
+  # Runs in parallel with the image jobs and create-release — the wheel
+  # doesn't need podman/docker, and pip/uv users (the #1607 / #1645 first-run
+  # audience)
   # get an installable artifact via `pip install klangk==<tag>`. The
   # distribution name is ``klangk`` (one unified wheel ships the klangkd
   # server + klangk CLI, #1606); the tag is ``vX.Y.Z``; hatch-vcs derives

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -529,9 +529,8 @@ sync` report a clear permission-denied error.
   Pushing `vX.Y.Z` publishes `klangk-host`, `klangk-host-fips`,
   `klangk-workspace`, `klangk-workspace-fips`, and the newly pullable
   `klangk-network-sidecar` to GHCR under that tag, built from the tagged
-  commit — `release.yml` now drives the image workflows via `workflow_call`
-  instead of building inline. Versioned tags only: the floating `:latest`
-  stays owned by the continuous builds. See
+  commit. Versioned tags only: the floating `:latest` stays owned by the
+  continuous builds. See
   [Building Images](development/building-images.md).
 - **`/health` now reports the instance id (#3057).** The health endpoint
   returns `{"status": "ok", "instance": "<id>"}` so a caller can confirm

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -525,6 +525,14 @@ sync` report a clear permission-denied error.
 
 ### Added
 
+- **All five container images now publish on a release tag (#3140).**
+  Pushing `vX.Y.Z` publishes `klangk-host`, `klangk-host-fips`,
+  `klangk-workspace`, `klangk-workspace-fips`, and the newly pullable
+  `klangk-network-sidecar` to GHCR under that tag, built from the tagged
+  commit — `release.yml` now drives the image workflows via `workflow_call`
+  instead of building inline. Versioned tags only: the floating `:latest`
+  stays owned by the continuous builds. See
+  [Building Images](development/building-images.md).
 - **`/health` now reports the instance id (#3057).** The health endpoint
   returns `{"status": "ok", "instance": "<id>"}` so a caller can confirm
   it reached the intended klangkd (the id is the same one in

--- a/docs/deployment/fips.md
+++ b/docs/deployment/fips.md
@@ -60,7 +60,8 @@ devenv shell -- podman build \
 ```
 
 To build on a published image instead, override the base tag — the
-registry carries `<calver>-<commit>` tags only, never `:latest`:
+registry carries `<calver>-<commit>` tags plus the immutable `vX.Y.Z`
+release tags, never `:latest`:
 
 ```bash
 podman build \
@@ -104,9 +105,13 @@ CLI/python MD5 are rejected, and the real auth KDF
 
 CI builds and publishes this image on every change to its inputs
 (`image-host-fips.yml`): `ghcr.io/mcdonc/klangk/klangk-host-fips`,
-tagged `:<calver>-<commit>` plus a floating `:latest`. The workflow's
-runtime spot-check runs klangkd's actual boot gate both ways — it must
-pass inside the FIPS image and refuse to boot inside the stock one.
+tagged `:<calver>-<commit>` plus a floating `:latest`. A `v*` tag push
+publishes the same image — and the FIPS workspace image — under the
+immutable `vX.Y.Z` tag as well: `release.yml` calls the same image
+workflows, so a release pins an auditable host/workspace combination
+(#3140). The workflow's runtime spot-check runs klangkd's actual boot
+gate both ways — it must pass inside the FIPS image and refuse to boot
+inside the stock one.
 
 **Enforcement posture inside a container:** with
 `KLANGKD_FIPS_MODE` on, klangkd detects it is containerized (the

--- a/docs/development/building-images.md
+++ b/docs/development/building-images.md
@@ -63,6 +63,32 @@ deterministic version tag (`YYYY.MM.DD-<commit>`). Stale version
 tags from previous builds are automatically removed so they don't
 accumulate. The local `:latest` tag is never pushed to GHCR.
 
+## Release Publishing
+
+Pushing a `v*` tag triggers `release.yml`, which publishes **all five**
+images to GHCR under the tag (`vX.Y.Z`), built from the tagged commit:
+
+| Image           | GHCR repo (under `ghcr.io/mcdonc/klangk/`) | Also built continuously by  |
+| --------------- | ------------------------------------------ | --------------------------- |
+| Host            | `klangk-host`                              | — (release-only)            |
+| FIPS host       | `klangk-host-fips`                         | `image-host-fips.yml`       |
+| Workspace       | `klangk-workspace`                         | `image-workspace.yml`       |
+| FIPS workspace  | `klangk-workspace-fips`                    | `image-workspace-fips.yml`  |
+| Network sidecar | `klangk-network-sidecar`                   | `image-network-sidecar.yml` |
+
+The release path owns no build steps: it calls those image workflows via
+`workflow_call` with the tag pinned, and each one builds and pushes the way
+its continuous runs do (host pair via docker, workspace + sidecar via
+podman). The host pair builds in one job, so the tarballs embedded in the
+host image come from that job's own workspace + sidecar builds, and the FIPS
+host layers that job's FIPS workspace — a release tag pins an auditable
+combination rather than a mix of floating tags.
+
+Release tags are immutable and versioned only: the release path never
+retags `:latest` (the floating `:latest` on the FIPS images stays owned by
+the continuous workflows). See [Releasing](releasing.md) for the full
+tag-push procedure.
+
 ## Workspace Base Image Pin
 
 The workspace `Dockerfile` pins its base image to an **immutable digest**

--- a/docs/development/building-images.md
+++ b/docs/development/building-images.md
@@ -51,11 +51,14 @@ fails a run — so reviewers check the Actions tab rather than gating CI.
 
 ## Image Versioning
 
-**No `:latest` tags are pushed to the registry.** Every image (host,
-workspace, workspace base) is pushed only with an explicit version
-tag. This prevents confusion when stable branches would otherwise
-overwrite `:latest` with an older version. Consumers always reference
-a specific version (by checking out the tag in their fork) or build locally.
+**Stock images carry no `:latest` tag in the registry.** The host,
+workspace, workspace base, and network sidecar images are pushed only
+with an explicit version tag. This prevents confusion when stable
+branches would otherwise overwrite `:latest` with an older version.
+Consumers always reference a specific version (by checking out the tag
+in their fork) or build locally. The FIPS variants are the exception:
+their continuous workflows also maintain a floating `:latest` for the
+e2e pull path (#2631) — the release path never retags `:latest`.
 
 Locally, `build-workspace-image` tags `klangk-workspace:latest`
 (used by the backend at runtime with pull policy `never`) and a

--- a/docs/development/ci.md
+++ b/docs/development/ci.md
@@ -40,20 +40,21 @@ runners; the self-hosted NixOS runner is an opt-in via `workflow_dispatch`.
 
 ## Container images
 
-| Workflow                       | File                       | Description                             |
-| ------------------------------ | -------------------------- | --------------------------------------- |
-| **Build Workspace Base Image** | `image-workspace-base.yml` | Build and push the base workspace image |
-| **Build Workspace Image**      | `image-workspace.yml`      | Build and push the workspace image      |
-| **Build FIPS Workspace Image** | `image-workspace-fips.yml` | Build and push the FIPS workspace image |
-| **Build FIPS Host Image**      | `image-host-fips.yml`      | Build and push the FIPS host image      |
+| Workflow                        | File                        | Description                              |
+| ------------------------------- | --------------------------- | ---------------------------------------- |
+| **Build Workspace Base Image**  | `image-workspace-base.yml`  | Build and push the base workspace image  |
+| **Build Workspace Image**       | `image-workspace.yml`       | Build and push the workspace image       |
+| **Build FIPS Workspace Image**  | `image-workspace-fips.yml`  | Build and push the FIPS workspace image  |
+| **Build FIPS Host Image**       | `image-host-fips.yml`       | Build and push the FIPS host image       |
+| **Build Network Sidecar Image** | `image-network-sidecar.yml` | Build and push the network sidecar image |
 
 ## Release and publishing
 
-| Workflow        | File             | Trigger                 | Description                                                                              |
-| --------------- | ---------------- | ----------------------- | ---------------------------------------------------------------------------------------- |
-| **Release**     | `release.yml`    | Push a `v*` tag         | Build and publish host container **and** the `klangk` wheel to PyPI (trusted publishing) |
-| **Dist Smoke**  | `dist-smoke.yml` | Manual                  | Verify the to-be-published wheel serves a working login page before tagging              |
-| **Deploy Docs** | `docs.yml`       | Push a `v*` tag, manual | Deploy versioned docs to GitHub Pages via the gh-pages branch                            |
+| Workflow        | File             | Trigger                 | Description                                                                                                         |
+| --------------- | ---------------- | ----------------------- | ------------------------------------------------------------------------------------------------------------------- |
+| **Release**     | `release.yml`    | Push a `v*` tag         | Publish **all five** container images under the version tag **and** the `klangk` wheel to PyPI (trusted publishing) |
+| **Dist Smoke**  | `dist-smoke.yml` | Manual                  | Verify the to-be-published wheel serves a working login page before tagging                                         |
+| **Deploy Docs** | `docs.yml`       | Push a `v*` tag, manual | Deploy versioned docs to GitHub Pages via the gh-pages branch                                                       |
 
 Releases are cut by pushing a `v*` tag; see
 [Releasing](releasing.md) for the full procedure.

--- a/docs/development/releasing.md
+++ b/docs/development/releasing.md
@@ -7,19 +7,31 @@ devenv shell -- git tag v0.1.0
 devenv shell -- git push origin v0.1.0
 ```
 
-The workflow runs two jobs in parallel:
+The workflow runs these jobs:
 
-- **`build-and-release`** — builds the host image (including workspace and
-  Flutter web), pushes both `klangk-host` and `klangk-workspace` to GHCR
-  tagged with the version (e.g. `v0.1.0`), and creates a GitHub Release. The
-  release body is GitHub's auto-generated notes (PR list + compare link)
-  **with that version's section from [the changelog](../changes.md)
-  prepended**, when one exists. No `:latest` tag is pushed — all images are
+- **Image jobs (`sidecar-image`, `workspace-image`, `workspace-fips-image`,
+  `host-images`)** — call the image workflows (`image-network-sidecar.yml`,
+  `image-workspace.yml`, `image-workspace-fips.yml`, `image-host-fips.yml`)
+  via `workflow_call` with the tag pinned, so all **five** images publish
+  from the tagged commit under the version tag (`v0.1.0`): `klangk-host`,
+  `klangk-host-fips`, `klangk-workspace`, `klangk-workspace-fips`, and
+  `klangk-network-sidecar`. There are no inline build steps here — the
+  called workflows build and push exactly the way their continuous runs
+  do (host pair via docker, workspace + sidecar via podman). The host
+  pair is built in one job, so the tarballs embedded in the host image
+  are that job's own workspace + sidecar builds, and the FIPS host layers
+  that job's FIPS workspace — the auditable combination a release tag
+  pins. No `:latest` tag is pushed — the floating `:latest` tags stay
+  owned by the continuous workflows, and all release images are
   referenced by explicit version.
+- **`create-release`** — after all five images are published, creates the
+  GitHub Release. The release body is GitHub's auto-generated notes (PR
+  list + compare link) **with that version's section from
+  [the changelog](../changes.md) prepended**, when one exists.
 - **`build-wheel`** — builds the `klangk` wheel (with the default-feature-set
   frontend baked in) and publishes it to PyPI, so `pip install klangk==<tag>`
   yields a working `klangkd` with the UI served from the in-wheel
-  `klangk/frontend/`.
+  `klangk/frontend/`. Runs in parallel with the image jobs.
 
 For patch releases, increment the patch version: `v0.1.1`.
 
@@ -65,4 +77,11 @@ devenv shell -- bash scripts/build_wheel.sh
 
 ## CI
 
-The `release.yml` workflow builds and pushes the host image to GHCR + the wheel to PyPI, triggered by pushing a version tag matching `v[0-9]*`. The `image-workspace.yml` workflow builds and pushes the workspace image independently on push to `main` (when workspace container files change).
+The `release.yml` workflow publishes all five container images to GHCR (host,
+FIPS host, workspace, FIPS workspace, network sidecar — each under the
+version tag) plus the `klangk` wheel to PyPI, triggered by pushing a version
+tag matching `v[0-9]*`. The `image-workspace.yml`, `image-workspace-fips.yml`,
+`image-host-fips.yml`, and `image-network-sidecar.yml` workflows also build
+and push their images independently on push to `main` (when their inputs
+change), under `<calver>-<commit>` tags (plus a floating `:latest` on the
+FIPS images).

--- a/docs/features/egress-filtering.md
+++ b/docs/features/egress-filtering.md
@@ -325,6 +325,10 @@ required for the common case.
    - **All-in-one host image** (`scripts/build-host-image.sh`): nothing to
      do — the sidecar image is embedded as a tarball in the host image and
      `podman load`ed on first startup.
+   - **Published image**: pull `ghcr.io/mcdonc/klangk/klangk-network-sidecar`
+     (immutable `vX.Y.Z` release tags, or `<calver>-<commit>` tags from the
+     continuous `image-network-sidecar.yml` builds) and retag it to the
+     default local name — `podman pull ... ; podman tag ... klangk-network-sidecar`.
    - **Dev**: the `klangk:build-network-sidecar` devenv task builds it from
      `src/containers/network/`.
    - **Other deploys**: publish the image to your registry and point


### PR DESCRIPTION
## Summary

A `v*` tag push now publishes **all five** container images to GHCR under the `vX.Y.Z` tag, built from the tagged commit — previously only `klangk-host` and `klangk-workspace` shipped from a release, the FIPS pair existed solely as continuously-built floating tags, and the network sidecar was not pullable at all.

| Image           | GHCR repo (under `ghcr.io/mcdonc/klangk/`) | Publish path                                     |
| --------------- | ------------------------------------------ | ------------------------------------------------ |
| Host            | `klangk-host`                              | release only (`image-host-fips.yml` release call) |
| FIPS host       | `klangk-host-fips`                         | release call + continuous `image-host-fips.yml`   |
| Workspace       | `klangk-workspace`                         | release call + continuous `image-workspace.yml`   |
| FIPS workspace  | `klangk-workspace-fips`                    | release call + continuous `image-workspace-fips.yml` |
| Network sidecar | `klangk-network-sidecar`                   | release call + continuous `image-network-sidecar.yml` (new — first time pullable) |

## How

- `release.yml` owns no build steps anymore. It calls the image workflows via `workflow_call` with `push-tag` pinned to the tag (`github.ref_name`), in four parallel jobs, then a `create-release` job (changelog extraction unchanged) runs after all four. `build-wheel` (PyPI) is untouched.
- `image-workspace.yml` (already callable) and `image-workspace-fips.yml` / `image-host-fips.yml` (new `workflow_call` triggers) gain a `push-tag` input: set → publish the immutable versioned tag only; empty (continuous runs, where the `inputs` context is empty) → the exact previous push behavior.
- The stock host publishes from `image-host-fips.yml`'s release branch — that workflow builds the stock host as its layering base anyway, and there is no separate stock-host workflow. Building the host pair in one job keeps the embedding auditable: the tars inside `klangk-host` are that job's own workspace + sidecar builds, and the FIPS host layers that job's FIPS workspace.
- New `image-network-sidecar.yml`: continuous `:<calver>-<commit>` tags (same convention as `klangk-workspace`, no `:latest` — stock-image rule) plus the release tag. One-time setup: flip the new GHCR package's visibility to public for anonymous pulls.

## Decisions (from the issue)

- **Versioned tags only** — the release path never retags `:latest`; floating `:latest` stays owned by the continuous workflows.
- **Store split kept** — host pair docker-built/pushed, workspace + sidecar podman-built/pushed, each workflow handling its own store as before.
- **Continuous workflows unchanged** — their push branches are the same commands as before, just behind an `if`.

## Docs

`releasing.md` (job layout), `building-images.md` (new "Release Publishing" section), `ci.md` (workflow table), `fips.md` (release tags for the FIPS pair), `egress-filtering.md` (published sidecar repo), changelog entry.

Closes #3140.
