### PR TITLE
Close consent-decider sockets on token revocation (#3162)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -294,12 +294,13 @@ operators or integrators to act when upgrading.
 
 - **Consent-decider sockets are closed on token revocation (#3162).**
   The `/ws/consent-decider` connection now shares the #3152 revocation
-  story: logging out, or being evicted by the per-user session limit,
-  immediately closes the decider sockets the revoked token
-  authenticated (close code 4001) and drops their registrations, so
-  egress-consent authority (verdicts, revokes, pause) ends with the
-  credential. Previously the decider socket — which lives in its own
-  registry — kept that authority indefinitely after logout. Refresh
+  story: logging out, being evicted by the per-user session limit, or
+  having the account disabled (admin action or the inactivity sweep)
+  immediately closes the decider sockets that credential authenticated
+  (close code 4001) and drops their registrations, so egress-consent
+  authority (verdicts, revokes, pause) ends with the credential.
+  Previously the decider socket — which lives in its own registry —
+  kept that authority indefinitely after logout or disable. Refresh
   rotation retargets the decider onto the new token instead of closing
   it.
 

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -292,6 +292,17 @@ operators or integrators to act when upgrading.
 
 ### Security
 
+- **Consent-decider sockets are closed on token revocation (#3162).**
+  The `/ws/consent-decider` connection now shares the #3152 revocation
+  story: logging out, or being evicted by the per-user session limit,
+  immediately closes the decider sockets the revoked token
+  authenticated (close code 4001) and drops their registrations, so
+  egress-consent authority (verdicts, revokes, pause) ends with the
+  credential. Previously the decider socket — which lives in its own
+  registry — kept that authority indefinitely after logout. Refresh
+  rotation retargets the decider onto the new token instead of closing
+  it.
+
 - **WebSocket connections are closed on token revocation (#3152).**
   Logging out, or being evicted by the per-user session limit, now
   immediately closes the live WebSocket connections the revoked token

--- a/src/klangk/klangk/api/admin.py
+++ b/src/klangk/klangk/api/admin.py
@@ -468,6 +468,11 @@ async def _update_user_disabled(
         kicked = await wshandler.disconnect_user(
             app.state.sockets, user_id, reason="Account disabled"
         )
+        # #3162: the consent-decider surface must not outlive the
+        # disable either — it holds egress-consent authority.
+        kicked += await wshandler.disconnect_deciders_by_user(
+            app, user_id, reason="Account disabled"
+        )
         if kicked:
             logger.info(
                 "admin: disabled user %s; closed %d live connection(s)",

--- a/src/klangk/klangk/api/admin.py
+++ b/src/klangk/klangk/api/admin.py
@@ -446,6 +446,29 @@ def _reject_self_disable(
         )
 
 
+async def _kick_disabled_user_sockets(app, user_id: str) -> None:
+    """Cut a just-disabled user's live sockets (#2588, #3162).
+
+    The main /ws connections (the terminal/control data plane) and the
+    consent-decider sockets (egress-consent authority) alike; 4001 ->
+    the clients log out rather than reconnect-looping.
+    """
+    kicked = await wshandler.disconnect_user(
+        app.state.sockets, user_id, reason="Account disabled"
+    )
+    deciders_kicked = await wshandler.disconnect_deciders_by_user(
+        app, user_id, reason="Account disabled"
+    )
+    if kicked or deciders_kicked:
+        logger.info(
+            "admin: disabled user %s; closed %d live connection(s)"
+            " and %d consent decider(s)",
+            user_id,
+            kicked,
+            deciders_kicked,
+        )
+
+
 async def _update_user_disabled(
     app, req: UpdateUserRequest, user_id: str, admin: dict
 ) -> None:
@@ -461,24 +484,7 @@ async def _update_user_disabled(
     if not updated:  # pragma: no cover — race between get and update
         raise HTTPException(status_code=404, detail="User not found")
     if req.disabled:
-        # Cut the user's live connections too (#2588 review): the
-        # WS is the terminal/control data plane, and a disabled
-        # account must not keep it. 4001 -> the client logs out
-        # rather than reconnect-looping.
-        kicked = await wshandler.disconnect_user(
-            app.state.sockets, user_id, reason="Account disabled"
-        )
-        # #3162: the consent-decider surface must not outlive the
-        # disable either — it holds egress-consent authority.
-        kicked += await wshandler.disconnect_deciders_by_user(
-            app, user_id, reason="Account disabled"
-        )
-        if kicked:
-            logger.info(
-                "admin: disabled user %s; closed %d live connection(s)",
-                user_id,
-                kicked,
-            )
+        await _kick_disabled_user_sockets(app, user_id)
 
 
 @router.post("/users/{user_id}/unlockout")

--- a/src/klangk/klangk/auth.py
+++ b/src/klangk/klangk/auth.py
@@ -721,12 +721,18 @@ class Auth:
         """Close live WS connections authenticated with *jti* (#3152).
 
         Revocation must cut the sockets the token opened, not just
-        reject the next connect. Minimal app states (tests) may not wire
-        ``sockets`` — then there is nothing to close.
+        reject the next connect — both the main ``/ws`` connections and
+        the consent-decider sockets (#3162: a decider holds
+        egress-consent authority and lives in its own registry). Minimal
+        app states (tests) may not wire ``sockets`` or
+        ``consent_deciders`` — then there is nothing to close.
         """
         sockets = getattr(self.app.state, "sockets", None)
         if sockets is not None:
             await sockets.disconnect_by_jti(jti, reason="Token revoked")
+        deciders = getattr(self.app.state, "consent_deciders", None)
+        if deciders is not None:
+            await deciders.disconnect_by_jti(jti, reason="Token revoked")
 
     async def revoke_all_user_sessions(self, user_id: str) -> None:
         """Blocklist and delete every session for *user_id* (#3152).
@@ -1096,12 +1102,17 @@ class Auth:
 
         Keeps ``conn.jti`` equal to the session row's current JTI so a
         later hard revocation (logout, eviction) still finds the socket
-        the refreshed session is using. Minimal app states (tests) may
-        not wire ``sockets`` — then there is nothing to retarget.
+        the refreshed session is using — for the main ``/ws``
+        connections and the consent-decider registrations alike
+        (#3162). Minimal app states (tests) may not wire ``sockets`` or
+        ``consent_deciders`` — then there is nothing to retarget.
         """
         sockets = getattr(self.app.state, "sockets", None)
         if sockets is not None:
             sockets.reattach_jti(old_jti, new_jti)
+        deciders = getattr(self.app.state, "consent_deciders", None)
+        if deciders is not None:
+            deciders.reattach_jti(old_jti, new_jti)
 
     async def _expired_token_response(self, token: str) -> TokenResponse:
         """A previously-refreshed expired token still returns its cached

--- a/src/klangk/klangk/consent/deciders.py
+++ b/src/klangk/klangk/consent/deciders.py
@@ -26,10 +26,12 @@ Owns only ``app`` (the app-ownership rule); the timeout is read live via
 property so a SIGHUP reload propagates.
 
 #3162: entries carry the JTI of the user JWT that authenticated the
-decider handshake, so a hard token revocation (logout, session-limit
-eviction) can close the decider sockets that token opened — the same
-kick the main ``/ws`` registry got in #3152. Refresh rotation
-retargets the entry onto the new JTI instead of closing it.
+decider handshake and the user id, so both a hard token revocation
+(logout, session-limit eviction — by JTI) and an account disable (admin
+route, inactivity sweep — by user) can close the decider sockets that
+credential opened — the same kicks the main ``/ws`` registry got in
+#3152/#2588. Refresh rotation retargets the entry onto the new JTI
+instead of closing it.
 """
 
 from __future__ import annotations
@@ -61,7 +63,7 @@ class ConsentDeciderRegistry:
         self.app = app
         # decider_id -> {"ws": workspace_id, "seen": monotonic,
         #                 "email": str, "sock": SafeWebSocket,
-        #                 "jti": str | None}
+        #                 "jti": str | None, "user_id": str | None}
         self._deciders: dict[str, dict] = {}
         self._reaper: asyncio.Task | None = None
 
@@ -79,6 +81,7 @@ class ConsentDeciderRegistry:
         email: str | None,
         sock,
         jti: str | None = None,
+        user_id: str | None = None,
     ) -> None:
         """Register a live decider (connect). Idempotent on decider_id.
 
@@ -86,8 +89,9 @@ class ConsentDeciderRegistry:
         lifecycle (start/stop sender) -- the registry holds only a reference for
         :meth:`broadcast` fanout. ``jti`` is the ID of the user JWT that
         authenticated the handshake (#3162) so a later hard revocation can
-        close exactly this decider; ``None`` on registrations built without
-        one (tests) -- never kicked by JTI.
+        close exactly this decider; ``user_id`` lets an account disable do
+        the same for every decider of the user. Both are ``None`` on
+        registrations built without them (tests) -- never kicked.
         """
         self._deciders[decider_id] = {
             "ws": workspace_id,
@@ -95,6 +99,7 @@ class ConsentDeciderRegistry:
             "email": email,
             "sock": sock,
             "jti": jti,
+            "user_id": user_id,
         }
         logger.info(
             "consent decider registered: scope=%s decider=%s",
@@ -159,6 +164,24 @@ class ConsentDeciderRegistry:
             self._deciders.pop(did, None)
         return delivered
 
+    async def _close_and_drop(
+        self, victims: list, code: int, reason: str
+    ) -> int:
+        """Close each victim decider's socket and drop its registration.
+
+        Shared sweep body of the two kick selectors; a socket already gone
+        must not abort the sweep over the rest.
+        """
+        for did, entry in victims:
+            self._deciders.pop(did, None)
+            try:
+                await entry["sock"].close(code=code, reason=reason)
+            except Exception:  # noqa: BLE001
+                logger.debug(
+                    "Error closing decider socket for %s", entry["email"]
+                )
+        return len(victims)
+
     async def disconnect_by_jti(
         self, jti: str, *, code: int = 4001, reason: str = ""
     ) -> int:
@@ -180,13 +203,26 @@ class ConsentDeciderRegistry:
             for did, entry in self._deciders.items()
             if entry["jti"] == jti
         ]
-        for did, entry in victims:
-            self._deciders.pop(did, None)
-            try:
-                await entry["sock"].close(code=code, reason=reason)
-            except Exception:  # noqa: BLE001
-                logger.debug("Error closing decider socket for jti %s", jti)
-        return len(victims)
+        return await self._close_and_drop(victims, code, reason)
+
+    async def disconnect_by_user(
+        self, user_id: str, *, code: int = 4001, reason: str = ""
+    ) -> int:
+        """Close every live decider registered by *user_id* (#3162).
+
+        Account disable (admin route, inactivity sweep) must cut the
+        user's decider sockets too — the per-user analogue of the #2588
+        ``disconnect_user`` kick, for a surface that holds
+        egress-consent authority. Same close/drop semantics as
+        :meth:`disconnect_by_jti`. Returns how many deciders were
+        closed.
+        """
+        victims = [
+            (did, entry)
+            for did, entry in self._deciders.items()
+            if entry["user_id"] == user_id
+        ]
+        return await self._close_and_drop(victims, code, reason)
 
     def reattach_jti(self, old_jti: str, new_jti: str) -> int:
         """Move live deciders from *old_jti* onto *new_jti* (#3162).

--- a/src/klangk/klangk/consent/deciders.py
+++ b/src/klangk/klangk/consent/deciders.py
@@ -24,6 +24,12 @@ for at most that long, not indefinitely.
 
 Owns only ``app`` (the app-ownership rule); the timeout is read live via
 property so a SIGHUP reload propagates.
+
+#3162: entries carry the JTI of the user JWT that authenticated the
+decider handshake, so a hard token revocation (logout, session-limit
+eviction) can close the decider sockets that token opened — the same
+kick the main ``/ws`` registry got in #3152. Refresh rotation
+retargets the entry onto the new JTI instead of closing it.
 """
 
 from __future__ import annotations
@@ -54,7 +60,8 @@ class ConsentDeciderRegistry:
     def __init__(self, app) -> None:
         self.app = app
         # decider_id -> {"ws": workspace_id, "seen": monotonic,
-        #                 "email": str, "sock": SafeWebSocket}
+        #                 "email": str, "sock": SafeWebSocket,
+        #                 "jti": str | None}
         self._deciders: dict[str, dict] = {}
         self._reaper: asyncio.Task | None = None
 
@@ -71,18 +78,23 @@ class ConsentDeciderRegistry:
         workspace_id: str,
         email: str | None,
         sock,
+        jti: str | None = None,
     ) -> None:
         """Register a live decider (connect). Idempotent on decider_id.
 
         ``sock`` is the decider's :class:`SafeWebSocket`; the endpoint owns its
         lifecycle (start/stop sender) -- the registry holds only a reference for
-        :meth:`broadcast` fanout.
+        :meth:`broadcast` fanout. ``jti`` is the ID of the user JWT that
+        authenticated the handshake (#3162) so a later hard revocation can
+        close exactly this decider; ``None`` on registrations built without
+        one (tests) -- never kicked by JTI.
         """
         self._deciders[decider_id] = {
             "ws": workspace_id,
             "seen": time.monotonic(),
             "email": email,
             "sock": sock,
+            "jti": jti,
         }
         logger.info(
             "consent decider registered: scope=%s decider=%s",
@@ -146,6 +158,52 @@ class ConsentDeciderRegistry:
         for did in dead:
             self._deciders.pop(did, None)
         return delivered
+
+    async def disconnect_by_jti(
+        self, jti: str, *, code: int = 4001, reason: str = ""
+    ) -> int:
+        """Close every live decider registered with *jti* (#3162).
+
+        Hard token revocation (logout, session-limit eviction) must cut
+        the decider sockets that token opened, not just reject the next
+        connect — a decider holds egress-consent authority (verdicts,
+        revokes, pause), so it must not outlive its credential. Code 4001
+        makes the client log out rather than reconnect-loop, the same
+        convention as ``WebSocketState.disconnect_by_jti`` (#3152).
+        Entries are dropped here so the workspace's consent authority
+        ends at revocation, not when the receive loop notices; the
+        endpoint's ``finally`` deregister is then a no-op. Returns how
+        many deciders were closed.
+        """
+        victims = [
+            (did, entry)
+            for did, entry in self._deciders.items()
+            if entry["jti"] == jti
+        ]
+        for did, entry in victims:
+            self._deciders.pop(did, None)
+            try:
+                await entry["sock"].close(code=code, reason=reason)
+            except Exception:  # noqa: BLE001
+                logger.debug("Error closing decider socket for jti %s", jti)
+        return len(victims)
+
+    def reattach_jti(self, old_jti: str, new_jti: str) -> int:
+        """Move live deciders from *old_jti* onto *new_jti* (#3162).
+
+        A token refresh keeps the session — and its decider socket —
+        alive under the new token; retargeting keeps the entry's JTI
+        equal to the session row's current JTI so a later hard
+        revocation (logout, session-limit eviction) still finds the
+        decider (mirrors ``WebSocketState.reattach_jti``, #3152).
+        Returns how many deciders were moved.
+        """
+        moved = 0
+        for entry in self._deciders.values():
+            if entry["jti"] == old_jti:
+                entry["jti"] = new_jti
+                moved += 1
+        return moved
 
     def start(self) -> None:
         """Start the liveness reaper (idempotent). Runs until :meth:`stop`."""

--- a/src/klangk/klangk/inactivity.py
+++ b/src/klangk/klangk/inactivity.py
@@ -62,6 +62,11 @@ class InactivitySweeper(IntervalWorker):
                     u["id"],
                     reason="Account disabled",
                 )
+                # #3162: the decider surface must not outlive the disable
+                # either — it holds egress-consent authority.
+                await wshandler.disconnect_deciders_by_user(
+                    self.app, u["id"], reason="Account disabled"
+                )
             logger.info(
                 "inactivity: disabled %d account(s) inactive for more than"
                 " %d day(s): %s",

--- a/src/klangk/klangk/wshandler/__init__.py
+++ b/src/klangk/klangk/wshandler/__init__.py
@@ -30,6 +30,7 @@ from .support import (
     broadcast_event as broadcast_event,
     disconnect_all_websockets as disconnect_all_websockets,
     disconnect_by_jti as disconnect_by_jti,
+    disconnect_deciders_by_user as disconnect_deciders_by_user,
     disconnect_user as disconnect_user,
     format_container_info as format_container_info,
     format_idle_timeout as format_idle_timeout,

--- a/src/klangk/klangk/wshandler/decider.py
+++ b/src/klangk/klangk/wshandler/decider.py
@@ -35,8 +35,10 @@ pause. Auth mirrors the main ``/ws`` handler: a user JWT in the ``token``
 query param — including its revocation story (#3162): the handshake
 records the token's JTI on the registry entry, and a hard revocation
 (logout, session-limit eviction) closes the decider socket with 4001,
-just like the main handler's connections (#3152). Refresh rotation
-retargets the entry onto the new JTI instead of closing it.
+just like the main handler's connections (#3152), and an account
+disable closes every decider of the user (#3162, mirroring the #2588
+per-user kick). Refresh rotation retargets the entry onto the new JTI
+instead of closing it.
 
 Outbound writes go through :class:`SafeWebSocket` (bounded queue +
 ``SlowClientError``) like the main ``/ws`` handler.
@@ -364,7 +366,9 @@ async def handle_consent_decider(websocket: WebSocket, app) -> None:
     decider_id = str(uuid.uuid4())
     email = user.get("email")
     try:
-        registry.register(decider_id, workspace, email, safe_ws, jti=jti)
+        registry.register(
+            decider_id, workspace, email, safe_ws, jti=jti, user_id=user["id"]
+        )
         # Register BEFORE reading the snapshot: a hold created between the two
         # is then delivered twice (once live via fanout, once from the
         # snapshot). That duplicate is benign -- the second verdict no-ops

--- a/src/klangk/klangk/wshandler/decider.py
+++ b/src/klangk/klangk/wshandler/decider.py
@@ -32,7 +32,11 @@ it targets the decider's own workspace (defense-in-depth), enforced in
 ``resolve`` via ``decider_workspace``. Pause/unpause share the same single
 gate as the connection itself (#2883): anyone who may register may also
 pause. Auth mirrors the main ``/ws`` handler: a user JWT in the ``token``
-query param.
+query param — including its revocation story (#3162): the handshake
+records the token's JTI on the registry entry, and a hard revocation
+(logout, session-limit eviction) closes the decider socket with 4001,
+just like the main handler's connections (#3152). Refresh rotation
+retargets the entry onto the new JTI instead of closing it.
 
 Outbound writes go through :class:`SafeWebSocket` (bounded queue +
 ``SlowClientError``) like the main ``/ws`` handler.
@@ -225,7 +229,12 @@ async def _dispatch_decider_message(
 
 
 async def _decider_authenticate(websocket: WebSocket, app, _hs_mark):
-    """Validate the decider socket's token; refuse + None on failure."""
+    """Validate the decider socket's token; refuse + None on failure.
+
+    Success returns ``(user, jti)`` — the token's JTI rides along so the
+    registration can be targeted for closing when that token is later
+    hard-revoked (#3162), mirroring ``ws_authenticate`` (#3152).
+    """
     token = websocket.query_params.get("token")
     if not token:
         await _refuse(websocket, 4001, "Missing token")
@@ -238,7 +247,7 @@ async def _decider_authenticate(websocket: WebSocket, app, _hs_mark):
     if result is None:
         await _refuse(websocket, 4001, "Invalid token")
         return None
-    return result
+    return result, app.state.auth.decode_token(token).get("jti")
 
 
 _FRAME_DISCONNECTED = object()
@@ -326,9 +335,10 @@ async def handle_consent_decider(websocket: WebSocket, app) -> None:
     def _hs_mark(label: str) -> None:
         _hs_marks.append((label, time.monotonic()))
 
-    user = await _decider_authenticate(websocket, app, _hs_mark)
-    if user is None:
+    authed = await _decider_authenticate(websocket, app, _hs_mark)
+    if authed is None:
         return
+    user, jti = authed
     workspace = websocket.query_params.get("workspace")
     if workspace is None:
         # #2976: consent is strictly a workspace concern -- there is no
@@ -354,7 +364,7 @@ async def handle_consent_decider(websocket: WebSocket, app) -> None:
     decider_id = str(uuid.uuid4())
     email = user.get("email")
     try:
-        registry.register(decider_id, workspace, email, safe_ws)
+        registry.register(decider_id, workspace, email, safe_ws, jti=jti)
         # Register BEFORE reading the snapshot: a hold created between the two
         # is then delivered twice (once live via fanout, once from the
         # snapshot). That duplicate is benign -- the second verdict no-ops

--- a/src/klangk/klangk/wshandler/decider.py
+++ b/src/klangk/klangk/wshandler/decider.py
@@ -52,8 +52,8 @@ import time
 import uuid
 
 from fastapi import WebSocket, WebSocketDisconnect
+from jose import ExpiredSignatureError, JWTError
 
-from .. import auth
 from .safe_websocket import SafeWebSocket, SlowClientError
 from ..model.egress_consent import (
     DECISION_ALLOWED,
@@ -241,15 +241,21 @@ async def _decider_authenticate(websocket: WebSocket, app, _hs_mark):
     if not token:
         await _refuse(websocket, 4001, "Missing token")
         return None
-    result = await app.state.auth.get_user_from_token(token)
-    _hs_mark("token")
-    if result is auth.Auth.TOKEN_EXPIRED:
+    a = app.state.auth
+    try:
+        payload = a.decode_token(token)
+    except ExpiredSignatureError:
         await _refuse(websocket, 4002, "Token expired")
         return None
-    if result is None:
+    except JWTError:
         await _refuse(websocket, 4001, "Invalid token")
         return None
-    return result, app.state.auth.decode_token(token).get("jti")
+    user = await a._user_from_valid_payload(payload)
+    _hs_mark("token")
+    if user is None:
+        await _refuse(websocket, 4001, "Invalid token")
+        return None
+    return user, payload.get("jti")
 
 
 _FRAME_DISCONNECTED = object()

--- a/src/klangk/klangk/wshandler/dispatch.py
+++ b/src/klangk/klangk/wshandler/dispatch.py
@@ -4,8 +4,8 @@ import json
 import logging
 
 from fastapi import WebSocket, WebSocketDisconnect
+from jose import ExpiredSignatureError, JWTError
 
-from .. import auth
 from .safe_websocket import SafeWebSocket, SlowClientError
 from .support import send_error, log_ws_msg
 from .connection import Connection
@@ -75,15 +75,20 @@ async def ws_authenticate(websocket: WebSocket, app):
         await websocket.close(code=4001, reason="Missing token")
         return None
 
-    result = await app.state.auth.get_user_from_token(token)
-    if result is auth.Auth.TOKEN_EXPIRED:
+    a = app.state.auth
+    try:
+        payload = a.decode_token(token)
+    except ExpiredSignatureError:
         await websocket.close(code=4002, reason="Token expired")
         return None
-    if result is None:
+    except JWTError:
         await websocket.close(code=4001, reason="Invalid token")
         return None
-    payload = app.state.auth.decode_token(token)
-    return result, payload.get("jti"), payload.get("exp")
+    user = await a._user_from_valid_payload(payload)
+    if user is None:
+        await websocket.close(code=4001, reason="Invalid token")
+        return None
+    return user, payload.get("jti"), payload.get("exp")
 
 
 # Exceptions raised by a *handler* that mean the connection itself is

--- a/src/klangk/klangk/wshandler/support.py
+++ b/src/klangk/klangk/wshandler/support.py
@@ -140,6 +140,22 @@ async def disconnect_by_jti(
     return await sockets.disconnect_by_jti(jti, code=code, reason=reason)
 
 
+async def disconnect_deciders_by_user(
+    app, user_id: str, *, code: int = 4001, reason: str = ""
+) -> int:
+    """Close the user's live consent-decider sockets (#3162).
+
+    Account-disable kicks (admin route, inactivity sweep) must cut the
+    decider surface too — a decider holds egress-consent authority.
+    Minimal app states (tests) may not wire ``consent_deciders`` — then
+    there is nothing to close (returns 0).
+    """
+    deciders = getattr(app.state, "consent_deciders", None)
+    if deciders is None:
+        return 0
+    return await deciders.disconnect_by_user(user_id, code=code, reason=reason)
+
+
 async def refresh_user_handle(
     sockets: WebSocketState, user_id: str, new_handle: str
 ) -> None:

--- a/src/klangk/klangkd-tests/tests/test_api.py
+++ b/src/klangk/klangkd-tests/tests/test_api.py
@@ -15399,6 +15399,51 @@ class TestInactivityDisable:
         assert closed[-1] == (4001, "Account disabled")
         app.state.sockets.connections.clear()
 
+    async def test_admin_disable_kicks_decider_sockets(
+        self, client, app, admin_user, user
+    ):
+        """#3162: disabling an account also closes its live
+        consent-decider sockets (4001) — a decider holds egress-consent
+        authority and must not outlive the disable. The decider is a
+        REAL SafeWebSocket over a mock raw socket (fakes masked the
+        reason-kwarg no-op class of bug, #3160 review)."""
+        from klangk.consent.deciders import ConsentDeciderRegistry
+        from klangk.wshandler.safe_websocket import SafeWebSocket
+
+        app.state.consent_deciders = ConsentDeciderRegistry(app)
+        victim_raw = AsyncMock()
+        victim_raw.close = AsyncMock()
+        other_raw = AsyncMock()
+        other_raw.close = AsyncMock()
+        app.state.consent_deciders.register(
+            "d-victim",
+            "ws-1",
+            user["email"],
+            SafeWebSocket(victim_raw),
+            jti="j-victim",
+            user_id=user["id"],
+        )
+        app.state.consent_deciders.register(
+            "d-other",
+            "ws-2",
+            "other@example.com",
+            SafeWebSocket(other_raw),
+            jti="j-other",
+            user_id="someone-else",
+        )
+        headers = await _admin_login(client)
+        resp = await client.patch(
+            f"/api/v1/users/{user['id']}",
+            headers=headers,
+            json={"disabled": True},
+        )
+        assert resp.status_code == 200
+        victim_raw.close.assert_awaited_once_with(
+            code=4001, reason="Account disabled"
+        )
+        other_raw.close.assert_not_awaited()
+        assert set(app.state.consent_deciders._deciders) == {"d-other"}
+
 
 class TestAdminServerSchedule:
     """#2661: schedule/list/cancel a server stop or recycle."""

--- a/src/klangk/klangkd-tests/tests/test_auth.py
+++ b/src/klangk/klangkd-tests/tests/test_auth.py
@@ -889,6 +889,22 @@ class TestTokenValidation:
         token = _auth().create_token("nonexistent-id", "ghost@example.com")
         assert await _auth().get_user_from_token(token) is None
 
+    async def test_get_user_from_token_expired(self, db):
+        """A valid-signature but expired token returns TOKEN_EXPIRED."""
+        expired = datetime.now(timezone.utc) - timedelta(hours=1)
+        token = jwt.encode(
+            {
+                "sub": "uid",
+                "email": "x",
+                "jti": "j1",
+                "exp": expired,
+            },
+            _auth().secret,
+            algorithm=_auth().algorithm,
+        )
+        result = await _auth().get_user_from_token(token)
+        assert result is _auth().TOKEN_EXPIRED
+
 
 class TestGetCurrentUser:
     async def test_valid_credentials(self, user):

--- a/src/klangk/klangkd-tests/tests/test_auth.py
+++ b/src/klangk/klangkd-tests/tests/test_auth.py
@@ -1655,6 +1655,99 @@ class TestRevocationKicksSockets:
         assert await a.app.state.model.sessions.list_sessions(user["id"]) == []
 
 
+class TestRevocationKicksDeciders:
+    """#3162: the consent-decider socket had the same revocation
+    survival as the main /ws socket (#3152) — it lives in its own
+    registry, so the logout/eviction kick must reach that registry too.
+    Refresh rotation retargets (not closes), exactly like the main
+    registry. Entries are REAL SafeWebSockets over mock raw sockets
+    (#3160 review: fakes masked the reason-kwarg no-op)."""
+
+    def _auth_with_deciders(self, env=None):
+        from klangk.consent.deciders import ConsentDeciderRegistry
+
+        a = _auth(env)
+        a.app.state.consent_deciders = ConsentDeciderRegistry(a.app)
+        return a
+
+    @staticmethod
+    def _decider_raw(a, jti, decider_id="d1"):
+        """A real SafeWebSocket over a mock raw socket, registered as a
+        live decider under *jti*; returns the raw socket."""
+        from unittest.mock import AsyncMock
+
+        from klangk.wshandler.safe_websocket import SafeWebSocket
+
+        raw = AsyncMock()
+        raw.close = AsyncMock()
+        a.app.state.consent_deciders.register(
+            decider_id, "ws-1", "d@x", SafeWebSocket(raw), jti=jti
+        )
+        return raw
+
+    async def _login(self, a):
+        result = await a.login(
+            auth.LoginRequest(
+                identifier="testuser@example.com", password="testpass"
+            )
+        )
+        return result.access_token
+
+    async def test_logout_closes_decider_for_that_jti(self, user, app_state):
+        a = self._auth_with_deciders()
+        token = await self._login(a)
+        jti = a.decode_token(token)["jti"]
+        victim = self._decider_raw(a, jti)
+        other = self._decider_raw(a, "other-jti", "d2")
+        await a.logout(token)
+        victim.close.assert_awaited_once_with(
+            code=4001, reason="Token revoked"
+        )
+        other.close.assert_not_awaited()
+        # The kicked decider's registration is gone (authority ends at
+        # revocation); the spared one stays live.
+        deciders = a.app.state.consent_deciders
+        assert set(deciders._deciders) == {"d2"}
+
+    async def test_session_limit_eviction_closes_evicted_decider(
+        self, user, app_state
+    ):
+        env = {"KLANGKD_MAX_SESSIONS_PER_USER": "1"}
+        a = self._auth_with_deciders(env)
+        first = await self._login(a)
+        victim = self._decider_raw(a, a.decode_token(first)["jti"])
+        # The second login evicts the first session past the cap of 1.
+        second = await self._login(a)
+        victim.close.assert_awaited_once_with(
+            code=4001, reason="Token revoked"
+        )
+        assert await a.get_user_from_token(second) is not None
+
+    async def test_refresh_rotation_retargets_decider_not_closed(
+        self, user, app_state
+    ):
+        a = self._auth_with_deciders()
+        token = await self._login(a)
+        raw = self._decider_raw(a, a.decode_token(token)["jti"])
+        refreshed = await a.refresh_token(token)
+        raw.close.assert_not_awaited()
+        # Retargeted onto the refreshed token's JTI, so a later hard
+        # revocation still finds the decider.
+        new_jti = a.decode_token(refreshed.access_token)["jti"]
+        deciders = a.app.state.consent_deciders
+        assert deciders._deciders["d1"]["jti"] == new_jti
+
+    async def test_logout_after_refresh_closes_retargeted_decider(
+        self, user, app_state
+    ):
+        a = self._auth_with_deciders()
+        token = await self._login(a)
+        raw = self._decider_raw(a, a.decode_token(token)["jti"])
+        refreshed = await a.refresh_token(token)
+        await a.logout(refreshed.access_token)
+        raw.close.assert_awaited_once_with(code=4001, reason="Token revoked")
+
+
 class TestConcurrentLogonAudit:
     """Audit records for concurrent logons from different workstations
     (#2586). A workstation is the effective client IP a session was

--- a/src/klangk/klangkd-tests/tests/test_auth.py
+++ b/src/klangk/klangkd-tests/tests/test_auth.py
@@ -1747,6 +1747,24 @@ class TestRevocationKicksDeciders:
         await a.logout(refreshed.access_token)
         raw.close.assert_awaited_once_with(code=4001, reason="Token revoked")
 
+    async def test_eviction_after_refresh_closes_retargeted_decider(
+        self, user, app_state
+    ):
+        """The typical eviction victim is a long-refreshing session
+        (replace_session keeps its original created_at, so it stays
+        oldest) — its decider must still be kickable after rotation."""
+        env = {"KLANGKD_MAX_SESSIONS_PER_USER": "1"}
+        a = self._auth_with_deciders(env)
+        first = await self._login(a)
+        raw = self._decider_raw(a, a.decode_token(first)["jti"])
+        refreshed = await a.refresh_token(first)
+        # The second login evicts the refreshed (still-oldest) session
+        # past the cap of 1.
+        second = await self._login(a)
+        raw.close.assert_awaited_once_with(code=4001, reason="Token revoked")
+        assert await a.get_user_from_token(second) is not None
+        assert await a.get_user_from_token(refreshed.access_token) is None
+
 
 class TestConcurrentLogonAudit:
     """Audit records for concurrent logons from different workstations

--- a/src/klangk/klangkd-tests/tests/test_consent_deciders.py
+++ b/src/klangk/klangkd-tests/tests/test_consent_deciders.py
@@ -956,11 +956,22 @@ class TestConsentDeciderWSJti:
 
         class RecordingRegistry(ConsentDeciderRegistry):
             def register(
-                self, decider_id, workspace_id, email, sock, jti=None
+                self,
+                decider_id,
+                workspace_id,
+                email,
+                sock,
+                jti=None,
+                user_id=None,
             ):
-                recorded.append(jti)
+                recorded.append((jti, user_id))
                 super().register(
-                    decider_id, workspace_id, email, sock, jti=jti
+                    decider_id,
+                    workspace_id,
+                    email,
+                    sock,
+                    jti=jti,
+                    user_id=user_id,
                 )
 
         app.state.consent_deciders = RecordingRegistry(app)
@@ -968,7 +979,7 @@ class TestConsentDeciderWSJti:
             {"token": "tok", "workspace": WS}, [WebSocketDisconnect()]
         )
         await handle_consent_decider(ws, app)
-        assert recorded == ["jti-decoded"]
+        assert recorded == [("jti-decoded", "u1")]
 
 
 class TestConsentDeciderRegistryJti:
@@ -980,11 +991,13 @@ class TestConsentDeciderRegistryJti:
     review)."""
 
     @staticmethod
-    def _real_decider(reg, jti, decider_id="d1"):
+    def _real_decider(reg, jti, decider_id="d1", user_id=None):
         """Register a decider backed by a real SafeWebSocket over a mock
         raw socket; return the raw socket for close-assertions."""
         raw = _mock_raw_sock()
-        reg.register(decider_id, WS, "a@x", SafeWebSocket(raw), jti=jti)
+        reg.register(
+            decider_id, WS, "a@x", SafeWebSocket(raw), jti=jti, user_id=user_id
+        )
         return raw
 
     async def test_register_records_jti(self):
@@ -1031,6 +1044,35 @@ class TestConsentDeciderRegistryJti:
         reg.register("d1", WS, "a@x", SafeWebSocket(raw), jti="jti-x")
         assert await reg.disconnect_by_jti("jti-x") == 1
         assert reg._deciders == {}
+
+    async def test_register_records_user_id(self):
+        reg = ConsentDeciderRegistry(_app())
+        reg.register("d1", WS, "a@x", _FakeSock(), user_id="u1")
+        assert reg._deciders["d1"]["user_id"] == "u1"
+
+    async def test_disconnect_by_user_closes_real_safe_websocket(self):
+        reg = ConsentDeciderRegistry(_app())
+        raw = self._real_decider(reg, "jti-x", "d1", user_id="u-victim")
+        kicked = await reg.disconnect_by_user(
+            "u-victim", reason="Account disabled"
+        )
+        assert kicked == 1
+        raw.close.assert_awaited_once_with(
+            code=4001, reason="Account disabled"
+        )
+        assert reg._deciders == {}
+
+    async def test_disconnect_by_user_spares_other_users(self):
+        reg = ConsentDeciderRegistry(_app())
+        raw_victim = self._real_decider(reg, "j1", "d1", user_id="u1")
+        raw_other = self._real_decider(reg, "j2", "d2", user_id="u2")
+        kicked = await reg.disconnect_by_user("u1", reason="Account disabled")
+        assert kicked == 1
+        raw_victim.close.assert_awaited_once_with(
+            code=4001, reason="Account disabled"
+        )
+        raw_other.close.assert_not_awaited()
+        assert set(reg._deciders) == {"d2"}
 
     async def test_reattach_jti_moves_decider_entries(self):
         reg = ConsentDeciderRegistry(_app())

--- a/src/klangk/klangkd-tests/tests/test_consent_deciders.py
+++ b/src/klangk/klangkd-tests/tests/test_consent_deciders.py
@@ -14,6 +14,10 @@ from klangk.wshandler.safe_websocket import SafeWebSocket
 WS = "ws-aaaa1111-2222-3333-4444-555566667777"
 WS2 = "ws-bbbb2222-3333-4444-5555-666677778888"
 
+# _ws_app sentinel: decode_token succeeds but _user_from_valid_payload
+# returns None (revoked/missing user) — the post-decode None-user arm.
+_DECODED_NO_USER = object()
+
 
 def _app(timeout: float = 45.0):
     app = types.SimpleNamespace()
@@ -242,7 +246,9 @@ def _ws_app(
         payload_result = None
     else:
         decode_side = None
-        payload_result = token_result
+        payload_result = (
+            None if token_result is _DECODED_NO_USER else token_result
+        )
 
     decode_mock = (
         MagicMock(side_effect=decode_side)
@@ -335,6 +341,15 @@ class TestConsentDeciderWS:
         ws = _FakeWS({"token": "stale"}, [])
         await handle_consent_decider(ws, app)
         assert ws.closed == (4002, "Token expired")
+
+    async def test_unknown_user_is_rejected(self):
+        # Valid signature, but the user no longer exists: 4001 refusal.
+        from klangk.wshandler.decider import handle_consent_decider
+
+        app = _ws_app(_DECODED_NO_USER)
+        ws = _FakeWS({"token": "tok", "workspace": WS}, [])
+        await handle_consent_decider(ws, app)
+        assert ws.closed == (4001, "Invalid token")
 
     async def test_non_member_workspace_scoped_is_forbidden(self):
         from klangk.wshandler.decider import handle_consent_decider

--- a/src/klangk/klangkd-tests/tests/test_consent_deciders.py
+++ b/src/klangk/klangkd-tests/tests/test_consent_deciders.py
@@ -9,6 +9,7 @@ from unittest.mock import AsyncMock
 
 from klangk.consent.deciders import ConsentDeciderRegistry
 from klangk.model.workspaces import EGRESS_MODE_INTERACTIVE
+from klangk.wshandler.safe_websocket import SafeWebSocket
 
 WS = "ws-aaaa1111-2222-3333-4444-555566667777"
 WS2 = "ws-bbbb2222-3333-4444-5555-666677778888"
@@ -32,6 +33,16 @@ class _FakeSock:
         if self._raising:
             raise RuntimeError("dead socket")
         self.sent.append(msg)
+
+
+def _mock_raw_sock():
+    """A mock raw FastAPI WebSocket for real-SafeWebSocket kick tests."""
+    raw = AsyncMock()
+    raw.close = AsyncMock()
+    raw.send_json = AsyncMock()
+    raw.receive_text = AsyncMock()
+    raw.accept = AsyncMock()
+    return raw
 
 
 class TestConsentDeciderRegistry:
@@ -218,7 +229,8 @@ def _ws_app(
     )
     app.state.consent_deciders = ConsentDeciderRegistry(app)
     app.state.auth = types.SimpleNamespace(
-        get_user_from_token=AsyncMock(return_value=token_result)
+        get_user_from_token=AsyncMock(return_value=token_result),
+        decode_token=lambda token: {"jti": "jti-decoded"},
     )
     app.state.acl = types.SimpleNamespace(
         get_principals=AsyncMock(
@@ -917,6 +929,117 @@ class TestConsentDeciderWS:
         )
         await handle_consent_decider(ws, app)
         assert app.state.consent_deciders.has_decider(WS) is False
+
+
+class TestConsentDeciderWSJti:
+    """#3162: the decider handshake records the token's JTI on the
+    registration, mirroring the main /ws handler (#3152)."""
+
+    async def test_decider_authenticate_returns_user_and_jti(self):
+        from klangk.wshandler.decider import _decider_authenticate
+
+        app = _ws_app({"id": "u1", "email": "a@x"})
+        ws = _FakeWS({"token": "tok"}, [])
+        result = await _decider_authenticate(ws, app, lambda label: None)
+        authed_user, jti = result
+        assert authed_user["id"] == "u1"
+        assert jti == "jti-decoded"
+        assert ws.closed is None  # authenticated, not refused
+
+    async def test_connection_records_authenticating_jti(self):
+        from fastapi import WebSocketDisconnect
+
+        from klangk.wshandler.decider import handle_consent_decider
+
+        app = _ws_app({"id": "u1", "email": "a@x"})
+        recorded: list = []
+
+        class RecordingRegistry(ConsentDeciderRegistry):
+            def register(
+                self, decider_id, workspace_id, email, sock, jti=None
+            ):
+                recorded.append(jti)
+                super().register(
+                    decider_id, workspace_id, email, sock, jti=jti
+                )
+
+        app.state.consent_deciders = RecordingRegistry(app)
+        ws = _FakeWS(
+            {"token": "tok", "workspace": WS}, [WebSocketDisconnect()]
+        )
+        await handle_consent_decider(ws, app)
+        assert recorded == ["jti-decoded"]
+
+
+class TestConsentDeciderRegistryJti:
+    """#3162: registrations carry the authenticating JWT's JTI; hard
+    revocation closes them (4001, like the main /ws registry in #3152)
+    and refresh rotation retargets them. Kick tests plant REAL
+    SafeWebSocket entries — fakes whose close() happens to accept
+    ``reason`` masked the reason-kwarg no-op class of bug (#3160
+    review)."""
+
+    @staticmethod
+    def _real_decider(reg, jti, decider_id="d1"):
+        """Register a decider backed by a real SafeWebSocket over a mock
+        raw socket; return the raw socket for close-assertions."""
+        raw = _mock_raw_sock()
+        reg.register(decider_id, WS, "a@x", SafeWebSocket(raw), jti=jti)
+        return raw
+
+    async def test_register_records_jti(self):
+        reg = ConsentDeciderRegistry(_app())
+        reg.register("d1", WS, "a@x", _FakeSock(), jti="jti-1")
+        assert reg._deciders["d1"]["jti"] == "jti-1"
+
+    async def test_register_without_jti_defaults_to_none(self):
+        reg = ConsentDeciderRegistry(_app())
+        reg.register("d1", WS, "a@x", _FakeSock())
+        assert reg._deciders["d1"]["jti"] is None
+
+    async def test_disconnect_by_jti_closes_real_safe_websocket(self):
+        reg = ConsentDeciderRegistry(_app())
+        raw = self._real_decider(reg, "jti-victim")
+        kicked = await reg.disconnect_by_jti(
+            "jti-victim", reason="Token revoked"
+        )
+        assert kicked == 1
+        raw.close.assert_awaited_once_with(code=4001, reason="Token revoked")
+        # The entry is dropped at kick time: consent authority ends at
+        # revocation, not when the receive loop notices the closed socket.
+        assert reg._deciders == {}
+
+    async def test_disconnect_by_jti_spares_other_jtis(self):
+        reg = ConsentDeciderRegistry(_app())
+        raw_victim = self._real_decider(reg, "jti-victim", "d1")
+        raw_other = self._real_decider(reg, "jti-other", "d2")
+        kicked = await reg.disconnect_by_jti(
+            "jti-victim", reason="Token revoked"
+        )
+        assert kicked == 1
+        raw_victim.close.assert_awaited_once_with(
+            code=4001, reason="Token revoked"
+        )
+        raw_other.close.assert_not_awaited()
+        assert set(reg._deciders) == {"d2"}
+
+    async def test_disconnect_by_jti_survives_close_error(self):
+        # A socket already gone must not abort the sweep over the rest.
+        reg = ConsentDeciderRegistry(_app())
+        raw = _mock_raw_sock()
+        raw.close = AsyncMock(side_effect=RuntimeError("already gone"))
+        reg.register("d1", WS, "a@x", SafeWebSocket(raw), jti="jti-x")
+        assert await reg.disconnect_by_jti("jti-x") == 1
+        assert reg._deciders == {}
+
+    async def test_reattach_jti_moves_decider_entries(self):
+        reg = ConsentDeciderRegistry(_app())
+        self._real_decider(reg, "old-jti", "d1")
+        self._real_decider(reg, "unrelated", "d2")
+        moved = reg.reattach_jti("old-jti", "new-jti")
+        assert moved == 1
+        assert reg._deciders["d1"]["jti"] == "new-jti"
+        assert reg._deciders["d2"]["jti"] == "unrelated"
 
 
 class TestConsentDeciderRegistryReconfigure:

--- a/src/klangk/klangkd-tests/tests/test_consent_deciders.py
+++ b/src/klangk/klangkd-tests/tests/test_consent_deciders.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import asyncio
 import json
 import types
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock
 
 from klangk.consent.deciders import ConsentDeciderRegistry
 from klangk.model.workspaces import EGRESS_MODE_INTERACTIVE
@@ -228,9 +228,31 @@ def _ws_app(
         ),
     )
     app.state.consent_deciders = ConsentDeciderRegistry(app)
+    # _decider_authenticate decodes the token once, then validates
+    # via _user_from_valid_payload.  The mock must raise the right
+    # exception for the expired-token path and return None for invalid.
+    from jose import ExpiredSignatureError, JWTError
+    from klangk import auth as auth_mod
+
+    if token_result is auth_mod.Auth.TOKEN_EXPIRED:
+        decode_side = ExpiredSignatureError("expired")
+        payload_result = None
+    elif token_result is None:
+        decode_side = JWTError("bad")
+        payload_result = None
+    else:
+        decode_side = None
+        payload_result = token_result
+
+    decode_mock = (
+        MagicMock(side_effect=decode_side)
+        if decode_side
+        else MagicMock(return_value={"jti": "jti-decoded", "sub": "u1"})
+    )
     app.state.auth = types.SimpleNamespace(
         get_user_from_token=AsyncMock(return_value=token_result),
-        decode_token=lambda token: {"jti": "jti-decoded"},
+        decode_token=decode_mock,
+        _user_from_valid_payload=AsyncMock(return_value=payload_result),
     )
     app.state.acl = types.SimpleNamespace(
         get_principals=AsyncMock(

--- a/src/klangk/klangkd-tests/tests/test_inactivity.py
+++ b/src/klangk/klangkd-tests/tests/test_inactivity.py
@@ -155,6 +155,37 @@ class TestInactivitySweeper:
             "u1", code=4001, reason="Account disabled"
         )
 
+    async def test_disabled_users_deciders_are_kicked(self):
+        """#3162: the sweep also closes the disabled user's live
+        consent-decider sockets — a decider holds egress-consent
+        authority and must not outlive the disable. The decider is a
+        REAL SafeWebSocket (fakes masked the reason-kwarg no-op class
+        of bug, #3160 review)."""
+        from klangk.consent.deciders import ConsentDeciderRegistry
+        from klangk.wshandler.safe_websocket import SafeWebSocket
+
+        app = _app(
+            disable_inactive=AsyncMock(
+                return_value=[{"id": "u1", "email": "gone@example.com"}]
+            )
+        )
+        app.state.consent_deciders = ConsentDeciderRegistry(app)
+        raw = AsyncMock()
+        raw.close = AsyncMock()
+        app.state.consent_deciders.register(
+            "d1",
+            "ws-1",
+            "gone@example.com",
+            SafeWebSocket(raw),
+            jti="j1",
+            user_id="u1",
+        )
+        await inactivity.InactivitySweeper(app).sweep()
+        raw.close.assert_awaited_once_with(
+            code=4001, reason="Account disabled"
+        )
+        assert app.state.consent_deciders._deciders == {}
+
 
 def await_count(mock) -> int:
     return mock.await_count if hasattr(mock, "await_count") else 0

--- a/src/klangk/klangkd-tests/tests/test_wshandler.py
+++ b/src/klangk/klangkd-tests/tests/test_wshandler.py
@@ -3056,6 +3056,17 @@ class TestHandleWebsocket:
             code=4002, reason="Token expired"
         )
 
+    async def test_unknown_user_token_rejected(self, db, app_state):
+        # Valid signature, but the user no longer exists: the connect is
+        # refused with 4001 (the post-decode None-user arm).
+        app_state = _make_app_state()
+        token = _auth().create_token("nonexistent-id", "ghost@example.com")
+        websocket = _mock_raw_sock(query_params={"token": token})
+        await handle_websocket(websocket, app_state)
+        websocket.close.assert_awaited_once_with(
+            code=4001, reason="Invalid token"
+        )
+
     async def test_valid_token_then_disconnect(self, user, app_state):
         app_state = _make_app_state()
 


### PR DESCRIPTION
## Summary

Follow-up to #3152 / PR #3160 for the consent-decider surface. The
`/ws/consent-decider` socket authenticated a user JWT once at handshake and
lived in its own registry (`app.state.consent_deciders`), so the #3152
`disconnect_by_jti` kick never reached it — after logout or session-limit
eviction the decider kept egress-consent authority (verdicts, revokes,
pause/unpause) indefinitely.

- **JTI + user id on registration.** `_decider_authenticate` now returns
  `(user, jti)` (mirroring `ws_authenticate`) and the handler records both
  the JTI and the user id on the `ConsentDeciderRegistry` entry.
- **Hard revocation kicks deciders.** `Auth._kick_revoked_sockets` (logout,
  session-limit eviction) now also closes decider sockets registered with
  the revoked JTI — close code 4001, entries dropped at kick time so consent
  authority ends with the credential (the workspace reverts to static
  allow-list immediately; the endpoint's `finally` deregister becomes a
  no-op).
- **Account disable kicks deciders.** Admin disable and the inactivity sweep
  now also call `ConsentDeciderRegistry.disconnect_by_user` via
  `wshandler.disconnect_deciders_by_user` — the per-user analogue of the
  #2588 `disconnect_user` kick. Without this a disabled account kept
  verdict/revoke/pause authority as long as it pinged.
- **Refresh rotation retargets.** `Auth._retarget_refreshed_sockets` also
  retargets decider entries onto the new JTI (`reattach_jti`), so a refresh
  keeps the decider alive but a later logout/eviction still finds it.

## Tests

Per the #3160 review lesson, all kick/retarget assertions plant **real
`SafeWebSocket` entries over mock raw sockets** and assert on the raw
`close(code=4001, reason=...)` await — a pop-only or reason-dropping no-op
kick fails them.

- Registry: JTI/user-id recording, `disconnect_by_jti` /
  `disconnect_by_user` close + drop + spare-others, close-error tolerance,
  `reattach_jti`.
- Handler: `_decider_authenticate` returns the JTI; registration carries it.
- Auth integration: logout, eviction, refresh-retarget, logout-after-refresh,
  eviction-after-refresh.
- Account disable: admin PATCH route and the inactivity sweep close the
  disabled user's deciders.

Stacked on #3160 (base `i3152-websocket`) — merge that PR first.

Closes #3162.
