### PR TITLE
Retry transient rootless-podman reexec failures in parallel image builds (#3168)

### DIFF
--- a/.github/workflows/image-network-sidecar.yml
+++ b/.github/workflows/image-network-sidecar.yml
@@ -31,6 +31,7 @@ on:
     paths:
       - "src/containers/network/**"
       - "scripts/build-network-sidecar.sh"
+      - "scripts/_podman_common.sh"
       - "src/klangksidecar/klangksidecar/**"
       - "src/klangksidecar/pyproject.toml"
       - ".github/workflows/image-network-sidecar.yml"

--- a/.github/workflows/image-workspace.yml
+++ b/.github/workflows/image-workspace.yml
@@ -14,6 +14,7 @@ on:
     paths:
       - "src/containers/workspace/**"
       - "scripts/build-workspace-image.sh"
+      - "scripts/_podman_common.sh"
       - ".github/workflows/image-workspace.yml"
 
 # Literal group prefix: in a workflow_call the `github` context is the

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -2031,6 +2031,17 @@ git-credential` (#1700).** `pig-latin` removed; `word-count` dormant.
 
 ### Fixed
 
+- **Parallel image-build tasks tolerate transient rootless-podman failures
+  (#3168).** `klangk:build-workspace-image` and `klangk:build-network-sidecar`
+  run in parallel and are a fresh machine's first rootless podman invocations;
+  the concurrent first-time user-namespace initialization intermittently
+  aborted one of them with `failed to reexec: Permission denied` before any
+  test ran, reding the whole CI job. Their podman calls now go through a
+  retry helper that retries exactly that failure signature once — printing
+  `podman info` / `podman unshare` diagnostics first so a persistent
+  occurrence stays attributable — and passes every other failure through
+  untouched.
+
 - **`build-host-image` / `build_wheel.sh` (#3143).** The release wheel is
   now built with `uv build`, which resolves hatchling/hatch-vcs into its own
   isolated build environment instead of transiently installing `build` into

--- a/scripts/_podman_common.sh
+++ b/scripts/_podman_common.sh
@@ -148,3 +148,88 @@ klangk::prune_old_tags() {
     esac
   done
 }
+
+# --- Rootless reexec retry guard (#3168) ----------------------------------
+#
+# "devenv tasks run klangk:build-workspace-image klangk:build-network-sidecar"
+# runs both tasks in parallel, and on a fresh machine (stock CI runners, first
+# "devenv up") those are the machine's first two rootless podman invocations.
+# Concurrent first-time user-namespace/storage initialization intermittently
+# kills one of them ~1.4s in with
+#
+#     failed to reexec: Permission denied
+#
+# before any test runs, reding the whole job (run 33888969754). The failure is
+# environmental and transient: by the time a retry runs, the sibling build has
+# finished initializing podman's state. klangk::run_podman wraps a podman
+# invocation so that exactly this signature is retried once (after capturing
+# diagnostics, so a persistent occurrence is attributable); every other
+# failure passes through untouched with its original exit code — the same
+# policy as scripts/retry-on-invalid-path.sh for the devenv eval UAF (#2775).
+
+# Fixed-string signature (grep -F): any "failed to reexec:" is the rootless
+# bootstrap (userns reexec) failing, which is runner-environment level — never
+# a klangk code path or a Dockerfile problem.
+REEXEC_SIGNATURE="failed to reexec:"
+
+# Seconds to let the sibling podman's first-time initialization finish before
+# the retry attempt. KLANGKBUILD_PODMAN_RETRY_SLEEP overrides (tests zero it).
+PODMAN_RETRY_SLEEP="${KLANGKBUILD_PODMAN_RETRY_SLEEP:-5}"
+
+# klangk::reexec_diagnostics — probes named in #3168 (podman info rc,
+# "podman unshare true" rc) plus the standard userns checklist (sysctls,
+# subid ranges). Best-effort: nothing here may fail the caller.
+klangk::reexec_diagnostics() {
+  local podman_bin="${KLANGKD_PODMAN_BIN:-podman}" f
+  echo "--- podman reexec diagnostics (#3168) ---" >&2
+  if "$podman_bin" info >/dev/null 2>&1; then
+    echo "podman info: ok" >&2
+  else
+    echo "podman info: FAILED rc=$?" >&2
+  fi
+  if "$podman_bin" unshare true >/dev/null 2>&1; then
+    echo "podman unshare true: ok (userns creatable)" >&2
+  else
+    echo "podman unshare true: FAILED rc=$?" >&2
+  fi
+  for f in /proc/sys/user/max_user_namespaces \
+    /proc/sys/kernel/unprivileged_userns_clone; do
+    [ -r "$f" ] || continue
+    echo "$f = $(cat "$f")" >&2
+  done
+  echo "subuid: $(grep "^$(id -un):" /etc/subuid 2>/dev/null || echo '<none>')" >&2
+  echo "subgid: $(grep "^$(id -un):" /etc/subgid 2>/dev/null || echo '<none>')" >&2
+  echo "------------------------------------------" >&2
+}
+
+# klangk::run_podman <args...> — run "${KLANGKD_PODMAN_BIN:-podman}" "$@"
+# with the #3168 reexec retry. The command's combined output streams live on
+# stderr (and into a temp log for the signature match); stdout stays clean so
+# callers may capture it. Returns the podman exit status: after one retry when
+# the reexec signature was seen, immediately otherwise.
+klangk::run_podman() {
+  local errlog attempt rc
+  for attempt in 1 2; do
+    rc=0
+    errlog="$(mktemp "${TMPDIR:-/tmp}/klangk-podman-XXXXXX")"
+    "${KLANGKD_PODMAN_BIN:-podman}" "$@" 2>&1 | tee "$errlog" >&2 ||
+      rc=${PIPESTATUS[0]}
+    if [ "$rc" -eq 0 ]; then
+      rm -f "$errlog"
+      return 0
+    fi
+    if grep -Fq "$REEXEC_SIGNATURE" "$errlog"; then
+      rm -f "$errlog"
+      klangk::reexec_diagnostics
+      if [ "$attempt" -eq 1 ]; then
+        echo "::warning::podman rootless reexec failure (attempt 1/2) — retrying once (#3168)" >&2
+        sleep "$PODMAN_RETRY_SLEEP"
+        continue
+      fi
+      echo "::error::podman rootless reexec failure persisted after retry (#3168)" >&2
+    else
+      rm -f "$errlog"
+    fi
+    return "$rc"
+  done
+}

--- a/scripts/_podman_common.sh
+++ b/scripts/_podman_common.sh
@@ -178,16 +178,18 @@ PODMAN_RETRY_SLEEP="${KLANGKBUILD_PODMAN_RETRY_SLEEP:-5}"
 
 # klangk::reexec_diagnostics — probes named in #3168 (podman info rc,
 # "podman unshare true" rc) plus the standard userns checklist (sysctls,
-# subid ranges). Best-effort: nothing here may fail the caller.
+# subid ranges). Best-effort: nothing here may fail the caller. Probes run
+# under timeout(1): a probe contending a storage flock held by the sibling
+# build must degrade to a "FAILED rc=124" line, not stall the retry.
 klangk::reexec_diagnostics() {
   local podman_bin="${KLANGKD_PODMAN_BIN:-podman}" f
   echo "--- podman reexec diagnostics (#3168) ---" >&2
-  if "$podman_bin" info >/dev/null 2>&1; then
+  if timeout 30 "$podman_bin" info >/dev/null 2>&1; then
     echo "podman info: ok" >&2
   else
     echo "podman info: FAILED rc=$?" >&2
   fi
-  if "$podman_bin" unshare true >/dev/null 2>&1; then
+  if timeout 30 "$podman_bin" unshare true >/dev/null 2>&1; then
     echo "podman unshare true: ok (userns creatable)" >&2
   else
     echo "podman unshare true: FAILED rc=$?" >&2

--- a/scripts/build-network-sidecar.sh
+++ b/scripts/build-network-sidecar.sh
@@ -2,7 +2,6 @@
 set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 cd "${DEVENV_ROOT:-$SCRIPT_DIR/..}"
-PODMAN="${KLANGKD_PODMAN_BIN:-podman}"
 # shellcheck source=_podman_common.sh disable=SC1091
 source "$SCRIPT_DIR/_podman_common.sh"
 
@@ -17,7 +16,10 @@ trap 'rm -rf "$STAGING"' EXIT
 uv build --package klangksidecar --wheel --out-dir "$STAGING"
 
 echo "Building network sidecar image ..."
-"$PODMAN" build -t klangk-network-sidecar \
+# Through klangk::run_podman: this task runs in parallel with
+# klangk:build-workspace-image, and the concurrent first-time rootless
+# podman init race needs the #3168 reexec retry + diagnostics.
+klangk::run_podman build -t klangk-network-sidecar \
   "${SIG_POLICY_ARGS[@]}" \
   "${BUILD_SECURITY_ARGS[@]}" \
   --build-context sidecar="$STAGING" \

--- a/scripts/build-workspace-image.sh
+++ b/scripts/build-workspace-image.sh
@@ -2,7 +2,6 @@
 set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 cd "${DEVENV_ROOT:-$SCRIPT_DIR/..}"
-PODMAN="${KLANGKD_PODMAN_BIN:-podman}"
 # shellcheck source=_podman_common.sh disable=SC1091
 source "$SCRIPT_DIR/_podman_common.sh"
 
@@ -32,8 +31,12 @@ CURRENT_HASH=$(find \
 # and the feature trees) covers every file that affects the image, so a
 # matching stamp means the image is up to date.
 klangk::parse_build_flags "$@"
+# podman calls go through klangk::run_podman: this task runs in parallel
+# with klangk:build-network-sidecar, and the concurrent first-time rootless
+# podman init race needs the #3168 reexec retry + diagnostics (stderr stays
+# visible — "podman image exists" is silent on its normal rc-1 path).
 if ! $FORCE_BUILD &&
-  "$PODMAN" image exists "${KLANGKD_IMAGE_NAME}" 2>/dev/null &&
+  klangk::run_podman image exists "${KLANGKD_IMAGE_NAME}" &&
   klangk::stamp_matches "$STAMP" "$CURRENT_HASH"; then
   echo "Image ${KLANGKD_IMAGE_NAME} is up to date, skipping build."
   exit 0
@@ -49,7 +52,7 @@ trap 'rm -rf "$FEATURES_PAYLOAD_DIR"' EXIT
 # by the backend at runtime) and a deterministic version tag (date +
 # commit hash), pruning stale version tags from previous builds.
 klangk::prune_old_tags "${KLANGKD_IMAGE_NAME}"
-"$PODMAN" build \
+klangk::run_podman build \
   "${SIG_POLICY_ARGS[@]}" \
   "${BUILD_SECURITY_ARGS[@]}" \
   --pull=newer \

--- a/scripts/tests/test_podman_reexec_retry.py
+++ b/scripts/tests/test_podman_reexec_retry.py
@@ -64,6 +64,14 @@ _UNRELATED = _FAKE_TEMPLATE.format(
 exit 42"""
 )
 
+# Diagnostics-probe failure: the info probe exits 3, unshare exits 5 — the
+# FAILED branches must report those rcs without failing the wrapper itself
+# (the wrapped command still fails once with the signature, then succeeds).
+_PROBES_FAIL = _FAIL_ONCE.replace(
+    "  info | unshare) exit 0 ;;",
+    "  info) exit 3 ;;\n  unshare) exit 5 ;;",
+)
+
 
 def _run_with_fake(fake_body: str) -> subprocess.CompletedProcess[str]:
     """Source the helper and run klangk::run_podman against a fake podman.
@@ -195,3 +203,12 @@ def test_persistent_reexec_fails_loudly_after_retry():
     assert "RC=1" in proc.stdout, proc.stderr
     assert "CALLS=2" in proc.stdout, proc.stderr
     assert "::error::" in proc.stderr
+
+
+def test_failing_diagnostics_probes_do_not_break_wrapper():
+    """FAILED probes report their rc; the retry still runs and succeeds."""
+    proc = _run_with_fake(_PROBES_FAIL)
+    assert "podman info: FAILED rc=3" in proc.stderr
+    assert "podman unshare true: FAILED rc=5" in proc.stderr
+    assert "RC=0" in proc.stdout, proc.stderr
+    assert "CALLS=2" in proc.stdout, proc.stderr

--- a/scripts/tests/test_podman_reexec_retry.py
+++ b/scripts/tests/test_podman_reexec_retry.py
@@ -1,0 +1,197 @@
+"""Tests for the rootless reexec retry guard (#3168).
+
+``devenv tasks run klangk:build-workspace-image klangk:build-network-sidecar``
+runs both tasks in parallel; on a fresh machine those are the first two
+rootless podman invocations, and the concurrent first-time user-namespace /
+storage initialization intermittently fails one of them with
+
+    failed to reexec: Permission denied
+
+reding the job before any test runs (CI run 33888969754). The fix in
+``scripts/_podman_common.sh`` — ``klangk::run_podman`` — retries exactly that
+signature once (after printing diagnostics) and passes every other failure
+through untouched.
+
+Contract tests pin the wiring (build scripts route their podman calls through
+the wrapper; the helper keeps the signature, the single retry, and the
+diagnostics probes); behavior tests execute the helper against a fake
+``$KLANGKD_PODMAN_BIN`` that fails with controlled signatures and exit codes.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import tempfile
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_PODMAN_COMMON = _REPO_ROOT / "scripts" / "_podman_common.sh"
+_BUILD_SCRIPTS = [
+    _REPO_ROOT / "scripts" / "build-workspace-image.sh",
+    _REPO_ROOT / "scripts" / "build-network-sidecar.sh",
+]
+
+# Shared fake-podman skeleton: the diagnostics probes (``info``, ``unshare``)
+# succeed silently and never touch the call counter, so CALLS counts only the
+# wrapped command's attempts. {probe} is the behavior under test.
+_FAKE_TEMPLATE = """\
+#!/usr/bin/env bash
+case "${{1:-}}" in
+  info | unshare) exit 0 ;;
+esac
+n=$(($(cat "$FAKE_COUNT" 2>/dev/null || echo 0) + 1))
+echo "$n" >"$FAKE_COUNT"
+{probe}
+"""
+
+_FAIL_ONCE = _FAKE_TEMPLATE.format(
+    probe="""if [ "$n" -eq 1 ]; then
+  echo "failed to reexec: Permission denied" >&2
+  exit 1
+fi
+echo "fake-podman-stdout"
+exit 0"""
+)
+
+_ALWAYS_REEXEC = _FAKE_TEMPLATE.format(
+    probe="""echo "failed to reexec: Permission denied" >&2
+exit 1"""
+)
+
+_UNRELATED = _FAKE_TEMPLATE.format(
+    probe="""echo "some unrelated podman error" >&2
+exit 42"""
+)
+
+
+def _run_with_fake(fake_body: str) -> subprocess.CompletedProcess[str]:
+    """Source the helper and run klangk::run_podman against a fake podman.
+
+    The retry sleep is zeroed so the retry path is exercised without
+    slowing the suite. Returns the bash process result; the inner script
+    prints ``RC=<exit>`` and ``CALLS=<probe invocations>`` on stdout.
+    """
+    with tempfile.TemporaryDirectory() as td:
+        fake = Path(td) / "podman-fake"
+        fake.write_text(fake_body)
+        fake.chmod(0o755)
+        count = Path(td) / "count"
+        script = "\n".join(
+            [
+                "set -euo pipefail",
+                f'source "{_PODMAN_COMMON}"',
+                "rc=0",
+                "klangk::run_podman probe || rc=$?",
+                'echo "RC=$rc"',
+                f'echo "CALLS=$(cat {count} 2>/dev/null || echo 0)"',
+            ]
+        )
+        env = {
+            **os.environ,
+            "KLANGKD_PODMAN_BIN": str(fake),
+            "KLANGKBUILD_PODMAN_RETRY_SLEEP": "0",
+            "FAKE_COUNT": str(count),
+        }
+        return subprocess.run(
+            ["bash", "-c", script],
+            capture_output=True,
+            text=True,
+            env=env,
+            check=False,
+        )
+
+
+# --- Contract tests -------------------------------------------------------
+
+
+def test_build_scripts_route_podman_through_wrapper():
+    """Both parallel-built images must go through klangk::run_podman.
+
+    A bare ``"$PODMAN" build`` in either script re-opens the #3168 race:
+    the two build tasks run in parallel and are the machine's first
+    rootless podman invocations.
+    """
+    for script in _BUILD_SCRIPTS:
+        text = script.read_text()
+        assert "klangk::run_podman build" in text, (
+            f"{script.name} no longer builds via klangk::run_podman — the "
+            f"concurrent-first-init reexec race can red CI again (#3168)"
+        )
+        assert '"$PODMAN" build' not in text, (
+            f"{script.name} has a bare podman build bypassing the #3168 retry"
+        )
+
+
+def test_helper_signature_single_retry():
+    """The retry must stay: signature-matched, exactly one retry."""
+    text = _PODMAN_COMMON.read_text()
+    assert 'REEXEC_SIGNATURE="failed to reexec:"' in text, (
+        "the #3168 reexec signature grep is gone from _podman_common.sh"
+    )
+    assert "for attempt in 1 2" in text, (
+        "klangk::run_podman must make at most two attempts (#3168) — an "
+        "unbounded retry loop would hang CI on a persistent failure"
+    )
+    assert "${KLANGKBUILD_PODMAN_RETRY_SLEEP:-5}" in text, (
+        "the retry backoff must stay overridable (tests zero it)"
+    )
+
+
+def test_helper_diagnostics_probes():
+    """The probes named in #3168 must stay in the diagnostics."""
+    text = _PODMAN_COMMON.read_text()
+    for probe in (
+        "info >/dev/null",
+        "unshare true >/dev/null",
+        "max_user_namespaces",
+        "subuid",
+    ):
+        assert probe in text, (
+            f"diagnostics probe {probe!r} missing from _podman_common.sh — "
+            f"a recurrence would no longer be attributable (#3168)"
+        )
+
+
+# --- Behavior tests -------------------------------------------------------
+
+
+def test_reexec_failure_retried_once():
+    """A reexec-signature failure is retried once and then succeeds."""
+    proc = _run_with_fake(_FAIL_ONCE)
+    assert "RC=0" in proc.stdout, proc.stderr
+    assert "CALLS=2" in proc.stdout, proc.stderr
+    assert "::warning::" in proc.stderr
+    assert "failed to reexec: Permission denied" in proc.stderr
+
+
+def test_diagnostics_printed_before_retry():
+    """Diagnostics precede the retry so a hard failure stays attributable."""
+    proc = _run_with_fake(_FAIL_ONCE)
+    err = proc.stderr
+    assert "podman info: ok" in err
+    assert "podman unshare true: ok (userns creatable)" in err
+    assert err.index("podman reexec diagnostics") < err.index("::warning::")
+
+
+def test_stdout_stays_clean():
+    """The wrapper keeps stdout clean (podman output streams on stderr)."""
+    proc = _run_with_fake(_FAIL_ONCE)
+    assert proc.stdout.splitlines() == ["RC=0", "CALLS=2"]
+
+
+def test_unrelated_failure_not_retried():
+    """Any other failure passes through: same rc, no retry, no diagnostics."""
+    proc = _run_with_fake(_UNRELATED)
+    assert "RC=42" in proc.stdout, proc.stderr
+    assert "CALLS=1" in proc.stdout, proc.stderr
+    assert "::warning::" not in proc.stderr
+    assert "podman reexec diagnostics" not in proc.stderr
+
+
+def test_persistent_reexec_fails_loudly_after_retry():
+    """A reexec failure that persists exits nonzero after exactly one retry."""
+    proc = _run_with_fake(_ALWAYS_REEXEC)
+    assert "RC=1" in proc.stdout, proc.stderr
+    assert "CALLS=2" in proc.stdout, proc.stderr
+    assert "::error::" in proc.stderr


### PR DESCRIPTION
Fixes #3168.

## Problem

On stock GitHub-hosted runners, the E2E suites' shared "Build images" step runs
`devenv tasks run klangk:build-workspace-image klangk:build-network-sidecar`,
which executes **both tasks in parallel** (devenv runs independent tasks
concurrently). On a fresh runner those are the machine's first two rootless
podman invocations, and the concurrent first-time user-namespace/storage
initialization intermittently kills one of them — observed as the sidecar build
dying ~1.4s in with:

```
Building network sidecar image ...
failed to reexec: Permission denied
✖ Running klangk:build-network-sidecar in 1.42s (failed)
```

reding the whole job before any test executes (run 33888969754; the same PR's
preceding run and adjacent runs in the same window all built fine — a per-run
coin flip). "reexec" is podman re-executing itself to enter its rootless user
namespace, so the failure is runner-environment level, not a klangk code path.

## Fix

`scripts/_podman_common.sh` gains `klangk::run_podman`, a wrapper that:

- streams podman's combined output on stderr (stdout stays clean for capturing
  callers) while teeing it to a temp log,
- on failure, greps the log for the fixed-string signature `failed to reexec:` —
  any hit is the rootless bootstrap failing, i.e. environmental,
- on that signature (and only it): prints diagnostics first — `podman info` rc,
  `podman unshare true` rc (the direct userns probe), the userns sysctls, and
  the subuid/subgid ranges, so a persistent occurrence is attributable — then
  retries **once** after a 5s backoff (`KLANGKBUILD_PODMAN_RETRY_SLEEP`
  overrides) while the sibling podman's first-time init finishes,
- passes every other failure through untouched with its original exit code,
  bounded at two attempts (no unbounded retry).

This is the same signature-matched single-retry policy the repo already uses
for the devenv eval UAF (`scripts/retry-on-invalid-path.sh`, #2774/#2775),
applied at the podman layer.

Both scripts whose tasks run in parallel now route their podman calls through
the wrapper:

- `scripts/build-network-sidecar.sh` — the `podman build` (the observed victim);
  the wheel build is not re-run on retry.
- `scripts/build-workspace-image.sh` — the `podman build` **and** the
  `podman image exists` freshness probe (it races the sibling task too; the
  dropped `2>/dev/null` is safe — `image exists` is silent on its normal rc-1
  "missing" path, and hiding stderr would have swallowed the retry's
  diagnostics).

Also fixes the wasteful (not red) variant of the same race: a transient reexec
failure in `image exists` previously forced a full image rebuild.

## Tests

New `scripts/tests/test_podman_reexec_retry.py` (contract + behavior):

- contract: both build scripts route `podman build` through the wrapper with no
  bare `"$PODMAN" build` left; the helper keeps the signature, the exactly-two-
  attempts loop, the overridable backoff, and all diagnostics probes;
- behavior (real `bash` subprocess sourcing the real helper against a fake
  `$KLANGKD_PODMAN_BIN`): reexec failure → retried once, `::warning::`,
  diagnostics, rc 0; unrelated rc-42 failure → no retry, no diagnostics,
  rc 42 propagated; persistent reexec → exactly two attempts, `::error::`,
  nonzero rc; stdout stays clean (podman output streams on stderr).

`scripts/tests` (the CI step covering these files) passes 117/117; shellcheck,
shfmt, xenon (rank A on the new test file), and the changelog entry are in.
