### PR TITLE
Force password change on admin-created/reset passwords (#3172)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -664,6 +664,17 @@ sync` report a clear permission-denied error.
   to `0` (disabled); the recommended hardening values are `24` hours /
   `60` days. Reloadable
   on SIGHUP; passwords set before the upgrade age from account creation.
+- **`must_change_password` (#3172).** Admin-chosen passwords now force a
+  change at next login (DISA ASD STIG V-222547, CAT II): creating a user
+  with a password or resetting one from the admin console sets a
+  `must_change_password` flag; the flagged session may do nothing except
+  change its password (API requests 403 `Password change required`, new
+  WS connections close with 4004 — including the consent-decider
+  socket). Login and token-refresh responses carry the flag so clients
+  drive a forced-change flow; both the web UI and the CLI TUI prompt
+  until the password is changed. Admins can set/clear the flag from the
+  user editor (local-password accounts only — flagging an OIDC account
+  is refused, since it could never be cleared).
 - **All five container images now publish on a release tag (#3140).**
   Pushing `vX.Y.Z` publishes `klangk-host`, `klangk-host-fips`,
   `klangk-workspace`, `klangk-workspace-fips`, and the newly pullable

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -665,7 +665,7 @@ sync` report a clear permission-denied error.
   `60` days. Reloadable
   on SIGHUP; passwords set before the upgrade age from account creation.
 - **`must_change_password` (#3172).** Admin-chosen passwords now force a
-  change at next login (DISA ASD STIG V-222547, CAT II): creating a user
+  change at next login: creating a user
   with a password or resetting one from the admin console sets a
   `must_change_password` flag; the flagged session may do nothing except
   change its password (API requests 403 `Password change required`, new

--- a/docs/reference/api-endpoints.md
+++ b/docs/reference/api-endpoints.md
@@ -907,9 +907,16 @@ disabled.
   "email": "new@example.com",
   "password": "newpass",
   "handle": "newhandle",
-  "disabled": true
+  "disabled": true,
+  "must_change_password": false
 }
 ```
+
+`must_change_password` (#3172) sets or clears the forced-change flag on
+a local-password account (`400` for OIDC-linked accounts — they have no
+local password to change). Setting `password` implies
+`must_change_password: true`; an explicit `must_change_password: false`
+in the same request overrides that.
 
 ```json
 { "status": "updated" }
@@ -1138,6 +1145,8 @@ for verification.
 ### POST `/api/v1/auth/change-password`
 
 Change the current user's password. Requires the current password.
+Clears `must_change_password` atomically with the new hash (#3172) —
+this is the **only** endpoint a flagged session may call.
 
 **Auth:** JWT required.
 
@@ -1217,8 +1226,18 @@ on the resolved user's canonical email, so attempts under either form
 share one counter.
 
 ```json
-{ "access_token": "jwt-string", "token_type": "bearer" }
+{
+  "access_token": "jwt-string",
+  "token_type": "bearer",
+  "must_change_password": false
+}
 ```
+
+`must_change_password` (#3172) is `true` when the password was set by an
+admin and has not been changed since. Such a session may only call
+`POST /api/v1/auth/change-password` (and refresh); every other
+authenticated request returns `403 Password change required` and new
+WebSocket connections close with `4004`.
 
 ---
 
@@ -1283,8 +1302,15 @@ blocklisted.
 No request body.
 
 ```json
-{ "access_token": "new-jwt-string", "token_type": "bearer" }
+{
+  "access_token": "new-jwt-string",
+  "token_type": "bearer",
+  "must_change_password": false
+}
 ```
+
+`must_change_password` (#3172) reflects the live flag at refresh time
+(the same semantics as the login response above).
 
 ---
 
@@ -1989,7 +2015,9 @@ delegate events.
 
 **Auth:** JWT required via `?token=` query param.
 
-Close codes: 4001 (missing/invalid token), 4002 (expired token).
+Close codes: 4001 (missing/invalid token), 4002 (expired token), 4004
+(password change required, #3172 — the account must change its password
+before opening any WebSocket connection).
 
 ---
 
@@ -2006,6 +2034,10 @@ strictly workspace-scoped: the `workspace` query param is
 required — a handshake without it is refused.
 
 **Auth:** JWT required. Query param: `workspace` (the workspace id).
+
+Close codes: 4001 (missing/invalid token), 4002 (expired token), 4003
+(forbidden — missing `egress-consent` or wrong scope), 4004 (password
+change required, #3172).
 
 ---
 

--- a/src/frontend/lib/admin/admin_users_page.dart
+++ b/src/frontend/lib/admin/admin_users_page.dart
@@ -326,11 +326,12 @@ class _AdminUsersPageState extends State<AdminUsersPage> {
 
   Future<void> _editUser(Map<String, dynamic> user) async {
     final auth = context.read<AuthService>();
-    final result = await showDialog<Map<String, String>>(
+    final result = await showDialog<Map<String, dynamic>>(
       context: context,
       builder: (ctx) => _EditUserDialog(
         currentEmail: user['email'] as String,
         currentHandle: user['handle'] as String? ?? '',
+        mustChangePassword: (user['must_change_password'] as bool?) ?? false,
         passwordPolicy: auth.passwordPolicy,
       ),
     );
@@ -430,6 +431,17 @@ class _AdminUsersPageState extends State<AdminUsersPage> {
                     style: const TextStyle(
                       color: KColors.textSecondary,
                       fontSize: 13,
+                    ),
+                  ),
+                ],
+                if (user['must_change_password'] == true) ...[
+                  const SizedBox(width: 8),
+                  Tooltip(
+                    message: 'Must change password on next login',
+                    child: Icon(
+                      Icons.lock_reset,
+                      size: 16,
+                      color: Colors.orange.shade700,
                     ),
                   ),
                 ],
@@ -1861,11 +1873,13 @@ class _AddUserDialogState extends State<_AddUserDialog> {
 class _EditUserDialog extends StatefulWidget {
   final String currentEmail;
   final String currentHandle;
+  final bool mustChangePassword;
   final PasswordPolicy passwordPolicy;
 
   const _EditUserDialog({
     required this.currentEmail,
     required this.currentHandle,
+    required this.mustChangePassword,
     this.passwordPolicy = const PasswordPolicy(),
   });
 
@@ -1880,12 +1894,14 @@ class _EditUserDialogState extends State<_EditUserDialog> {
   final _confirmController = TextEditingController();
   bool _obscurePassword = true;
   bool _obscureConfirm = true;
+  late bool _mustChangePassword;
 
   @override
   void initState() {
     super.initState();
     _emailController = TextEditingController(text: widget.currentEmail);
     _handleController = TextEditingController(text: widget.currentHandle);
+    _mustChangePassword = widget.mustChangePassword;
   }
 
   @override
@@ -1994,6 +2010,20 @@ class _EditUserDialogState extends State<_EditUserDialog> {
                 onChanged: (_) => setState(() {}),
               ),
             ],
+            const SizedBox(height: 12),
+            CheckboxListTile(
+              title: const Text('Must change password on next login'),
+              subtitle: const Text(
+                'Forces the user to choose a new password before '
+                'they can do anything else',
+                style: TextStyle(fontSize: 12),
+              ),
+              value: _mustChangePassword,
+              onChanged: (v) =>
+                  setState(() => _mustChangePassword = v ?? false),
+              contentPadding: EdgeInsets.zero,
+              controlAffinity: ListTileControlAffinity.leading,
+            ),
           ],
         ),
       ),
@@ -2010,9 +2040,12 @@ class _EditUserDialogState extends State<_EditUserDialog> {
           onPressed: canSave
               ? () {
                   final handle = _handleController.text.trim();
-                  final result = <String, String>{'email': email};
+                  final result = <String, dynamic>{'email': email};
                   if (handle != widget.currentHandle) result['handle'] = handle;
                   if (password.isNotEmpty) result['password'] = password;
+                  if (_mustChangePassword != widget.mustChangePassword) {
+                    result['must_change_password'] = _mustChangePassword;
+                  }
                   Navigator.pop(context, result);
                 }
               : null,

--- a/src/frontend/lib/admin/admin_users_page.dart
+++ b/src/frontend/lib/admin/admin_users_page.dart
@@ -333,6 +333,7 @@ class _AdminUsersPageState extends State<AdminUsersPage> {
         currentHandle: user['handle'] as String? ?? '',
         mustChangePassword: (user['must_change_password'] as bool?) ?? false,
         passwordPolicy: auth.passwordPolicy,
+        isLocalAccount: (user['provider'] as String? ?? 'local') == 'local',
       ),
     );
     if (result == null) return;
@@ -1876,11 +1877,17 @@ class _EditUserDialog extends StatefulWidget {
   final bool mustChangePassword;
   final PasswordPolicy passwordPolicy;
 
+  /// #3172: the must-change checkbox is offered only for local-password
+  /// accounts — flagging an OIDC account is a permanent lockout (the
+  /// server rejects it too; this hides the dead control).
+  final bool isLocalAccount;
+
   const _EditUserDialog({
     required this.currentEmail,
     required this.currentHandle,
     required this.mustChangePassword,
     this.passwordPolicy = const PasswordPolicy(),
+    this.isLocalAccount = true,
   });
 
   @override
@@ -2010,20 +2017,22 @@ class _EditUserDialogState extends State<_EditUserDialog> {
                 onChanged: (_) => setState(() {}),
               ),
             ],
-            const SizedBox(height: 12),
-            CheckboxListTile(
-              title: const Text('Must change password on next login'),
-              subtitle: const Text(
-                'Forces the user to choose a new password before '
-                'they can do anything else',
-                style: TextStyle(fontSize: 12),
+            if (widget.isLocalAccount) ...[
+              const SizedBox(height: 12),
+              CheckboxListTile(
+                title: const Text('Must change password on next login'),
+                subtitle: const Text(
+                  'Forces the user to choose a new password before '
+                  'they can do anything else',
+                  style: TextStyle(fontSize: 12),
+                ),
+                value: _mustChangePassword,
+                onChanged: (v) =>
+                    setState(() => _mustChangePassword = v ?? false),
+                contentPadding: EdgeInsets.zero,
+                controlAffinity: ListTileControlAffinity.leading,
               ),
-              value: _mustChangePassword,
-              onChanged: (v) =>
-                  setState(() => _mustChangePassword = v ?? false),
-              contentPadding: EdgeInsets.zero,
-              controlAffinity: ListTileControlAffinity.leading,
-            ),
+            ],
           ],
         ),
       ),

--- a/src/frontend/lib/app.dart
+++ b/src/frontend/lib/app.dart
@@ -13,6 +13,7 @@ import 'auth/verify_page.dart';
 import 'auth/forgot_password_page.dart';
 import 'auth/accept_invite_page.dart';
 import 'auth/oidc_complete_page.dart';
+import 'auth/forced_change_password_page.dart';
 import 'auth/reset_password_page.dart';
 import 'auth/settings_page.dart';
 import 'widgets/stale_build_banner.dart';
@@ -81,6 +82,7 @@ class _KlangkAppState extends State<KlangkApp> {
         return evaluateGuards(
           isLoggedIn: auth.isLoggedIn,
           bannerRequired: auth.bannerRequired,
+          mustChangePassword: auth.mustChangePassword,
           loc: loc,
           currentUri: state.uri.toString(),
           publicRoutes: routes,
@@ -123,6 +125,10 @@ class _KlangkAppState extends State<KlangkApp> {
         GoRoute(
           path: '/settings',
           builder: (context, state) => const SettingsPage(),
+        ),
+        GoRoute(
+          path: '/change-password',
+          builder: (context, state) => const ForcedChangePasswordPage(),
         ),
         GoRoute(
           path: '/forgot-password',

--- a/src/frontend/lib/app_guards.dart
+++ b/src/frontend/lib/app_guards.dart
@@ -136,6 +136,21 @@ String? guardAdminRoute({
   return null;
 }
 
+/// Forced password change gate (#3172).
+///
+/// A logged-in user whose session carries `must_change_password` is
+/// forced to `/change-password` on every route except `/change-password`
+/// itself. Like the banner gate, this is terminal — no other guard runs
+/// while the flag is set.
+String? guardForcedPasswordChange({
+  required bool isLoggedIn,
+  required bool mustChangePassword,
+  required String loc,
+}) {
+  if (!isLoggedIn || !mustChangePassword) return null;
+  return loc == '/change-password' ? null : '/change-password';
+}
+
 /// Root shortcut: a logged-in user at `/` goes to `/workspaces`.
 ///
 /// Returns the redirect target, or null to allow.
@@ -160,6 +175,7 @@ String? guardRoot({required bool isLoggedIn, required String loc}) {
 String? evaluateGuards({
   required bool isLoggedIn,
   required bool bannerRequired,
+  required bool mustChangePassword,
   required String loc,
   required String currentUri,
   required Set<String> publicRoutes,
@@ -175,6 +191,11 @@ String? evaluateGuards({
         loc: loc,
         publicRoutes: publicRoutes,
         currentUri: currentUri,
+      ) ??
+      guardForcedPasswordChange(
+        isLoggedIn: isLoggedIn,
+        mustChangePassword: mustChangePassword,
+        loc: loc,
       ) ??
       guardLoggedInPublicRoute(
         isLoggedIn: isLoggedIn,

--- a/src/frontend/lib/auth/auth_service.dart
+++ b/src/frontend/lib/auth/auth_service.dart
@@ -70,6 +70,9 @@ class AuthService extends ChangeNotifier {
   /// this is false: every workspace then gets the shared /home/klangk
   /// regardless of the stored column.
   bool _perHandleHomeAvailable = false;
+  // #3172: server signals that the session's password was admin-chosen
+  // and must be changed before any other action is possible.
+  bool _mustChangePassword = false;
   Timer? _permissionTimer;
   Timer? _refreshTimer;
 
@@ -143,6 +146,11 @@ class AuthService extends ChangeNotifier {
   /// the per-workspace home-layout toggle opts in below. False (also
   /// pre-auth, where the field is absent) hides the toggle everywhere.
   bool get perHandleHomeAvailable => _perHandleHomeAvailable;
+
+  /// #3172: the session carries an admin-chosen temporary password
+  /// that must be changed before any other action. The router guard
+  /// forces `/change-password` when true.
+  bool get mustChangePassword => _mustChangePassword;
 
   /// Decode the JWT payload.
   Map<String, dynamic>? get _payload {
@@ -368,6 +376,7 @@ class AuthService extends ChangeNotifier {
     _permissions = {};
     _groups = [];
     _isAdmin = false;
+    _mustChangePassword = false;
     // The pending redirect belongs to the session being cleared; drop it
     // so the next login can never inherit the old session's destination
     // (#2670). If the user was on a protected page, guardAuth re-stashes
@@ -431,6 +440,7 @@ class AuthService extends ChangeNotifier {
       );
       if (response.statusCode == 200) {
         final data = jsonDecode(response.body);
+        _mustChangePassword = (data['must_change_password'] as bool?) ?? false;
         await _saveToken(data['access_token']);
         return null;
       }
@@ -467,6 +477,14 @@ class AuthService extends ChangeNotifier {
       _loading = false;
       notifyListeners();
     }
+  }
+
+  /// Clear the forced-change flag after a successful password change
+  /// (#3172). Called by the change-password UI after the server returns
+  /// 200.
+  void clearMustChangePassword() {
+    _mustChangePassword = false;
+    notifyListeners();
   }
 
   Future<String?> resendVerification(String email, String password) async {

--- a/src/frontend/lib/auth/auth_service.dart
+++ b/src/frontend/lib/auth/auth_service.dart
@@ -506,12 +506,36 @@ class AuthService extends ChangeNotifier {
 
   /// Make an authenticated HTTP request. If the response is 401,
   /// clear the token (router will redirect to login).
+  /// Shared post-flight handling for authenticated requests.
+  ///
+  /// A 401 ends the session. A 403 "Password change required" (#3172)
+  /// flips the local must-change flag so guardForcedPasswordChange
+  /// routes to /change-password on the next notifyListeners — this is
+  /// how a mid-session admin password reset reaches the UI without
+  /// waiting for the next token refresh.
+  Future<void> _handleAuthFailure(http.Response response) async {
+    if (response.statusCode == 401) {
+      await _clearToken();
+      return;
+    }
+    if (response.statusCode != 403 || _token == null) return;
+    try {
+      final detail = jsonDecode(response.body)['detail'];
+      if (detail == 'Password change required' && !_mustChangePassword) {
+        _mustChangePassword = true;
+        notifyListeners();
+      }
+    } catch (_) {
+      // Not JSON (or no detail) — leave the flag alone.
+    }
+  }
+
   Future<http.Response> authGet(String path) async {
     final response = await _client.get(
       Uri.parse('$_baseUrl$path'),
       headers: _authHeaders,
     );
-    if (response.statusCode == 401) await _clearToken();
+    await _handleAuthFailure(response);
     return response;
   }
 
@@ -521,7 +545,7 @@ class AuthService extends ChangeNotifier {
       headers: _authHeaders,
       body: body,
     );
-    if (response.statusCode == 401) await _clearToken();
+    await _handleAuthFailure(response);
     return response;
   }
 
@@ -531,7 +555,7 @@ class AuthService extends ChangeNotifier {
       headers: _authHeaders,
       body: body,
     );
-    if (response.statusCode == 401) await _clearToken();
+    await _handleAuthFailure(response);
     return response;
   }
 
@@ -544,7 +568,7 @@ class AuthService extends ChangeNotifier {
       },
       body: body,
     );
-    if (response.statusCode == 401) await _clearToken();
+    await _handleAuthFailure(response);
     return response;
   }
 
@@ -553,7 +577,7 @@ class AuthService extends ChangeNotifier {
       Uri.parse('$_baseUrl$path'),
       headers: _authHeaders,
     );
-    if (response.statusCode == 401) await _clearToken();
+    await _handleAuthFailure(response);
     return response;
   }
 
@@ -587,6 +611,13 @@ class AuthService extends ChangeNotifier {
         final data = jsonDecode(response.body);
         final newToken = data['access_token'] as String?;
         if (newToken != null) {
+          // #3172: the refresh response carries the live
+          // must-change flag (e.g. an admin reset the password
+          // mid-session). Set it BEFORE _saveToken so its
+          // notifyListeners — which re-runs the router guards —
+          // sees the new value.
+          _mustChangePassword =
+              (data['must_change_password'] as bool?) ?? false;
           await _saveToken(newToken);
         }
       } else if (response.statusCode == 401) {

--- a/src/frontend/lib/auth/forced_change_password_page.dart
+++ b/src/frontend/lib/auth/forced_change_password_page.dart
@@ -56,6 +56,7 @@ class _ForcedChangePasswordPageState extends State<ForcedChangePasswordPage> {
       );
       if (!mounted) return;
       if (resp.statusCode == 200) {
+        setState(() => _changing = false);
         auth.clearMustChangePassword();
         if (mounted) context.go('/workspaces');
       } else {

--- a/src/frontend/lib/auth/forced_change_password_page.dart
+++ b/src/frontend/lib/auth/forced_change_password_page.dart
@@ -1,0 +1,198 @@
+import 'dart:convert';
+
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+import 'package:provider/provider.dart';
+
+import '../theme/colors.dart';
+import 'auth_service.dart';
+import '../widgets/obscure_toggle.dart';
+
+/// Full-screen password change gate shown when the server sets
+/// `must_change_password` on login (#3172, STIG V-222547).
+///
+/// The user cannot navigate away until they choose a new password.
+class ForcedChangePasswordPage extends StatefulWidget {
+  const ForcedChangePasswordPage({super.key});
+
+  @override
+  State<ForcedChangePasswordPage> createState() =>
+      _ForcedChangePasswordPageState();
+}
+
+class _ForcedChangePasswordPageState extends State<ForcedChangePasswordPage> {
+  final _currentPasswordController = TextEditingController();
+  final _newPasswordController = TextEditingController();
+  final _confirmPasswordController = TextEditingController();
+  final _formKey = GlobalKey<FormState>();
+  bool _changing = false;
+  String? _error;
+  bool _obscureCurrent = true;
+  bool _obscureNew = true;
+
+  @override
+  void dispose() {
+    _currentPasswordController.dispose();
+    _newPasswordController.dispose();
+    _confirmPasswordController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _changePassword() async {
+    if (!_formKey.currentState!.validate()) return;
+    setState(() {
+      _changing = true;
+      _error = null;
+    });
+
+    final auth = context.read<AuthService>();
+    try {
+      final resp = await auth.authPost(
+        '/api/v1/auth/change-password',
+        body: jsonEncode({
+          'current_password': _currentPasswordController.text,
+          'new_password': _newPasswordController.text,
+        }),
+      );
+      if (!mounted) return;
+      if (resp.statusCode == 200) {
+        auth.clearMustChangePassword();
+        if (mounted) context.go('/workspaces');
+      } else {
+        final data = jsonDecode(resp.body);
+        setState(() {
+          _error = data['detail'] ?? 'Failed to change password.';
+          _changing = false;
+        });
+      }
+    } catch (e) {
+      if (!mounted) return;
+      setState(() {
+        _error = 'Network error.';
+        _changing = false;
+      });
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Center(
+        child: ConstrainedBox(
+          constraints: const BoxConstraints(maxWidth: 400),
+          child: Card(
+            child: Padding(
+              padding: const EdgeInsets.all(32),
+              child: Form(
+                key: _formKey,
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  crossAxisAlignment: CrossAxisAlignment.stretch,
+                  children: [
+                    const Icon(
+                      Icons.lock_reset,
+                      size: 48,
+                      color: KColors.textSecondary,
+                    ),
+                    const SizedBox(height: 16),
+                    Text(
+                      'Password Change Required',
+                      style: Theme.of(context).textTheme.headlineSmall,
+                      textAlign: TextAlign.center,
+                    ),
+                    const SizedBox(height: 8),
+                    Text(
+                      'Your password was set by an administrator. '
+                      'You must choose a new password before continuing.',
+                      style: TextStyle(color: KColors.textSecondary),
+                      textAlign: TextAlign.center,
+                    ),
+                    const SizedBox(height: 24),
+                    TextFormField(
+                      controller: _currentPasswordController,
+                      decoration: InputDecoration(
+                        labelText: 'Current Password',
+                        border: const OutlineInputBorder(),
+                        suffixIcon: KObscureToggle(
+                          obscured: _obscureCurrent,
+                          onToggle: () => setState(
+                            () => _obscureCurrent = !_obscureCurrent,
+                          ),
+                        ),
+                      ),
+                      obscureText: _obscureCurrent,
+                      validator: (v) =>
+                          v == null || v.isEmpty ? 'Required' : null,
+                    ),
+                    const SizedBox(height: 12),
+                    TextFormField(
+                      controller: _newPasswordController,
+                      decoration: InputDecoration(
+                        labelText: 'New Password',
+                        border: const OutlineInputBorder(),
+                        suffixIcon: KObscureToggle(
+                          obscured: _obscureNew,
+                          onToggle: () =>
+                              setState(() => _obscureNew = !_obscureNew),
+                        ),
+                      ),
+                      obscureText: _obscureNew,
+                      validator: (v) {
+                        if (v == null || v.isEmpty) return 'Required';
+                        return context
+                            .read<AuthService>()
+                            .passwordPolicy
+                            .validate(v);
+                      },
+                    ),
+                    const SizedBox(height: 12),
+                    TextFormField(
+                      controller: _confirmPasswordController,
+                      decoration: InputDecoration(
+                        labelText: 'Confirm New Password',
+                        border: const OutlineInputBorder(),
+                        suffixIcon: KObscureToggle(
+                          obscured: _obscureNew,
+                          onToggle: () =>
+                              setState(() => _obscureNew = !_obscureNew),
+                        ),
+                      ),
+                      obscureText: _obscureNew,
+                      validator: (v) {
+                        if (v != _newPasswordController.text) {
+                          return 'Passwords do not match';
+                        }
+                        return null;
+                      },
+                      onFieldSubmitted: (_) => _changePassword(),
+                    ),
+                    if (_error != null) ...[
+                      const SizedBox(height: 12),
+                      Text(
+                        _error!,
+                        style: TextStyle(
+                          color: Theme.of(context).colorScheme.error,
+                        ),
+                      ),
+                    ],
+                    const SizedBox(height: 24),
+                    FilledButton(
+                      onPressed: _changing ? null : _changePassword,
+                      child: _changing
+                          ? const SizedBox(
+                              height: 20,
+                              width: 20,
+                              child: CircularProgressIndicator(strokeWidth: 2),
+                            )
+                          : const Text('Change Password'),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/src/frontend/lib/auth/forced_change_password_page.dart
+++ b/src/frontend/lib/auth/forced_change_password_page.dart
@@ -9,7 +9,7 @@ import 'auth_service.dart';
 import '../widgets/obscure_toggle.dart';
 
 /// Full-screen password change gate shown when the server sets
-/// `must_change_password` on login (#3172, STIG V-222547).
+/// `must_change_password` on login (#3172).
 ///
 /// The user cannot navigate away until they choose a new password.
 class ForcedChangePasswordPage extends StatefulWidget {
@@ -56,9 +56,19 @@ class _ForcedChangePasswordPageState extends State<ForcedChangePasswordPage> {
       );
       if (!mounted) return;
       if (resp.statusCode == 200) {
+        // The change revokes every session of the old credential
+        // (#3152), including this one — end the client session and
+        // send the user to log in with the new password (#3172).
         setState(() => _changing = false);
-        auth.clearMustChangePassword();
-        if (mounted) context.go('/workspaces');
+        await auth.logout();
+        if (mounted) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            const SnackBar(
+              content: Text('Password changed. Log in with your new password.'),
+            ),
+          );
+          context.go('/login');
+        }
       } else {
         final data = jsonDecode(resp.body);
         setState(() {

--- a/src/frontend/lib/workspace/consent_decider_service.dart
+++ b/src/frontend/lib/workspace/consent_decider_service.dart
@@ -443,7 +443,8 @@ class ConsentDeciderService extends ChangeNotifier {
   bool _stopped = false;
   int _attempt = 0;
 
-  /// Whether the last disconnect was an auth failure (close codes 4001/4002).
+  /// Whether the last disconnect was an auth failure (close codes
+  /// 4001/4002/4004 — the last is the must-change-password gate, #3172).
   /// While true the service stops reconnecting -- the app surfaces re-login.
   bool _authFailed = false;
   bool get authFailed => _authFailed;
@@ -651,7 +652,7 @@ class ConsentDeciderService extends ChangeNotifier {
     _stopPing();
     _connected = false;
     final code = ch.closeCode;
-    if (code == 4001 || code == 4002) {
+    if (code == 4001 || code == 4002 || code == 4004) {
       _authFailed = true;
       notifyListeners();
       return; // stop reconnecting; the app surfaces re-login

--- a/src/frontend/lib/ws/ws_client.dart
+++ b/src/frontend/lib/ws/ws_client.dart
@@ -85,11 +85,19 @@ class WsClient extends ChangeNotifier {
   int get reconnectAttempt => _reconnectAttempt;
 
   /// Whether the last disconnect was caused by an auth failure (WebSocket
-  /// close codes 4001/4002). The UI reads this to suppress the "Server
-  /// unreachable" reconnect overlay and surface only the re-login path, so
-  /// the two never overlap (#2227). Reset on a successful connect.
+  /// close codes 4001/4002/4004 — invalid/expired token, or a session
+  /// under the must-change-password flag, #3172). The UI reads this to
+  /// suppress the "Server unreachable" reconnect overlay and surface only
+  /// the re-login path, so the two never overlap (#2227). Reset on a
+  /// successful connect.
   bool _authFailed = false;
   bool get authFailed => _authFailed;
+
+  /// Close codes that must stop reconnection and end the session (#2227,
+  /// #3172). 4004 ("Password change required") logs the user out; the
+  /// next login replays the forced-change flow.
+  static bool isAuthCloseCode(int? code) =>
+      code == 4001 || code == 4002 || code == 4004;
 
   Timer? _reconnectTimer;
 
@@ -346,7 +354,7 @@ class WsClient extends ChangeNotifier {
     } catch (e) {
       debugPrint('[WsClient] channel.ready failed: $e ${DateTime.now()}');
       final code = _channel?.closeCode;
-      if (code == 4001 || code == 4002) {
+      if (isAuthCloseCode(code)) {
         _authFailed = true;
         _errorController.add(
           const WsError(message: 'Session expired, please log in again'),
@@ -493,7 +501,7 @@ class WsClient extends ChangeNotifier {
         // can no longer be refreshed is worse than none).
         _serverSchedules = null;
         final code = _channel?.closeCode;
-        final authFailure = code == 4001 || code == 4002;
+        final authFailure = isAuthCloseCode(code);
         // Set the auth-failure flag BEFORE notifyListeners so the UI (which
         // rebuilds on this notification) suppresses the reconnect overlay
         // immediately and shows only the re-login path (#2227).
@@ -525,7 +533,7 @@ class WsClient extends ChangeNotifier {
         sharedTerminals = [];
         _serverSchedules = null;
         final code = _channel?.closeCode;
-        final authFailure = code == 4001 || code == 4002;
+        final authFailure = isAuthCloseCode(code);
         if (authFailure) {
           _authFailed = true;
           _reconnecting = false;

--- a/src/frontend/test/admin_users_page_test.dart
+++ b/src/frontend/test/admin_users_page_test.dart
@@ -292,6 +292,41 @@ void main() {
       expect(find.textContaining('Groups:'), findsNothing);
     });
 
+    testWidgets(
+        'edit dialog shows the must-change checkbox per provider '
+        '(#3172)', (tester) async {
+      final oidc = _user('oidc@example.com');
+      oidc['provider'] = 'oidc';
+      serveUsers(
+        (page, pageSize, sort, order, q) => [
+          _user('local@example.com'),
+          oidc,
+        ],
+        total: 2,
+      );
+
+      await pumpPage(tester);
+
+      // Local account: the flag control is offered.
+      await tester.tap(
+        find.text('local@example.com', skipOffstage: false),
+      );
+      await tester.pumpAndSettle();
+      expect(find.text('Must change password on next login'), findsOneWidget);
+      await tester.tap(find.text('Cancel'));
+      await tester.pumpAndSettle();
+
+      // OIDC account: no local password to change — the control is
+      // hidden (the server also refuses the field).
+      await tester.tap(
+        find.text('oidc@example.com', skipOffstage: false),
+      );
+      await tester.pumpAndSettle();
+      expect(find.text('Must change password on next login'), findsNothing);
+      await tester.tap(find.text('Cancel'));
+      await tester.pumpAndSettle();
+    });
+
     testWidgets('shows pagination controls when more than one page', (
       tester,
     ) async {

--- a/src/frontend/test/app_guards_test.dart
+++ b/src/frontend/test/app_guards_test.dart
@@ -359,6 +359,52 @@ void main() {
     });
   });
 
+  group('guardForcedPasswordChange (#3172)', () {
+    test('forces /change-password when flag is set', () {
+      expect(
+        guardForcedPasswordChange(
+          isLoggedIn: true,
+          mustChangePassword: true,
+          loc: '/workspaces',
+        ),
+        '/change-password',
+      );
+    });
+
+    test('allows /change-password when flag is set', () {
+      expect(
+        guardForcedPasswordChange(
+          isLoggedIn: true,
+          mustChangePassword: true,
+          loc: '/change-password',
+        ),
+        isNull,
+      );
+    });
+
+    test('no redirect when flag is false', () {
+      expect(
+        guardForcedPasswordChange(
+          isLoggedIn: true,
+          mustChangePassword: false,
+          loc: '/workspaces',
+        ),
+        isNull,
+      );
+    });
+
+    test('no redirect when not logged in', () {
+      expect(
+        guardForcedPasswordChange(
+          isLoggedIn: false,
+          mustChangePassword: true,
+          loc: '/workspaces',
+        ),
+        isNull,
+      );
+    });
+  });
+
   group('evaluateGuards precedence', () {
     final featurePaths = {'/celebrate'};
     final routes = _routesWithFeatures(featurePaths);
@@ -368,6 +414,7 @@ void main() {
       // sent to /consent, not /login, and pendingRedirect untouched.
       expect(
         evaluateGuards(
+          mustChangePassword: false,
           isLoggedIn: false,
           bannerRequired: true,
           loc: '/workspaces',
@@ -388,6 +435,7 @@ void main() {
       // in an infinite loop. The banner gate must decide alone here.
       expect(
         evaluateGuards(
+          mustChangePassword: false,
           isLoggedIn: true,
           bannerRequired: true,
           loc: '/consent',
@@ -403,6 +451,7 @@ void main() {
     test('banner gate forces /consent even for logged-in users', () {
       expect(
         evaluateGuards(
+          mustChangePassword: false,
           isLoggedIn: true,
           bannerRequired: true,
           loc: '/workspaces',
@@ -418,6 +467,7 @@ void main() {
     test('logged-out protected route -> /login with pendingRedirect', () {
       expect(
         evaluateGuards(
+          mustChangePassword: false,
           isLoggedIn: false,
           bannerRequired: false,
           loc: '/workspace/abc',
@@ -435,6 +485,7 @@ void main() {
       pendingRedirect = '/workspace/zzz';
       expect(
         evaluateGuards(
+          mustChangePassword: false,
           isLoggedIn: true,
           bannerRequired: false,
           loc: '/login',
@@ -455,6 +506,7 @@ void main() {
       pendingRedirect = '/admin/users';
       expect(
         evaluateGuards(
+          mustChangePassword: false,
           isLoggedIn: true,
           bannerRequired: false,
           loc: '/login',
@@ -475,6 +527,7 @@ void main() {
       pendingRedirect = '/admin/users';
       expect(
         evaluateGuards(
+          mustChangePassword: false,
           isLoggedIn: true,
           bannerRequired: false,
           loc: '/login',
@@ -490,6 +543,7 @@ void main() {
     test('logged-in non-admin on /admin/users -> /workspaces (#2669)', () {
       expect(
         evaluateGuards(
+          mustChangePassword: false,
           isLoggedIn: true,
           bannerRequired: false,
           loc: '/admin/users',
@@ -505,6 +559,7 @@ void main() {
     test('logged-in admin on /admin/users -> allowed (null) (#2669)', () {
       expect(
         evaluateGuards(
+          mustChangePassword: false,
           isLoggedIn: true,
           bannerRequired: false,
           loc: '/admin/users',
@@ -523,6 +578,7 @@ void main() {
       // preempt it (see guardAdminRoute 'logged-out' test).
       expect(
         evaluateGuards(
+          mustChangePassword: false,
           isLoggedIn: false,
           bannerRequired: false,
           loc: '/admin/users',
@@ -541,6 +597,7 @@ void main() {
       // the root guard then redirects.
       expect(
         evaluateGuards(
+          mustChangePassword: false,
           isLoggedIn: true,
           bannerRequired: false,
           loc: '/',
@@ -556,6 +613,7 @@ void main() {
     test('logged-in on /workspaces -> allowed (null)', () {
       expect(
         evaluateGuards(
+          mustChangePassword: false,
           isLoggedIn: true,
           bannerRequired: false,
           loc: '/workspaces',
@@ -571,6 +629,7 @@ void main() {
     test('logged-in on feature route -> allowed (null)', () {
       expect(
         evaluateGuards(
+          mustChangePassword: false,
           isLoggedIn: true,
           bannerRequired: false,
           loc: '/celebrate',
@@ -583,9 +642,42 @@ void main() {
       );
     });
 
+    test('forced password change overrides normal navigation (#3172)', () {
+      expect(
+        evaluateGuards(
+          mustChangePassword: true,
+          isLoggedIn: true,
+          bannerRequired: false,
+          loc: '/workspaces',
+          currentUri: '/workspaces',
+          publicRoutes: routes,
+          featurePaths: featurePaths,
+          canAccessAdmin: false,
+        ),
+        '/change-password',
+      );
+    });
+
+    test('forced password change allows /change-password (#3172)', () {
+      expect(
+        evaluateGuards(
+          mustChangePassword: true,
+          isLoggedIn: true,
+          bannerRequired: false,
+          loc: '/change-password',
+          currentUri: '/change-password',
+          publicRoutes: routes,
+          featurePaths: featurePaths,
+          canAccessAdmin: false,
+        ),
+        isNull,
+      );
+    });
+
     test('logged-out on /consent with no banner -> /login', () {
       expect(
         evaluateGuards(
+          mustChangePassword: false,
           isLoggedIn: false,
           bannerRequired: false,
           loc: '/consent',

--- a/src/frontend/test/app_redirect_test.dart
+++ b/src/frontend/test/app_redirect_test.dart
@@ -115,6 +115,7 @@ void main() {
         return evaluateGuards(
           isLoggedIn: auth.isLoggedIn,
           bannerRequired: auth.bannerRequired,
+          mustChangePassword: auth.mustChangePassword,
           loc: loc,
           currentUri: state.uri.toString(),
           publicRoutes: routes,

--- a/src/frontend/test/auth_service_test.dart
+++ b/src/frontend/test/auth_service_test.dart
@@ -189,15 +189,15 @@ void main() {
       expect(service2.sudoAvailable, isTrue);
     });
 
-    test('loads default_classification_banner from /api/config (#2768)',
-        () async {
-      // Empty by default (no banner, no reserved space); set when the
-      // server advertises one.
-      testAuthHttpClientOverride = _bannerClient();
-      final service = AuthService();
-      await Future.delayed(Duration.zero);
-      expect(service.defaultClassificationBanner, '');
-
+    test(
+      'loads default_classification_banner from /api/config (#2768)',
+      () async {
+        // Empty by default (no banner, no reserved space); set when the
+        // server advertises one.
+        testAuthHttpClientOverride = _bannerClient();
+        final service = AuthService();
+        await Future.delayed(Duration.zero);
+        expect(service.defaultClassificationBanner, '');
 
         testAuthHttpClientOverride = _bannerClient(
           defaultClassificationBanner: 'CUI',
@@ -553,6 +553,80 @@ void main() {
       await service.login('user', 'pass');
       expect(wasLoading, isTrue);
       expect(service.loading, isFalse);
+    });
+  });
+
+  group('mustChangePassword (#3172)', () {
+    test('login sets mustChangePassword from response', () async {
+      testAuthHttpClientOverride = MockClient((request) async {
+        if (request.url.path.contains('/api/v1/auth/login')) {
+          return http.Response(
+            jsonEncode({
+              'access_token': 'tok',
+              'must_change_password': true,
+            }),
+            200,
+          );
+        }
+        return http.Response('{}', 200);
+      });
+
+      final service = AuthService();
+      await Future.delayed(Duration.zero);
+
+      expect(service.mustChangePassword, isFalse);
+      await service.login('user', 'pass');
+      expect(service.mustChangePassword, isTrue);
+    });
+
+    test('clearMustChangePassword resets flag and notifies', () async {
+      testAuthHttpClientOverride = MockClient((request) async {
+        if (request.url.path.contains('/api/v1/auth/login')) {
+          return http.Response(
+            jsonEncode({
+              'access_token': 'tok',
+              'must_change_password': true,
+            }),
+            200,
+          );
+        }
+        return http.Response('{}', 200);
+      });
+
+      final service = AuthService();
+      await Future.delayed(Duration.zero);
+      await service.login('user', 'pass');
+      expect(service.mustChangePassword, isTrue);
+
+      bool notified = false;
+      service.addListener(() => notified = true);
+      service.clearMustChangePassword();
+
+      expect(service.mustChangePassword, isFalse);
+      expect(notified, isTrue);
+    });
+
+    test('logout clears mustChangePassword', () async {
+      testAuthHttpClientOverride = MockClient((request) async {
+        if (request.url.path.contains('/api/v1/auth/login')) {
+          return http.Response(
+            jsonEncode({
+              'access_token': 'tok',
+              'must_change_password': true,
+            }),
+            200,
+          );
+        }
+        return http.Response('{}', 200);
+      });
+
+      final service = AuthService();
+      await Future.delayed(Duration.zero);
+      await service.login('user', 'pass');
+      expect(service.mustChangePassword, isTrue);
+
+      await service.logout();
+      expect(service.mustChangePassword, isFalse);
     });
   });
 

--- a/src/frontend/test/auth_service_test.dart
+++ b/src/frontend/test/auth_service_test.dart
@@ -628,6 +628,122 @@ void main() {
       await service.logout();
       expect(service.mustChangePassword, isFalse);
     });
+
+    test('refresh response sets mustChangePassword (#3172)', () async {
+      testAuthHttpClientOverride = MockClient((request) async {
+        if (request.url.path.contains('/api/v1/auth/login')) {
+          return http.Response(
+            jsonEncode({'access_token': 'tok'}),
+            200,
+          );
+        }
+        if (request.url.path.contains('/api/v1/auth/refresh')) {
+          return http.Response(
+            jsonEncode({
+              'access_token': 'tok2',
+              'must_change_password': true,
+            }),
+            200,
+          );
+        }
+        return http.Response('{}', 200);
+      });
+
+      final service = AuthService();
+      await Future.delayed(Duration.zero);
+      await service.login('user', 'pass');
+      expect(service.mustChangePassword, isFalse);
+
+      await service.testRefreshToken();
+      expect(service.mustChangePassword, isTrue);
+    });
+
+    test('refresh response clears mustChangePassword (#3172)', () async {
+      testAuthHttpClientOverride = MockClient((request) async {
+        if (request.url.path.contains('/api/v1/auth/login')) {
+          return http.Response(
+            jsonEncode({
+              'access_token': 'tok',
+              'must_change_password': true,
+            }),
+            200,
+          );
+        }
+        if (request.url.path.contains('/api/v1/auth/refresh')) {
+          return http.Response(
+            jsonEncode({
+              'access_token': 'tok2',
+              'must_change_password': false,
+            }),
+            200,
+          );
+        }
+        return http.Response('{}', 200);
+      });
+
+      final service = AuthService();
+      await Future.delayed(Duration.zero);
+      await service.login('user', 'pass');
+      expect(service.mustChangePassword, isTrue);
+
+      await service.testRefreshToken();
+      expect(service.mustChangePassword, isFalse);
+    });
+
+    test('403 Password change required flips the flag (#3172)', () async {
+      testAuthHttpClientOverride = MockClient((request) async {
+        if (request.url.path.contains('/api/v1/auth/login')) {
+          return http.Response(
+            jsonEncode({'access_token': 'tok'}),
+            200,
+          );
+        }
+        if (request.url.path.contains('/api/v1/workspaces')) {
+          return http.Response(
+            jsonEncode({'detail': 'Password change required'}),
+            403,
+          );
+        }
+        return http.Response('{}', 200);
+      });
+
+      final service = AuthService();
+      await Future.delayed(Duration.zero);
+      await service.login('user', 'pass');
+      expect(service.mustChangePassword, isFalse);
+
+      bool notified = false;
+      service.addListener(() => notified = true);
+      final resp = await service.authGet('/api/v1/workspaces');
+      expect(resp.statusCode, 403);
+      expect(service.mustChangePassword, isTrue);
+      expect(notified, isTrue);
+    });
+
+    test('403 with another detail does not flip the flag (#3172)', () async {
+      testAuthHttpClientOverride = MockClient((request) async {
+        if (request.url.path.contains('/api/v1/auth/login')) {
+          return http.Response(
+            jsonEncode({'access_token': 'tok'}),
+            200,
+          );
+        }
+        if (request.url.path.contains('/api/v1/workspaces')) {
+          return http.Response(
+            jsonEncode({'detail': 'Permission denied'}),
+            403,
+          );
+        }
+        return http.Response('{}', 200);
+      });
+
+      final service = AuthService();
+      await Future.delayed(Duration.zero);
+      await service.login('user', 'pass');
+      final resp = await service.authGet('/api/v1/workspaces');
+      expect(resp.statusCode, 403);
+      expect(service.mustChangePassword, isFalse);
+    });
   });
 
   group('AuthService.localLogin', () {

--- a/src/frontend/test/consent_decider_service_test.dart
+++ b/src/frontend/test/consent_decider_service_test.dart
@@ -775,6 +775,21 @@ void main() {
       },
     );
 
+    test(
+      'must-change gate close (4004, #3172) sets authFailed and stops reconnecting',
+      () async {
+        final svc = ConsentDeciderService(workspaceId: 'ws', token: 't');
+        svc.connect();
+        channel.serverSend({'type': 'egress_request', 'request': _request()});
+        await Future.delayed(Duration.zero);
+        expect(svc.pending, isNotEmpty);
+        channel.serverClose(4004);
+        await Future.delayed(Duration.zero);
+        expect(svc.authFailed, isTrue);
+        svc.dispose();
+      },
+    );
+
     test('remainingSeconds counts down from requested_at + holdTimeout', () {
       // Fixed clock at epoch-second 1000; requested at 1000, hold 120s.
       final svc = ConsentDeciderService(

--- a/src/frontend/test/ws_client_test.dart
+++ b/src/frontend/test/ws_client_test.dart
@@ -1274,6 +1274,32 @@ void main() {
       client.disconnect();
       client.dispose();
     });
+
+    test('auth close code 4004 (#3172) triggers logout instead of reconnect',
+        () async {
+      final auth = AuthService();
+      await Future.delayed(Duration.zero);
+
+      final client = WsClient();
+      client.updateAuth(auth);
+      await client.connect();
+      client.connectWorkspace('ws-1');
+      channels[0].serverSend({
+        'type': 'container_ready',
+        'workspaceId': 'ws-1',
+      });
+      await Future.delayed(Duration.zero);
+
+      // Server closes with the must-change-password gate code
+      channels[0].serverClose(4004);
+      await Future.delayed(Duration.zero);
+
+      expect(client.reconnecting, isFalse);
+      expect(client.authFailed, isTrue);
+
+      client.disconnect();
+      client.dispose();
+    });
   });
 
   group('WsClient with fake channel', () {

--- a/src/klangk/klangk/api/admin.py
+++ b/src/klangk/klangk/api/admin.py
@@ -306,6 +306,9 @@ async def admin_create_user(
     user = await app.state.model.users.create_user(
         req.email, password_hash, verified=True
     )
+    # Admin-chosen password: force the user to change it on first
+    # login (#3172, STIG V-222547).
+    await app.state.model.users.set_must_change_password(user["id"], True)
     return {"id": user["id"], "email": user["email"], "status": "created"}
 
 
@@ -370,6 +373,7 @@ class UpdateUserRequest(auth.BaseModel):
     password: str | None = None
     handle: str | None = None
     disabled: bool | None = None
+    must_change_password: bool | None = None
 
 
 async def _require_user(app, user_id: str) -> dict:
@@ -386,6 +390,9 @@ async def _update_user_password(app, user_id: str, password: str) -> None:
     await app.state.auth.validate_password_not_reused(user_id, password)
     password_hash = await asyncio.to_thread(auth.hash_password, password)
     await app.state.model.users.update_password(user_id, password_hash)
+    # Admin-chosen password: force the user to change it on next
+    # login (#3172, STIG V-222547).
+    await app.state.model.users.set_must_change_password(user_id, True)
 
 
 async def _update_user_email(app, user_id: str, email: str) -> None:
@@ -415,6 +422,22 @@ async def _update_user_handle(app, user_id: str, handle: str) -> None:
     await wshandler.refresh_user_handle(app.state.sockets, user_id, handle)
 
 
+async def _apply_user_field_updates(
+    app, req: "UpdateUserRequest", user_id: str
+) -> None:
+    """Apply simple field updates from an admin user-update request."""
+    if req.email is not None:
+        await _update_user_email(app, user_id, req.email)
+    if req.password is not None:
+        await _update_user_password(app, user_id, req.password)
+    if req.handle is not None:
+        await _update_user_handle(app, user_id, req.handle)
+    if req.must_change_password is not None:
+        await app.state.model.users.set_must_change_password(
+            user_id, req.must_change_password
+        )
+
+
 @router.patch("/users/{user_id}")
 async def update_user(
     user_id: str,
@@ -423,12 +446,7 @@ async def update_user(
     app=Depends(get_app_dep),
 ):
     await _require_user(app, user_id)
-    if req.email is not None:
-        await _update_user_email(app, user_id, req.email)
-    if req.password is not None:
-        await _update_user_password(app, user_id, req.password)
-    if req.handle is not None:
-        await _update_user_handle(app, user_id, req.handle)
+    await _apply_user_field_updates(app, req, user_id)
     if req.disabled is not None:
         await _update_user_disabled(app, req, user_id, admin)
     return {"status": "updated"}

--- a/src/klangk/klangk/api/admin.py
+++ b/src/klangk/klangk/api/admin.py
@@ -303,12 +303,12 @@ async def admin_create_user(
         )
     app.state.auth.validate_password(req.password)
     password_hash = await asyncio.to_thread(auth.hash_password, req.password)
-    user = await app.state.model.users.create_user(
-        req.email, password_hash, verified=True
-    )
     # Admin-chosen password: force the user to change it on first
-    # login (#3172, STIG V-222547).
-    await app.state.model.users.set_must_change_password(user["id"], True)
+    # login (#3172, STIG V-222547). The flag lands in the same INSERT,
+    # so no crash window can leave an unflagged admin-chosen password.
+    user = await app.state.model.users.create_user(
+        req.email, password_hash, verified=True, must_change_password=True
+    )
     return {"id": user["id"], "email": user["email"], "status": "created"}
 
 
@@ -389,10 +389,11 @@ async def _update_user_password(app, user_id: str, password: str) -> None:
     app.state.auth.validate_password(password)
     await app.state.auth.validate_password_not_reused(user_id, password)
     password_hash = await asyncio.to_thread(auth.hash_password, password)
-    await app.state.model.users.update_password(user_id, password_hash)
     # Admin-chosen password: force the user to change it on next
-    # login (#3172, STIG V-222547).
-    await app.state.model.users.set_must_change_password(user_id, True)
+    # login (#3172, STIG V-222547) — hash + flag land in one transaction.
+    await app.state.model.users.set_password_force_change(
+        user_id, password_hash
+    )
 
 
 async def _update_user_email(app, user_id: str, email: str) -> None:
@@ -423,9 +424,10 @@ async def _update_user_handle(app, user_id: str, handle: str) -> None:
 
 
 async def _apply_user_field_updates(
-    app, req: "UpdateUserRequest", user_id: str
+    app, req: "UpdateUserRequest", user: dict
 ) -> None:
     """Apply simple field updates from an admin user-update request."""
+    user_id = user["id"]
     if req.email is not None:
         await _update_user_email(app, user_id, req.email)
     if req.password is not None:
@@ -433,9 +435,22 @@ async def _apply_user_field_updates(
     if req.handle is not None:
         await _update_user_handle(app, user_id, req.handle)
     if req.must_change_password is not None:
-        await app.state.model.users.set_must_change_password(
-            user_id, req.must_change_password
+        await _update_must_change_password(app, user, req.must_change_password)
+
+
+async def _update_must_change_password(app, user: dict, flag: bool) -> None:
+    """Set/clear the forced-change flag (#3172). Rejected for
+    non-local accounts: an OIDC user cannot ever clear it (their
+    passwords live with the IdP), so flagging one is a permanent
+    lockout."""
+    if user.get("provider") not in (None, "local"):
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                "must_change_password applies only to local-password accounts"
+            ),
         )
+    await app.state.model.users.set_must_change_password(user["id"], flag)
 
 
 @router.patch("/users/{user_id}")
@@ -445,8 +460,8 @@ async def update_user(
     admin: dict = Depends(acl.has_permission("manage-users")),
     app=Depends(get_app_dep),
 ):
-    await _require_user(app, user_id)
-    await _apply_user_field_updates(app, req, user_id)
+    user = await _require_user(app, user_id)
+    await _apply_user_field_updates(app, req, user)
     if req.disabled is not None:
         await _update_user_disabled(app, req, user_id, admin)
     return {"status": "updated"}

--- a/src/klangk/klangk/api/admin.py
+++ b/src/klangk/klangk/api/admin.py
@@ -304,7 +304,7 @@ async def admin_create_user(
     app.state.auth.validate_password(req.password)
     password_hash = await asyncio.to_thread(auth.hash_password, req.password)
     # Admin-chosen password: force the user to change it on first
-    # login (#3172, STIG V-222547). The flag lands in the same INSERT,
+    # login (#3172). The flag lands in the same INSERT,
     # so no crash window can leave an unflagged admin-chosen password.
     user = await app.state.model.users.create_user(
         req.email, password_hash, verified=True, must_change_password=True
@@ -390,7 +390,7 @@ async def _update_user_password(app, user_id: str, password: str) -> None:
     await app.state.auth.validate_password_not_reused(user_id, password)
     password_hash = await asyncio.to_thread(auth.hash_password, password)
     # Admin-chosen password: force the user to change it on next
-    # login (#3172, STIG V-222547) — hash + flag land in one transaction.
+    # login (#3172) — hash + flag land in one transaction.
     await app.state.model.users.set_password_force_change(
         user_id, password_hash
     )

--- a/src/klangk/klangk/api/auth.py
+++ b/src/klangk/klangk/api/auth.py
@@ -615,8 +615,13 @@ async def change_password(
         req.current_password,
         incorrect_detail="Current password is incorrect",
     )
-    # Self-service changes respect the minimum age (#3177).
-    request.app.state.auth.validate_password_min_age(user)
+    # Self-service changes respect the minimum age (#3177) — except the
+    # forced first change after an admin-set password (#3172): the
+    # temporary password must be replaceable *immediately*, and the
+    # admin reset that set this password already bypassed the age
+    # check.
+    if not user.get("must_change_password"):
+        request.app.state.auth.validate_password_min_age(user)
     request.app.state.auth.validate_password(req.new_password)
     request.app.state.auth.validate_password_changed_enough(
         req.current_password, req.new_password

--- a/src/klangk/klangk/api/auth.py
+++ b/src/klangk/klangk/api/auth.py
@@ -464,6 +464,11 @@ async def reset_password(req: ResetPasswordRequest, request: Request):
     )
     password_hash = await asyncio.to_thread(auth.hash_password, req.password)
     await request.app.state.model.users.update_password(user_id, password_hash)
+    # A self-chosen password via forgot-password clears the forced-change
+    # flag (#3172) — the user chose this password themselves.
+    await request.app.state.model.users.set_must_change_password(
+        user_id, False
+    )
     # Auto-login after reset
     source_ip, user_agent = workstation(request)
     token = await request.app.state.auth.issue_token(
@@ -596,9 +601,14 @@ async def verify_password_confirmation(
 async def change_password(
     req: ChangePasswordRequest,
     request: Request,
-    user: dict = Depends(auth.get_current_user),
+    user: dict = Depends(auth.get_current_user_allow_forced_change),
 ):
-    """Change password. Requires current password."""
+    """Change password. Requires current password.
+
+    Uses ``get_current_user_allow_forced_change`` instead of the standard
+    ``get_current_user`` so a session under the ``must_change_password``
+    flag can reach this endpoint (#3172).
+    """
     await verify_password_confirmation(
         request.app,
         user,
@@ -617,7 +627,9 @@ async def change_password(
     password_hash = await asyncio.to_thread(
         auth.hash_password, req.new_password
     )
-    await request.app.state.model.users.update_password(
+    # clear_must_change_password atomically updates the hash AND clears
+    # the flag in one transaction (#3172).
+    await request.app.state.model.users.clear_must_change_password(
         user["id"], password_hash
     )
     # Revoke every session so the old credential cannot be reused and

--- a/src/klangk/klangk/api/auth.py
+++ b/src/klangk/klangk/api/auth.py
@@ -463,11 +463,11 @@ async def reset_password(req: ResetPasswordRequest, request: Request):
         user_id, req.password
     )
     password_hash = await asyncio.to_thread(auth.hash_password, req.password)
-    await request.app.state.model.users.update_password(user_id, password_hash)
     # A self-chosen password via forgot-password clears the forced-change
-    # flag (#3172) — the user chose this password themselves.
-    await request.app.state.model.users.set_must_change_password(
-        user_id, False
+    # flag (#3172) — the user chose this password themselves. Hash write
+    # and flag clear land in the same transaction.
+    await request.app.state.model.users.clear_must_change_password(
+        user_id, password_hash
     )
     # Auto-login after reset
     source_ip, user_agent = workstation(request)

--- a/src/klangk/klangk/auth.py
+++ b/src/klangk/klangk/auth.py
@@ -1303,6 +1303,23 @@ class Auth:
             must_change_password=user.get("must_change_password", False),
         )
 
+    async def _cached_refresh_response(self, cached: str) -> TokenResponse:
+        """A cached refresh replacement stamped with the *live*
+        must_change_password flag (#3172) — the flag can flip (admin
+        reset) after the replacement was minted, so the cached token's
+        own issue-time state is not authoritative."""
+        flag = False
+        try:
+            payload = self.decode_token(cached)
+            user = await self.app.state.model.users.get_user_by_id(
+                payload.get("sub", "")
+            )
+            if user is not None:
+                flag = user.get("must_change_password", False)
+        except JWTError:
+            pass
+        return TokenResponse(access_token=cached, must_change_password=flag)
+
     async def _refreshed_or_revoked(self, jti: str) -> TokenResponse | None:
         """The cached replacement when *jti* was already refreshed.
 
@@ -1313,7 +1330,7 @@ class Auth:
             return None
         cached = await self.app.state.model.tokens.get_refreshed_token(jti)
         if cached is not None:
-            return TokenResponse(access_token=cached)
+            return await self._cached_refresh_response(cached)
         raise HTTPException(status_code=401, detail="Token has been revoked")
 
     async def _require_active_user(self, user_id: str) -> dict:
@@ -1379,7 +1396,7 @@ class Auth:
         if jti:
             cached = await self.app.state.model.tokens.get_refreshed_token(jti)
             if cached is not None:
-                return TokenResponse(access_token=cached)
+                return await self._cached_refresh_response(cached)
         raise HTTPException(status_code=401, detail="Token expired")
 
     async def refresh_token(self, token: str) -> TokenResponse:

--- a/src/klangk/klangk/auth.py
+++ b/src/klangk/klangk/auth.py
@@ -204,6 +204,21 @@ def ensure_not_disabled(user: dict) -> None:
         raise HTTPException(status_code=403, detail="Account disabled")
 
 
+def ensure_password_changed(user: dict) -> None:
+    """Raise 403 when the account requires a password change (#3172).
+
+    Called by ``get_current_user`` on every authenticated request.
+    The change-password endpoint is exempt so the user can actually
+    clear the flag. 403 with a machine-readable detail so clients
+    can drive the forced-change flow.
+    """
+    if user.get("must_change_password"):
+        raise HTTPException(
+            status_code=403,
+            detail="Password change required",
+        )
+
+
 def hash_password(password: str) -> str:
     """Hash a password with PBKDF2-HMAC-SHA512 (#2576).
 
@@ -320,6 +335,7 @@ class EmailRequest(BaseModel):
 class TokenResponse(BaseModel):
     access_token: str
     token_type: str = "bearer"
+    must_change_password: bool = False
 
 
 class RegisterResult(BaseModel):
@@ -1282,7 +1298,10 @@ class Auth:
         # Stamp after minting, matching every other session-issuing site
         # (#2583): if minting fails, no login is recorded.
         await self.app.state.model.users.record_login(user["id"])
-        return TokenResponse(access_token=token)
+        return TokenResponse(
+            access_token=token,
+            must_change_password=user.get("must_change_password", False),
+        )
 
     async def _refreshed_or_revoked(self, jti: str) -> TokenResponse | None:
         """The cached replacement when *jti* was already refreshed.
@@ -1538,6 +1557,35 @@ async def get_current_user(
         # to the set-new-password flow instead of looping on refresh.
         if auth.password_expired(user):
             raise password_expired_error()
+        # A forced-change account cannot do anything except change its
+        # password (#3172); the change-password endpoint uses
+        # get_current_user_allow_forced_change instead.
+        ensure_password_changed(user)
+        await auth.record_activity(user["id"])
+        return user
+    except JWTError:
+        raise HTTPException(status_code=401, detail="Invalid token")
+
+
+async def get_current_user_allow_forced_change(
+    request: Request,
+    credentials: HTTPAuthorizationCredentials | None = Depends(security),
+) -> dict:
+    """Like ``get_current_user`` but does not reject sessions under the
+    ``must_change_password`` flag (#3172). Used by the change-password
+    endpoint so a forced-change user can actually clear the flag.
+
+    Expired passwords still fail (#3177) — they are resolved by the
+    unauthenticated ``/auth/change-expired-password`` flow, not here."""
+    auth = request.app.state.auth
+    if credentials is None:
+        raise HTTPException(status_code=401, detail="Not authenticated")
+
+    try:
+        user = await _authenticated_user(request, credentials)
+        ensure_not_disabled(user)
+        if auth.password_expired(user):
+            raise password_expired_error()
         await auth.record_activity(user["id"])
         return user
     except JWTError:
@@ -1568,6 +1616,7 @@ async def get_current_user_optional(
         ensure_not_disabled(user)
         if auth.password_expired(user):
             raise password_expired_error()
+        ensure_password_changed(user)
         await auth.record_activity(user["id"])
         return user
     except JWTError:

--- a/src/klangk/klangk/auth.py
+++ b/src/klangk/klangk/auth.py
@@ -1402,7 +1402,7 @@ class Auth:
             if cached is not None:
                 return cached
 
-            await self._require_active_user(user_id)
+            user = await self._require_active_user(user_id)
             # A refresh is authenticated API use (#2588 review): stamp so
             # a headless client that only refreshes (no other API calls)
             # still counts as active.
@@ -1414,7 +1414,10 @@ class Auth:
             # so the cap holds on every path that adds a session row,
             # not just logins (#2585 review).
             await self._enforce_session_limit(user_id)
-            return TokenResponse(access_token=new_token)
+            return TokenResponse(
+                access_token=new_token,
+                must_change_password=user.get("must_change_password", False),
+            )
 
         except ExpiredSignatureError:
             # Token expired — check if it was previously refreshed

--- a/src/klangk/klangk/cli/auth.py
+++ b/src/klangk/klangk/cli/auth.py
@@ -318,13 +318,14 @@ _FORCED_CHANGE_MAX_ATTEMPTS = 5
 
 def _try_change_password(
     server_url: str, token: str, current_password: str
-) -> bool:
-    """Prompt once and POST; True on success, False on failure."""
+) -> str | None:
+    """Prompt once and POST; the new password on success, None on
+    failure."""
     new_password = Prompt.ask("[bold]New password[/bold]", password=True)
     confirm = Prompt.ask("[bold]Confirm new password[/bold]", password=True)
     if new_password != confirm:
         _err.print("[red]Passwords do not match.[/red]")
-        return False
+        return None
     resp = http_request(
         server_url,
         "POST",
@@ -338,28 +339,72 @@ def _try_change_password(
     )
     if resp.status_code == 200:
         _out.print("[green]Password changed.[/green]")
-        return True
+        return new_password
     _err.print(
         f"[red]Password change failed:[/red] {login_failure_detail(resp)}"
     )
-    return False
+    return None
 
 
 def _forced_password_change(
     server_url: str, token: str, current_password: str
 ) -> str:
-    """Prompt for a new password and POST it. Returns the same token
-    (the server clears the flag server-side). Exits after
+    """Prompt for a new password and POST it. Returns the NEW password
+    — the change revokes every session of the old credential (#3152),
+    so the caller logs in again with it. Exits after
     ``_FORCED_CHANGE_MAX_ATTEMPTS`` failed attempts."""
     _out.print(
         "\n[yellow]Your password was set by an administrator."
         " You must change it now.[/yellow]\n"
     )
     for _ in range(_FORCED_CHANGE_MAX_ATTEMPTS):
-        if _try_change_password(server_url, token, current_password):
-            return token
+        new_password = _try_change_password(
+            server_url, token, current_password
+        )
+        if new_password is not None:
+            return new_password
     _err.print("[red]Too many failed attempts. Login aborted.[/red]")
     raise SystemExit(1)
+
+
+def _fresh_login_token(server_url: str, email: str, password: str) -> str:
+    """Re-login after a forced change revoked the old session (#3152,
+    #3172). Any failure exits through the normal login-failure path."""
+    resp = http_request(
+        server_url,
+        "POST",
+        "/api/v1/auth/login",
+        json={"identifier": email, "password": password},
+        timeout=15.0,
+    )
+    if resp.status_code != 200:
+        print_login_failure(resp)
+    return resp.json()["access_token"]
+
+
+def _login_data(
+    server_url: str, email: str, password: str, state
+) -> dict | None:
+    """The parsed login response, or None when an expired password
+    (#3177) was rotated and the login is already persisted. Any other
+    failure exits through the login-failure path."""
+    resp = http_request(
+        server_url,
+        "POST",
+        "/api/v1/auth/login",
+        json={"identifier": email, "password": password},
+        timeout=15.0,
+    )
+    if resp.status_code == 200:
+        return resp.json()
+    expired = password_expired_message(resp)
+    if expired is not None:
+        token = expired_password_rotation(
+            server_url, email, password, notice=expired
+        )
+        persist_login(state, server_url, email, token)
+        return None
+    print_login_failure(resp)
 
 
 def password_login(server_url, email, password, state) -> None:
@@ -369,32 +414,28 @@ def password_login(server_url, email, password, state) -> None:
     email = email or Prompt.ask("[bold]Email or handle[/bold]")
     password = password or Prompt.ask("[bold]Password[/bold]", password=True)
 
-    resp = http_request(
-        server_url,
-        "POST",
-        "/api/v1/auth/login",
-        json={"identifier": email, "password": password},
-        timeout=15.0,
-    )
-    if resp.status_code != 200:
-        expired = password_expired_message(resp)
-        if expired is not None:
-            token = expired_password_rotation(
-                server_url, email, password, notice=expired
-            )
-            persist_login(state, server_url, email, token)
-            return
-        print_login_failure(resp)
-
-    data = resp.json()
+    data = _login_data(server_url, email, password, state)
+    if data is None:
+        return
     token = data["access_token"]
 
     # #3172: server signals that the password was admin-chosen and must
     # be changed before any other action.
     if data.get("must_change_password"):
-        token = _forced_password_change(server_url, token, password)
+        token = _complete_forced_change(server_url, email, password, token)
 
     persist_login(state, server_url, email, token)
+
+
+def _complete_forced_change(
+    server_url: str, email: str, password: str, token: str
+) -> str:
+    """Run the forced-change flow and return the token to persist. The
+    change revokes the current session (#3152), so the caller cannot
+    reuse *token* — a fresh login with the new password mints the
+    replacement."""
+    new_password = _forced_password_change(server_url, token, password)
+    return _fresh_login_token(server_url, email, new_password)
 
 
 def persist_login(state, server_url, email, token) -> None:

--- a/src/klangk/klangk/cli/auth.py
+++ b/src/klangk/klangk/cli/auth.py
@@ -313,6 +313,41 @@ def print_login_failure(resp) -> None:
     raise SystemExit(1)
 
 
+def _forced_password_change(
+    server_url: str, token: str, current_password: str
+) -> str:
+    """Prompt for a new password and POST it. Returns the same token
+    (the server clears the flag server-side). Exits on failure."""
+    _out.print(
+        "\n[yellow]Your password was set by an administrator."
+        " You must change it now.[/yellow]\n"
+    )
+    while True:
+        new_password = Prompt.ask("[bold]New password[/bold]", password=True)
+        confirm = Prompt.ask(
+            "[bold]Confirm new password[/bold]", password=True
+        )
+        if new_password != confirm:
+            _err.print("[red]Passwords do not match.[/red]")
+            continue
+        resp = http_request(
+            server_url,
+            "POST",
+            "/api/v1/auth/change-password",
+            json={
+                "current_password": current_password,
+                "new_password": new_password,
+            },
+            headers={"Authorization": f"Bearer {token}"},
+            timeout=15.0,
+        )
+        if resp.status_code == 200:
+            _out.print("[green]Password changed.[/green]")
+            return token
+        detail = login_failure_detail(resp)
+        _err.print(f"[red]Password change failed:[/red] {detail}")
+
+
 def password_login(server_url, email, password, state) -> None:
     """Prompt for credentials (accepts an email or a handle, #616), POST
     them, and persist the returned token. An expired password (#3177)
@@ -337,7 +372,13 @@ def password_login(server_url, email, password, state) -> None:
             return
         print_login_failure(resp)
 
-    token = resp.json()["access_token"]
+    data = resp.json()
+    token = data["access_token"]
+
+    # #3172: server signals that the password was admin-chosen and must
+    # be changed before any other action.
+    if data.get("must_change_password"):
+        token = _forced_password_change(server_url, token, password)
 
     persist_login(state, server_url, email, token)
 

--- a/src/klangk/klangk/cli/auth.py
+++ b/src/klangk/klangk/cli/auth.py
@@ -313,39 +313,53 @@ def print_login_failure(resp) -> None:
     raise SystemExit(1)
 
 
+_FORCED_CHANGE_MAX_ATTEMPTS = 5
+
+
+def _try_change_password(
+    server_url: str, token: str, current_password: str
+) -> bool:
+    """Prompt once and POST; True on success, False on failure."""
+    new_password = Prompt.ask("[bold]New password[/bold]", password=True)
+    confirm = Prompt.ask("[bold]Confirm new password[/bold]", password=True)
+    if new_password != confirm:
+        _err.print("[red]Passwords do not match.[/red]")
+        return False
+    resp = http_request(
+        server_url,
+        "POST",
+        "/api/v1/auth/change-password",
+        json={
+            "current_password": current_password,
+            "new_password": new_password,
+        },
+        headers={"Authorization": f"Bearer {token}"},
+        timeout=15.0,
+    )
+    if resp.status_code == 200:
+        _out.print("[green]Password changed.[/green]")
+        return True
+    _err.print(
+        f"[red]Password change failed:[/red] {login_failure_detail(resp)}"
+    )
+    return False
+
+
 def _forced_password_change(
     server_url: str, token: str, current_password: str
 ) -> str:
     """Prompt for a new password and POST it. Returns the same token
-    (the server clears the flag server-side). Exits on failure."""
+    (the server clears the flag server-side). Exits after
+    ``_FORCED_CHANGE_MAX_ATTEMPTS`` failed attempts."""
     _out.print(
         "\n[yellow]Your password was set by an administrator."
         " You must change it now.[/yellow]\n"
     )
-    while True:
-        new_password = Prompt.ask("[bold]New password[/bold]", password=True)
-        confirm = Prompt.ask(
-            "[bold]Confirm new password[/bold]", password=True
-        )
-        if new_password != confirm:
-            _err.print("[red]Passwords do not match.[/red]")
-            continue
-        resp = http_request(
-            server_url,
-            "POST",
-            "/api/v1/auth/change-password",
-            json={
-                "current_password": current_password,
-                "new_password": new_password,
-            },
-            headers={"Authorization": f"Bearer {token}"},
-            timeout=15.0,
-        )
-        if resp.status_code == 200:
-            _out.print("[green]Password changed.[/green]")
+    for _ in range(_FORCED_CHANGE_MAX_ATTEMPTS):
+        if _try_change_password(server_url, token, current_password):
             return token
-        detail = login_failure_detail(resp)
-        _err.print(f"[red]Password change failed:[/red] {detail}")
+    _err.print("[red]Too many failed attempts. Login aborted.[/red]")
+    raise SystemExit(1)
 
 
 def password_login(server_url, email, password, state) -> None:

--- a/src/klangk/klangk/model/migrations/__init__.py
+++ b/src/klangk/klangk/model/migrations/__init__.py
@@ -79,6 +79,7 @@ from klangk.model.migrations import m0028_invitations_pending_unique
 from klangk.model.migrations import m0029_members_create_workspace
 from klangk.model.migrations import m0030_audit_hmac
 from klangk.model.migrations import m0031_password_age
+from klangk.model.migrations import m0032_must_change_password
 from klangk.model.migrations.base import Migration
 
 __all__ = ["MIGRATIONS", "Migration", "run_migrations"]
@@ -118,6 +119,7 @@ MIGRATIONS: list[Migration] = [
     m0029_members_create_workspace.migration,
     m0030_audit_hmac.migration,
     m0031_password_age.migration,
+    m0032_must_change_password.migration,
 ]
 
 

--- a/src/klangk/klangk/model/migrations/m0032_must_change_password.py
+++ b/src/klangk/klangk/model/migrations/m0032_must_change_password.py
@@ -1,9 +1,9 @@
 """Migration 0032: add ``must_change_password`` flag to users (#3172).
 
-DISA ASD STIG finding V-222547 (CAT II) requires forcing a password
-change on first login when an admin creates a user with a password or
-resets an existing user's password. The flag is set by the admin paths
-and cleared atomically when the user changes their own password.
+An admin-chosen password (user creation with a password, or an admin
+password reset) is temporary: the user must be forced to change it on
+first login. The flag is set by the admin paths and cleared atomically
+when the user changes their own password.
 
 The column defaults to 0 (false): existing users keep their current
 passwords without being forced to change. Only new admin-set passwords

--- a/src/klangk/klangk/model/migrations/m0032_must_change_password.py
+++ b/src/klangk/klangk/model/migrations/m0032_must_change_password.py
@@ -1,0 +1,27 @@
+"""Migration 0032: add ``must_change_password`` flag to users (#3172).
+
+DISA ASD STIG finding V-222547 (CAT II) requires forcing a password
+change on first login when an admin creates a user with a password or
+resets an existing user's password. The flag is set by the admin paths
+and cleared atomically when the user changes their own password.
+
+The column defaults to 0 (false): existing users keep their current
+passwords without being forced to change. Only new admin-set passwords
+trigger the flag going forward.
+"""
+
+from klangk.model.migrations.base import Migration
+
+
+async def apply(db) -> None:
+    await db.execute(
+        "ALTER TABLE users ADD COLUMN"
+        " must_change_password INTEGER NOT NULL DEFAULT 0"
+    )
+
+
+migration = Migration(
+    id=32,
+    name="0032_must_change_password",
+    apply=apply,
+)

--- a/src/klangk/klangk/model/users.py
+++ b/src/klangk/klangk/model/users.py
@@ -267,7 +267,8 @@ ADMIN_USER_SORT_COLUMNS = {
 # new columns from drifting between lookups.
 _USER_COLUMNS = (
     "SELECT id, email, password_hash, verified, provider, external_id,"
-    " handle, disabled, last_activity_at, created_at, password_set_at"
+    " handle, disabled, last_activity_at, created_at, password_set_at,"
+    " must_change_password"
 )
 
 
@@ -284,6 +285,7 @@ def _user_row_to_dict(row) -> dict:
         "last_activity_at": row["last_activity_at"],
         "created_at": row["created_at"],
         "password_set_at": row["password_set_at"],
+        "must_change_password": bool(row["must_change_password"]),
     }
 
 
@@ -960,7 +962,8 @@ class UsersModel(Submodel):
 
             cursor = await db.execute(
                 "SELECT id, email, handle, verified, provider, created_at,"
-                " disabled, last_login_at, last_activity_at"
+                " disabled, last_login_at, last_activity_at,"
+                " must_change_password"
                 f" FROM users{where_clause}"
                 f" ORDER BY {sort_col} {direction}, id"
                 " LIMIT ? OFFSET ?",
@@ -977,6 +980,7 @@ class UsersModel(Submodel):
                     "disabled": bool(row["disabled"]),
                     "last_login_at": row["last_login_at"],
                     "last_activity_at": row["last_activity_at"],
+                    "must_change_password": bool(row["must_change_password"]),
                 }
                 for row in await cursor.fetchall()
             ]
@@ -1073,6 +1077,42 @@ class UsersModel(Submodel):
                     datetime.now(timezone.utc).isoformat(),
                     user_id,
                 ),
+            )
+            if count > 0 and row["password_hash"] is not None:
+                await self._retire_password(
+                    db, user_id, row["password_hash"], count
+                )
+
+    async def set_must_change_password(self, user_id: str, flag: bool) -> None:
+        """Set or clear the must-change-password flag (#3172)."""
+        async with self.app.state.db.transaction() as db:
+            await db.execute(
+                "UPDATE users SET must_change_password = ? WHERE id = ?",
+                (int(flag), user_id),
+            )
+
+    async def clear_must_change_password(
+        self, user_id: str, password_hash: str
+    ) -> None:
+        """Update a user's password and atomically clear the forced-change
+        flag (#3172). The old hash is retired into password history, same
+        as ``update_password``."""
+        if user_id == AGENT_USER_ID:
+            raise AgentPrincipalError(
+                "Cannot set a password on the system agent user"
+            )
+        count = self.app.state.settings.password_history_count
+        async with self.app.state.db.transaction() as db:
+            cursor = await db.execute(
+                "SELECT password_hash FROM users WHERE id = ?", (user_id,)
+            )
+            row = await cursor.fetchone()
+            if row is None:
+                return
+            await db.execute(
+                "UPDATE users SET password_hash = ?,"
+                " must_change_password = 0 WHERE id = ?",
+                (password_hash, user_id),
             )
             if count > 0 and row["password_hash"] is not None:
                 await self._retire_password(
@@ -1230,7 +1270,7 @@ class UsersModel(Submodel):
         row = await self.app.state.db.fetchone(
             "SELECT id, email, handle, last_login_at, disabled,"
             " last_activity_at, created_at, password_set_at,"
-            " password_hash"
+            " password_hash, must_change_password"
             " FROM users WHERE id = ?",
             (user_id,),
         )
@@ -1246,6 +1286,7 @@ class UsersModel(Submodel):
             "created_at": row["created_at"],
             "password_set_at": row["password_set_at"],
             "password_hash": row["password_hash"],
+            "must_change_password": bool(row["must_change_password"]),
         }
 
     async def search_users(self, query: str, limit: int = 10) -> list[dict]:

--- a/src/klangk/klangk/model/users.py
+++ b/src/klangk/klangk/model/users.py
@@ -489,13 +489,15 @@ class UsersModel(Submodel):
         verified: bool = False,
         provider: str = "local",
         external_id: str | None = None,
+        must_change_password: bool = False,
     ) -> dict:
         async with self.app.state.db.transaction() as db:
             user_id = str(uuid.uuid4())
             handle = await self.generate_handle(db, email)
             await db.execute(
                 "INSERT INTO users (id, email, password_hash, verified,"
-                " provider, external_id, handle) VALUES (?, ?, ?, ?, ?, ?, ?)",
+                " provider, external_id, handle, must_change_password)"
+                " VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
                 (
                     user_id,
                     email,
@@ -504,6 +506,7 @@ class UsersModel(Submodel):
                     provider,
                     external_id,
                     handle,
+                    int(must_change_password),
                 ),
             )
         # #2569: auto-add to the members group if it exists.
@@ -519,6 +522,7 @@ class UsersModel(Submodel):
             # ``ensure_not_disabled`` gate reads (#2588 review) — a
             # fresh user is enabled by definition.
             "disabled": False,
+            "must_change_password": must_change_password,
         }
 
     async def insert_unverified_user(
@@ -1057,6 +1061,57 @@ class UsersModel(Submodel):
         crucially records nothing, so a reset token for a since-deleted
         user cannot trip the history FK (#2611 review).
         """
+        await self._set_password_and_flag(user_id, password_hash, None)
+
+    async def set_must_change_password(self, user_id: str, flag: bool) -> None:
+        """Set or clear the must-change-password flag (#3172).
+
+        Raises ``AgentPrincipalError`` for the system agent, matching
+        the password-setting methods (#3172 review)."""
+        if user_id == AGENT_USER_ID:
+            raise AgentPrincipalError(
+                "Cannot set the must-change flag on the system agent user"
+            )
+        async with self.app.state.db.transaction() as db:
+            await db.execute(
+                "UPDATE users SET must_change_password = ? WHERE id = ?",
+                (int(flag), user_id),
+            )
+
+    async def _write_password_row(
+        self, db, user_id: str, password_hash: str, must_change: bool | None
+    ) -> None:
+        """The users-row UPDATE for a password replacement — with or
+        without a same-transaction flag write (#3172). Always stamps
+        ``password_set_at`` — the password-age policy reads it for both
+        the minimum and maximum lifetime (#3177)."""
+        stamp = datetime.now(timezone.utc).isoformat()
+        if must_change is None:
+            await db.execute(
+                "UPDATE users SET password_hash = ?, password_set_at = ?"
+                " WHERE id = ?",
+                (password_hash, stamp, user_id),
+            )
+        else:
+            await db.execute(
+                "UPDATE users SET password_hash = ?, password_set_at = ?,"
+                " must_change_password = ? WHERE id = ?",
+                (password_hash, stamp, int(must_change), user_id),
+            )
+
+    async def _set_password_and_flag(
+        self, user_id: str, password_hash: str, must_change: bool | None
+    ) -> None:
+        """Replace a password hash in one transaction (#2582, #3172).
+
+        ``must_change`` also writes the forced-change flag inside the
+        same transaction; ``None`` leaves the flag untouched. Raises
+        ``AgentPrincipalError`` if the target is the system agent. A
+        missing user is a silent no-op — callers translate (reset/change
+        404 via their own lookups) — and crucially records nothing, so a
+        reset token for a since-deleted user cannot trip the history FK
+        (#2611 review).
+        """
         if user_id == AGENT_USER_ID:
             raise AgentPrincipalError(
                 "Cannot set a password on the system agent user"
@@ -1069,27 +1124,21 @@ class UsersModel(Submodel):
             row = await cursor.fetchone()
             if row is None:  # deleted user: nothing to update or retire
                 return
-            await db.execute(
-                "UPDATE users SET password_hash = ?, password_set_at = ?"
-                " WHERE id = ?",
-                (
-                    password_hash,
-                    datetime.now(timezone.utc).isoformat(),
-                    user_id,
-                ),
+            await self._write_password_row(
+                db, user_id, password_hash, must_change
             )
             if count > 0 and row["password_hash"] is not None:
                 await self._retire_password(
                     db, user_id, row["password_hash"], count
                 )
 
-    async def set_must_change_password(self, user_id: str, flag: bool) -> None:
-        """Set or clear the must-change-password flag (#3172)."""
-        async with self.app.state.db.transaction() as db:
-            await db.execute(
-                "UPDATE users SET must_change_password = ? WHERE id = ?",
-                (int(flag), user_id),
-            )
+    async def set_password_force_change(
+        self, user_id: str, password_hash: str
+    ) -> None:
+        """Set an admin-chosen password hash and raise the forced-change
+        flag atomically (#3172, STIG V-222547). The old hash retires into
+        password history, same as ``update_password``."""
+        await self._set_password_and_flag(user_id, password_hash, True)
 
     async def clear_must_change_password(
         self, user_id: str, password_hash: str
@@ -1097,27 +1146,7 @@ class UsersModel(Submodel):
         """Update a user's password and atomically clear the forced-change
         flag (#3172). The old hash is retired into password history, same
         as ``update_password``."""
-        if user_id == AGENT_USER_ID:
-            raise AgentPrincipalError(
-                "Cannot set a password on the system agent user"
-            )
-        count = self.app.state.settings.password_history_count
-        async with self.app.state.db.transaction() as db:
-            cursor = await db.execute(
-                "SELECT password_hash FROM users WHERE id = ?", (user_id,)
-            )
-            row = await cursor.fetchone()
-            if row is None:
-                return
-            await db.execute(
-                "UPDATE users SET password_hash = ?,"
-                " must_change_password = 0 WHERE id = ?",
-                (password_hash, user_id),
-            )
-            if count > 0 and row["password_hash"] is not None:
-                await self._retire_password(
-                    db, user_id, row["password_hash"], count
-                )
+        await self._set_password_and_flag(user_id, password_hash, False)
 
     # --- password history (#2582; table from migration 0001) ---
 
@@ -1270,7 +1299,7 @@ class UsersModel(Submodel):
         row = await self.app.state.db.fetchone(
             "SELECT id, email, handle, last_login_at, disabled,"
             " last_activity_at, created_at, password_set_at,"
-            " password_hash, must_change_password"
+            " password_hash, must_change_password, provider"
             " FROM users WHERE id = ?",
             (user_id,),
         )
@@ -1287,6 +1316,7 @@ class UsersModel(Submodel):
             "password_set_at": row["password_set_at"],
             "password_hash": row["password_hash"],
             "must_change_password": bool(row["must_change_password"]),
+            "provider": row["provider"],
         }
 
     async def search_users(self, query: str, limit: int = 10) -> list[dict]:

--- a/src/klangk/klangk/model/users.py
+++ b/src/klangk/klangk/model/users.py
@@ -1136,7 +1136,7 @@ class UsersModel(Submodel):
         self, user_id: str, password_hash: str
     ) -> None:
         """Set an admin-chosen password hash and raise the forced-change
-        flag atomically (#3172, STIG V-222547). The old hash retires into
+        flag atomically (#3172). The old hash retires into
         password history, same as ``update_password``."""
         await self._set_password_and_flag(user_id, password_hash, True)
 

--- a/src/klangk/klangk/wshandler/decider.py
+++ b/src/klangk/klangk/wshandler/decider.py
@@ -250,12 +250,30 @@ async def _decider_authenticate(websocket: WebSocket, app, _hs_mark):
     except JWTError:
         await _refuse(websocket, 4001, "Invalid token")
         return None
-    user = await a._user_from_valid_payload(payload)
+    user = await _decider_user_or_refuse(websocket, a, payload)
+    if user is None:
+        return None
     _hs_mark("token")
+    return user, payload.get("jti")
+
+
+async def _decider_user_or_refuse(websocket: WebSocket, a, payload):
+    """The authenticated user for a decider registration, or None
+    after refusing the handshake.
+
+    Two refusal arms: an unknown user (4001) and a session under the
+    must_change_password flag (4004, #3172) — resolving egress holds
+    is exactly the kind of action a forced-change session must not
+    take, and 4004 matches the main WS gate in ws_authenticate.
+    """
+    user = await a._user_from_valid_payload(payload)
     if user is None:
         await _refuse(websocket, 4001, "Invalid token")
         return None
-    return user, payload.get("jti")
+    if user.get("must_change_password"):
+        await _refuse(websocket, 4004, "Password change required")
+        return None
+    return user
 
 
 _FRAME_DISCONNECTED = object()

--- a/src/klangk/klangk/wshandler/dispatch.py
+++ b/src/klangk/klangk/wshandler/dispatch.py
@@ -88,6 +88,14 @@ async def ws_authenticate(websocket: WebSocket, app):
     if user is None:
         await websocket.close(code=4001, reason="Invalid token")
         return None
+    # A session under the must_change_password flag cannot open a WS
+    # connection (#3172) — the client must change the password first.
+    # 4004, not 4003: the decider socket already uses 4003 for authz
+    # refusals, and duplicate close codes are indistinguishable to
+    # clients (#3172 review).
+    if user.get("must_change_password"):
+        await websocket.close(code=4004, reason="Password change required")
+        return None
     return user, payload.get("jti"), payload.get("exp")
 
 

--- a/src/klangk/klangk/wshandler/dispatch.py
+++ b/src/klangk/klangk/wshandler/dispatch.py
@@ -84,19 +84,30 @@ async def ws_authenticate(websocket: WebSocket, app):
     except JWTError:
         await websocket.close(code=4001, reason="Invalid token")
         return None
+    user = await _user_or_close(websocket, a, payload)
+    if user is None:
+        return None
+    return user, payload.get("jti"), payload.get("exp")
+
+
+async def _user_or_close(websocket: WebSocket, a, payload) -> dict | None:
+    """The authenticated user for a main-WS connect, or None after
+    closing the socket.
+
+    Two refusal arms: an unknown user (4001) and a session under the
+    must_change_password flag (4004, #3172 — the client must change
+    the password first; 4004, not 4003, because the decider socket
+    already uses 4003 for authz refusals, and duplicate close codes
+    are indistinguishable to clients, #3172 review).
+    """
     user = await a._user_from_valid_payload(payload)
     if user is None:
         await websocket.close(code=4001, reason="Invalid token")
         return None
-    # A session under the must_change_password flag cannot open a WS
-    # connection (#3172) — the client must change the password first.
-    # 4004, not 4003: the decider socket already uses 4003 for authz
-    # refusals, and duplicate close codes are indistinguishable to
-    # clients (#3172 review).
     if user.get("must_change_password"):
         await websocket.close(code=4004, reason="Password change required")
         return None
-    return user, payload.get("jti"), payload.get("exp")
+    return user
 
 
 # Exceptions raised by a *handler* that mean the connection itself is

--- a/src/klangk/klangkc-tests/tests/test_cli.py
+++ b/src/klangk/klangkc-tests/tests/test_cli.py
@@ -1063,7 +1063,8 @@ class TestAuth:
 
     def test_login_forced_password_change_success(self, tmp_path, monkeypatch):
         """#3172: must_change_password login forces one change prompt, then
-        completes login with the same token."""
+        re-logins (the change revokes the old session, #3152) and
+        persists the fresh token."""
         state_path = tmp_path / "klangk-state.yaml"
         monkeypatch.setattr("klangk.cli.config.STATE_PATH", state_path)
         login_resp = MagicMock()
@@ -1074,9 +1075,12 @@ class TestAuth:
         }
         change_resp = MagicMock()
         change_resp.status_code = 200
+        relogin_resp = MagicMock()
+        relogin_resp.status_code = 200
+        relogin_resp.json.return_value = {"access_token": "jwt-fresh"}
         with patch(
             "klangk.cli.transport.httpx.request",
-            side_effect=[login_resp, change_resp],
+            side_effect=[login_resp, change_resp, relogin_resp],
         ):
             with patch(
                 "klangk.cli.auth.Prompt.ask",
@@ -1090,7 +1094,7 @@ class TestAuth:
                     password="adminpass1",
                 )
         state = CLIState.load()
-        assert state.get_token("http://localhost:8995") == "jwt-temp"
+        assert state.get_token("http://localhost:8995") == "jwt-fresh"
         assert state.get_email("http://localhost:8995") == "u@test.com"
 
     def test_login_forced_password_change_mismatch_then_success(
@@ -1107,9 +1111,12 @@ class TestAuth:
         }
         change_resp = MagicMock()
         change_resp.status_code = 200
+        relogin_resp = MagicMock()
+        relogin_resp.status_code = 200
+        relogin_resp.json.return_value = {"access_token": "jwt-fresh"}
         with patch(
             "klangk.cli.transport.httpx.request",
-            side_effect=[login_resp, change_resp],
+            side_effect=[login_resp, change_resp, relogin_resp],
         ) as mock_request:
             with patch(
                 "klangk.cli.auth.Prompt.ask",
@@ -1122,10 +1129,50 @@ class TestAuth:
                     email="u@test.com",
                     password="adminpass1",
                 )
-        # Only two HTTP calls: login + the one successful change POST.
-        assert mock_request.call_count == 2
+        # Three HTTP calls: login + the one successful change POST + the
+        # post-change re-login (the mismatch attempt never POSTs).
+        assert mock_request.call_count == 3
         state = CLIState.load()
-        assert state.get_token("http://localhost:8995") == "jwt-temp"
+        assert state.get_token("http://localhost:8995") == "jwt-fresh"
+
+    def test_login_forced_password_change_relogin_fails(
+        self, tmp_path, monkeypatch
+    ):
+        """#3172: when the post-change re-login fails (the change
+        succeeded but the new password is somehow refused), the login
+        aborts through the normal failure path and nothing persists."""
+        state_path = tmp_path / "klangk-state.yaml"
+        monkeypatch.setattr("klangk.cli.config.STATE_PATH", state_path)
+        login_resp = MagicMock()
+        login_resp.status_code = 200
+        login_resp.json.return_value = {
+            "access_token": "jwt-temp",
+            "must_change_password": True,
+        }
+        change_resp = MagicMock()
+        change_resp.status_code = 200
+        relogin_resp = MagicMock()
+        relogin_resp.status_code = 401
+        relogin_resp.json.return_value = {"detail": "Bad credentials"}
+        with patch(
+            "klangk.cli.transport.httpx.request",
+            side_effect=[login_resp, change_resp, relogin_resp],
+        ):
+            with patch(
+                "klangk.cli.auth.Prompt.ask",
+                side_effect=["newpass1", "newpass1"],
+            ):
+                from klangk.cli import auth
+
+                with pytest.raises(SystemExit) as caught:
+                    auth.login(
+                        "http://localhost:8995",
+                        email="u@test.com",
+                        password="adminpass1",
+                    )
+        assert caught.value.code == 1
+        state = CLIState.load()
+        assert state.get_token("http://localhost:8995") is None
 
     def test_login_forced_password_change_exhausted(
         self, tmp_path, monkeypatch

--- a/src/klangk/klangkc-tests/tests/test_cli.py
+++ b/src/klangk/klangkc-tests/tests/test_cli.py
@@ -1061,6 +1061,108 @@ class TestAuth:
                 with pytest.raises(SystemExit):
                     auth.login("http://localhost:8995")
 
+    def test_login_forced_password_change_success(self, tmp_path, monkeypatch):
+        """#3172: must_change_password login forces one change prompt, then
+        completes login with the same token."""
+        state_path = tmp_path / "klangk-state.yaml"
+        monkeypatch.setattr("klangk.cli.config.STATE_PATH", state_path)
+        login_resp = MagicMock()
+        login_resp.status_code = 200
+        login_resp.json.return_value = {
+            "access_token": "jwt-temp",
+            "must_change_password": True,
+        }
+        change_resp = MagicMock()
+        change_resp.status_code = 200
+        with patch(
+            "klangk.cli.transport.httpx.request",
+            side_effect=[login_resp, change_resp],
+        ):
+            with patch(
+                "klangk.cli.auth.Prompt.ask",
+                side_effect=["newpass1", "newpass1"],
+            ):
+                from klangk.cli import auth
+
+                auth.login(
+                    "http://localhost:8995",
+                    email="u@test.com",
+                    password="adminpass1",
+                )
+        state = CLIState.load()
+        assert state.get_token("http://localhost:8995") == "jwt-temp"
+        assert state.get_email("http://localhost:8995") == "u@test.com"
+
+    def test_login_forced_password_change_mismatch_then_success(
+        self, tmp_path, monkeypatch
+    ):
+        """#3172: a mismatched confirm does not POST; the retry succeeds."""
+        state_path = tmp_path / "klangk-state.yaml"
+        monkeypatch.setattr("klangk.cli.config.STATE_PATH", state_path)
+        login_resp = MagicMock()
+        login_resp.status_code = 200
+        login_resp.json.return_value = {
+            "access_token": "jwt-temp",
+            "must_change_password": True,
+        }
+        change_resp = MagicMock()
+        change_resp.status_code = 200
+        with patch(
+            "klangk.cli.transport.httpx.request",
+            side_effect=[login_resp, change_resp],
+        ) as mock_request:
+            with patch(
+                "klangk.cli.auth.Prompt.ask",
+                side_effect=["newpass1", "typo", "newpass1", "newpass1"],
+            ):
+                from klangk.cli import auth
+
+                auth.login(
+                    "http://localhost:8995",
+                    email="u@test.com",
+                    password="adminpass1",
+                )
+        # Only two HTTP calls: login + the one successful change POST.
+        assert mock_request.call_count == 2
+        state = CLIState.load()
+        assert state.get_token("http://localhost:8995") == "jwt-temp"
+
+    def test_login_forced_password_change_exhausted(
+        self, tmp_path, monkeypatch
+    ):
+        """#3172: after _FORCED_CHANGE_MAX_ATTEMPTS failed change POSTs the
+        login aborts with SystemExit and no token is persisted."""
+        state_path = tmp_path / "klangk-state.yaml"
+        monkeypatch.setattr("klangk.cli.config.STATE_PATH", state_path)
+        login_resp = MagicMock()
+        login_resp.status_code = 200
+        login_resp.json.return_value = {
+            "access_token": "jwt-temp",
+            "must_change_password": True,
+        }
+        fail_resp = MagicMock()
+        fail_resp.status_code = 401
+        fail_resp.json.return_value = {"detail": "Current password incorrect"}
+        with patch(
+            "klangk.cli.transport.httpx.request",
+            side_effect=[login_resp] + [fail_resp] * 5,
+        ):
+            with patch(
+                "klangk.cli.auth.Prompt.ask",
+                side_effect=["newpass1", "newpass1"] * 5,
+            ):
+                from klangk.cli import auth
+
+                with pytest.raises(SystemExit) as caught:
+                    auth.login(
+                        "http://localhost:8995",
+                        email="u@test.com",
+                        password="adminpass1",
+                    )
+        assert caught.value.code == 1
+        state = CLIState.load()
+        assert state.get_token("http://localhost:8995") is None
+
     def test_logout_clears_token(self, tmp_path, monkeypatch):
         state_path = tmp_path / "klangk-state.yaml"
         monkeypatch.setattr("klangk.cli.config.STATE_PATH", state_path)

--- a/src/klangk/klangkd-tests/tests/test_api.py
+++ b/src/klangk/klangkd-tests/tests/test_api.py
@@ -1670,6 +1670,36 @@ class TestPasswordAgeRoutes:
         assert resp.status_code == 400
         assert "must be kept" in resp.json()["detail"]
 
+    async def test_change_password_min_age_bypassed_under_flag(
+        self, client, app, db, app_state, monkeypatch
+    ):
+        """#3172: the forced first change after an admin-set password
+        ignores the minimum age — the temporary password must be
+        replaceable immediately, and blocking it would lock the account
+        behind its own flag."""
+        monkeypatch.setattr(app.state.settings, "password_min_age_hours", 24)
+        await self._fresh_user(app_state, "forcedage@example.com")
+        flagged = await app_state.state.model.users.get_user_by_email(
+            "forcedage@example.com"
+        )
+        await app_state.state.model.users.set_must_change_password(
+            flagged["id"], True
+        )
+        headers = await self._login_token(client, "forcedage@example.com")
+        resp = await client.post(
+            "/api/v1/auth/change-password",
+            json={
+                "current_password": "testpass",
+                "new_password": "freshpass1",
+            },
+            headers=headers,
+        )
+        assert resp.status_code == 200
+        user = await app_state.state.model.users.get_user_by_email(
+            "forcedage@example.com"
+        )
+        assert user["must_change_password"] is False
+
     async def test_reset_password_min_age_refused(
         self, client, app, db, app_state, monkeypatch
     ):
@@ -1728,6 +1758,27 @@ class TestPasswordAgeRoutes:
         headers = await self._login_token(client, "midcfg@example.com")
         await self._backdate_password(app_state, user["id"], days=61)
         resp = await client.get("/api/v1/config", headers=headers)
+        assert resp.status_code == 403
+        assert resp.json()["detail"]["error"] == "password_expired"
+
+    async def test_expired_session_refused_on_change_password(
+        self, client, app, db, app_state, monkeypatch
+    ):
+        """#3172: the change-password dependency keeps the expiry gate
+        (#3177) — an expired password is resolved by the
+        /auth/change-expired-password flow, not here."""
+        monkeypatch.setattr(app.state.settings, "password_max_age_days", 60)
+        user = await self._fresh_user(app_state, "midchg@example.com")
+        headers = await self._login_token(client, "midchg@example.com")
+        await self._backdate_password(app_state, user["id"], days=61)
+        resp = await client.post(
+            "/api/v1/auth/change-password",
+            json={
+                "current_password": "testpass",
+                "new_password": "freshpass1",
+            },
+            headers=headers,
+        )
         assert resp.status_code == 403
         assert resp.json()["detail"]["error"] == "password_expired"
 

--- a/src/klangk/klangkd-tests/tests/test_api.py
+++ b/src/klangk/klangkd-tests/tests/test_api.py
@@ -9919,6 +9919,8 @@ class TestAdminEndpoints:
             },
         )
         assert login_resp.status_code == 200
+        # #3172: admin-created user must change password
+        assert login_resp.json()["must_change_password"] is True
 
     async def test_admin_create_user_duplicate(self, client, admin_user, user):
         headers = await self._admin_headers(client)
@@ -10530,6 +10532,204 @@ class TestUserSessionsAudit:
             f"/api/v1/users/{user['id']}/sessions", headers=headers
         )
         assert resp.status_code == 403
+
+
+class TestMustChangePassword:
+    """#3172 — force password change on admin-created/reset passwords."""
+
+    async def _admin_headers(self, client):
+        resp = await client.post(
+            "/api/v1/auth/login",
+            json={
+                "identifier": "testadmin@example.com",
+                "password": "testpass",
+            },
+        )
+        return {"Authorization": f"Bearer {resp.json()['access_token']}"}
+
+    async def test_admin_create_user_sets_flag(
+        self, client, admin_user, app_state
+    ):
+        """Admin-created user with password has must_change_password."""
+        headers = await self._admin_headers(client)
+        resp = await client.post(
+            "/api/v1/users",
+            headers=headers,
+            json={"email": "forced@example.com", "password": "testpass123"},
+        )
+        assert resp.status_code == 200
+        user = await app_state.state.model.users.get_user_by_email(
+            "forced@example.com"
+        )
+        assert user["must_change_password"] is True
+
+    async def test_admin_password_reset_sets_flag(
+        self, client, admin_user, user, app_state
+    ):
+        """Admin password reset sets must_change_password."""
+        headers = await self._admin_headers(client)
+        resp = await client.patch(
+            f"/api/v1/users/{user['id']}",
+            headers=headers,
+            json={"password": "newpass12345"},
+        )
+        assert resp.status_code == 200
+        u = await app_state.state.model.users.get_user_by_id(user["id"])
+        assert u["must_change_password"] is True
+
+    async def test_login_returns_flag(self, client, admin_user, app_state):
+        """Login response includes must_change_password when set."""
+        headers = await self._admin_headers(client)
+        await client.post(
+            "/api/v1/users",
+            headers=headers,
+            json={"email": "flagged@example.com", "password": "testpass123"},
+        )
+        resp = await client.post(
+            "/api/v1/auth/login",
+            json={
+                "identifier": "flagged@example.com",
+                "password": "testpass123",
+            },
+        )
+        assert resp.status_code == 200
+        assert resp.json()["must_change_password"] is True
+
+    async def test_api_gated_under_flag(self, client, admin_user, app_state):
+        """API requests (other than change-password) are rejected under
+        the must_change_password flag."""
+        headers = await self._admin_headers(client)
+        await client.post(
+            "/api/v1/users",
+            headers=headers,
+            json={"email": "gated@example.com", "password": "testpass123"},
+        )
+        login_resp = await client.post(
+            "/api/v1/auth/login",
+            json={
+                "identifier": "gated@example.com",
+                "password": "testpass123",
+            },
+        )
+        token = login_resp.json()["access_token"]
+        flagged_headers = {"Authorization": f"Bearer {token}"}
+        # A normal endpoint should be rejected
+        resp = await client.get(
+            "/api/v1/my-permissions", headers=flagged_headers
+        )
+        assert resp.status_code == 403
+        assert resp.json()["detail"] == "Password change required"
+
+    async def test_change_password_clears_flag(
+        self, client, admin_user, app_state
+    ):
+        """Changing password clears the must_change_password flag."""
+        headers = await self._admin_headers(client)
+        await client.post(
+            "/api/v1/users",
+            headers=headers,
+            json={"email": "clearflag@example.com", "password": "testpass123"},
+        )
+        login_resp = await client.post(
+            "/api/v1/auth/login",
+            json={
+                "identifier": "clearflag@example.com",
+                "password": "testpass123",
+            },
+        )
+        token = login_resp.json()["access_token"]
+        flagged_headers = {"Authorization": f"Bearer {token}"}
+        # Change password should work even under the flag
+        resp = await client.post(
+            "/api/v1/auth/change-password",
+            headers=flagged_headers,
+            json={
+                "current_password": "testpass123",
+                "new_password": "brandnewpass1",
+            },
+        )
+        assert resp.status_code == 200
+        # Verify flag is cleared
+        user = await app_state.state.model.users.get_user_by_email(
+            "clearflag@example.com"
+        )
+        assert user["must_change_password"] is False
+        # Now API should work
+        login2 = await client.post(
+            "/api/v1/auth/login",
+            json={
+                "identifier": "clearflag@example.com",
+                "password": "brandnewpass1",
+            },
+        )
+        assert login2.json()["must_change_password"] is False
+
+    async def test_admin_can_clear_flag(self, client, admin_user, app_state):
+        """Admin can explicitly clear the flag via PATCH."""
+        headers = await self._admin_headers(client)
+        resp = await client.post(
+            "/api/v1/users",
+            headers=headers,
+            json={
+                "email": "adminclear@example.com",
+                "password": "testpass123",
+            },
+        )
+        user_id = resp.json()["id"]
+        resp = await client.patch(
+            f"/api/v1/users/{user_id}",
+            headers=headers,
+            json={"must_change_password": False},
+        )
+        assert resp.status_code == 200
+        user = await app_state.state.model.users.get_user_by_id(user_id)
+        assert user["must_change_password"] is False
+
+    async def test_reset_password_clears_flag(
+        self, client, app, admin_user, app_state
+    ):
+        """Self-service password reset clears the flag."""
+        headers = await self._admin_headers(client)
+        await client.post(
+            "/api/v1/users",
+            headers=headers,
+            json={
+                "email": "resetclear@example.com",
+                "password": "testpass123",
+            },
+        )
+        user = await app_state.state.model.users.get_user_by_email(
+            "resetclear@example.com"
+        )
+        assert user["must_change_password"] is True
+        # Generate a reset token and use it
+        reset_token = app.state.auth.create_password_reset_token(user["id"])
+        resp = await client.post(
+            "/api/v1/auth/reset-password",
+            json={"token": reset_token, "password": "selfchosen999"},
+        )
+        assert resp.status_code == 200
+        user = await app_state.state.model.users.get_user_by_email(
+            "resetclear@example.com"
+        )
+        assert user["must_change_password"] is False
+
+    async def test_list_users_includes_flag(
+        self, client, admin_user, app_state
+    ):
+        """The admin user list includes the must_change_password field."""
+        headers = await self._admin_headers(client)
+        await client.post(
+            "/api/v1/users",
+            headers=headers,
+            json={"email": "listed@example.com", "password": "testpass123"},
+        )
+        resp = await client.get("/api/v1/users", headers=headers)
+        assert resp.status_code == 200
+        users = resp.json()["users"]
+        listed = [u for u in users if u["email"] == "listed@example.com"]
+        assert len(listed) == 1
+        assert listed[0]["must_change_password"] is True
 
 
 class TestGroupEndpoints:

--- a/src/klangk/klangkd-tests/tests/test_api.py
+++ b/src/klangk/klangkd-tests/tests/test_api.py
@@ -2366,10 +2366,21 @@ class TestChangePassword:
         headers = await _auth_headers(client)
         # One inserted character — the positional-diff workaround that a
         # naive per-position diff would score as a full overwrite.
+
+    async def test_change_password_garbage_token(self, client, db):
+        """#3172: change-password uses its own dependency (flagged sessions
+        allowed), so its invalid-token arm needs its own test."""
         resp = await client.post(
             "/api/v1/auth/change-password",
             json={
                 "current_password": "testpass",
+                "new_password": "newpass1",
+            },
+            headers={"Authorization": "Bearer garbage"},
+        )
+        assert resp.status_code == 401
+        assert resp.json()["detail"] == "Invalid token"
+
                 "new_password": "xtestpass",
             },
             headers=headers,

--- a/src/klangk/klangkd-tests/tests/test_api.py
+++ b/src/klangk/klangkd-tests/tests/test_api.py
@@ -2366,6 +2366,16 @@ class TestChangePassword:
         headers = await _auth_headers(client)
         # One inserted character — the positional-diff workaround that a
         # naive per-position diff would score as a full overwrite.
+        resp = await client.post(
+            "/api/v1/auth/change-password",
+            json={
+                "current_password": "testpass",
+                "new_password": "xtestpass",
+            },
+            headers=headers,
+        )
+        assert resp.status_code == 400
+        assert "change at least 8 characters" in resp.json()["detail"]
 
     async def test_change_password_garbage_token(self, client, db):
         """#3172: change-password uses its own dependency (flagged sessions
@@ -2380,13 +2390,6 @@ class TestChangePassword:
         )
         assert resp.status_code == 401
         assert resp.json()["detail"] == "Invalid token"
-
-                "new_password": "xtestpass",
-            },
-            headers=headers,
-        )
-        assert resp.status_code == 400
-        assert "change at least 8 characters" in resp.json()["detail"]
 
     async def test_change_password_wrong_current_beats_too_similar(
         self, client, user, app, monkeypatch
@@ -10741,6 +10744,199 @@ class TestMustChangePassword:
         listed = [u for u in users if u["email"] == "listed@example.com"]
         assert len(listed) == 1
         assert listed[0]["must_change_password"] is True
+
+    async def test_refresh_returns_flag_primary_and_cached(
+        self, client, admin_user, app_state
+    ):
+        """#3172: refresh carries the flag on the primary path AND on the
+        idempotent cached retry — the cached response reads the live
+        flag, not the mint-time one."""
+        headers = await self._admin_headers(client)
+        await client.post(
+            "/api/v1/users",
+            headers=headers,
+            json={"email": "rf@example.com", "password": "testpass123"},
+        )
+        login = await client.post(
+            "/api/v1/auth/login",
+            json={"identifier": "rf@example.com", "password": "testpass123"},
+        )
+        token = login.json()["access_token"]
+        # Primary path: valid (not yet refreshed) token.
+        resp = await client.post(
+            "/api/v1/auth/refresh",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["must_change_password"] is True
+        # Cached path: retrying with the now-blocklisted old token
+        # replays the cached replacement — which must still report the
+        # LIVE flag.
+        resp2 = await client.post(
+            "/api/v1/auth/refresh",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert resp2.status_code == 200
+        assert resp2.json()["access_token"] == resp.json()["access_token"]
+        assert resp2.json()["must_change_password"] is True
+        # Admin clears the flag; the SAME cached retry now reports false.
+        user = await app_state.state.model.users.get_user_by_email(
+            "rf@example.com"
+        )
+        await client.patch(
+            f"/api/v1/users/{user['id']}",
+            headers=headers,
+            json={"must_change_password": False},
+        )
+        resp3 = await client.post(
+            "/api/v1/auth/refresh",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert resp3.status_code == 200
+        assert resp3.json()["must_change_password"] is False
+
+    async def test_cached_refresh_for_deleted_user_reports_unflagged(
+        self, client, admin_user, app_state
+    ):
+        """#3172: the cached refresh retry for a since-deleted user
+        still replays the cached token, with the flag defaulting false
+        (there is no user row left to read)."""
+        headers = await self._admin_headers(client)
+        await client.post(
+            "/api/v1/users",
+            headers=headers,
+            json={"email": "gone@example.com", "password": "testpass123"},
+        )
+        login = await client.post(
+            "/api/v1/auth/login",
+            json={
+                "identifier": "gone@example.com",
+                "password": "testpass123",
+            },
+        )
+        token = login.json()["access_token"]
+        user = await app_state.state.model.users.get_user_by_email(
+            "gone@example.com"
+        )
+        # First refresh caches the replacement under the old jti.
+        await client.post(
+            "/api/v1/auth/refresh",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        await client.delete(f"/api/v1/users/{user['id']}", headers=headers)
+        resp = await client.post(
+            "/api/v1/auth/refresh",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["must_change_password"] is False
+
+    async def test_flag_patch_rejected_for_oidc_user(
+        self, client, admin_user, app_state
+    ):
+        """#3172: flagging an OIDC account is a permanent lockout (it has
+        no local password to change) — the admin PATCH refuses."""
+        headers = await self._admin_headers(client)
+        user = await app_state.state.model.users.create_user(
+            "oidcflag@example.com", None, verified=True, provider="oidc"
+        )
+        resp = await client.patch(
+            f"/api/v1/users/{user['id']}",
+            headers=headers,
+            json={"must_change_password": True},
+        )
+        assert resp.status_code == 400
+        assert "local-password" in resp.json()["detail"]
+        fresh = await app_state.state.model.users.get_user_by_id(user["id"])
+        assert fresh["must_change_password"] is False
+
+    async def test_flag_patch_rearm(self, client, admin_user, app_state):
+        """#3172: must_change_password: true alone re-arms the flag."""
+        headers = await self._admin_headers(client)
+        resp = await client.post(
+            "/api/v1/users",
+            headers=headers,
+            json={"email": "rearm@example.com", "password": "testpass123"},
+        )
+        user_id = resp.json()["id"]
+        await client.patch(
+            f"/api/v1/users/{user_id}",
+            headers=headers,
+            json={"must_change_password": False},
+        )
+        resp = await client.patch(
+            f"/api/v1/users/{user_id}",
+            headers=headers,
+            json={"must_change_password": True},
+        )
+        assert resp.status_code == 200
+        user = await app_state.state.model.users.get_user_by_id(user_id)
+        assert user["must_change_password"] is True
+
+    async def test_password_patch_with_flag_false_not_flagged(
+        self, client, admin_user, app_state
+    ):
+        """#3172: password + must_change_password: false in one PATCH —
+        the explicit field wins over the password's implicit flag."""
+        headers = await self._admin_headers(client)
+        await client.post(
+            "/api/v1/users",
+            headers=headers,
+            json={
+                "email": "combined@example.com",
+                "password": "testpass123",
+            },
+        )
+        user = await app_state.state.model.users.get_user_by_email(
+            "combined@example.com"
+        )
+        resp = await client.patch(
+            f"/api/v1/users/{user['id']}",
+            headers=headers,
+            json={"password": "newpass12345", "must_change_password": False},
+        )
+        assert resp.status_code == 200
+        fresh = await app_state.state.model.users.get_user_by_id(user["id"])
+        assert fresh["must_change_password"] is False
+
+    async def test_gate_sweep_across_routers(
+        self, client, admin_user, app_state
+    ):
+        """#3172: the gate rejects a flagged session on representative
+        endpoints across routers, not just /my-permissions."""
+        headers = await self._admin_headers(client)
+        await client.post(
+            "/api/v1/users",
+            headers=headers,
+            json={"email": "sweep@example.com", "password": "testpass123"},
+        )
+        login = await client.post(
+            "/api/v1/auth/login",
+            json={
+                "identifier": "sweep@example.com",
+                "password": "testpass123",
+            },
+        )
+        flagged = {"Authorization": f"Bearer {login.json()['access_token']}"}
+        cases = [
+            ("GET", "/api/v1/workspaces"),
+            ("GET", "/api/v1/my-permissions"),
+            ("GET", "/api/v1/config"),
+            ("POST", "/api/v1/workspaces"),
+        ]
+        for method, path in cases:
+            call = getattr(client, method.lower())
+            resp = await call(path, headers=flagged)
+            assert resp.status_code == 403, (method, path)
+            assert resp.json()["detail"] == "Password change required", (
+                method,
+                path,
+            )
+        # Refresh stays open (the client needs a live token to change
+        # the password) and reports the flag.
+        resp = await client.post("/api/v1/auth/refresh", headers=flagged)
+        assert resp.status_code == 200
+        assert resp.json()["must_change_password"] is True
 
 
 class TestGroupEndpoints:

--- a/src/klangk/klangkd-tests/tests/test_consent_deciders.py
+++ b/src/klangk/klangkd-tests/tests/test_consent_deciders.py
@@ -333,6 +333,21 @@ class TestConsentDeciderWS:
         await handle_consent_decider(ws, app)
         assert ws.closed == (4001, "Invalid token")
 
+    async def test_must_change_password_is_rejected(self):
+        # #3172: a forced-change session must not act as a live decider
+        # — resolving egress holds is exactly the action the gate
+        # exists to block. 4004 matches the main WS gate.
+        from klangk.wshandler.decider import handle_consent_decider
+
+        app = _ws_app(
+            {"id": "u1", "email": "a@x", "must_change_password": True}
+        )
+        ws = _FakeWS({"token": "tok", "workspace": WS}, [])
+        await handle_consent_decider(ws, app)
+        assert ws.closed == (4004, "Password change required")
+        assert ws.accepted is False
+        assert app.state.consent_deciders.has_decider(WS) is False
+
     async def test_expired_token_is_rejected(self):
         from klangk import auth
         from klangk.wshandler.decider import handle_consent_decider

--- a/src/klangk/klangkd-tests/tests/test_migrations.py
+++ b/src/klangk/klangkd-tests/tests/test_migrations.py
@@ -92,6 +92,7 @@ class TestRunner:
             (29, "0029_members_create_workspace"),
             (30, "0030_audit_hmac"),
             (31, "0031_password_age"),
+            (32, "0032_must_change_password"),
         ]
         async with aiosqlite.connect(str(app_state.state.db.db_path)) as db:
             assert await _recorded(db) == expected
@@ -193,6 +194,7 @@ class TestRunner:
                 (29, "0029_members_create_workspace"),
                 (30, "0030_audit_hmac"),
                 (31, "0031_password_age"),
+                (32, "0032_must_change_password"),
             ]
 
     async def test_m0008_agent_identity_and_human_collision(

--- a/src/klangk/klangkd-tests/tests/test_model_users.py
+++ b/src/klangk/klangkd-tests/tests/test_model_users.py
@@ -641,3 +641,17 @@ class TestUsersBranchGaps2834:
             user["email"]
         )
         assert refreshed["handle"] == handle_before
+
+
+class TestClearMustChangePassword:
+    """#3172: clear_must_change_password branch coverage."""
+
+    async def test_agent_user_rejected(self, users):
+        with pytest.raises(AgentPrincipalError):
+            await users.clear_must_change_password(AGENT_USER_ID, "hash")
+
+    async def test_deleted_user_is_noop(self, users, user):
+        await users.delete_user(user["id"])
+        # Must not raise — a deleted user is a silent no-op, same as
+        # update_password.
+        await users.clear_must_change_password(user["id"], "hash")

--- a/src/klangk/klangkd-tests/tests/test_model_users.py
+++ b/src/klangk/klangkd-tests/tests/test_model_users.py
@@ -262,6 +262,10 @@ async def test_agent_principal_guards(users):
         await users.update_email(AGENT_USER_ID, "x@x.com")
     with pytest.raises(AgentPrincipalError):
         await users.update_password(AGENT_USER_ID, "h")
+    with pytest.raises(AgentPrincipalError):
+        await users.set_password_force_change(AGENT_USER_ID, "h")
+    with pytest.raises(AgentPrincipalError):
+        await users.set_must_change_password(AGENT_USER_ID, True)
 
 
 async def test_agent_user_cache(users, agent_user):
@@ -655,3 +659,39 @@ class TestClearMustChangePassword:
         # Must not raise — a deleted user is a silent no-op, same as
         # update_password.
         await users.clear_must_change_password(user["id"], "hash")
+
+
+class TestSetPasswordForceChange:
+    """#3172: set_password_force_change — hash + flag in one write."""
+
+    async def test_sets_hash_and_flag(self, users, user):
+        await users.set_password_force_change(user["id"], "newhash")
+        row = await users.get_user_by_id(user["id"])
+        # get_user_by_id does not expose the hash; the flag and a
+        # working login-path lookup cover the write.
+        assert row["must_change_password"] is True
+        by_email = await users.get_user_by_email(user["email"])
+        assert by_email["password_hash"] == "newhash"
+        assert by_email["must_change_password"] is True
+
+    async def test_deleted_user_is_noop(self, users, user):
+        await users.delete_user(user["id"])
+        await users.set_password_force_change(user["id"], "newhash")
+
+
+class TestCreateUserMustChangeFlag:
+    """#3172: create_user lands the flag in the INSERT itself."""
+
+    async def test_flag_in_insert(self, users):
+        u = await users.create_user(
+            "flagged@x.com", "hash", verified=True, must_change_password=True
+        )
+        assert u["must_change_password"] is True
+        row = await users.get_user_by_email("flagged@x.com")
+        assert row["must_change_password"] is True
+
+    async def test_default_is_false(self, users):
+        u = await users.create_user("plain@x.com", "hash")
+        assert u["must_change_password"] is False
+        row = await users.get_user_by_email("plain@x.com")
+        assert row["must_change_password"] is False

--- a/src/klangk/klangkd-tests/tests/test_wshandler.py
+++ b/src/klangk/klangkd-tests/tests/test_wshandler.py
@@ -3067,6 +3067,19 @@ class TestHandleWebsocket:
             code=4001, reason="Invalid token"
         )
 
+    async def test_must_change_password_rejected(self, user, app_state):
+        """#3172: a session under must_change_password gets 4004."""
+        app_state = _make_app_state()
+        await app_state.state.model.users.set_must_change_password(
+            user["id"], True
+        )
+        token = _auth().create_token(user["id"], user["email"])
+        websocket = _mock_raw_sock(query_params={"token": token})
+        await handle_websocket(websocket, app_state)
+        websocket.close.assert_awaited_once_with(
+            code=4004, reason="Password change required"
+        )
+
     async def test_valid_token_then_disconnect(self, user, app_state):
         app_state = _make_app_state()
 


### PR DESCRIPTION
## Summary

- Adds a `must_change_password` column to the users table (migration 0030) that is set when an admin creates a user with a password or resets an existing user's password
- Gates all API endpoints and WebSocket connections on the flag — a session under the flag gets 403 "Password change required" on everything except the change-password endpoint
- Clears the flag atomically when the user changes their own password; also cleared by self-service forgot-password reset and explicit admin toggle
- Login response carries the flag so clients can drive the forced-change flow; OIDC and none-mode logins are exempt (no local password to rotate)
- Frontend adds a full-screen ForcedChangePasswordPage with a router guard that blocks all navigation until the password is changed, plus an admin UI toggle and indicator icon in the user list
- CLI detects the flag on login and enters a forced-change prompt loop, reusing the login password as the current password

Closes #3172 (DISA ASD STIG V-222547, CAT II)

## Test plan

- [x] Backend: 6986 tests pass (9 new tests in `TestMustChangePassword` covering flag-set on create/reset, login response, API gating, change-password clears, admin toggle, reset-password clears, list-users inclusion)
- [x] Frontend: 1217 tests pass (6 new guard tests for `guardForcedPasswordChange` + 2 `evaluateGuards` precedence tests)
- [x] Migration test updated for m0030
- [ ] E2E: CI