### PR TITLE
Build the release wheel with uv build (#3143)

### DIFF
--- a/.github/workflows/dist-smoke.yml
+++ b/.github/workflows/dist-smoke.yml
@@ -42,11 +42,11 @@ jobs:
       - name: Build wheel
         run: |
           . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh
-          # scripts/build_wheel.sh installs python-build transiently (uv-sync
-          # at shell entry would wipe it; the script installs + builds in one
-          # process). Requires the frontend artifact from klangk:flutter-build
-          # above — the hatch build hook force-includes it and requires it for
-          # non-editable wheel builds (#1600).
+          # scripts/build_wheel.sh builds via `uv build` in its own isolated
+          # env — the shared devenv venv is never touched (#3143). Requires
+          # the frontend artifact from klangk:flutter-build above — the hatch
+          # build hook force-includes it and requires it for non-editable
+          # wheel builds (#1600).
           devenv shell -- bash scripts/build_wheel.sh
 
       - name: Upload wheel artifact

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -123,11 +123,11 @@ jobs:
       - name: Build wheel
         run: |
           . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh
-          # scripts/build_wheel.sh installs python-build transiently (uv-sync
-          # at shell entry would wipe it; the script installs + builds in one
-          # process). Requires the frontend artifact from klangk:flutter-build
-          # above — the hatch build hook force-includes it and requires it for
-          # non-editable wheel builds (#1600).
+          # scripts/build_wheel.sh builds via `uv build` in its own isolated
+          # env — the shared devenv venv is never touched (#3143). Requires
+          # the frontend artifact from klangk:flutter-build above — the hatch
+          # build hook force-includes it and requires it for non-editable
+          # wheel builds (#1600).
           devenv shell -- bash scripts/build_wheel.sh
 
       - name: Publish to PyPI

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -1988,6 +1988,13 @@ git-credential` (#1700).** `pig-latin` removed; `word-count` dormant.
 
 ### Fixed
 
+- **`build-host-image` / `build_wheel.sh` (#3143).** The release wheel is
+  now built with `uv build`, which resolves hatchling/hatch-vcs into its own
+  isolated build environment instead of transiently installing `build` into
+  the shared devenv venv. Previously a concurrent `uv-sync` from another
+  devenv shell entry could wipe `pyproject-hooks` mid-build, failing the
+  wheel build with `can't open ... _in_process.py: [Errno 2]`.
+
 - **Workspace settings panel name validation (#3130).** Clearing the
   _Name_ field and tapping _Save_ used to fail the whole panel update
   with an opaque `Failed: Error: 422`, blocking every other field from

--- a/docs/development/releasing.md
+++ b/docs/development/releasing.md
@@ -43,9 +43,10 @@ authenticated purely via OIDC attestation. `skip-existing: true` makes the
 upload idempotent on re-runs of the same tag (PyPI refuses re-upload of the
 same filename).
 
-The wheel is built by `scripts/build_wheel.sh`, which installs
-`python-build` transiently (it's not a declared dependency of the runtime
-venv) and runs `python3 -m build --wheel` from `src/klangk/`. The hatch
+The wheel is built by `scripts/build_wheel.sh`, which runs `uv build
+--package klangk --wheel` — uv resolves hatchling/hatch-vcs into its own
+cached, isolated build environment, so the shared devenv venv is never
+touched (#3143). The hatch
 build hook (`src/klangk/hatch_build_package_data.py`) includes the Flutter
 web build at `klangk/frontend/` and **requires** it for non-editable wheel
 builds — so the `build-wheel` job runs `klangk:flutter-build` first (which

--- a/scripts/_python_common.sh
+++ b/scripts/_python_common.sh
@@ -1,7 +1,7 @@
 # shellcheck shell=bash
 # Shared helper: resolve the Python interpreter for scripts that need the
 # project's dependencies. Sourced (not executed) by:
-#   flutterbuildweb.sh, build_wheel.sh, test-push.sh, _podman_common.sh
+#   flutterbuildweb.sh, test-push.sh, _podman_common.sh
 #
 # Task and process exec environments (devenv tasks run / processes up) do
 # NOT put the uv-managed venv (.devenv/state/venv) on PATH — ambient

--- a/scripts/build-host-image.sh
+++ b/scripts/build-host-image.sh
@@ -16,8 +16,7 @@ bash "$SCRIPT_DIR/flutterbuildweb.sh"
 # Build the klangk wheel locally (#1603). flutterbuildweb.sh populated
 # src/frontend/build/web, which the hatch build hook bundles into the wheel
 # at klangk/frontend (#1600). Clean dist/ first so the Dockerfile's wheel
-# glob matches exactly one file. Run in the devenv shell (build_wheel.sh
-# transiently installs the PEP 517 `build` frontend).
+# glob matches exactly one file.
 rm -rf src/klangk/dist
 bash "$SCRIPT_DIR/build_wheel.sh"
 

--- a/scripts/build_wheel.sh
+++ b/scripts/build_wheel.sh
@@ -7,33 +7,35 @@
 # this as the "Build wheel" step with klangk:flutter-build as the devenv
 # build-task, which runs flutterbuildweb.sh first.
 #
-# The ``build`` package isn't a declared dependency of the klangk venv (the
-# venv is the app's runtime, not a build env). uv-sync runs at devenv shell
-# entry and would wipe a transiently-installed build on the next shell, so
-# this script installs it and builds in the same shell invocation.
+# The wheel is built with `uv build` (#3143): uv resolves hatchling/hatch-vcs
+# into its own cached, isolated build environment and never touches the
+# shared devenv venv. The pre-#3143 approach (`uv pip install build` +
+# `python -m build`) transiently polluted .devenv/state/venv, which raced
+# with a concurrent uv-sync at another devenv shell entry — the sync wiped
+# pyproject-hooks mid-build and the backend died with "can't open ...
+# _in_process.py". `--no-isolation` variants have the same problem (they
+# would require installing the build deps into the shared venv); `uv build`
+# avoids the shared venv entirely, same as scripts/build-network-sidecar.sh
+# (#2450).
 #
 # Usage: devenv shell -- bash scripts/build_wheel.sh
 #   (or directly, inside a devenv shell)
 # Produces: src/klangk/dist/klangk-<version>-py3-none-any.whl
 set -euo pipefail
-# shellcheck disable=SC1091 # sourced sibling helper
-source "$(dirname "${BASH_SOURCE[0]}")/_python_common.sh"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
-# Install the PEP 517 build frontend transiently. uv-sync has already run by
-# the time we're inside the shell; this install persists for this process.
-uv pip install build
+# Build the klangk workspace member's wheel from the repo root (the hatch
+# build hook resolves the frontend artifact via absolute paths, so CWD
+# doesn't matter; --out-dir keeps the wheel where the Dockerfile glob and
+# release.yml's pypi-publish step expect it).
+cd "$REPO_ROOT"
+uv build --package klangk --wheel --out-dir src/klangk/dist
 
-# Build the wheel from src/klangk (where pyproject.toml + the build hook live).
-cd "$REPO_ROOT/src/klangk"
-"${KLANGK_PYTHON}" -m build --wheel
-
-# Report what we produced. The script cd'd into src/klangk before building,
-# so dist/ is relative to that dir, not the caller's CWD — print absolute
-# paths so the wheel can be located from anywhere.
+# Report what we produced, with absolute paths so the wheel can be located
+# from anywhere.
 echo "=== built wheels ==="
-ls -lh dist/*.whl
-for whl in dist/*.whl; do
+ls -lh src/klangk/dist/*.whl
+for whl in src/klangk/dist/*.whl; do
   echo "$(cd "$(dirname "$whl")" && pwd)/$(basename "$whl")"
 done


### PR DESCRIPTION
## Summary

`scripts/build_wheel.sh` transiently installed the PEP 517 `build` frontend into the shared devenv venv (`.devenv/state/venv`) before running `python -m build`. A concurrent `uv sync` at another devenv shell entry (e.g. a second terminal, or an agent) wiped `pyproject-hooks` mid-build, so the isolated env's interpreter couldn't find the in-process shim and the backend died with:

```
/tmp/build-env-XXXX/bin/python: can't open file '.devenv/state/venv/.../pyproject_hooks/_in_process/_in_process.py': [Errno 2] No such file or directory
ERROR Backend subprocess exited when trying to invoke get_requires_for_build_wheel
```

Fixes #3143.

## Approach

Switch to `uv build --package klangk --wheel --out-dir src/klangk/dist` from the repo root — the same isolated pattern `scripts/build-network-sidecar.sh` already uses (#2450). uv resolves hatchling/hatch-vcs into its own cached build environment, so the shared venv is never touched and there is nothing left for a concurrent `uv-sync` to race with.

- Wheel output path unchanged (`src/klangk/dist/klangk-<version>-py3-none-any.whl`) — the Dockerfile glob and release.yml's pypi-publish step keep working.
- Interpreter stays pinned to the devenv 3.14 venv via `env.UV_PYTHON` (devenv.nix).
- Dropped the now-unused `_python_common.sh` source from the script.
- Updated the stale comments in `build-host-image.sh`, `release.yml`, `dist-smoke.yml`, and `releasing.md`; changelog entry added.

## Verification

- Built the frontend (`flutterbuildweb.sh`) and the wheel in the worktree with the new script: `src/klangk/dist/klangk-1.0.5.dev827+gcf880acf...-py3-none-any.whl` (31M, 58 files under `klangk/frontend/`, nix-seed Dockerfile included, correct hatch-vcs version from the worktree commit).
- After the build, the shared venv contains no `build`/`pyproject-hooks`.
- `scripts/tests`: 109 passed (build-path contract suite).
- Fresh-eyes review (below) — approved, both findings addressed.
