### PR TITLE
Silence zensical link-reference warning from changelog headings (#3142)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,9 +56,14 @@ jobs:
             # Extract the body of the `## [<version>]` section. Matched as a
             # prefix so an optional trailing date (`## [v1.0.5] - 2026-07-07`)
             # still matches. Captured up to the next `## [` heading or EOF.
+            # Backslashes are stripped from each line before matching, so the
+            # escaped heading form used in docs/changes.md (`## \[v1.0.5]`,
+            # which keeps the docs build from parsing the heading as a link
+            # reference, #3142) and a bare `## [v1.0.5]` both match.
             SECTION="$(awk -v ver="$VERSION" '
-              $0 ~ "^## \\[" ver "]" { found=1; next }
-              found && /^## \[/ { exit }
+              { line = $0; gsub(/\\/, "", line) }
+              line ~ "^## \\[" ver "]" { found=1; next }
+              found && line ~ /^## \[/ { exit }
               found { print }
             ' docs/changes.md)"
           fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -336,7 +336,10 @@ shared code somewhere both can import without crossing the boundary.
 ## Changelog (`docs/changes.md`)
 
 `docs/changes.md` is the single source of truth for human-authored release notes,
-formatted as [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). It has two
+formatted as [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Version
+headings escape the opening bracket (`## \[Unreleased]`, `## \[v1.2.3] - date`)
+so the docs build does not parse them as Markdown link references (#3142); they
+render as plain `## [Unreleased]`-style headings. The file has two
 rendering surfaces:
 
 - **Docs site** — the whole file renders as one page at `/changes/`, sidebar entry
@@ -348,7 +351,7 @@ rendering surfaces:
 
 ### When to add an entry
 
-Add a bullet under `## [Unreleased]` **in the same PR that introduces the change**
+Add a bullet under `## \[Unreleased]` **in the same PR that introduces the change**
 (not as an afterthought, not after merge). Use the matching subsection:
 
 - **Added** — new feature, config var, CLI flag, endpoint.
@@ -389,11 +392,14 @@ create noise — do not add changelog entries for them.
 
 Right before pushing the tag — do this as its own commit on `main`:
 
-1. Rename `## [Unreleased]` → `## [vX.Y.Z] - YYYY-MM-DD`
+1. Rename `## \[Unreleased]` → `## \[vX.Y.Z] - YYYY-MM-DD`
    (today's date). The `v` prefix and bracket form **must match the tag exactly**;
-   the `- YYYY-MM-DD` date suffix is optional but conventional. The workflow matches the section
-   heading as a prefix, so `## [v1.0.5] - 2026-07-07` matches tag `v1.0.5`.
-2. Insert a fresh, empty `## [Unreleased]` heading directly above it.
+   the `- YYYY-MM-DD` date suffix is optional but conventional. Escape the
+   opening bracket (`\[`) as shown — it keeps the docs build warning-free
+   (#3142). The workflow matches the section heading as a prefix and strips
+   backslashes first, so `## \[v1.0.5] - 2026-07-07` matches tag `v1.0.5` (a
+   bare `## [v1.0.5]` would still match, but don't write it that way).
+2. Insert a fresh, empty `## \[Unreleased]` heading directly above it.
 3. Commit, e.g. `chore(changelog): cut vX.Y.Z`.
 4. Tag and push: `devenv --quiet -O dotenv.enable:bool false shell -- git tag vX.Y.Z && devenv --quiet -O dotenv.enable:bool false shell -- git push origin vX.Y.Z`.
 

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -25,11 +25,11 @@ A `Breaking` subsection may appear under any version for changes that require
 operators or integrators to act when upgrading.
 
 <!-- The release workflow prepends each released version's section to its GitHub
-     Release body. Keep one `## [<version>]` section per release; unreleased
-     changes accumulate under `## [Unreleased]`. The opening bracket in these
-     headings is escaped (`## \[...]`) so the docs build does not parse them
-     as Markdown link references (#3142); they render as plain `[...]` text
-     and the release workflow matches both the escaped and bare forms. -->
+     Release body. Keep one `## \[<version>]` section per release; unreleased
+     changes accumulate under `## \[Unreleased]`. The opening bracket in these
+     headings is escaped so the docs build does not parse them as Markdown
+     link references (#3142); they render as plain `[...]` text and the
+     release workflow matches both the escaped and bare forms. -->
 
 ## \[Unreleased]
 

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -26,9 +26,12 @@ operators or integrators to act when upgrading.
 
 <!-- The release workflow prepends each released version's section to its GitHub
      Release body. Keep one `## [<version>]` section per release; unreleased
-     changes accumulate under `## [Unreleased]`. -->
+     changes accumulate under `## [Unreleased]`. The opening bracket in these
+     headings is escaped (`## \[...]`) so the docs build does not parse them
+     as Markdown link references (#3142); they render as plain `[...]` text
+     and the release workflow matches both the escaped and bare forms. -->
 
-## [Unreleased]
+## \[Unreleased]
 
 ### Breaking
 

--- a/docs/development/releasing.md
+++ b/docs/development/releasing.md
@@ -60,7 +60,7 @@ devenv shell -- bash scripts/build_wheel.sh
 
 ## Gardening the changelog before a tag
 
-`docs/changes.md` is the source of truth for human-authored release notes. Right before tagging, rename the accumulated `## [Unreleased]` section to `## [vX.Y.Z] - YYYY-MM-DD` and add a fresh empty `## [Unreleased]` above it, in its own commit. The release workflow extracts the `## [vX.Y.Z]` section from the checkout at the tag, so the rename must land in (or before) the commit you tag. See `AGENTS.md` for the full maintenance rules (when to add entries, what qualifies).
+`docs/changes.md` is the source of truth for human-authored release notes. Right before tagging, rename the accumulated `## \[Unreleased]` section to `## \[vX.Y.Z] - YYYY-MM-DD` and add a fresh empty `## \[Unreleased]` above it, in its own commit. The opening bracket in version headings is escaped (`\[`) so the docs build does not parse them as Markdown link references — they render as plain `[...]` (#3142), and the release workflow matches both the escaped and bare forms. The release workflow extracts the `## [vX.Y.Z]` section from the checkout at the tag, so the rename must land in (or before) the commit you tag. See `AGENTS.md` for the full maintenance rules (when to add entries, what qualifies).
 
 ## CI
 


### PR DESCRIPTION
Fixes #3142.

## Problem

`build-docs` (zensical) warned on every build:

```
Warning: unresolved link reference
    ╭─[ changes.md:31:5 ]
 31 │ ## [Unreleased]
    ╰── unresolved link reference
```

The Keep a Changelog heading form uses bare square brackets, which Markdown
parses as a link reference with no matching definition.

## Fix

Escape the opening bracket in version headings — `## \[Unreleased]` — per
[zensical's documented recommendation](https://zensical.org/docs/setup/validation/#escaping)
for brackets that are text, not links. The heading still renders as
`## [Unreleased]` and the TOC anchor stays `#unreleased` (verified in the
built HTML). This keeps link-reference validation on for the rest of the
docs (no project-wide `[project.validation]` toggling, which is deprecated
and would mask genuine mistakes).

`release.yml`'s section extraction now strips backslashes before its
`## [<version>]` prefix match, so the escaped form (and a bare
`## [v1.2.3]`, as a tolerance fallback) both extract correctly — verified
with a fixture matrix: escaped + date, bare, last-section-to-EOF, and
missing version (empty section → `--generate-notes` fallback unchanged).

Guidance updated in `AGENTS.md`, `docs/development/releasing.md`, and the
HTML comment in `docs/changes.md`: the release-cut ritual now writes
`## \[vX.Y.Z] - YYYY-MM-DD`.

## Verification

- `build-docs`: `No issues found` (was: 1 warning).
- Rendered `site/changes/index.html`: `<h2 id="unreleased">[Unreleased]`,
  zero stray backslashes on the page.
- awk extraction fixture matrix (above) — all cases extract identically to
  the old logic on bare headings.
- Full diff is docs + one workflow regex; no Python/Flutter surface.
