### PR TITLE
Flag a/b/rc-tagged releases as GitHub pre-releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,6 +84,13 @@ jobs:
           # auto-generated commit summaries (#2125).
           # Fallback: no changelog section → pure auto-generated notes.
           VERSION="$GITHUB_REF_NAME"
+          # Pre-release tag (vX.Y.ZaN / bN / rcN, e.g. v2.0.0a1) → mark
+          # the GitHub Release as a pre-release so it does not claim
+          # "latest" from the last stable release.
+          PRE_ARGS=()
+          if [[ "$VERSION" =~ ^v[0-9]+(\.[0-9]+){0,2}(a|b|rc)[0-9]+$ ]]; then
+            PRE_ARGS=(--prerelease)
+          fi
           SECTION=""
           if [ -f docs/changes.md ]; then
             # Extract the body of the `## [<version>]` section. Matched as a
@@ -101,15 +108,15 @@ jobs:
             ' docs/changes.md)"
           fi
           if [ -n "$SECTION" ]; then
-            gh release create "$VERSION" \
-              --title "$VERSION" \
-              --notes "$SECTION"
+            NOTES_ARGS=(--notes "$SECTION")
           else
             # No changelog section for this version — pure auto-generated notes.
-            gh release create "$VERSION" \
-              --title "$VERSION" \
-              --generate-notes
+            NOTES_ARGS=(--generate-notes)
           fi
+          gh release create "$VERSION" \
+            --title "$VERSION" \
+            "${NOTES_ARGS[@]}" \
+            "${PRE_ARGS[@]}"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -1638,6 +1638,9 @@ stop)`) and a `server: stop at 23:00 (in 1h 12m)` status line in the
 
 ### Changed
 
+- **Pre-release tags.** Cutting a release from an `a`/`b`/`rc` tag
+  (e.g. `v2.0.0a1`) now marks the GitHub Release as a pre-release, so
+  it no longer claims "latest" from the most recent stable release.
 - **`klangk sandbox` `copy:` destinations are literal container paths
   (#3118).** Only a leading `~` is special (it expands to
   `/home/{handle}`); no other shell expansion happens — a destination

--- a/docs/development/releasing.md
+++ b/docs/development/releasing.md
@@ -35,6 +35,18 @@ The workflow runs these jobs:
 
 For patch releases, increment the patch version: `v0.1.1`.
 
+## Pre-releases
+
+A tag with a PEP 440 pre-release segment — `v2.0.0a1`, `v1.2.3b2`,
+`v2.0.0rc1` — runs the same pipeline: all five images publish under the
+tag, the wheel publishes to PyPI (plain `pip install klangk` keeps
+resolving to the last stable release; testers opt in with `--pre` or an
+exact pin), and the GitHub Release is created **flagged as a
+pre-release**, so it does not claim "latest" from the most recent
+stable release. The changelog section must carry the full suffix
+(`## \[v2.0.0a1]`) — the workflow's prefix match is anchored on `]`, so
+`## \[v2.0.0]` does not satisfy tag `v2.0.0a1`.
+
 ## PyPI publishing
 
 The `build-wheel` job publishes via **trusted publishing (OIDC)** — no API


### PR DESCRIPTION
## Summary

`release.yml`'s `create-release` job now detects PEP 440 pre-release tags (`v2.0.0a1`, `v1.2.3b2`, `v1.0.0rc1`) and passes `--prerelease` to `gh release create`, so an alpha/beta/rc GitHub Release no longer claims "latest" from the most recent stable release. Stable tags are unaffected.

Implementation detail: the flag is built as a bash array (`PRE_ARGS`) and the previously duplicated `gh release create` invocations (changelog-notes vs auto-generated fallback) are collapsed into one call with a `NOTES_ARGS` array.

## Verification

- Regex checked against tag shapes: `a1`/`b2`/`rc1` → flagged; `v1.0.0`, incomplete suffixes (`v2.0.0a`), `.dev1` → not flagged.
- `actionlint`, `yamllint`, markdownlint, prettier pass (pre-commit).
- New "Pre-releases" section in `docs/development/releasing.md` documents the flow (changelog section must carry the full suffix; pip behavior unchanged — `--pre` or exact pin required).
- Changelog entry added under `[Unreleased]` → Changed.
