### PR TITLE
Close live WebSocket connections on token revocation (#3152)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -301,6 +301,16 @@ operators or integrators to act when upgrading.
   unaffected — a refreshed session keeps its socket, retargeted onto
   the new token so a later revocation still closes it.
 
+- **WebSocket connections close on token expiry (#3152).** A socket
+  now schedules its own close (code 4002) at the access token's `exp`
+  time. Previously a socket established before the token expired would
+  stay open indefinitely until the client happened to reconnect.
+
+- **Password change revokes all sessions (#3152).** `POST
+/api/v1/auth/change-password` now blocklists every active session
+  token and closes their WebSocket connections, forcing re-login on
+  all devices.
+
 - **Bounded rate-limit state for the email cooldowns (#3113).** The
   per-address cooldown dicts behind
   `POST /api/v1/auth/forgot-password` and

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -298,7 +298,8 @@ operators or integrators to act when upgrading.
   authenticated (close code 4001, so clients log out instead of
   reconnect-looping). Previously an established socket kept full
   data-plane access until the next reconnect. Refresh rotation is
-  unaffected — a refreshed session keeps its socket.
+  unaffected — a refreshed session keeps its socket, retargeted onto
+  the new token so a later revocation still closes it.
 
 - **Bounded rate-limit state for the email cooldowns (#3113).** The
   per-address cooldown dicts behind
@@ -2049,6 +2050,14 @@ git-credential` (#1700).** `pig-latin` removed; `word-count` dormant.
   `podman info` / `podman unshare` diagnostics first so a persistent
   occurrence stays attributable — and passes every other failure through
   untouched.
+
+- **Account-disable / inactivity socket kick was a no-op (#3152).**
+  `SafeWebSocket.close` dropped the `reason` argument, so the 4001
+  close that admin-disable and the inactivity sweep issue for a
+  disabled user's live connections raised a TypeError that was
+  swallowed — no socket was ever actually closed. `close` now forwards
+  `reason` to the transport, and the kick paths have regression tests
+  against the real `SafeWebSocket`.
 
 - **`build-host-image` / `build_wheel.sh` (#3143).** The release wheel is
   now built with `uv build`, which resolves hatchling/hatch-vcs into its own

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -292,6 +292,14 @@ operators or integrators to act when upgrading.
 
 ### Security
 
+- **WebSocket connections are closed on token revocation (#3152).**
+  Logging out, or being evicted by the per-user session limit, now
+  immediately closes the live WebSocket connections the revoked token
+  authenticated (close code 4001, so clients log out instead of
+  reconnect-looping). Previously an established socket kept full
+  data-plane access until the next reconnect. Refresh rotation is
+  unaffected — a refreshed session keeps its socket.
+
 - **Bounded rate-limit state for the email cooldowns (#3113).** The
   per-address cooldown dicts behind
   `POST /api/v1/auth/forgot-password` and

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -292,6 +292,18 @@ operators or integrators to act when upgrading.
 
 ### Security
 
+- **Consent-decider sockets are closed on token revocation (#3162).**
+  The `/ws/consent-decider` connection now shares the #3152 revocation
+  story: logging out, being evicted by the per-user session limit, or
+  having the account disabled (admin action or the inactivity sweep)
+  immediately closes the decider sockets that credential authenticated
+  (close code 4001) and drops their registrations, so egress-consent
+  authority (verdicts, revokes, pause) ends with the credential.
+  Previously the decider socket — which lives in its own registry —
+  kept that authority indefinitely after logout or disable. Refresh
+  rotation retargets the decider onto the new token instead of closing
+  it.
+
 - **WebSocket connections are closed on token revocation (#3152).**
   Logging out, or being evicted by the per-user session limit, now
   immediately closes the live WebSocket connections the revoked token

--- a/src/frontend/e2e-tests/e2e/password-history.spec.ts
+++ b/src/frontend/e2e-tests/e2e/password-history.spec.ts
@@ -148,9 +148,18 @@ test.describe("Password reuse gate (#2582)", () => {
     expect(await submitChange(page, TEST_PASSWORD, TEST_PASSWORD)).toBe(400);
     expect(await apiLoginStatus(request, email, TEST_PASSWORD)).toBe(200);
 
-    // 2. A novel password change succeeds through the UI.
+    // 2. A novel password change succeeds through the UI.  The server
+    //    revokes all sessions on password change (#3152), so the client
+    //    is kicked back to login — re-login and navigate to settings.
     expect(await submitChange(page, TEST_PASSWORD, newPassword)).toBe(200);
     expect(await apiLoginStatus(request, email, newPassword)).toBe(200);
+
+    await loginViaUI(page, email, newPassword);
+    await page.goto("/#/settings");
+    await expect(page).toHaveTitle(/Settings/i, { timeout: 10_000 });
+    await page.reload();
+    await waitForFlutter(page);
+    await enableSemantics(page);
 
     // 3. Changing back to the just-retired password is rejected — the
     //    new one is still current, the old one no longer works.

--- a/src/klangk/klangk/api/admin.py
+++ b/src/klangk/klangk/api/admin.py
@@ -446,6 +446,29 @@ def _reject_self_disable(
         )
 
 
+async def _kick_disabled_user_sockets(app, user_id: str) -> None:
+    """Cut a just-disabled user's live sockets (#2588, #3162).
+
+    The main /ws connections (the terminal/control data plane) and the
+    consent-decider sockets (egress-consent authority) alike; 4001 ->
+    the clients log out rather than reconnect-looping.
+    """
+    kicked = await wshandler.disconnect_user(
+        app.state.sockets, user_id, reason="Account disabled"
+    )
+    deciders_kicked = await wshandler.disconnect_deciders_by_user(
+        app, user_id, reason="Account disabled"
+    )
+    if kicked or deciders_kicked:
+        logger.info(
+            "admin: disabled user %s; closed %d live connection(s)"
+            " and %d consent decider(s)",
+            user_id,
+            kicked,
+            deciders_kicked,
+        )
+
+
 async def _update_user_disabled(
     app, req: UpdateUserRequest, user_id: str, admin: dict
 ) -> None:
@@ -461,19 +484,7 @@ async def _update_user_disabled(
     if not updated:  # pragma: no cover — race between get and update
         raise HTTPException(status_code=404, detail="User not found")
     if req.disabled:
-        # Cut the user's live connections too (#2588 review): the
-        # WS is the terminal/control data plane, and a disabled
-        # account must not keep it. 4001 -> the client logs out
-        # rather than reconnect-looping.
-        kicked = await wshandler.disconnect_user(
-            app.state.sockets, user_id, reason="Account disabled"
-        )
-        if kicked:
-            logger.info(
-                "admin: disabled user %s; closed %d live connection(s)",
-                user_id,
-                kicked,
-            )
+        await _kick_disabled_user_sockets(app, user_id)
 
 
 @router.post("/users/{user_id}/unlockout")

--- a/src/klangk/klangk/api/auth.py
+++ b/src/klangk/klangk/api/auth.py
@@ -612,6 +612,9 @@ async def change_password(
     await request.app.state.model.users.update_password(
         user["id"], password_hash
     )
+    # Revoke every session so the old credential cannot be reused and
+    # any live WebSocket connections are closed (#3152).
+    await request.app.state.auth.revoke_all_user_sessions(user["id"])
     return {"status": "updated"}
 
 

--- a/src/klangk/klangk/auth.py
+++ b/src/klangk/klangk/auth.py
@@ -717,6 +717,17 @@ class Auth:
             ", ".join(others),
         )
 
+    async def _kick_revoked_sockets(self, jti: str) -> None:
+        """Close live WS connections authenticated with *jti* (#3152).
+
+        Revocation must cut the sockets the token opened, not just
+        reject the next connect. Minimal app states (tests) may not wire
+        ``sockets`` — then there is nothing to close.
+        """
+        sockets = getattr(self.app.state, "sockets", None)
+        if sockets is not None:
+            await sockets.disconnect_by_jti(jti, reason="Token revoked")
+
     async def _revoke_sessions(
         self, user_id: str, rows: list[dict], limit: int
     ) -> None:
@@ -725,7 +736,8 @@ class Auth:
         Victims are removed oldest-first by blocklisting their JTIs (the
         same revocation path as logout: the next HTTP request 401s with
         "Token has been revoked"; the next WebSocket connect is rejected
-        with 4001 → client logout), then their session rows are deleted.
+        with 4001 → client logout), then their session rows are deleted,
+        and their live WebSocket connections are closed (#3152).
         Blocklisting happens BEFORE the delete so a crash between the two
         can only leave a dead token's row behind (purged on the next
         issuance), never a live token without a row.
@@ -741,6 +753,7 @@ class Auth:
             await self.app.state.model.tokens.blocklist_token(
                 row["jti"], row["expires_at"]
             )
+            await self._kick_revoked_sockets(row["jti"])
         await self.app.state.model.sessions.remove_sessions(
             [row["jti"] for row in rows]
         )
@@ -1159,7 +1172,8 @@ class Auth:
             return None
 
     async def logout(self, token: str) -> None:
-        """Blocklist the token's JTI and drop its session row."""
+        """Blocklist the token's JTI, drop its session row, and close the
+        WebSocket connections it authenticated (#3152)."""
         try:
             payload = self.decode_token(token)
             jti = payload.get("jti")
@@ -1172,6 +1186,7 @@ class Auth:
                     jti, expires_at
                 )
                 await self.app.state.model.sessions.remove_session(jti)
+                await self._kick_revoked_sockets(jti)
         except JWTError:
             pass
 

--- a/src/klangk/klangk/auth.py
+++ b/src/klangk/klangk/auth.py
@@ -1066,6 +1066,19 @@ class Auth:
         await self.app.state.model.sessions.replace_session(
             jti, user_id, new_payload["jti"], new_expires_at
         )
+        self._retarget_refreshed_sockets(jti, new_payload["jti"])
+
+    def _retarget_refreshed_sockets(self, old_jti: str, new_jti: str) -> None:
+        """Move live WS connections onto the refreshed token's JTI (#3152).
+
+        Keeps ``conn.jti`` equal to the session row's current JTI so a
+        later hard revocation (logout, eviction) still finds the socket
+        the refreshed session is using. Minimal app states (tests) may
+        not wire ``sockets`` — then there is nothing to retarget.
+        """
+        sockets = getattr(self.app.state, "sockets", None)
+        if sockets is not None:
+            sockets.reattach_jti(old_jti, new_jti)
 
     async def _expired_token_response(self, token: str) -> TokenResponse:
         """A previously-refreshed expired token still returns its cached

--- a/src/klangk/klangk/auth.py
+++ b/src/klangk/klangk/auth.py
@@ -721,12 +721,18 @@ class Auth:
         """Close live WS connections authenticated with *jti* (#3152).
 
         Revocation must cut the sockets the token opened, not just
-        reject the next connect. Minimal app states (tests) may not wire
-        ``sockets`` — then there is nothing to close.
+        reject the next connect — both the main ``/ws`` connections and
+        the consent-decider sockets (#3162: a decider holds
+        egress-consent authority and lives in its own registry). Minimal
+        app states (tests) may not wire ``sockets`` or
+        ``consent_deciders`` — then there is nothing to close.
         """
         sockets = getattr(self.app.state, "sockets", None)
         if sockets is not None:
             await sockets.disconnect_by_jti(jti, reason="Token revoked")
+        deciders = getattr(self.app.state, "consent_deciders", None)
+        if deciders is not None:
+            await deciders.disconnect_by_jti(jti, reason="Token revoked")
 
     async def revoke_all_user_sessions(self, user_id: str) -> None:
         """Blocklist and delete every session for *user_id* (#3152).
@@ -1096,12 +1102,17 @@ class Auth:
 
         Keeps ``conn.jti`` equal to the session row's current JTI so a
         later hard revocation (logout, eviction) still finds the socket
-        the refreshed session is using. Minimal app states (tests) may
-        not wire ``sockets`` — then there is nothing to retarget.
+        the refreshed session is using — for the main ``/ws``
+        connections and the consent-decider registrations alike
+        (#3162). Minimal app states (tests) may not wire ``sockets`` or
+        ``consent_deciders`` — then there is nothing to retarget.
         """
         sockets = getattr(self.app.state, "sockets", None)
         if sockets is not None:
             sockets.reattach_jti(old_jti, new_jti)
+        deciders = getattr(self.app.state, "consent_deciders", None)
+        if deciders is not None:
+            deciders.reattach_jti(old_jti, new_jti)
 
     async def _expired_token_response(self, token: str) -> TokenResponse:
         """A previously-refreshed expired token still returns its cached

--- a/src/klangk/klangk/auth.py
+++ b/src/klangk/klangk/auth.py
@@ -728,6 +728,29 @@ class Auth:
         if sockets is not None:
             await sockets.disconnect_by_jti(jti, reason="Token revoked")
 
+    async def revoke_all_user_sessions(self, user_id: str) -> None:
+        """Blocklist and delete every session for *user_id* (#3152).
+
+        Called after a password change: the old credential is invalid, so
+        every session minted with it must be forcibly ended — both the
+        HTTP side (blocklist → 401) and the WebSocket side (kick).
+        """
+        rows = await self.app.state.model.sessions.list_sessions(user_id)
+        for row in rows:
+            logger.info(
+                "password change: revoking session jti=%s (user %s)",
+                row["jti"],
+                user_id,
+            )
+            await self.app.state.model.tokens.blocklist_token(
+                row["jti"], row["expires_at"]
+            )
+            await self._kick_revoked_sockets(row["jti"])
+        if rows:
+            await self.app.state.model.sessions.remove_sessions(
+                [row["jti"] for row in rows]
+            )
+
     async def _revoke_sessions(
         self, user_id: str, rows: list[dict], limit: int
     ) -> None:

--- a/src/klangk/klangk/consent/deciders.py
+++ b/src/klangk/klangk/consent/deciders.py
@@ -24,6 +24,14 @@ for at most that long, not indefinitely.
 
 Owns only ``app`` (the app-ownership rule); the timeout is read live via
 property so a SIGHUP reload propagates.
+
+#3162: entries carry the JTI of the user JWT that authenticated the
+decider handshake and the user id, so both a hard token revocation
+(logout, session-limit eviction — by JTI) and an account disable (admin
+route, inactivity sweep — by user) can close the decider sockets that
+credential opened — the same kicks the main ``/ws`` registry got in
+#3152/#2588. Refresh rotation retargets the entry onto the new JTI
+instead of closing it.
 """
 
 from __future__ import annotations
@@ -54,7 +62,8 @@ class ConsentDeciderRegistry:
     def __init__(self, app) -> None:
         self.app = app
         # decider_id -> {"ws": workspace_id, "seen": monotonic,
-        #                 "email": str, "sock": SafeWebSocket}
+        #                 "email": str, "sock": SafeWebSocket,
+        #                 "jti": str | None, "user_id": str | None}
         self._deciders: dict[str, dict] = {}
         self._reaper: asyncio.Task | None = None
 
@@ -71,18 +80,26 @@ class ConsentDeciderRegistry:
         workspace_id: str,
         email: str | None,
         sock,
+        jti: str | None = None,
+        user_id: str | None = None,
     ) -> None:
         """Register a live decider (connect). Idempotent on decider_id.
 
         ``sock`` is the decider's :class:`SafeWebSocket`; the endpoint owns its
         lifecycle (start/stop sender) -- the registry holds only a reference for
-        :meth:`broadcast` fanout.
+        :meth:`broadcast` fanout. ``jti`` is the ID of the user JWT that
+        authenticated the handshake (#3162) so a later hard revocation can
+        close exactly this decider; ``user_id`` lets an account disable do
+        the same for every decider of the user. Both are ``None`` on
+        registrations built without them (tests) -- never kicked.
         """
         self._deciders[decider_id] = {
             "ws": workspace_id,
             "seen": time.monotonic(),
             "email": email,
             "sock": sock,
+            "jti": jti,
+            "user_id": user_id,
         }
         logger.info(
             "consent decider registered: scope=%s decider=%s",
@@ -146,6 +163,83 @@ class ConsentDeciderRegistry:
         for did in dead:
             self._deciders.pop(did, None)
         return delivered
+
+    async def _close_and_drop(
+        self, victims: list, code: int, reason: str
+    ) -> int:
+        """Close each victim decider's socket and drop its registration.
+
+        Shared sweep body of the two kick selectors; a socket already gone
+        must not abort the sweep over the rest.
+        """
+        for did, entry in victims:
+            self._deciders.pop(did, None)
+            try:
+                await entry["sock"].close(code=code, reason=reason)
+            except Exception:  # noqa: BLE001
+                logger.debug(
+                    "Error closing decider socket for %s", entry["email"]
+                )
+        return len(victims)
+
+    async def disconnect_by_jti(
+        self, jti: str, *, code: int = 4001, reason: str = ""
+    ) -> int:
+        """Close every live decider registered with *jti* (#3162).
+
+        Hard token revocation (logout, session-limit eviction) must cut
+        the decider sockets that token opened, not just reject the next
+        connect — a decider holds egress-consent authority (verdicts,
+        revokes, pause), so it must not outlive its credential. Code 4001
+        makes the client log out rather than reconnect-loop, the same
+        convention as ``WebSocketState.disconnect_by_jti`` (#3152).
+        Entries are dropped here so the workspace's consent authority
+        ends at revocation, not when the receive loop notices; the
+        endpoint's ``finally`` deregister is then a no-op. Returns how
+        many deciders were closed.
+        """
+        victims = [
+            (did, entry)
+            for did, entry in self._deciders.items()
+            if entry["jti"] == jti
+        ]
+        return await self._close_and_drop(victims, code, reason)
+
+    async def disconnect_by_user(
+        self, user_id: str, *, code: int = 4001, reason: str = ""
+    ) -> int:
+        """Close every live decider registered by *user_id* (#3162).
+
+        Account disable (admin route, inactivity sweep) must cut the
+        user's decider sockets too — the per-user analogue of the #2588
+        ``disconnect_user`` kick, for a surface that holds
+        egress-consent authority. Same close/drop semantics as
+        :meth:`disconnect_by_jti`. Returns how many deciders were
+        closed.
+        """
+        victims = [
+            (did, entry)
+            for did, entry in self._deciders.items()
+            if entry["user_id"] == user_id
+        ]
+        return await self._close_and_drop(victims, code, reason)
+
+    def reattach_jti(self, old_jti: str, new_jti: str) -> int:
+        """Move live deciders from *old_jti* onto *new_jti* (#3162).
+
+        A token refresh keeps the session — and its decider socket —
+        alive under the new token; retargeting keeps the entry's JTI
+        equal to the session row's current JTI so a later hard
+        revocation (logout, session-limit eviction) still finds the
+        decider (mirrors ``WebSocketState.reattach_jti``, #3152).
+        Returns how many deciders were moved.
+        """
+        moved = 0
+        for entry in self._deciders.values():
+            if entry["jti"] == old_jti:
+                entry["jti"] = new_jti
+                moved += 1
+        return moved
 
     def start(self) -> None:
         """Start the liveness reaper (idempotent). Runs until :meth:`stop`."""

--- a/src/klangk/klangk/inactivity.py
+++ b/src/klangk/klangk/inactivity.py
@@ -62,6 +62,11 @@ class InactivitySweeper(IntervalWorker):
                     u["id"],
                     reason="Account disabled",
                 )
+                # #3162: the decider surface must not outlive the disable
+                # either — it holds egress-consent authority.
+                await wshandler.disconnect_deciders_by_user(
+                    self.app, u["id"], reason="Account disabled"
+                )
             logger.info(
                 "inactivity: disabled %d account(s) inactive for more than"
                 " %d day(s): %s",

--- a/src/klangk/klangk/wshandler/__init__.py
+++ b/src/klangk/klangk/wshandler/__init__.py
@@ -30,6 +30,7 @@ from .support import (
     broadcast_event as broadcast_event,
     disconnect_all_websockets as disconnect_all_websockets,
     disconnect_by_jti as disconnect_by_jti,
+    disconnect_deciders_by_user as disconnect_deciders_by_user,
     disconnect_user as disconnect_user,
     format_container_info as format_container_info,
     format_idle_timeout as format_idle_timeout,

--- a/src/klangk/klangk/wshandler/__init__.py
+++ b/src/klangk/klangk/wshandler/__init__.py
@@ -29,6 +29,7 @@ from .support import (
     WS_DEBUG as WS_DEBUG,
     broadcast_event as broadcast_event,
     disconnect_all_websockets as disconnect_all_websockets,
+    disconnect_by_jti as disconnect_by_jti,
     disconnect_user as disconnect_user,
     format_container_info as format_container_info,
     format_idle_timeout as format_idle_timeout,
@@ -62,4 +63,5 @@ from .dispatch import (
     WS_CONNECTION_COMMANDS as WS_CONNECTION_COMMANDS,
     WS_STATE_COMMANDS as WS_STATE_COMMANDS,
     handle_websocket as handle_websocket,
+    ws_authenticate as ws_authenticate,
 )

--- a/src/klangk/klangk/wshandler/connection.py
+++ b/src/klangk/klangk/wshandler/connection.py
@@ -106,7 +106,7 @@ class Connection:
         token expires. Called once after the connection is registered."""
         if self.token_exp is None:
             return
-        self._expiry_task = asyncio.ensure_future(self._expire_when_due())
+        self._expiry_task = asyncio.create_task(self._expire_when_due())
 
     async def _expire_when_due(self) -> None:
         """Sleep until the token's ``exp`` claim, then close the socket."""

--- a/src/klangk/klangk/wshandler/connection.py
+++ b/src/klangk/klangk/wshandler/connection.py
@@ -34,10 +34,17 @@ logger = logging.getLogger(__name__)
 class Connection:
     """Per-WebSocket connection state and command handlers."""
 
-    def __init__(self, ws: SafeWebSocket, user: dict, app):
+    def __init__(
+        self, ws: SafeWebSocket, user: dict, app, jti: str | None = None
+    ):
         self.app = app
         self.sock = ws
         self.user = user
+        # JTI of the access token this socket authenticated with (#3152):
+        # lets a hard revocation (logout, session-limit eviction) close
+        # exactly the connections that token opened — not every session
+        # of the user. ``None`` on connections built without one (tests).
+        self.jti = jti
         self.workspace_id: str | None = None
         self.container_id: str | None = None
         # Terminal sessions are owned by the TerminalController

--- a/src/klangk/klangk/wshandler/connection.py
+++ b/src/klangk/klangk/wshandler/connection.py
@@ -1,5 +1,6 @@
 """Connection: per-WebSocket connection state and command handlers."""
 
+import asyncio
 import logging
 import time
 from datetime import datetime, timedelta, timezone
@@ -35,7 +36,12 @@ class Connection:
     """Per-WebSocket connection state and command handlers."""
 
     def __init__(
-        self, ws: SafeWebSocket, user: dict, app, jti: str | None = None
+        self,
+        ws: SafeWebSocket,
+        user: dict,
+        app,
+        jti: str | None = None,
+        token_exp: float | None = None,
     ):
         self.app = app
         self.sock = ws
@@ -45,6 +51,11 @@ class Connection:
         # exactly the connections that token opened — not every session
         # of the user. ``None`` on connections built without one (tests).
         self.jti = jti
+        # Unix-epoch expiry of the access token (#3152): the socket must
+        # not outlive its token. ``_schedule_token_expiry`` starts a task
+        # that closes the socket at this time.
+        self.token_exp = token_exp
+        self._expiry_task: asyncio.Task | None = None
         self.workspace_id: str | None = None
         self.container_id: str | None = None
         # Terminal sessions are owned by the TerminalController
@@ -87,6 +98,29 @@ class Connection:
         # it. Relay state (proc/task/socket) lives on the forwarder
         # (``self.ssh_agent.*``), not on Connection.
         self.ssh_agent = SshAgentForwarder(self)
+
+    # --- token expiry timer (#3152) ---
+
+    def schedule_token_expiry(self) -> None:
+        """Start a background task that closes the socket when the access
+        token expires. Called once after the connection is registered."""
+        if self.token_exp is None:
+            return
+        self._expiry_task = asyncio.ensure_future(self._expire_when_due())
+
+    async def _expire_when_due(self) -> None:
+        """Sleep until the token's ``exp`` claim, then close the socket."""
+        remaining = self.token_exp - time.time()
+        if remaining > 0:
+            await asyncio.sleep(remaining)
+        logger.info(
+            "Access token expired for user %s — closing socket",
+            self.user.get("email"),
+        )
+        try:
+            await self.sock.close(code=4002, reason="Token expired")
+        except Exception:  # noqa: BLE001
+            logger.debug("Error closing expired socket")
 
     # --- SSH agent forwarding (delegates to SshAgentForwarder) ---
 
@@ -764,6 +798,11 @@ class Connection:
         self._user_home = container_home
 
     async def cleanup(self) -> None:
+        # Cancel the token-expiry timer if still pending (#3152).
+        if self._expiry_task is not None:
+            self._expiry_task.cancel()
+            self._expiry_task = None
+
         # Remove idle callback
         workspace_id = self.workspace_id
         self._remove_idle_callback(workspace_id)

--- a/src/klangk/klangk/wshandler/connection.py
+++ b/src/klangk/klangk/wshandler/connection.py
@@ -119,7 +119,7 @@ class Connection:
         )
         try:
             await self.sock.close(code=4002, reason="Token expired")
-        except Exception:  # noqa: BLE001
+        except Exception:  # pragma: no cover  # noqa: BLE001
             logger.debug("Error closing expired socket")
 
     # --- SSH agent forwarding (delegates to SshAgentForwarder) ---

--- a/src/klangk/klangk/wshandler/decider.py
+++ b/src/klangk/klangk/wshandler/decider.py
@@ -32,7 +32,13 @@ it targets the decider's own workspace (defense-in-depth), enforced in
 ``resolve`` via ``decider_workspace``. Pause/unpause share the same single
 gate as the connection itself (#2883): anyone who may register may also
 pause. Auth mirrors the main ``/ws`` handler: a user JWT in the ``token``
-query param.
+query param — including its revocation story (#3162): the handshake
+records the token's JTI on the registry entry, and a hard revocation
+(logout, session-limit eviction) closes the decider socket with 4001,
+just like the main handler's connections (#3152), and an account
+disable closes every decider of the user (#3162, mirroring the #2588
+per-user kick). Refresh rotation retargets the entry onto the new JTI
+instead of closing it.
 
 Outbound writes go through :class:`SafeWebSocket` (bounded queue +
 ``SlowClientError``) like the main ``/ws`` handler.
@@ -46,8 +52,8 @@ import time
 import uuid
 
 from fastapi import WebSocket, WebSocketDisconnect
+from jose import ExpiredSignatureError, JWTError
 
-from .. import auth
 from .safe_websocket import SafeWebSocket, SlowClientError
 from ..model.egress_consent import (
     DECISION_ALLOWED,
@@ -225,20 +231,31 @@ async def _dispatch_decider_message(
 
 
 async def _decider_authenticate(websocket: WebSocket, app, _hs_mark):
-    """Validate the decider socket's token; refuse + None on failure."""
+    """Validate the decider socket's token; refuse + None on failure.
+
+    Success returns ``(user, jti)`` — the token's JTI rides along so the
+    registration can be targeted for closing when that token is later
+    hard-revoked (#3162), mirroring ``ws_authenticate`` (#3152).
+    """
     token = websocket.query_params.get("token")
     if not token:
         await _refuse(websocket, 4001, "Missing token")
         return None
-    result = await app.state.auth.get_user_from_token(token)
-    _hs_mark("token")
-    if result is auth.Auth.TOKEN_EXPIRED:
+    a = app.state.auth
+    try:
+        payload = a.decode_token(token)
+    except ExpiredSignatureError:
         await _refuse(websocket, 4002, "Token expired")
         return None
-    if result is None:
+    except JWTError:
         await _refuse(websocket, 4001, "Invalid token")
         return None
-    return result
+    user = await a._user_from_valid_payload(payload)
+    _hs_mark("token")
+    if user is None:
+        await _refuse(websocket, 4001, "Invalid token")
+        return None
+    return user, payload.get("jti")
 
 
 _FRAME_DISCONNECTED = object()
@@ -326,9 +343,10 @@ async def handle_consent_decider(websocket: WebSocket, app) -> None:
     def _hs_mark(label: str) -> None:
         _hs_marks.append((label, time.monotonic()))
 
-    user = await _decider_authenticate(websocket, app, _hs_mark)
-    if user is None:
+    authed = await _decider_authenticate(websocket, app, _hs_mark)
+    if authed is None:
         return
+    user, jti = authed
     workspace = websocket.query_params.get("workspace")
     if workspace is None:
         # #2976: consent is strictly a workspace concern -- there is no
@@ -354,7 +372,9 @@ async def handle_consent_decider(websocket: WebSocket, app) -> None:
     decider_id = str(uuid.uuid4())
     email = user.get("email")
     try:
-        registry.register(decider_id, workspace, email, safe_ws)
+        registry.register(
+            decider_id, workspace, email, safe_ws, jti=jti, user_id=user["id"]
+        )
         # Register BEFORE reading the snapshot: a hold created between the two
         # is then delivered twice (once live via fanout, once from the
         # snapshot). That duplicate is benign -- the second verdict no-ops

--- a/src/klangk/klangk/wshandler/dispatch.py
+++ b/src/klangk/klangk/wshandler/dispatch.py
@@ -63,7 +63,12 @@ WS_STATE_COMMANDS: dict[str, str] = {
 
 
 async def ws_authenticate(websocket: WebSocket, app):
-    """Validate the socket's token; close and return None on failure."""
+    """Validate the socket's token; close and return None on failure.
+
+    Success returns ``(user, jti)`` — the token's JTI rides along so
+    the connection can be targeted for closing when that token is
+    later hard-revoked (#3152).
+    """
     token = websocket.query_params.get("token")
     if not token:
         await websocket.close(code=4001, reason="Missing token")
@@ -76,7 +81,7 @@ async def ws_authenticate(websocket: WebSocket, app):
     if result is None:
         await websocket.close(code=4001, reason="Invalid token")
         return None
-    return result
+    return result, app.state.auth.decode_token(token).get("jti")
 
 
 # Exceptions raised by a *handler* that mean the connection itself is
@@ -192,14 +197,15 @@ async def _run_websocket_session(conn, safe_ws, user: dict, app) -> None:
 async def handle_websocket(websocket: WebSocket, app) -> None:
     """Main WebSocket handler."""
     # Authenticate via query param
-    user = await ws_authenticate(websocket, app)
-    if user is None:
+    authed = await ws_authenticate(websocket, app)
+    if authed is None:
         return
+    user, jti = authed
 
     await websocket.accept()
     safe_ws = SafeWebSocket(websocket)
     safe_ws.start_sender()
-    conn = Connection(safe_ws, user, app)
+    conn = Connection(safe_ws, user, app, jti=jti)
     app.state.sockets.connections[safe_ws] = conn
     # Everything from here on is inside the try so a failure in the
     # connect-time work below still runs the ``finally`` cleanup — the

--- a/src/klangk/klangk/wshandler/dispatch.py
+++ b/src/klangk/klangk/wshandler/dispatch.py
@@ -4,8 +4,8 @@ import json
 import logging
 
 from fastapi import WebSocket, WebSocketDisconnect
+from jose import ExpiredSignatureError, JWTError
 
-from .. import auth
 from .safe_websocket import SafeWebSocket, SlowClientError
 from .support import send_error, log_ws_msg
 from .connection import Connection
@@ -75,15 +75,20 @@ async def ws_authenticate(websocket: WebSocket, app):
         await websocket.close(code=4001, reason="Missing token")
         return None
 
-    result = await app.state.auth.get_user_from_token(token)
-    if result is auth.Auth.TOKEN_EXPIRED:
+    a = app.state.auth
+    try:
+        payload = a.decode_token(token)
+    except ExpiredSignatureError:
         await websocket.close(code=4002, reason="Token expired")
         return None
-    if result is None:
+    except JWTError:
         await websocket.close(code=4001, reason="Invalid token")
         return None
-    payload = app.state.auth.decode_token(token)
-    return result, payload.get("jti"), payload.get("exp")
+    user = await a._user_from_valid_payload(payload)
+    if user is None:
+        await websocket.close(code=4001, reason="Invalid token")
+        return None
+    return user, payload.get("jti"), payload.get("exp")
 
 
 # Exceptions raised by a *handler* that mean the connection itself is

--- a/src/klangk/klangk/wshandler/dispatch.py
+++ b/src/klangk/klangk/wshandler/dispatch.py
@@ -65,9 +65,10 @@ WS_STATE_COMMANDS: dict[str, str] = {
 async def ws_authenticate(websocket: WebSocket, app):
     """Validate the socket's token; close and return None on failure.
 
-    Success returns ``(user, jti)`` — the token's JTI rides along so
-    the connection can be targeted for closing when that token is
-    later hard-revoked (#3152).
+    Success returns ``(user, jti, exp)`` — the token's JTI rides along
+    so the connection can be targeted for closing when that token is
+    later hard-revoked (#3152), and ``exp`` (Unix epoch) lets the
+    connection schedule its own close when the token expires.
     """
     token = websocket.query_params.get("token")
     if not token:
@@ -81,7 +82,8 @@ async def ws_authenticate(websocket: WebSocket, app):
     if result is None:
         await websocket.close(code=4001, reason="Invalid token")
         return None
-    return result, app.state.auth.decode_token(token).get("jti")
+    payload = app.state.auth.decode_token(token)
+    return result, payload.get("jti"), payload.get("exp")
 
 
 # Exceptions raised by a *handler* that mean the connection itself is
@@ -200,13 +202,14 @@ async def handle_websocket(websocket: WebSocket, app) -> None:
     authed = await ws_authenticate(websocket, app)
     if authed is None:
         return
-    user, jti = authed
+    user, jti, token_exp = authed
 
     await websocket.accept()
     safe_ws = SafeWebSocket(websocket)
     safe_ws.start_sender()
-    conn = Connection(safe_ws, user, app, jti=jti)
+    conn = Connection(safe_ws, user, app, jti=jti, token_exp=token_exp)
     app.state.sockets.connections[safe_ws] = conn
+    conn.schedule_token_expiry()
     # Everything from here on is inside the try so a failure in the
     # connect-time work below still runs the ``finally`` cleanup — the
     # snapshot (#1714) awaits DB queries, and a raise there used to

--- a/src/klangk/klangk/wshandler/safe_websocket.py
+++ b/src/klangk/klangk/wshandler/safe_websocket.py
@@ -101,8 +101,8 @@ class SafeWebSocket:
     async def receive_text(self) -> str:
         return await self._sock.receive_text()
 
-    async def close(self, code: int = 1000) -> None:
-        await self._sock.close(code=code)
+    async def close(self, code: int = 1000, reason: str | None = None) -> None:
+        await self._sock.close(code=code, reason=reason)
 
     @property
     def stopped(self) -> bool:

--- a/src/klangk/klangk/wshandler/session.py
+++ b/src/klangk/klangk/wshandler/session.py
@@ -1020,6 +1020,22 @@ class WebSocketState:
                 logger.debug("Error closing socket for jti %s", jti)
         return len(socks)
 
+    def reattach_jti(self, old_jti: str, new_jti: str) -> int:
+        """Move live connections from *old_jti* onto *new_jti* (#3152).
+
+        A token refresh keeps the session — and its socket — alive under
+        the new token; retargeting keeps ``conn.jti`` equal to the
+        session row's current JTI so a later hard revocation (logout,
+        session-limit eviction) still finds the socket. Returns how many
+        connections were moved.
+        """
+        moved = 0
+        for conn in self.connections.values():
+            if conn.jti == old_jti:
+                conn.jti = new_jti
+                moved += 1
+        return moved
+
     async def reset_workspace(
         self, workspace_id: str, *, expected_container_id: str | None = None
     ) -> None:

--- a/src/klangk/klangk/wshandler/session.py
+++ b/src/klangk/klangk/wshandler/session.py
@@ -995,6 +995,31 @@ class WebSocketState:
                 logger.debug("Error closing socket for user %s", user_id)
         return len(socks)
 
+    async def disconnect_by_jti(
+        self, jti: str, *, code: int = 4001, reason: str = ""
+    ) -> int:
+        """Close every live connection authenticated with *jti* (#3152).
+
+        Hard token revocation (logout, session-limit eviction) must cut
+        the sockets that token opened, not just reject the next connect.
+        Refresh rotation deliberately does not come through here — a
+        refresh keeps the session (and its socket) alive under the new
+        token. Code 4001 makes the client log out rather than
+        reconnect-loop, the same convention as ``disconnect_user``.
+        Only the sockets are closed — each handler's ``finally`` block
+        then runs the normal disconnect cleanup. Returns how many
+        connections were closed.
+        """
+        socks = [
+            sock for sock, conn in self.connections.items() if conn.jti == jti
+        ]
+        for sock in socks:
+            try:
+                await sock.close(code=code, reason=reason)
+            except Exception:  # noqa: BLE001
+                logger.debug("Error closing socket for jti %s", jti)
+        return len(socks)
+
     async def reset_workspace(
         self, workspace_id: str, *, expected_container_id: str | None = None
     ) -> None:

--- a/src/klangk/klangk/wshandler/support.py
+++ b/src/klangk/klangk/wshandler/support.py
@@ -140,6 +140,22 @@ async def disconnect_by_jti(
     return await sockets.disconnect_by_jti(jti, code=code, reason=reason)
 
 
+async def disconnect_deciders_by_user(
+    app, user_id: str, *, code: int = 4001, reason: str = ""
+) -> int:
+    """Close the user's live consent-decider sockets (#3162).
+
+    Account-disable kicks (admin route, inactivity sweep) must cut the
+    decider surface too — a decider holds egress-consent authority.
+    Minimal app states (tests) may not wire ``consent_deciders`` — then
+    there is nothing to close (returns 0).
+    """
+    deciders = getattr(app.state, "consent_deciders", None)
+    if deciders is None:
+        return 0
+    return await deciders.disconnect_by_user(user_id, code=code, reason=reason)
+
+
 async def refresh_user_handle(
     sockets: WebSocketState, user_id: str, new_handle: str
 ) -> None:

--- a/src/klangk/klangk/wshandler/support.py
+++ b/src/klangk/klangk/wshandler/support.py
@@ -124,6 +124,22 @@ async def disconnect_user(
     return await sockets.disconnect_user(user_id, code=code, reason=reason)
 
 
+async def disconnect_by_jti(
+    sockets: WebSocketState,
+    jti: str,
+    *,
+    code: int = 4001,
+    reason: str = "",
+) -> int:
+    """Close every live connection authenticated with *jti* (#3152).
+
+    Hard revocation (logout, session-limit eviction) cuts the sockets
+    that token opened; 4001 makes the client log out rather than
+    reconnect-loop. Thin delegation to ``WebSocketState.disconnect_by_jti``.
+    """
+    return await sockets.disconnect_by_jti(jti, code=code, reason=reason)
+
+
 async def refresh_user_handle(
     sockets: WebSocketState, user_id: str, new_handle: str
 ) -> None:

--- a/src/klangk/klangkd-tests/e2e-tests/test_password_history_e2e.py
+++ b/src/klangk/klangkd-tests/e2e-tests/test_password_history_e2e.py
@@ -65,6 +65,8 @@ class TestPasswordHistoryE2E:
 
     def test_reuse_gate_lifecycle(self, api):
         # All passwords must clear the default 8-char minimum policy.
+        # Each successful change revokes all sessions (#3152), so we
+        # must re-login after every 200.
         seed = "adminpass"
         p1, p2, p3, p4 = (
             "e2e-pass-one",
@@ -81,6 +83,7 @@ class TestPasswordHistoryE2E:
 
         # Change away: retires the seed hash into history.
         assert _change(api, headers, seed, p1).status_code == 200
+        headers = _login(api, p1)
 
         # Changing back to the just-retired seed is rejected.
         resp = _change(api, headers, current=p1, new=seed)
@@ -91,8 +94,11 @@ class TestPasswordHistoryE2E:
         # [p2, p1, seed] after p3, then [p3, p2, p1] after p4 —
         # the seed falls out of the 3-deep window.
         assert _change(api, headers, p1, p2).status_code == 200
+        headers = _login(api, p2)
         assert _change(api, headers, p2, p3).status_code == 200
+        headers = _login(api, p3)
         assert _change(api, headers, p3, p4).status_code == 200
+        headers = _login(api, p4)
 
         # Still inside the window: p1 is rejected.
         resp = _change(api, headers, current=p4, new=p1)
@@ -102,11 +108,13 @@ class TestPasswordHistoryE2E:
         # Pruned out of the window: the seed is reusable again. This
         # retires p4, pruning p1 — history is now [p2, p3, seed].
         assert _change(api, headers, p4, seed).status_code == 200
+        headers = _login(api, seed)
 
         # p1 just fell out of the window -> reusable. That change
         # retires the seed, so history is now [p3, p4, seed]: p3 is
         # still in the window — the gate stays live for the next cycle.
         assert _change(api, headers, seed, p1).status_code == 200
+        headers = _login(api, p1)
         resp = _change(api, headers, current=p1, new=p3)
         assert resp.status_code == 400, resp.text
         assert "recently" in resp.json()["detail"]

--- a/src/klangk/klangkd-tests/e2e-tests/test_token_revocation_e2e.py
+++ b/src/klangk/klangkd-tests/e2e-tests/test_token_revocation_e2e.py
@@ -1,0 +1,350 @@
+"""Token-revocation E2E tests.
+
+Runtime verification, against real klangkd + real websockets, of the
+session-token revocation machinery in ``auth.py`` (the jti blocklist)
+across BOTH surfaces that consume a token:
+
+- the HTTP API (``get_user_from_token`` → 401 for a blocklisted token),
+- the workspace websocket (``ws_authenticate`` → close 4001
+  "Invalid token"; 4002 "Token expired" for a lapsed one).
+
+Covers the three producers of a revocation — logout, refresh (the old
+jti is blocklisted with the replacement cached), and expiry (a
+separate short-TTL server) — plus the two documented behaviors that
+are easy to regress:
+
+- logout is idempotent (#2687): revoking an already-revoked token is
+  still 200;
+- a refresh is replayable: the blocklisted old token returns its
+  CACHED replacement, not an error — while a token revoked by LOGOUT
+  can never refresh.
+
+Also covers #3152's pushed eviction: a hard revocation (logout)
+closes the live sockets that token authenticated (4001 "Token
+revoked"), refresh rotation retargets instead of kicking, the kick is
+per-JTI (other sessions survive), and token expiry closes an open
+socket at exp (4002 "Token expired").
+
+Run with: devenv shell -- test-backend-e2e test_token_revocation_e2e.py
+"""
+
+import asyncio
+import json
+
+import pytest
+from websockets.exceptions import ConnectionClosed, InvalidStatus
+
+from _e2e_server import (
+    httpx_async_client,
+    httpx_client,
+    start_server,
+    stop_server,
+    ws_connect,
+)
+
+# ~1.1s: long enough to log in and dial, short enough that the token
+# has lapsed after a 3s sleep.
+SHORT_TOKEN_HOURS = "0.0003"
+
+
+@pytest.fixture(scope="module")
+def server():
+    """A real klangkd with default token lifetime."""
+    server = start_server(
+        KLANGKD_JWT_SECRET="token-revocation-e2e-secret",
+        KLANGKD_DEFAULT_USER="admin@example.com",
+        KLANGKD_DEFAULT_PASSWORD="adminpass",
+        KLANGKD_TEST_MODE="1",
+        KLANGKD_IDLE_TIMEOUT_SECONDS="300",
+        LOGFIRE_TOKEN="",
+    )
+    yield server
+    stop_server(server)
+
+
+@pytest.fixture(scope="module")
+def api(server):
+    with httpx_client(server, timeout=10.0) as client:
+        yield client
+
+
+@pytest.fixture(scope="module")
+def short_server():
+    """A second klangkd whose tokens lapse in ~1 second."""
+    server = start_server(
+        KLANGKD_JWT_SECRET="token-expiry-e2e-secret",
+        KLANGKD_DEFAULT_USER="admin@example.com",
+        KLANGKD_DEFAULT_PASSWORD="adminpass",
+        KLANGKD_TEST_MODE="1",
+        KLANGKD_IDLE_TIMEOUT_SECONDS="300",
+        KLANGKD_ACCESS_TOKEN_HOURS=SHORT_TOKEN_HOURS,
+        LOGFIRE_TOKEN="",
+    )
+    yield server
+    stop_server(server)
+
+
+def login(api) -> str:
+    """A fresh access token (each login is its own session/jti)."""
+    resp = api.post(
+        "/api/v1/auth/login",
+        json={"identifier": "admin@example.com", "password": "adminpass"},
+        timeout=10,
+    )
+    assert resp.status_code == 200, resp.text
+    return resp.json()["access_token"]
+
+
+def headers(token: str) -> dict:
+    return {"Authorization": f"Bearer {token}"}
+
+
+async def alogin(aapi) -> str:
+    """A fresh token via the ASYNC client (tests that hold a live
+    websocket open across an HTTP call must not block the event loop:
+    the sync client would freeze the websockets background task that
+    must ACK the server's close handshake during a kick)."""
+    resp = await aapi.post(
+        "/api/v1/auth/login",
+        json={"identifier": "admin@example.com", "password": "adminpass"},
+    )
+    assert resp.status_code == 200, resp.text
+    return resp.json()["access_token"]
+
+
+async def alogout(aapi, token) -> int:
+    resp = await aapi.post("/api/v1/auth/logout", headers=headers(token))
+    return resp.status_code
+
+
+async def arefresh(aapi, token):
+    return await aapi.post("/api/v1/auth/refresh", headers=headers(token))
+
+
+def logout(api, token) -> int:
+    return api.post("/api/v1/auth/logout", headers=headers(token)).status_code
+
+
+def refresh(api, token):
+    return api.post("/api/v1/auth/refresh", headers=headers(token))
+
+
+async def probe_liveness(ws) -> str:
+    """Send an unknown command and drain (broadcast frames like
+    server_schedule race the reply) until the error frame arrives."""
+    await ws.send(json.dumps({"cmd": "definitely-not-a-command"}))
+    deadline = asyncio.get_event_loop().time() + 5
+    while asyncio.get_event_loop().time() < deadline:
+        msg = await asyncio.wait_for(ws.recv(), timeout=5)
+        if "Unknown command" in str(msg):
+            return str(msg)
+    raise AssertionError("no error frame answered the probe")
+
+
+async def expect_live_close(ws, code: int, reason_part: str = "") -> None:
+    """Assert an OPEN socket is closed with *code* (broadcast frames
+    may precede the close — drain until ConnectionClosed)."""
+    with pytest.raises(ConnectionClosed) as excinfo:
+        while True:
+            await asyncio.wait_for(ws.recv(), timeout=10)
+    rcvd = excinfo.value.rcvd
+    assert rcvd is not None, f"no close frame: {excinfo.value}"
+    assert rcvd.code == code, f"expected close {code}, got {rcvd}"
+    if reason_part:
+        assert reason_part in (rcvd.reason or ""), (
+            f"expected reason ~{reason_part!r}, got {rcvd.reason!r}"
+        )
+
+
+@pytest.fixture
+async def aapi(server):
+    """An async httpx client on the same event loop as the websockets
+    (see alogin for why the eviction tests need it)."""
+    async with httpx_async_client(server, timeout=10.0) as client:
+        yield client
+
+
+async def expect_ws_rejected(server, token: str) -> None:
+    """Dial ``/ws?token=...`` with a dead token and assert the
+    handshake is refused.
+
+    ``ws_authenticate`` runs BEFORE ``websocket.accept()``
+    (dispatch.py), and an ASGI close on an unaccepted socket is an
+    HTTP 403 handshake rejection — the in-code close codes (4001
+    invalid / 4002 expired) never cross the wire to a fresh dial; a
+    client sees a refused upgrade. This pins that observable
+    contract."""
+    with pytest.raises(InvalidStatus) as excinfo:
+        await ws_connect(server, f"/ws?token={token}")
+    assert excinfo.value.response.status_code == 403, (
+        f"expected handshake 403, got {excinfo.value.response.status_code}"
+    )
+
+
+class TestLogoutRevocation:
+    async def test_logout_revokes_api_and_ws(self, server, api):
+        """A logged-out token is dead on both surfaces; a fresh login
+        works."""
+        token = login(api)
+        assert (
+            api.get("/api/v1/workspaces", headers=headers(token)).status_code
+            == 200
+        )
+        assert logout(api, token) == 200
+        # API: 401
+        resp = api.get("/api/v1/workspaces", headers=headers(token))
+        assert resp.status_code == 401
+        # WS: the handshake itself is refused (403) — see
+        # expect_ws_rejected for why this is not a 4001 close code
+        await expect_ws_rejected(server, token)
+        # A fresh session is unaffected
+        fresh = login(api)
+        assert (
+            api.get("/api/v1/workspaces", headers=headers(fresh)).status_code
+            == 200
+        )
+
+    def test_logout_idempotent(self, api):
+        """#2687: revoking an already-revoked token is still 200."""
+        token = login(api)
+        assert logout(api, token) == 200
+        assert logout(api, token) == 200
+
+    def test_revoked_by_logout_cannot_refresh(self, api):
+        """A token revoked by LOGOUT has no cached replacement — the
+        refresh endpoint must refuse it (401 'Token has been
+        revoked'), not mint a new session."""
+        token = login(api)
+        assert logout(api, token) == 200
+        resp = refresh(api, token)
+        assert resp.status_code == 401
+        assert "revoked" in resp.json().get("detail", "").lower()
+
+
+class TestRefreshRevocation:
+    async def test_refresh_revokes_old_token_everywhere(self, server, api):
+        """After a refresh, the old jti is dead on API and WS; the new
+        token works."""
+        old = login(api)
+        resp = refresh(api, old)
+        assert resp.status_code == 200, resp.text
+        new = resp.json()["access_token"]
+        assert new != old
+        # Old token: API 401, WS handshake refused
+        assert (
+            api.get("/api/v1/workspaces", headers=headers(old)).status_code
+            == 401
+        )
+        await expect_ws_rejected(server, old)
+        # New token: API 200
+        assert (
+            api.get("/api/v1/workspaces", headers=headers(new)).status_code
+            == 200
+        )
+
+    def test_refresh_is_replayable(self, api):
+        """Refreshing with the already-refreshed token returns the
+        CACHED replacement (the same new token), not an error — the
+        idempotency contract that lets a racing client retry its
+        refresh."""
+        old = login(api)
+        first = refresh(api, old)
+        assert first.status_code == 200
+        again = refresh(api, old)
+        assert again.status_code == 200
+        assert again.json()["access_token"] == first.json()["access_token"]
+
+
+class TestLiveSocketEviction:
+    """#3152: a hard revocation pushes — the live sockets a revoked
+    token authenticated are closed immediately (4001 'Token revoked'),
+    not at the next connect. Refresh rotation is exempt (the socket is
+    retargeted to the new jti instead), and the kick is per-JTI: other
+    sessions of the same user stay connected."""
+
+    async def test_logout_closes_open_socket(self, server, aapi):
+        token = await alogin(aapi)
+        ws = await ws_connect(server, f"/ws?token={token}")
+        try:
+            await probe_liveness(ws)
+            assert await alogout(aapi, token) == 200
+            await expect_live_close(ws, 4001, "Token revoked")
+        finally:
+            await ws.close()
+        # And the NEXT connect with the revoked token is also refused
+        await expect_ws_rejected(server, token)
+
+    async def test_refresh_keeps_socket_and_retargets(self, server, aapi):
+        """A refresh must NOT kick the live socket (rotation exempt);
+        it retargets the connection onto the new jti, so a LATER logout
+        still closes it."""
+        old = await alogin(aapi)
+        ws = await ws_connect(server, f"/ws?token={old}")
+        try:
+            await probe_liveness(ws)
+            resp = await arefresh(aapi, old)
+            assert resp.status_code == 200
+            new = resp.json()["access_token"]
+            # Rotation: the open socket survives...
+            await probe_liveness(ws)
+            # ...and is kickable under the NEW token
+            assert await alogout(aapi, new) == 200
+            await expect_live_close(ws, 4001, "Token revoked")
+        finally:
+            await ws.close()
+
+    async def test_logout_kicks_only_that_session(self, server, aapi):
+        """The kick is per-JTI: logging out one session leaves the
+        same user's other live socket connected."""
+        token_a = await alogin(aapi)
+        token_b = await alogin(aapi)
+        ws_a = await ws_connect(server, f"/ws?token={token_a}")
+        ws_b = await ws_connect(server, f"/ws?token={token_b}")
+        try:
+            await probe_liveness(ws_a)
+            await probe_liveness(ws_b)
+            assert await alogout(aapi, token_b) == 200
+            await expect_live_close(ws_b, 4001, "Token revoked")
+            await probe_liveness(ws_a)  # untouched
+        finally:
+            await ws_b.close()
+            await ws_a.close()
+
+
+class TestExpiredToken:
+    async def test_expired_token_rejected_api_and_ws(self, short_server):
+        """A lapsed token is 401 'Token expired' on the API and close
+        4002 'Token expired' on the WS (distinct from revocation's
+        4001)."""
+        with httpx_client(short_server, timeout=10.0) as api:
+            token = login(api)
+            assert (
+                api.get(
+                    "/api/v1/workspaces", headers=headers(token)
+                ).status_code
+                == 200
+            )
+            await asyncio.sleep(3)
+            # On a normal endpoint a lapsed token is 401 (the generic
+            # dependency maps the expired-signature error to Invalid
+            # token); the refresh endpoint is where the distinction
+            # surfaces — ExpiredSignatureError -> 'Token expired'.
+            resp = api.get("/api/v1/workspaces", headers=headers(token))
+            assert resp.status_code == 401
+            await expect_ws_rejected(short_server, token)
+            # A lapsed token that was NEVER refreshed cannot refresh
+            resp = refresh(api, token)
+            assert resp.status_code == 401
+            assert "expired" in resp.json().get("detail", "").lower()
+
+    async def test_expiry_closes_open_socket(self, short_server):
+        """#3152: an open socket does not outlive its token — the
+        connection schedules its own close at exp (4002 'Token
+        expired')."""
+        async with httpx_async_client(short_server, timeout=10.0) as aapi:
+            token = await alogin(aapi)
+        ws = await ws_connect(short_server, f"/ws?token={token}")
+        try:
+            await expect_live_close(ws, 4002, "Token expired")
+        finally:
+            await ws.close()

--- a/src/klangk/klangkd-tests/tests/test_api.py
+++ b/src/klangk/klangkd-tests/tests/test_api.py
@@ -945,6 +945,68 @@ class TestAuthRoutes:
         assert resp.json()["status"] == "ok"
         mock_stop.assert_not_called()
 
+    async def test_logout_kicks_live_sockets(self, client, app, user):
+        """#3152: logout closes the WS connections the logged-out token
+        authenticated (4001 -> client logout), not just future connects —
+        and leaves other sessions of the same user connected."""
+        from klangk.wshandler.session import WebSocketState
+        from klangk import wshandler
+
+        assert isinstance(app.state.sockets, WebSocketState)
+        resp = await client.post(
+            "/api/v1/auth/login",
+            json={
+                "identifier": "testuser@example.com",
+                "password": "testpass",
+            },
+        )
+        token = resp.json()["access_token"]
+        jti = app.state.auth.decode_token(token)["jti"]
+        closed: list[tuple[int, str]] = []
+
+        class FakeSock:
+            async def close(self, code=1000, reason=""):
+                closed.append((code, reason))
+
+        # Same user, different session; and another user entirely: both
+        # must survive the logout of the victim's token.
+        victim = types.SimpleNamespace(
+            user={"id": user["id"], "email": user["email"]}, jti=jti
+        )
+        other_session = types.SimpleNamespace(
+            user={"id": user["id"], "email": user["email"]},
+            jti="another-jti",
+        )
+        other_user = types.SimpleNamespace(
+            user={"id": "someone-else", "email": "other@example.com"},
+            jti="third-jti",
+        )
+        app.state.sockets.connections[FakeSock()] = other_user
+        app.state.sockets.connections[FakeSock()] = other_session
+        app.state.sockets.connections[FakeSock()] = victim
+
+        resp = await client.post(
+            "/api/v1/auth/logout",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert resp.status_code == 200
+        assert closed == [(4001, "Token revoked")]
+
+        # A socket whose close() raises must not break the kick: the
+        # remaining sockets are still closed and the count is right.
+        class BadSock:
+            async def close(self, code=1000, reason=""):
+                raise RuntimeError("already closed")
+
+        app.state.sockets.connections.clear()
+        app.state.sockets.connections[BadSock()] = victim
+        app.state.sockets.connections[FakeSock()] = victim
+        kicked = await wshandler.disconnect_by_jti(
+            app.state.sockets, jti, reason="Token revoked"
+        )
+        assert kicked == 2
+        app.state.sockets.connections.clear()
+
     async def test_logout_no_auth(self, client):
         # Idempotent (#2687): no token presented means nothing to revoke,
         # which is the desired end state — not an auth failure.

--- a/src/klangk/klangkd-tests/tests/test_api.py
+++ b/src/klangk/klangkd-tests/tests/test_api.py
@@ -2066,7 +2066,15 @@ class TestChangePassword:
             3,
             raising=False,
         )
-        headers = await _auth_headers(client)
+
+        async def _login(pw):
+            r = await client.post(
+                "/api/v1/auth/login",
+                json={"identifier": "testuser@example.com", "password": pw},
+            )
+            return {"Authorization": f"Bearer {r.json()['access_token']}"}
+
+        headers = await _login("testpass")
         # Change away from the seed password once — this retires the
         # seed hash into history; the new hash is never recorded until
         # the user changes away from *it* (#2582).
@@ -2079,6 +2087,8 @@ class TestChangePassword:
             headers=headers,
         )
         assert resp.status_code == 200
+        # Re-login: change-password revokes the old token (#3152).
+        headers = await _login("midpass1")
         # To the current password.
         resp = await client.post(
             "/api/v1/auth/change-password",
@@ -2100,6 +2110,8 @@ class TestChangePassword:
             headers=headers,
         )
         assert resp.status_code == 200
+        # Re-login after the second change.
+        headers = await _login("newpass1")
         resp2 = await client.post(
             "/api/v1/auth/change-password",
             json={
@@ -2137,6 +2149,31 @@ class TestChangePassword:
             resp.json()["detail"]
             == "Account is managed by your identity provider"
         )
+
+
+class TestChangePasswordRevokesTokens:
+    """#3152: changing a password must revoke all existing sessions."""
+
+    async def test_old_token_rejected_after_password_change(
+        self, client, user
+    ):
+        headers = await _auth_headers(client)
+        old_token = headers["Authorization"].split()[-1]
+        resp = await client.post(
+            "/api/v1/auth/change-password",
+            json={
+                "current_password": "testpass",
+                "new_password": "newpass1",
+            },
+            headers=headers,
+        )
+        assert resp.status_code == 200
+        # The old token is now blocklisted — a protected call should 401.
+        resp2 = await client.get(
+            "/api/v1/auth/me",
+            headers={"Authorization": f"Bearer {old_token}"},
+        )
+        assert resp2.status_code == 401
 
 
 class TestChangeEmail:

--- a/src/klangk/klangkd-tests/tests/test_api.py
+++ b/src/klangk/klangkd-tests/tests/test_api.py
@@ -15399,6 +15399,51 @@ class TestInactivityDisable:
         assert closed[-1] == (4001, "Account disabled")
         app.state.sockets.connections.clear()
 
+    async def test_admin_disable_kicks_decider_sockets(
+        self, client, app, admin_user, user
+    ):
+        """#3162: disabling an account also closes its live
+        consent-decider sockets (4001) — a decider holds egress-consent
+        authority and must not outlive the disable. The decider is a
+        REAL SafeWebSocket over a mock raw socket (fakes masked the
+        reason-kwarg no-op class of bug, #3160 review)."""
+        from klangk.consent.deciders import ConsentDeciderRegistry
+        from klangk.wshandler.safe_websocket import SafeWebSocket
+
+        app.state.consent_deciders = ConsentDeciderRegistry(app)
+        victim_raw = AsyncMock()
+        victim_raw.close = AsyncMock()
+        other_raw = AsyncMock()
+        other_raw.close = AsyncMock()
+        app.state.consent_deciders.register(
+            "d-victim",
+            "ws-1",
+            user["email"],
+            SafeWebSocket(victim_raw),
+            jti="j-victim",
+            user_id=user["id"],
+        )
+        app.state.consent_deciders.register(
+            "d-other",
+            "ws-2",
+            "other@example.com",
+            SafeWebSocket(other_raw),
+            jti="j-other",
+            user_id="someone-else",
+        )
+        headers = await _admin_login(client)
+        resp = await client.patch(
+            f"/api/v1/users/{user['id']}",
+            headers=headers,
+            json={"disabled": True},
+        )
+        assert resp.status_code == 200
+        victim_raw.close.assert_awaited_once_with(
+            code=4001, reason="Account disabled"
+        )
+        other_raw.close.assert_not_awaited()
+        assert set(app.state.consent_deciders._deciders) == {"d-other"}
+
 
 class TestAdminServerSchedule:
     """#2661: schedule/list/cancel a server stop or recycle."""

--- a/src/klangk/klangkd-tests/tests/test_auth.py
+++ b/src/klangk/klangkd-tests/tests/test_auth.py
@@ -1457,6 +1457,95 @@ class TestSessionLimit:
         assert len(rows) == 1
 
 
+class TestRevocationKicksSockets:
+    """#3152: hard revocation (logout, session-limit eviction) closes the
+    live WS connections the revoked token authenticated; refresh rotation
+    (which blocklists the old JTI via _swap_token) must NOT kick — the
+    session lives on under the new token."""
+
+    def _auth_with_sockets(self, env=None):
+        """An Auth whose app_state wires a real WebSocketState, plus that
+        state — fake connections can be planted in ``sockets.connections``."""
+        from klangk.wshandler.session import WebSocketState
+
+        a = _auth(env)
+        sockets = WebSocketState(a.app)
+        a.app.state.sockets = sockets
+        return a, sockets
+
+    @staticmethod
+    def _fake_conn(user, jti):
+        return _types.SimpleNamespace(
+            user={"id": user["id"], "email": user["email"]}, jti=jti
+        )
+
+    async def _login(self, a):
+        result = await a.login(
+            auth.LoginRequest(
+                identifier="testuser@example.com", password="testpass"
+            )
+        )
+        return result.access_token
+
+    async def test_logout_closes_socket_for_that_jti(self, user, app_state):
+        a, sockets = self._auth_with_sockets()
+        token = await self._login(a)
+        jti = a.decode_token(token)["jti"]
+        closed: list[tuple[int, str]] = []
+
+        class FakeSock:
+            async def close(self, code=1000, reason=""):
+                closed.append((code, reason))
+
+        sockets.connections[FakeSock()] = self._fake_conn(user, jti)
+        sockets.connections[FakeSock()] = self._fake_conn(user, "other-jti")
+        await a.logout(token)
+        # Only the connection the revoked token authenticated is closed.
+        assert closed == [(4001, "Token revoked")]
+        sockets.connections.clear()
+
+    async def test_session_limit_eviction_closes_evicted_sockets(
+        self, user, app_state
+    ):
+        env = {"KLANGKD_MAX_SESSIONS_PER_USER": "1"}
+        a, sockets = self._auth_with_sockets(env)
+        first = await self._login(a)
+        first_jti = a.decode_token(first)["jti"]
+        closed: list[tuple[int, str]] = []
+
+        class FakeSock:
+            async def close(self, code=1000, reason=""):
+                closed.append((code, reason))
+
+        sockets.connections[FakeSock()] = self._fake_conn(user, first_jti)
+        # The second login evicts the first session past the cap of 1.
+        second = await self._login(a)
+        assert closed == [(4001, "Token revoked")]
+        # The surviving session's token still works.
+        assert await a.get_user_from_token(second) is not None
+        sockets.connections.clear()
+
+    async def test_refresh_rotation_does_not_close_socket(
+        self, user, app_state
+    ):
+        """A refresh blocklists the old JTI (idempotent rotation cache)
+        but keeps the session — the socket opened with the old token must
+        stay connected."""
+        a, sockets = self._auth_with_sockets()
+        token = await self._login(a)
+        jti = a.decode_token(token)["jti"]
+        closed: list[tuple[int, str]] = []
+
+        class FakeSock:
+            async def close(self, code=1000, reason=""):
+                closed.append((code, reason))
+
+        sockets.connections[FakeSock()] = self._fake_conn(user, jti)
+        await a.refresh_token(token)
+        assert closed == []
+        sockets.connections.clear()
+
+
 class TestConcurrentLogonAudit:
     """Audit records for concurrent logons from different workstations
     (#2586). A workstation is the effective client IP a session was

--- a/src/klangk/klangkd-tests/tests/test_auth.py
+++ b/src/klangk/klangkd-tests/tests/test_auth.py
@@ -1499,10 +1499,12 @@ class TestRevocationKicksSockets:
 
         sockets.connections[FakeSock()] = self._fake_conn(user, jti)
         sockets.connections[FakeSock()] = self._fake_conn(user, "other-jti")
-        await a.logout(token)
-        # Only the connection the revoked token authenticated is closed.
-        assert closed == [(4001, "Token revoked")]
-        sockets.connections.clear()
+        try:
+            await a.logout(token)
+            # Only the connection the revoked token authenticated is closed.
+            assert closed == [(4001, "Token revoked")]
+        finally:
+            sockets.connections.clear()
 
     async def test_session_limit_eviction_closes_evicted_sockets(
         self, user, app_state
@@ -1518,19 +1520,21 @@ class TestRevocationKicksSockets:
                 closed.append((code, reason))
 
         sockets.connections[FakeSock()] = self._fake_conn(user, first_jti)
-        # The second login evicts the first session past the cap of 1.
-        second = await self._login(a)
-        assert closed == [(4001, "Token revoked")]
-        # The surviving session's token still works.
-        assert await a.get_user_from_token(second) is not None
-        sockets.connections.clear()
+        try:
+            # The second login evicts the first session past the cap of 1.
+            second = await self._login(a)
+            assert closed == [(4001, "Token revoked")]
+            # The surviving session's token still works.
+            assert await a.get_user_from_token(second) is not None
+        finally:
+            sockets.connections.clear()
 
     async def test_refresh_rotation_does_not_close_socket(
         self, user, app_state
     ):
         """A refresh blocklists the old JTI (idempotent rotation cache)
         but keeps the session — the socket opened with the old token must
-        stay connected."""
+        stay connected, retargeted onto the new JTI."""
         a, sockets = self._auth_with_sockets()
         token = await self._login(a)
         jti = a.decode_token(token)["jti"]
@@ -1540,10 +1544,77 @@ class TestRevocationKicksSockets:
             async def close(self, code=1000, reason=""):
                 closed.append((code, reason))
 
-        sockets.connections[FakeSock()] = self._fake_conn(user, jti)
-        await a.refresh_token(token)
-        assert closed == []
-        sockets.connections.clear()
+        conn = self._fake_conn(user, jti)
+        bystander = self._fake_conn(user, "unrelated-jti")
+        sockets.connections[FakeSock()] = conn
+        sockets.connections[FakeSock()] = bystander
+        try:
+            refreshed = await a.refresh_token(token)
+            assert closed == []
+            # Retargeted (#3152 review): the live connection now carries
+            # the refreshed token's JTI; unrelated connections are left
+            # alone.
+            new_jti = a.decode_token(refreshed.access_token)["jti"]
+            assert conn.jti == new_jti
+            assert bystander.jti == "unrelated-jti"
+        finally:
+            sockets.connections.clear()
+
+    async def test_logout_after_refresh_closes_retargeted_socket(
+        self, user, app_state
+    ):
+        """#3152 review: the WS outlives the HTTP token refresh (it keeps
+        the old, rotated JTI), so logging out with the NEW token must
+        still close it — via the refresh-time retarget onto the new JTI."""
+        a, sockets = self._auth_with_sockets()
+        token = await self._login(a)
+        closed: list[tuple[int, str]] = []
+
+        class FakeSock:
+            async def close(self, code=1000, reason=""):
+                closed.append((code, reason))
+
+        # A connection opened with the pre-refresh token, planted BEFORE
+        # the refresh: the refresh retargets its JTI onto the new token.
+        conn = self._fake_conn(user, a.decode_token(token)["jti"])
+        sockets.connections[FakeSock()] = conn
+        try:
+            refreshed = await a.refresh_token(token)
+            await a.logout(refreshed.access_token)
+            assert closed == [(4001, "Token revoked")]
+        finally:
+            sockets.connections.clear()
+
+    async def test_eviction_after_refresh_closes_retargeted_socket(
+        self, user, app_state
+    ):
+        """#3152 review: the typical eviction victim is a long-refreshing
+        session (replace_session keeps its original created_at, so it
+        stays oldest) — its socket must still be kickable after rotation.
+        """
+        env = {"KLANGKD_MAX_SESSIONS_PER_USER": "1"}
+        a, sockets = self._auth_with_sockets(env)
+        first = await self._login(a)
+        closed: list[tuple[int, str]] = []
+
+        class FakeSock:
+            async def close(self, code=1000, reason=""):
+                closed.append((code, reason))
+
+        # The connection opened with the pre-refresh token, planted
+        # BEFORE the refresh so the rotation retargets it.
+        conn = self._fake_conn(user, a.decode_token(first)["jti"])
+        sockets.connections[FakeSock()] = conn
+        try:
+            refreshed = await a.refresh_token(first)
+            # The second login evicts the refreshed (still-oldest)
+            # session past the cap of 1.
+            second = await self._login(a)
+            assert closed == [(4001, "Token revoked")]
+            assert await a.get_user_from_token(second) is not None
+            assert await a.get_user_from_token(refreshed.access_token) is None
+        finally:
+            sockets.connections.clear()
 
 
 class TestConcurrentLogonAudit:

--- a/src/klangk/klangkd-tests/tests/test_auth.py
+++ b/src/klangk/klangkd-tests/tests/test_auth.py
@@ -889,6 +889,22 @@ class TestTokenValidation:
         token = _auth().create_token("nonexistent-id", "ghost@example.com")
         assert await _auth().get_user_from_token(token) is None
 
+    async def test_get_user_from_token_expired(self, db):
+        """A valid-signature but expired token returns TOKEN_EXPIRED."""
+        expired = datetime.now(timezone.utc) - timedelta(hours=1)
+        token = jwt.encode(
+            {
+                "sub": "uid",
+                "email": "x",
+                "jti": "j1",
+                "exp": expired,
+            },
+            _auth().secret,
+            algorithm=_auth().algorithm,
+        )
+        result = await _auth().get_user_from_token(token)
+        assert result is _auth().TOKEN_EXPIRED
+
 
 class TestGetCurrentUser:
     async def test_valid_credentials(self, user):
@@ -1653,6 +1669,117 @@ class TestRevocationKicksSockets:
         await a.revoke_all_user_sessions(user["id"])
         assert not sockets.connections
         assert await a.app.state.model.sessions.list_sessions(user["id"]) == []
+
+
+class TestRevocationKicksDeciders:
+    """#3162: the consent-decider socket had the same revocation
+    survival as the main /ws socket (#3152) — it lives in its own
+    registry, so the logout/eviction kick must reach that registry too.
+    Refresh rotation retargets (not closes), exactly like the main
+    registry. Entries are REAL SafeWebSockets over mock raw sockets
+    (#3160 review: fakes masked the reason-kwarg no-op)."""
+
+    def _auth_with_deciders(self, env=None):
+        from klangk.consent.deciders import ConsentDeciderRegistry
+
+        a = _auth(env)
+        a.app.state.consent_deciders = ConsentDeciderRegistry(a.app)
+        return a
+
+    @staticmethod
+    def _decider_raw(a, jti, decider_id="d1"):
+        """A real SafeWebSocket over a mock raw socket, registered as a
+        live decider under *jti*; returns the raw socket."""
+        from unittest.mock import AsyncMock
+
+        from klangk.wshandler.safe_websocket import SafeWebSocket
+
+        raw = AsyncMock()
+        raw.close = AsyncMock()
+        a.app.state.consent_deciders.register(
+            decider_id, "ws-1", "d@x", SafeWebSocket(raw), jti=jti
+        )
+        return raw
+
+    async def _login(self, a):
+        result = await a.login(
+            auth.LoginRequest(
+                identifier="testuser@example.com", password="testpass"
+            )
+        )
+        return result.access_token
+
+    async def test_logout_closes_decider_for_that_jti(self, user, app_state):
+        a = self._auth_with_deciders()
+        token = await self._login(a)
+        jti = a.decode_token(token)["jti"]
+        victim = self._decider_raw(a, jti)
+        other = self._decider_raw(a, "other-jti", "d2")
+        await a.logout(token)
+        victim.close.assert_awaited_once_with(
+            code=4001, reason="Token revoked"
+        )
+        other.close.assert_not_awaited()
+        # The kicked decider's registration is gone (authority ends at
+        # revocation); the spared one stays live.
+        deciders = a.app.state.consent_deciders
+        assert set(deciders._deciders) == {"d2"}
+
+    async def test_session_limit_eviction_closes_evicted_decider(
+        self, user, app_state
+    ):
+        env = {"KLANGKD_MAX_SESSIONS_PER_USER": "1"}
+        a = self._auth_with_deciders(env)
+        first = await self._login(a)
+        victim = self._decider_raw(a, a.decode_token(first)["jti"])
+        # The second login evicts the first session past the cap of 1.
+        second = await self._login(a)
+        victim.close.assert_awaited_once_with(
+            code=4001, reason="Token revoked"
+        )
+        assert await a.get_user_from_token(second) is not None
+
+    async def test_refresh_rotation_retargets_decider_not_closed(
+        self, user, app_state
+    ):
+        a = self._auth_with_deciders()
+        token = await self._login(a)
+        raw = self._decider_raw(a, a.decode_token(token)["jti"])
+        refreshed = await a.refresh_token(token)
+        raw.close.assert_not_awaited()
+        # Retargeted onto the refreshed token's JTI, so a later hard
+        # revocation still finds the decider.
+        new_jti = a.decode_token(refreshed.access_token)["jti"]
+        deciders = a.app.state.consent_deciders
+        assert deciders._deciders["d1"]["jti"] == new_jti
+
+    async def test_logout_after_refresh_closes_retargeted_decider(
+        self, user, app_state
+    ):
+        a = self._auth_with_deciders()
+        token = await self._login(a)
+        raw = self._decider_raw(a, a.decode_token(token)["jti"])
+        refreshed = await a.refresh_token(token)
+        await a.logout(refreshed.access_token)
+        raw.close.assert_awaited_once_with(code=4001, reason="Token revoked")
+
+    async def test_eviction_after_refresh_closes_retargeted_decider(
+        self, user, app_state
+    ):
+        """The typical eviction victim is a long-refreshing session
+        (replace_session keeps its original created_at, so it stays
+        oldest) — its decider must still be kickable after rotation."""
+        env = {"KLANGKD_MAX_SESSIONS_PER_USER": "1"}
+        a = self._auth_with_deciders(env)
+        first = await self._login(a)
+        raw = self._decider_raw(a, a.decode_token(first)["jti"])
+        refreshed = await a.refresh_token(first)
+        # The second login evicts the refreshed (still-oldest) session
+        # past the cap of 1.
+        second = await self._login(a)
+        raw.close.assert_awaited_once_with(code=4001, reason="Token revoked")
+        assert await a.get_user_from_token(second) is not None
+        assert await a.get_user_from_token(refreshed.access_token) is None
 
 
 class TestConcurrentLogonAudit:

--- a/src/klangk/klangkd-tests/tests/test_auth.py
+++ b/src/klangk/klangkd-tests/tests/test_auth.py
@@ -1644,6 +1644,16 @@ class TestRevocationKicksSockets:
         finally:
             sockets.connections.clear()
 
+    async def test_revoke_all_user_sessions_no_sessions_is_noop(
+        self, user, app_state
+    ):
+        """A user with no sessions (rows empty) skips the kick loop and
+        the remove_sessions call entirely."""
+        a, sockets = self._auth_with_sockets()
+        await a.revoke_all_user_sessions(user["id"])
+        assert not sockets.connections
+        assert await a.app.state.model.sessions.list_sessions(user["id"]) == []
+
 
 class TestConcurrentLogonAudit:
     """Audit records for concurrent logons from different workstations

--- a/src/klangk/klangkd-tests/tests/test_auth.py
+++ b/src/klangk/klangkd-tests/tests/test_auth.py
@@ -1616,6 +1616,34 @@ class TestRevocationKicksSockets:
         finally:
             sockets.connections.clear()
 
+    async def test_revoke_all_user_sessions_closes_every_socket(
+        self, user, app_state
+    ):
+        """revoke_all_user_sessions (used by change-password) blocklists
+        and kicks every session, not just one."""
+        a, sockets = self._auth_with_sockets()
+        t1 = await self._login(a)
+        t2 = await self._login(a)
+        jti1 = a.decode_token(t1)["jti"]
+        jti2 = a.decode_token(t2)["jti"]
+        closed: list[tuple[int, str]] = []
+
+        class FakeSock:
+            async def close(self, code=1000, reason=""):
+                closed.append((code, reason))
+
+        sockets.connections[FakeSock()] = self._fake_conn(user, jti1)
+        sockets.connections[FakeSock()] = self._fake_conn(user, jti2)
+        try:
+            await a.revoke_all_user_sessions(user["id"])
+            assert len(closed) == 2
+            assert all(code == 4001 for code, _ in closed)
+            # Both tokens are now blocklisted.
+            assert await a.get_user_from_token(t1) is None
+            assert await a.get_user_from_token(t2) is None
+        finally:
+            sockets.connections.clear()
+
 
 class TestConcurrentLogonAudit:
     """Audit records for concurrent logons from different workstations

--- a/src/klangk/klangkd-tests/tests/test_consent_deciders.py
+++ b/src/klangk/klangkd-tests/tests/test_consent_deciders.py
@@ -5,13 +5,18 @@ from __future__ import annotations
 import asyncio
 import json
 import types
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock
 
 from klangk.consent.deciders import ConsentDeciderRegistry
 from klangk.model.workspaces import EGRESS_MODE_INTERACTIVE
+from klangk.wshandler.safe_websocket import SafeWebSocket
 
 WS = "ws-aaaa1111-2222-3333-4444-555566667777"
 WS2 = "ws-bbbb2222-3333-4444-5555-666677778888"
+
+# _ws_app sentinel: decode_token succeeds but _user_from_valid_payload
+# returns None (revoked/missing user) — the post-decode None-user arm.
+_DECODED_NO_USER = object()
 
 
 def _app(timeout: float = 45.0):
@@ -32,6 +37,16 @@ class _FakeSock:
         if self._raising:
             raise RuntimeError("dead socket")
         self.sent.append(msg)
+
+
+def _mock_raw_sock():
+    """A mock raw FastAPI WebSocket for real-SafeWebSocket kick tests."""
+    raw = AsyncMock()
+    raw.close = AsyncMock()
+    raw.send_json = AsyncMock()
+    raw.receive_text = AsyncMock()
+    raw.accept = AsyncMock()
+    return raw
 
 
 class TestConsentDeciderRegistry:
@@ -217,8 +232,33 @@ def _ws_app(
         ),
     )
     app.state.consent_deciders = ConsentDeciderRegistry(app)
+    # _decider_authenticate decodes the token once, then validates
+    # via _user_from_valid_payload.  The mock must raise the right
+    # exception for the expired-token path and return None for invalid.
+    from jose import ExpiredSignatureError, JWTError
+    from klangk import auth as auth_mod
+
+    if token_result is auth_mod.Auth.TOKEN_EXPIRED:
+        decode_side = ExpiredSignatureError("expired")
+        payload_result = None
+    elif token_result is None:
+        decode_side = JWTError("bad")
+        payload_result = None
+    else:
+        decode_side = None
+        payload_result = (
+            None if token_result is _DECODED_NO_USER else token_result
+        )
+
+    decode_mock = (
+        MagicMock(side_effect=decode_side)
+        if decode_side
+        else MagicMock(return_value={"jti": "jti-decoded", "sub": "u1"})
+    )
     app.state.auth = types.SimpleNamespace(
-        get_user_from_token=AsyncMock(return_value=token_result)
+        get_user_from_token=AsyncMock(return_value=token_result),
+        decode_token=decode_mock,
+        _user_from_valid_payload=AsyncMock(return_value=payload_result),
     )
     app.state.acl = types.SimpleNamespace(
         get_principals=AsyncMock(
@@ -301,6 +341,15 @@ class TestConsentDeciderWS:
         ws = _FakeWS({"token": "stale"}, [])
         await handle_consent_decider(ws, app)
         assert ws.closed == (4002, "Token expired")
+
+    async def test_unknown_user_is_rejected(self):
+        # Valid signature, but the user no longer exists: 4001 refusal.
+        from klangk.wshandler.decider import handle_consent_decider
+
+        app = _ws_app(_DECODED_NO_USER)
+        ws = _FakeWS({"token": "tok", "workspace": WS}, [])
+        await handle_consent_decider(ws, app)
+        assert ws.closed == (4001, "Invalid token")
 
     async def test_non_member_workspace_scoped_is_forbidden(self):
         from klangk.wshandler.decider import handle_consent_decider
@@ -917,6 +966,159 @@ class TestConsentDeciderWS:
         )
         await handle_consent_decider(ws, app)
         assert app.state.consent_deciders.has_decider(WS) is False
+
+
+class TestConsentDeciderWSJti:
+    """#3162: the decider handshake records the token's JTI on the
+    registration, mirroring the main /ws handler (#3152)."""
+
+    async def test_decider_authenticate_returns_user_and_jti(self):
+        from klangk.wshandler.decider import _decider_authenticate
+
+        app = _ws_app({"id": "u1", "email": "a@x"})
+        ws = _FakeWS({"token": "tok"}, [])
+        result = await _decider_authenticate(ws, app, lambda label: None)
+        authed_user, jti = result
+        assert authed_user["id"] == "u1"
+        assert jti == "jti-decoded"
+        assert ws.closed is None  # authenticated, not refused
+
+    async def test_connection_records_authenticating_jti(self):
+        from fastapi import WebSocketDisconnect
+
+        from klangk.wshandler.decider import handle_consent_decider
+
+        app = _ws_app({"id": "u1", "email": "a@x"})
+        recorded: list = []
+
+        class RecordingRegistry(ConsentDeciderRegistry):
+            def register(
+                self,
+                decider_id,
+                workspace_id,
+                email,
+                sock,
+                jti=None,
+                user_id=None,
+            ):
+                recorded.append((jti, user_id))
+                super().register(
+                    decider_id,
+                    workspace_id,
+                    email,
+                    sock,
+                    jti=jti,
+                    user_id=user_id,
+                )
+
+        app.state.consent_deciders = RecordingRegistry(app)
+        ws = _FakeWS(
+            {"token": "tok", "workspace": WS}, [WebSocketDisconnect()]
+        )
+        await handle_consent_decider(ws, app)
+        assert recorded == [("jti-decoded", "u1")]
+
+
+class TestConsentDeciderRegistryJti:
+    """#3162: registrations carry the authenticating JWT's JTI; hard
+    revocation closes them (4001, like the main /ws registry in #3152)
+    and refresh rotation retargets them. Kick tests plant REAL
+    SafeWebSocket entries — fakes whose close() happens to accept
+    ``reason`` masked the reason-kwarg no-op class of bug (#3160
+    review)."""
+
+    @staticmethod
+    def _real_decider(reg, jti, decider_id="d1", user_id=None):
+        """Register a decider backed by a real SafeWebSocket over a mock
+        raw socket; return the raw socket for close-assertions."""
+        raw = _mock_raw_sock()
+        reg.register(
+            decider_id, WS, "a@x", SafeWebSocket(raw), jti=jti, user_id=user_id
+        )
+        return raw
+
+    async def test_register_records_jti(self):
+        reg = ConsentDeciderRegistry(_app())
+        reg.register("d1", WS, "a@x", _FakeSock(), jti="jti-1")
+        assert reg._deciders["d1"]["jti"] == "jti-1"
+
+    async def test_register_without_jti_defaults_to_none(self):
+        reg = ConsentDeciderRegistry(_app())
+        reg.register("d1", WS, "a@x", _FakeSock())
+        assert reg._deciders["d1"]["jti"] is None
+
+    async def test_disconnect_by_jti_closes_real_safe_websocket(self):
+        reg = ConsentDeciderRegistry(_app())
+        raw = self._real_decider(reg, "jti-victim")
+        kicked = await reg.disconnect_by_jti(
+            "jti-victim", reason="Token revoked"
+        )
+        assert kicked == 1
+        raw.close.assert_awaited_once_with(code=4001, reason="Token revoked")
+        # The entry is dropped at kick time: consent authority ends at
+        # revocation, not when the receive loop notices the closed socket.
+        assert reg._deciders == {}
+
+    async def test_disconnect_by_jti_spares_other_jtis(self):
+        reg = ConsentDeciderRegistry(_app())
+        raw_victim = self._real_decider(reg, "jti-victim", "d1")
+        raw_other = self._real_decider(reg, "jti-other", "d2")
+        kicked = await reg.disconnect_by_jti(
+            "jti-victim", reason="Token revoked"
+        )
+        assert kicked == 1
+        raw_victim.close.assert_awaited_once_with(
+            code=4001, reason="Token revoked"
+        )
+        raw_other.close.assert_not_awaited()
+        assert set(reg._deciders) == {"d2"}
+
+    async def test_disconnect_by_jti_survives_close_error(self):
+        # A socket already gone must not abort the sweep over the rest.
+        reg = ConsentDeciderRegistry(_app())
+        raw = _mock_raw_sock()
+        raw.close = AsyncMock(side_effect=RuntimeError("already gone"))
+        reg.register("d1", WS, "a@x", SafeWebSocket(raw), jti="jti-x")
+        assert await reg.disconnect_by_jti("jti-x") == 1
+        assert reg._deciders == {}
+
+    async def test_register_records_user_id(self):
+        reg = ConsentDeciderRegistry(_app())
+        reg.register("d1", WS, "a@x", _FakeSock(), user_id="u1")
+        assert reg._deciders["d1"]["user_id"] == "u1"
+
+    async def test_disconnect_by_user_closes_real_safe_websocket(self):
+        reg = ConsentDeciderRegistry(_app())
+        raw = self._real_decider(reg, "jti-x", "d1", user_id="u-victim")
+        kicked = await reg.disconnect_by_user(
+            "u-victim", reason="Account disabled"
+        )
+        assert kicked == 1
+        raw.close.assert_awaited_once_with(
+            code=4001, reason="Account disabled"
+        )
+        assert reg._deciders == {}
+
+    async def test_disconnect_by_user_spares_other_users(self):
+        reg = ConsentDeciderRegistry(_app())
+        raw_victim = self._real_decider(reg, "j1", "d1", user_id="u1")
+        raw_other = self._real_decider(reg, "j2", "d2", user_id="u2")
+        kicked = await reg.disconnect_by_user("u1", reason="Account disabled")
+        assert kicked == 1
+        raw_victim.close.assert_awaited_once_with(
+            code=4001, reason="Account disabled"
+        )
+        raw_other.close.assert_not_awaited()
+        assert set(reg._deciders) == {"d2"}
+
+    async def test_reattach_jti_moves_decider_entries(self):
+        reg = ConsentDeciderRegistry(_app())
+        self._real_decider(reg, "old-jti", "d1")
+        self._real_decider(reg, "unrelated", "d2")
+        moved = reg.reattach_jti("old-jti", "new-jti")
+        assert moved == 1
+        assert reg._deciders["d1"]["jti"] == "new-jti"
+        assert reg._deciders["d2"]["jti"] == "unrelated"
 
 
 class TestConsentDeciderRegistryReconfigure:

--- a/src/klangk/klangkd-tests/tests/test_inactivity.py
+++ b/src/klangk/klangkd-tests/tests/test_inactivity.py
@@ -155,6 +155,37 @@ class TestInactivitySweeper:
             "u1", code=4001, reason="Account disabled"
         )
 
+    async def test_disabled_users_deciders_are_kicked(self):
+        """#3162: the sweep also closes the disabled user's live
+        consent-decider sockets — a decider holds egress-consent
+        authority and must not outlive the disable. The decider is a
+        REAL SafeWebSocket (fakes masked the reason-kwarg no-op class
+        of bug, #3160 review)."""
+        from klangk.consent.deciders import ConsentDeciderRegistry
+        from klangk.wshandler.safe_websocket import SafeWebSocket
+
+        app = _app(
+            disable_inactive=AsyncMock(
+                return_value=[{"id": "u1", "email": "gone@example.com"}]
+            )
+        )
+        app.state.consent_deciders = ConsentDeciderRegistry(app)
+        raw = AsyncMock()
+        raw.close = AsyncMock()
+        app.state.consent_deciders.register(
+            "d1",
+            "ws-1",
+            "gone@example.com",
+            SafeWebSocket(raw),
+            jti="j1",
+            user_id="u1",
+        )
+        await inactivity.InactivitySweeper(app).sweep()
+        raw.close.assert_awaited_once_with(
+            code=4001, reason="Account disabled"
+        )
+        assert app.state.consent_deciders._deciders == {}
+
 
 def await_count(mock) -> int:
     return mock.await_count if hasattr(mock, "await_count") else 0

--- a/src/klangk/klangkd-tests/tests/test_wshandler.py
+++ b/src/klangk/klangkd-tests/tests/test_wshandler.py
@@ -2830,8 +2830,8 @@ class TestHandleWebsocketDispatch:
         seen: list = []
 
         class RecordingConnection(Connection):
-            def __init__(self, ws, u, app, jti=None):
-                super().__init__(ws, u, app, jti=jti)
+            def __init__(self, ws, u, app, jti=None, token_exp=None):
+                super().__init__(ws, u, app, jti=jti, token_exp=token_exp)
                 seen.append(jti)
 
         with patch.object(dispatch_mod, "Connection", RecordingConnection):
@@ -2840,15 +2840,17 @@ class TestHandleWebsocketDispatch:
 
     async def test_ws_authenticate_returns_user_and_jti(self, user):
         """#3152: ws_authenticate hands the caller the authenticated user
-        plus the token's JTI."""
+        plus the token's JTI and exp."""
         app_state = _make_app_state()
         token = _auth().create_token(user["id"], user["email"])
+        payload = _auth().decode_token(token)
         websocket = _mock_raw_sock(query_params={"token": token})
         result = await ws_authenticate(websocket, app_state)
         assert isinstance(result, tuple)
-        authed_user, jti = result
+        authed_user, jti, exp = result
         assert authed_user["id"] == user["id"]
-        assert jti == _auth().decode_token(token)["jti"]
+        assert jti == payload["jti"]
+        assert exp == payload["exp"]
         websocket.close.assert_not_awaited()
 
     async def test_dispatch_terminal_input(self, user):
@@ -12758,3 +12760,40 @@ class TestNoCoverAudit2910Part3:
         await ctrl.handle_list_error(RuntimeError("listing broke"))
         sent = [c[0][0] for c in sock.send_json.call_args_list]
         assert any(m.get("type") == "error" for m in sent)
+
+
+class TestTokenExpiryTimer:
+    """#3152: the connection must close when the access token expires."""
+
+    async def test_socket_closes_when_token_expires(self):
+        """schedule_token_expiry closes the socket at exp time."""
+        sock = _mock_sock()
+        # token_exp in the past → immediate close
+        conn = _base_conn(ws=sock)
+        conn.token_exp = time.time() - 1
+        conn._expiry_task = None
+        conn.schedule_token_expiry()
+        assert conn._expiry_task is not None
+        await conn._expiry_task
+        sock.close.assert_awaited_once_with(code=4002, reason="Token expired")
+
+    async def test_no_timer_without_token_exp(self):
+        """No expiry task when token_exp is None (e.g. test connections)."""
+        conn = _base_conn()
+        conn.token_exp = None
+        conn._expiry_task = None
+        conn.schedule_token_expiry()
+        assert conn._expiry_task is None
+
+    async def test_cleanup_cancels_expiry_task(self):
+        """cleanup() cancels the pending expiry task."""
+        app_state = _make_app_state()
+        sock = _mock_sock()
+        conn = _base_conn(ws=sock, app_state=app_state)
+        conn.token_exp = time.time() + 3600
+        conn._expiry_task = None
+        conn.schedule_token_expiry()
+        assert conn._expiry_task is not None
+        assert not conn._expiry_task.done()
+        await conn.cleanup()
+        assert conn._expiry_task is None

--- a/src/klangk/klangkd-tests/tests/test_wshandler.py
+++ b/src/klangk/klangkd-tests/tests/test_wshandler.py
@@ -11844,7 +11844,13 @@ class TestTokenRenewal:
             ):
                 expiry = datetime.now(timezone.utc) + timedelta(seconds=0.1)
                 session.start_token_renewal(expiry)
-                await original_sleep(0.5)
+                # Poll for the retry instead of a fixed sleep budget: a
+                # busy CI runner (xdist + SQLite migrations) can starve
+                # the renewal task's loop turns well past 0.5s, which
+                # flaked this test on the macOS backend matrix.
+                deadline = time.monotonic() + 5.0
+                while call_count < 2 and time.monotonic() < deadline:
+                    await original_sleep(0.01)
                 session._token_renewal_task.cancel()
                 try:
                     await session._token_renewal_task

--- a/src/klangk/klangkd-tests/tests/test_wshandler.py
+++ b/src/klangk/klangkd-tests/tests/test_wshandler.py
@@ -3056,6 +3056,17 @@ class TestHandleWebsocket:
             code=4002, reason="Token expired"
         )
 
+    async def test_unknown_user_token_rejected(self, db, app_state):
+        # Valid signature, but the user no longer exists: the connect is
+        # refused with 4001 (the post-decode None-user arm).
+        app_state = _make_app_state()
+        token = _auth().create_token("nonexistent-id", "ghost@example.com")
+        websocket = _mock_raw_sock(query_params={"token": token})
+        await handle_websocket(websocket, app_state)
+        websocket.close.assert_awaited_once_with(
+            code=4001, reason="Invalid token"
+        )
+
     async def test_valid_token_then_disconnect(self, user, app_state):
         app_state = _make_app_state()
 

--- a/src/klangk/klangkd-tests/tests/test_wshandler.py
+++ b/src/klangk/klangkd-tests/tests/test_wshandler.py
@@ -51,6 +51,7 @@ from klangk.wshandler import (
     disconnect_all_websockets,
     send_error,
     handle_websocket,
+    ws_authenticate,
     reset_workspace_state,
     log_ws_msg,
     SEND_QUEUE_SIZE,
@@ -2809,6 +2810,41 @@ class TestHandleWebsocketDispatch:
             await handle_websocket(websocket, app_state)  # must not raise
         assert app_state.state.sockets.connections == {}
         assert "Connection cleanup failed" in caplog.text
+
+    async def test_connection_records_authenticating_jti(self, user):
+        """#3152: the Connection built by handle_websocket records the
+        JTI of the token it authenticated with, so a later hard revocation
+        can close exactly this connection."""
+        from klangk.wshandler import dispatch as dispatch_mod
+
+        app_state = _make_app_state()
+        token = _auth().create_token(user["id"], user["email"])
+        jti = _auth().decode_token(token)["jti"]
+        websocket = _mock_raw_sock(query_params={"token": token})
+        websocket.receive_text = AsyncMock(side_effect=[WebSocketDisconnect()])
+        seen: list = []
+
+        class RecordingConnection(Connection):
+            def __init__(self, ws, u, app, jti=None):
+                super().__init__(ws, u, app, jti=jti)
+                seen.append(jti)
+
+        with patch.object(dispatch_mod, "Connection", RecordingConnection):
+            await handle_websocket(websocket, app_state)
+        assert seen == [jti]
+
+    async def test_ws_authenticate_returns_user_and_jti(self, user):
+        """#3152: ws_authenticate hands the caller the authenticated user
+        plus the token's JTI."""
+        app_state = _make_app_state()
+        token = _auth().create_token(user["id"], user["email"])
+        websocket = _mock_raw_sock(query_params={"token": token})
+        result = await ws_authenticate(websocket, app_state)
+        assert isinstance(result, tuple)
+        authed_user, jti = result
+        assert authed_user["id"] == user["id"]
+        assert jti == _auth().decode_token(token)["jti"]
+        websocket.close.assert_not_awaited()
 
     async def test_dispatch_terminal_input(self, user):
         websocket = await self._run_commands(

--- a/src/klangk/klangkd-tests/tests/test_wshandler.py
+++ b/src/klangk/klangkd-tests/tests/test_wshandler.py
@@ -315,7 +315,12 @@ class TestSafeWebSocket:
         raw = AsyncMock()
         sw = SafeWebSocket(raw)
         await sw.close(code=4001)
-        raw.close.assert_awaited_once_with(code=4001)
+        raw.close.assert_awaited_once_with(code=4001, reason=None)
+        # #3152: the kick paths close with a reason; it must reach the
+        # transport (it used to be dropped here, making every
+        # reason-carrying kick a swallowed TypeError no-op).
+        await sw.close(code=4001, reason="Token revoked")
+        raw.close.assert_awaited_with(code=4001, reason="Token revoked")
 
     async def test_headers_delegates(self):
         raw = AsyncMock()
@@ -2954,6 +2959,57 @@ class TestHandleWebsocketDispatch:
             await handle_websocket(websocket, app_state)
 
         mock_stop.assert_not_awaited()
+
+
+def _planted_safe_socket(app_state, jti, user_id="uid"):
+    """A real SafeWebSocket over a mock raw socket, planted in the
+    registry under a fake connection with *jti* (#3152 review: fakes
+    whose close() happens to accept ``reason`` masked that
+    SafeWebSocket.close historically dropped it)."""
+    raw = _mock_raw_sock()
+    sock = SafeWebSocket(raw)
+    app_state.state.sockets.connections[sock] = types.SimpleNamespace(
+        user={"id": user_id, "email": f"{user_id}@example.com"}, jti=jti
+    )
+    return raw, sock
+
+
+class TestKicksCloseRealSockets:
+    """#3152 review: the kick paths must close REAL SafeWebSocket entries.
+    Both disconnect_by_jti and disconnect_user pass ``reason``; when
+    SafeWebSocket.close silently dropped the kwarg, every such kick was
+    a swallowed TypeError no-op — fake sockets with matching signatures
+    hid it, so these tests use the real writer class."""
+
+    async def test_disconnect_by_jti_closes_real_safe_websocket(self):
+        app_state = _make_app_state()
+        raw, _ = _planted_safe_socket(app_state, "jti-victim")
+        try:
+            kicked = await app_state.state.sockets.disconnect_by_jti(
+                "jti-victim", reason="Token revoked"
+            )
+            assert kicked == 1
+            raw.close.assert_awaited_once_with(
+                code=4001, reason="Token revoked"
+            )
+        finally:
+            app_state.state.sockets.connections.clear()
+
+    async def test_disconnect_user_closes_real_safe_websocket(self):
+        """Regression for the pre-existing latent no-op (#2588 kick):
+        account-disable / inactivity closes also carry ``reason``."""
+        app_state = _make_app_state()
+        raw, _ = _planted_safe_socket(app_state, "jti-x", "u1")
+        try:
+            kicked = await app_state.state.sockets.disconnect_user(
+                "u1", reason="Account disabled"
+            )
+            assert kicked == 1
+            raw.close.assert_awaited_once_with(
+                code=4001, reason="Account disabled"
+            )
+        finally:
+            app_state.state.sockets.connections.clear()
 
 
 # --- handle_restart_container additional coverage ---


### PR DESCRIPTION
## Summary

Closes #3152 (audit finding V-222567).

A WebSocket connection was authenticated once at handshake and never re-validated, so a hard token revocation (logout, session-limit eviction) left already-established sockets with full data-plane access — terminal I/O, file operations, browser streaming, workspace control — until the client happened to reconnect.

Now the revocation **pushes**: the sockets a revoked token authenticated are closed immediately, event-driven (no per-connection polling of the blocklist).

## How it works

- `Connection` records the **JTI** of the token it authenticated with at handshake (`ws_authenticate` now returns `(user, jti)`).
- New `WebSocketState.disconnect_by_jti` closes exactly the connections that JTI opened — not every session of the user, so logging out one device leaves the user's other live sessions connected. Close code **4001** per the existing convention (#2588 account-disable kick): the client logs out instead of reconnect-looping.
- `Auth.logout` and `Auth._revoke_sessions` (session-limit eviction) call the kick after blocklisting the JTI.
- **Refresh rotation is deliberately exempt from the kick** (`_swap_token` also blocklists the old JTI, but a refresh keeps the session alive under the new token — kicking there would drop every user's socket on every token refresh). Instead, `_swap_token` **retargets** the live connections' `conn.jti` old→new (`reattach_jti`), so a refreshed session's socket stays kickable by a later logout or eviction. Without retargeting, the typical eviction victim (a long-refreshing session — `replace_session` preserves `created_at`, so it stays oldest) would be permanently unkickable.
- **Token expiry** no longer outlives the socket: `Connection.schedule_token_expiry` closes the connection at the access token's `exp` (close code **4002**).
- **Password change revokes every session**: `POST /auth/change-password` now calls `Auth.revoke_all_user_sessions` — blocklists each active token, drops the session rows, and kicks their sockets — forcing re-login on all devices.
- Fixed en route (found by the fresh-eyes review): `SafeWebSocket.close` dropped the `reason` kwarg, which made **every reason-carrying kick a swallowed TypeError no-op** — including the pre-existing #2588 admin-disable/inactivity kick, which has never actually closed a socket. `close` now forwards `reason` to the transport.

Same-process push, no polling: logout, the blocklist, and the socket registry all live in one klangkd process, so the revocation call sites close the sockets directly.

## Tests

- `test_api.py`: end-to-end — `POST /auth/logout` closes the victim JTI's socket with `(4001, "Token revoked")`; the same user's *other* session and other users' sockets survive; the close-raises branch doesn't break the kick.
- `test_auth.py`: logout kick, session-limit eviction kick (cap=1), refresh rotation does **not** kick but **retargets**, logout-after-refresh closes the retargeted socket, eviction-after-refresh closes the retargeted socket; password-change revocation (all sessions) and its empty-rows no-op.
- `test_wshandler.py`: `ws_authenticate` returns `(user, jti)`; `handle_websocket` wires the JTI onto the `Connection`; and — per the review — the kick paths are tested against **real `SafeWebSocket`** entries (fake sockets masked the `reason` no-op), for both `disconnect_by_jti` and the pre-existing `disconnect_user`.
- Password-history e2e (`test_password_history_e2e.py`, frontend `password-history.spec.ts`) re-login after every successful change, covering the new revocation.

Full suite green with the 100% branch-coverage gate (`-n auto`, CI invocation).

## Scope of the audit finding (V-222567)

Three follow-up gaps were originally cut from scope; two were folded into this PR:

- **Plain token expiry** — addressed here (`schedule_token_expiry`, close 4002 at `exp`).
- **`change-password` session revocation** — addressed here (`revoke_all_user_sessions`).
- **Consent-decider sockets** (`wshandler/decider.py`) — the only remaining gap: the decider authenticated a user JWT at handshake, never re-validated, and lived in its own registry. Closed by the stacked follow-up PR #3167 (`Closes #3162`), which mirrors this PR's kick/retarget story onto the decider registry.
