### PR TITLE
Fail to a secure state on shutdown/abort failure (#3176)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -360,6 +360,13 @@ operators or integrators to act when upgrading.
   consumers such as off-host audit backups. Rotating the key
   invalidates tags written under the old key.
 
+- **Fail to a secure state on shutdown/abort failure (#3176).** The
+  lifespan teardown is now hardened so a failure in one step never skips
+  the rest (proxy child, containers, DB dispose all run). A drain
+  failure during SIGTERM/SIGINT triggers a forced backstop before exit,
+  and a failed SIGHUP recovery sends SIGTERM for a clean teardown
+  instead of calling `os._exit(1)`.
+
 - **Bounded rate-limit state for the email cooldowns (#3113).** The
   per-address cooldown dicts behind
   `POST /api/v1/auth/forgot-password` and

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -361,11 +361,12 @@ operators or integrators to act when upgrading.
   invalidates tags written under the old key.
 
 - **Fail to a secure state on shutdown/abort failure (#3176).** The
-  lifespan teardown is now hardened so a failure in one step never skips
+  shutdown teardown is hardened so a failure in one step never skips
   the rest (proxy child, containers, DB dispose all run). A drain
-  failure during SIGTERM/SIGINT triggers a forced backstop before exit,
-  and a failed SIGHUP recovery sends SIGTERM for a clean teardown
-  instead of calling `os._exit(1)`.
+  that fails or under-stops during SIGTERM/SIGINT now triggers a
+  verified forced backstop (CRITICAL names any leftover containers),
+  and a failed SIGHUP recovery exits with status 1 after the graceful
+  teardown so `Restart=on-failure` supervisors restart the node.
 
 - **Bounded rate-limit state for the email cooldowns (#3113).** The
   per-address cooldown dicts behind

--- a/docs/deployment/signals.md
+++ b/docs/deployment/signals.md
@@ -44,13 +44,15 @@ Workspaces go away; on the next start, `auto_start` brings back any
 that are configured for it. For a config reload with the same drain
 treatment while keeping the listener up, use SIGHUP (below).
 
-A drain failure is logged and never blocks the exit — the process always
-terminates. Budget the quiesce + drain inside your service manager's
-stop deadline (`TimeoutStopSec` under systemd): up to
-`KLANGKD_QUIESCE_TIMEOUT` seconds (default 15) of request quiesce, plus
-one per-workspace stop grace (5s; stops run concurrently across
-workspaces). Raising `KLANGKD_QUIESCE_TIMEOUT` past ~85s blows the
-default 90s `TimeoutStopSec`.
+If the graceful drain fails, a forced backstop runs (`podman stop` +
+`rm -f` per container). If the backstop also fails, a `CRITICAL` log
+warns that unsupervised containers may remain — the process still
+terminates so the service manager can restart it. Budget the quiesce +
+drain inside your service manager's stop deadline (`TimeoutStopSec`
+under systemd): up to `KLANGKD_QUIESCE_TIMEOUT` seconds (default 15)
+of request quiesce, plus one per-workspace stop grace (5s; stops run
+concurrently across workspaces). Raising `KLANGKD_QUIESCE_TIMEOUT`
+past ~85s blows the default 90s `TimeoutStopSec`.
 
 ## SIGHUP — graceful runtime recycle
 
@@ -114,9 +116,10 @@ authenticated WebSocket clients receive a `server_recycle` event with a
 
 If any step fails, the failure is logged, a recovery pass re-runs the
 startup sequence, and `host_started` is broadcast on recovery; if the
-recovery itself fails the process exits (code 1) so the service manager
-restarts it — the node never lingers half-restarted while its HTTP
-listener keeps serving.
+recovery itself fails the process sends itself SIGTERM, triggering the
+graceful-stop teardown (proxy child stop, container cleanup, DB dispose)
+before the service manager restarts it — the node never lingers
+half-restarted while its HTTP listener keeps serving.
 
 ### When to use it
 
@@ -209,3 +212,18 @@ RestartPreventExitStatus=78
 A bad password then stops the unit in a single failed attempt instead of
 burning CPU in a restart loop; `journalctl -u <unit>` shows the
 `ConfigurationError` naming the setting to fix.
+
+## Accepted residual risks (V-222585)
+
+Two startup checks intentionally log a warning and continue rather than
+aborting boot:
+
+- **FIPS process self-check** (`KLANGKD_FIPS_MODE=1`): if the klangkd
+  host's OpenSSL is not FIPS-enforcing, boot continues with a warning.
+  This is legitimate for control-host deployments where the klangkd
+  process itself runs on a non-FIPS host while workspace containers
+  (the fail-closed gate) enforce FIPS.
+- **Podman pre-warm**: if the throwaway `podman create`/`rm` fails
+  (storage locked, stale container name), boot continues with a
+  warning. The failure means the first real workspace start pays the
+  cold-start latency; it does not affect security posture.

--- a/docs/deployment/signals.md
+++ b/docs/deployment/signals.md
@@ -44,15 +44,23 @@ Workspaces go away; on the next start, `auto_start` brings back any
 that are configured for it. For a config reload with the same drain
 treatment while keeping the listener up, use SIGHUP (below).
 
-If the graceful drain fails, a forced backstop runs (`podman stop` +
-`rm -f` per container). If the backstop also fails, a `CRITICAL` log
-warns that unsupervised containers may remain — the process still
-terminates so the service manager can restart it. Budget the quiesce +
-drain inside your service manager's stop deadline (`TimeoutStopSec`
-under systemd): up to `KLANGKD_QUIESCE_TIMEOUT` seconds (default 15)
-of request quiesce, plus one per-workspace stop grace (5s; stops run
-concurrently across workspaces). Raising `KLANGKD_QUIESCE_TIMEOUT`
-past ~85s blows the default 90s `TimeoutStopSec`.
+If the graceful drain fails outright _or_ under-stops (returns fewer
+stopped containers than were running — per-container stop failures
+are logged, not raised), a forced backstop runs (`podman stop` +
+`rm -f` per container, plus a sweep of any instance-labelled
+stragglers). The backstop's outcome is then verified against a fresh
+container listing: if containers of this instance are still listed —
+or the listing itself fails — a `CRITICAL` log names the leftovers
+(operators should expect unsupervised containers until the next
+boot's reaps); the process still terminates so the service manager
+can restart it. Budget the quiesce + drain inside your service
+manager's stop deadline (`TimeoutStopSec` under systemd): up to
+`KLANGKD_QUIESCE_TIMEOUT` seconds (default 15) of request quiesce,
+plus one per-workspace stop grace (5s; stops run concurrently across
+workspaces) — and when the backstop runs, a second full stop round
+(each podman command bounded by its ~30s timeout). Raising
+`KLANGKD_QUIESCE_TIMEOUT` toward ~85s or more blows the default 90s
+`TimeoutStopSec`, which would SIGKILL the process mid-teardown.
 
 ## SIGHUP — graceful runtime recycle
 
@@ -117,9 +125,12 @@ authenticated WebSocket clients receive a `server_recycle` event with a
 If any step fails, the failure is logged, a recovery pass re-runs the
 startup sequence, and `host_started` is broadcast on recovery; if the
 recovery itself fails the process sends itself SIGTERM, triggering the
-graceful-stop teardown (proxy child stop, container cleanup, DB dispose)
-before the service manager restarts it — the node never lingers
-half-restarted while its HTTP listener keeps serving.
+graceful-stop teardown (proxy child stop, container cleanup, DB
+dispose) and then exits with **status 1** — a failure exit, so a
+`Restart=on-failure` service manager restarts the node — rather than
+dying with SIGTERM's status (143), which supervisors treat as a clean
+stop. The node never lingers half-restarted while its HTTP listener
+keeps serving.
 
 ### When to use it
 
@@ -192,11 +203,11 @@ or drop-in).
 particular, whether restarting can help:
 
 | Status | Meaning                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
-| ------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `0`    | Clean shutdown (SIGINT/SIGTERM).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
+| ------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | --- |
+| `0`    | Clean shutdown. A SIGINT/SIGTERM-driven graceful exit ends with the signal's status (130/143), which supervisors treat as clean.                                                                                                                                                                                                                                                                                                                                                                                                     |     |
 | `78`   | **Configuration error** (`EX_CONFIG`, sysexits.h). Startup was refused over bad configuration — e.g. a `KLANGKD_DEFAULT_PASSWORD` that violates the password policy, `auth_modes: password` without a staged password, an insecure JWT secret with prevention on, `auth_modes: none` on a non-loopback bind, a missing OIDC login hook, or a containerized FIPS backend whose OpenSSL is not FIPS-enforcing. **Restarting cannot fix this** — fix the config/image first. The refusal reason is logged at `ERROR` right before exit. |
 | `3`    | uvicorn startup failure that is _not_ a config refusal (e.g. an unusable database). Retrying makes sense once the underlying fault is repaired.                                                                                                                                                                                                                                                                                                                                                                                      |
-| `1`    | Launcher pre-flight refusals (another instance already running, a browser/egress port already owned) or a UDS bind failure.                                                                                                                                                                                                                                                                                                                                                                                                          |
+| `1`    | Launcher pre-flight refusals (another instance already running, a browser/egress port already owned), a UDS bind failure, or a failed SIGHUP restart recovery (after the graceful teardown ran — restarting makes sense).                                                                                                                                                                                                                                                                                                            |     |
 
 ### Telling systemd not to restart-loop a config error
 

--- a/src/klangk/klangk/container/registry.py
+++ b/src/klangk/klangk/container/registry.py
@@ -2442,6 +2442,26 @@ class ContainerRegistry(NetworkSidecarMixin):
         stopped += await self._sweep_drain_leftovers()
         return stopped
 
+    def tracked_container_count(self) -> int:
+        """Running containers a drain is expected to stop (V-222585,
+        #3176): the drain's own snapshot baseline, counted up front so
+        the caller can detect an under-stopping drain by outcome —
+        per-container stop failures never raise out of
+        ``drain_all_containers``."""
+        return sum(1 for state in self.states.values() if state.container_id)
+
+    async def leftover_containers(self) -> list[str]:
+        """Idents of this instance's containers still listed as
+        running (V-222585, #3176) — ground truth for verifying a
+        forced-backstop stop actually left nothing behind (the stop
+        path swallows per-container failures). Raises on a listing
+        failure so the caller can treat "cannot verify" as insecure.
+        """
+        containers = await self.app.state.podman.list_containers(
+            f"klangk.instance={self.app.state.util.instance_id()}"
+        )
+        return [ident for ident in map(container_ident, containers) if ident]
+
     async def _drain_one(self, ws_id: str, cid: str, reason: str) -> bool:
         """Notify + stop one workspace for a drain, with the same
         "stopped on purpose" broadcast as the /stop endpoint (clients

--- a/src/klangk/klangk/lifecycle.py
+++ b/src/klangk/klangk/lifecycle.py
@@ -184,6 +184,11 @@ class Lifecycle:
         # strong references to the hook task while it drains.
         self.shutting_down: bool = False
         self._shutdown_tasks: set[asyncio.Task] = set()
+        # V-222585 (#3176): non-zero exit the GracefulExitServer must
+        # translate after the teardown completes (set on the failed
+        # SIGHUP-recovery path; death-by-SIGTERM alone reads as a
+        # "clean" exit to a Restart=on-failure supervisor).
+        self.forced_exit_status: int | None = None
 
     def reconfigure(self, app) -> None:
         self.app = app
@@ -975,6 +980,26 @@ class Lifecycle:
             )
         try:
             logger.info("%s: phase: drain (stopping workspaces)", name)
+            await self._drain_workspaces(name)
+        except Exception as exc:  # noqa: BLE001 — never block the exit
+            logger.warning(
+                "%s: drain phase failed (proceeding with exit): %s", name, exc
+            )
+        logger.info("%s: handing off to server exit", name)
+
+    async def _drain_workspaces(self, name: str) -> None:
+        """Drain phase with V-222585 escalation (#3176).
+
+        A drain that raised *or* verifiably under-stopped (stopped
+        fewer than the tracked containers) triggers the forced
+        backstop — per-container stop failures are swallowed by
+        ``drain_all_containers``, so the count is the only honest
+        failure signal — and the backstop's outcome is verified
+        against a fresh container listing.
+        """
+        registry = self.app.state.container_registry
+        expected = registry.tracked_container_count()
+        try:
             stopped = await registry.drain_all_containers(
                 reason="host shutdown"
             )
@@ -985,20 +1010,72 @@ class Lifecycle:
                 name,
                 exc,
             )
-            # V-222585: a graceful drain failure must not leave
-            # unsupervised containers — escalate to the forced
-            # shutdown path (podman stop + rm -f per container).
-            try:
-                await registry.shutdown()
-                logger.warning("%s: forced backstop completed", name)
-            except Exception:  # noqa: BLE001
-                logger.critical(
-                    "%s: forced backstop also failed; unsupervised "
-                    "containers may remain",
-                    name,
-                    exc_info=True,
-                )
-        logger.info("%s: handing off to server exit", name)
+            await self._forced_backstop(name)
+            return
+        if stopped < expected:
+            logger.warning(
+                "%s: drain stopped %d of %d tracked container(s); "
+                "attempting forced backstop",
+                name,
+                stopped,
+                expected,
+            )
+            await self._forced_backstop(name)
+
+    async def _forced_backstop(self, name: str) -> None:
+        """Forced shutdown backstop, verified (V-222585 / #3176).
+
+        Re-run the registry stop path, then verify against the live
+        container listing that nothing of this instance survives —
+        ``shutdown()`` swallows per-container failures too, so the
+        listing is the only trustworthy completion signal. Any path
+        that cannot prove no unsupervised containers remain logs
+        CRITICAL.
+        """
+        registry = self.app.state.container_registry
+        try:
+            await registry.shutdown()
+        except Exception:  # noqa: BLE001 — CRITICAL is the floor
+            logger.critical(
+                "%s: forced backstop failed; unsupervised containers "
+                "may remain",
+                name,
+                exc_info=True,
+            )
+            return
+        leftovers = await self._listed_leftovers(name)
+        if leftovers is None:
+            return  # already logged CRITICAL (could not verify)
+        if leftovers:
+            logger.critical(
+                "%s: %d container(s) still running after the forced "
+                "backstop (%s); unsupervised containers remain",
+                name,
+                len(leftovers),
+                ", ".join(leftovers),
+            )
+        else:
+            logger.warning(
+                "%s: forced backstop completed; verified no containers remain",
+                name,
+            )
+
+    async def _listed_leftovers(self, name: str) -> list[str] | None:
+        """This instance's still-listed containers, or ``None`` when
+        the listing itself failed (logged CRITICAL — the secure state
+        cannot be confirmed)."""
+        try:
+            return await (
+                self.app.state.container_registry.leftover_containers()
+            )
+        except Exception as exc:  # noqa: BLE001 — CRITICAL is the floor
+            logger.critical(
+                "%s: could not verify containers are stopped (%s); "
+                "unsupervised containers may remain",
+                name,
+                exc,
+            )
+            return None
 
     def on_sighup(self) -> None:
         """SIGHUP: schedule a graceful runtime restart.
@@ -1070,10 +1147,12 @@ class Lifecycle:
         Re-run ``startup()`` (idempotent by design). On success the node
         is serving and starting containers again. On failure, a live
         process that can neither restart its runtime nor serve workloads
-        would masquerade as healthy — exit(1) and let systemd/docker
-        restart us instead. Skipped entirely when a shutdown owns the
-        process (#2527 review): resurrecting the runtime during teardown
-        is exactly what the shutdown is undoing.
+        would masquerade as healthy — route the exit through the
+        graceful-stop hook and exit non-zero (1) after the teardown so a
+        Restart=on-failure supervisor restarts us instead. Skipped
+        entirely when a shutdown owns the process (#2527 review):
+        resurrecting the runtime during teardown is exactly what the
+        shutdown is undoing.
         """
         if self.shutting_down:
             logger.info("SIGHUP: restart recovery skipped; shutting down")
@@ -1093,7 +1172,11 @@ class Lifecycle:
             # teardown and orphans the proxy child), send ourselves
             # SIGTERM — the GracefulExitServer hook runs the hardened
             # teardown (proxy stop, container cleanup, DB dispose)
-            # before the process exits.
+            # before the process exits — and mark the exit so the
+            # server raises SystemExit(1) after the teardown instead of
+            # dying by the re-raised SIGTERM (143), which a
+            # Restart=on-failure supervisor treats as a clean exit.
+            self.forced_exit_status = 1
             os.kill(os.getpid(), signal.SIGTERM)
             return  # SIGTERM handler takes over
         logger.error(

--- a/src/klangk/klangk/lifecycle.py
+++ b/src/klangk/klangk/lifecycle.py
@@ -981,8 +981,23 @@ class Lifecycle:
             logger.info("%s: drained %d workspace(s)", name, stopped)
         except Exception as exc:  # noqa: BLE001 — never block the exit
             logger.warning(
-                "%s: drain failed (proceeding with exit): %s", name, exc
+                "%s: drain failed (%s); attempting forced backstop",
+                name,
+                exc,
             )
+            # V-222585: a graceful drain failure must not leave
+            # unsupervised containers — escalate to the forced
+            # shutdown path (podman stop + rm -f per container).
+            try:
+                await registry.shutdown()
+                logger.warning("%s: forced backstop completed", name)
+            except Exception:  # noqa: BLE001
+                logger.critical(
+                    "%s: forced backstop also failed; unsupervised "
+                    "containers may remain",
+                    name,
+                    exc_info=True,
+                )
         logger.info("%s: handing off to server exit", name)
 
     def on_sighup(self) -> None:
@@ -1069,12 +1084,18 @@ class Lifecycle:
             await self.startup()
         except Exception as exc:  # noqa: BLE001
             logger.critical(
-                "SIGHUP: restart recovery failed (%s); exiting for a "
-                "process restart",
+                "SIGHUP: restart recovery failed (%s); sending SIGTERM "
+                "for a clean shutdown",
                 exc,
                 exc_info=exc,
             )
-            os._exit(1)
+            # V-222585: instead of os._exit(1) (which skips lifespan
+            # teardown and orphans the proxy child), send ourselves
+            # SIGTERM — the GracefulExitServer hook runs the hardened
+            # teardown (proxy stop, container cleanup, DB dispose)
+            # before the process exits.
+            os.kill(os.getpid(), signal.SIGTERM)
+            return  # SIGTERM handler takes over
         logger.error(
             "SIGHUP: recycle failed but runtime recovered; "
             "configuration may be stale"
@@ -1274,7 +1295,18 @@ async def lifespan(app: FastAPI):
         yield
     finally:
         loop.remove_signal_handler(signal.SIGHUP)
-        await stop_background_workers(app)
-        await app.state.lifecycle.runtime_shutdown()
-        await app.state.lifecycle.process_shutdown()
+        # Each teardown step is wrapped so one failure cannot skip the
+        # rest — all steps always attempted, each failure logged
+        # (V-222585: fail to a secure state on shutdown failure).
+        for step_name, step_coro in (
+            ("stop_background_workers", stop_background_workers(app)),
+            ("runtime_shutdown", app.state.lifecycle.runtime_shutdown()),
+            ("process_shutdown", app.state.lifecycle.process_shutdown()),
+        ):
+            try:
+                await step_coro
+            except Exception:  # noqa: BLE001
+                logger.error(
+                    "Teardown step %s failed", step_name, exc_info=True
+                )
         logger.info("Klangk backend stopped")

--- a/src/klangk/klangk/main.py
+++ b/src/klangk/klangk/main.py
@@ -883,6 +883,16 @@ def make_graceful_exit_server(asgi_app):
         finally:
             for sig, handler in original_handlers.items():
                 signal_mod.signal(sig, handler)
+        # V-222585 (#3176): a failed-recovery exit is routed through
+        # this hook with a forced status — translate it here, after the
+        # lifespan teardown has fully run (uvicorn's shutdown completes
+        # inside the with-block above). Dying by the re-raised SIGTERM
+        # (143) instead would read as a "clean" exit to a
+        # Restart=on-failure supervisor, leaving the node down.
+        lifecycle = getattr(asgi_app.state, "lifecycle", None)
+        forced = getattr(lifecycle, "forced_exit_status", None)
+        if forced is not None:
+            raise SystemExit(forced)
         for captured_signal in reversed(self._captured_signals):
             signal_mod.raise_signal(captured_signal)
 

--- a/src/klangk/klangkd-tests/tests/test_draining.py
+++ b/src/klangk/klangkd-tests/tests/test_draining.py
@@ -190,6 +190,39 @@ class TestDrain:
         assert n == 3
         assert sorted(stopped) == ["ws-0", "ws-1", "ws-2"]
 
+    def test_tracked_container_count_is_drain_baseline(self, app_state, db):
+        """The count matches the drain's own snapshot: only states with
+        a container_id — an under-stopping drain is detected by
+        comparing against it (V-222585)."""
+        from klangk.container.basics import ContainerState
+
+        registry = app_state.state.container_registry
+        self._track(app_state, registry, 2)
+        # A stopped/idle workspace (no container_id) is not a drain
+        # target and must not inflate the count.
+        registry.states["ws-2"] = ContainerState("ws-2", None, app_state)
+        assert registry.tracked_container_count() == 2
+
+    async def test_leftover_containers_lists_instance_label(
+        self, app_state, db
+    ):
+        """Verification listing (V-222585): this instance's still-listed
+        containers by ident (name fallback; unidentifiable entries
+        dropped), queried with the instance label."""
+        registry = app_state.state.container_registry
+        self._stub_sweep(
+            app_state,
+            containers=[
+                {"Id": "abc123", "Labels": {}},
+                {"Names": ["sidecar-1"], "Labels": {}},
+                {"Labels": {}},
+            ],
+        )
+        leftovers = await registry.leftover_containers()
+        assert leftovers == ["abc123", "sidecar-1"]
+        label = f"klangk.instance={app_state.state.util.instance_id()}"
+        app_state.state.podman.list_containers.assert_awaited_with(label)
+
     async def test_drain_runs_concurrently(self, app_state, db):
         """Per-workspace stops overlap (a node with many workspaces must
         not pay N sequential 5s stops) — a stop that is still in flight

--- a/src/klangk/klangkd-tests/tests/test_main.py
+++ b/src/klangk/klangkd-tests/tests/test_main.py
@@ -100,6 +100,40 @@ def _make_app_state(settings=None):
     return app_state
 
 
+def _lifespan_test_app():
+    """A FastAPI app wired like ``build_app`` for direct ``lifespan()``
+    tests (V-222585 teardown / fail-secure coverage): fresh state
+    objects sharing the fake app_state's registry, sockets, settings,
+    db, model, hooks, and lifecycle."""
+    app = FastAPI()
+    app_state = _make_app_state()
+    app.state.container_registry = app_state.state.container_registry
+    app.state.sockets = app_state.state.sockets
+    app.state.settings = app_state.state.settings
+    app.state.ssl_trust = app_state.state.ssl_trust
+    app.state.db = app_state.state.db
+    app.state.model = app_state.state.model
+    app.state.proxy_watchdog = caddy_mod.CaddyWatchdog(app)
+    app.state.consent_sweeper = consent.EgressConsentSweeper(app)
+    app.state.inactivity_sweeper = inactivity.InactivitySweeper(app)
+    app.state.memory_evictor = container.eviction.MemoryPressureEvictor(app)
+    app.state.consent_deciders = consent.ConsentDeciderRegistry(app)
+    app.state.consent_coordinator = consent.ConsentCoordinator(app)
+    app.state.sidecar_connections = sidecar_connections.SidecarConnections(app)
+    app.state.oidc = oidc.OIDC(app)
+    app.state.features = features.Features(app)
+    app.state.hooks = app_state.state.hooks
+    app.state.workspaces = workspaces.Workspaces(app)
+    app.state.email = emailsvc_mod.EmailService(app)
+    app.state.util = util_mod.Util(app)
+    app.state.auth = auth_mod.Auth(app)
+    app.state.lifecycle = app_state.state.lifecycle
+    app.state.server_scheduler = types.SimpleNamespace(
+        start=MagicMock(), stop=AsyncMock()
+    )
+    return app, app_state
+
+
 def _lifecycle(settings):
     """A ``Lifecycle`` whose app can reach ``model.acl``.
 
@@ -1436,7 +1470,8 @@ class TestGracefulShutdown:
         self, app_state, caplog
     ):
         """A drain exception triggers the forced backstop
-        (registry.shutdown) before exiting (V-222585)."""
+        (registry.shutdown, then a verified-clean listing) before
+        exiting (V-222585)."""
         import signal as signal_mod
 
         app_state = _make_app_state()
@@ -1455,6 +1490,12 @@ class TestGracefulShutdown:
                 new_callable=AsyncMock,
             ) as mock_shutdown,
             patch.object(
+                registry,
+                "leftover_containers",
+                new_callable=AsyncMock,
+                return_value=[],
+            ) as mock_leftovers,
+            patch.object(
                 app_state.state.sockets, "notify_host_shutdown"
             ) as mock_notify,
             caplog.at_level("WARNING"),
@@ -1463,8 +1504,11 @@ class TestGracefulShutdown:
         mock_notify.assert_called_once()
         assert any("drain failed" in r.message for r in caplog.records)
         mock_shutdown.assert_awaited_once()
+        mock_leftovers.assert_awaited_once()
         assert any(
-            "forced backstop completed" in r.message for r in caplog.records
+            "forced backstop completed; verified no containers remain"
+            in r.message
+            for r in caplog.records
         )
 
     async def test_drain_failure_backstop_also_fails_logs_critical(
@@ -1495,10 +1539,154 @@ class TestGracefulShutdown:
         ):
             await lc.graceful_shutdown(signal_num=signal_mod.SIGTERM)
         assert any(
-            "forced backstop also failed" in r.message
+            "forced backstop failed" in r.message and r.levelname == "CRITICAL"
+            for r in caplog.records
+        )
+
+    async def test_drain_understop_triggers_forced_backstop(
+        self, app_state, caplog
+    ):
+        """A drain that returns without raising but stopped fewer
+        containers than were tracked still triggers the backstop —
+        per-container stop failures are swallowed by
+        drain_all_containers, so the count is the only failure signal
+        (V-222585)."""
+        import signal as signal_mod
+
+        app_state = _make_app_state()
+        lc = app_state.state.lifecycle
+        registry = app_state.state.container_registry
+        with (
+            patch.object(registry, "tracked_container_count", return_value=2),
+            patch.object(
+                registry,
+                "drain_all_containers",
+                new_callable=AsyncMock,
+                return_value=1,
+            ),
+            patch.object(
+                registry, "shutdown", new_callable=AsyncMock
+            ) as mock_shutdown,
+            patch.object(
+                registry,
+                "leftover_containers",
+                new_callable=AsyncMock,
+                return_value=[],
+            ),
+            patch.object(app_state.state.sockets, "notify_host_shutdown"),
+            caplog.at_level("WARNING"),
+        ):
+            await lc.graceful_shutdown(signal_num=signal_mod.SIGTERM)
+        mock_shutdown.assert_awaited_once()
+        assert any("drain stopped 1 of 2" in r.message for r in caplog.records)
+        assert any(
+            "forced backstop completed" in r.message for r in caplog.records
+        )
+
+    async def test_backstop_leftover_containers_log_critical(
+        self, app_state, caplog
+    ):
+        """A backstop that "succeeds" while containers remain listed
+        is NOT success: the verification listing wins over the stop
+        path's swallowed failures and CRITICAL names the leftovers
+        (V-222585)."""
+        import signal as signal_mod
+
+        app_state = _make_app_state()
+        lc = app_state.state.lifecycle
+        registry = app_state.state.container_registry
+        with (
+            patch.object(
+                registry,
+                "drain_all_containers",
+                new_callable=AsyncMock,
+                side_effect=RuntimeError("drain exploded"),
+            ),
+            patch.object(
+                registry, "shutdown", new_callable=AsyncMock
+            ) as mock_shutdown,
+            patch.object(
+                registry,
+                "leftover_containers",
+                new_callable=AsyncMock,
+                return_value=["deadbeef1234", "cafef00d5678"],
+            ),
+            patch.object(app_state.state.sockets, "notify_host_shutdown"),
+            caplog.at_level("CRITICAL"),
+        ):
+            await lc.graceful_shutdown(signal_num=signal_mod.SIGTERM)
+        mock_shutdown.assert_awaited_once()
+        assert any(
+            "2 container(s) still running after the forced backstop"
+            in r.message
+            and "deadbeef1234" in r.message
             and r.levelname == "CRITICAL"
             for r in caplog.records
         )
+
+    async def test_backstop_verification_failure_logs_critical(
+        self, app_state, caplog
+    ):
+        """When the post-backstop listing itself fails, the secure
+        state cannot be confirmed — CRITICAL, never a silent exit
+        (V-222585)."""
+        import signal as signal_mod
+
+        app_state = _make_app_state()
+        lc = app_state.state.lifecycle
+        registry = app_state.state.container_registry
+        with (
+            patch.object(
+                registry,
+                "drain_all_containers",
+                new_callable=AsyncMock,
+                side_effect=RuntimeError("drain exploded"),
+            ),
+            patch.object(
+                registry, "shutdown", new_callable=AsyncMock
+            ) as mock_shutdown,
+            patch.object(
+                registry,
+                "leftover_containers",
+                new_callable=AsyncMock,
+                side_effect=RuntimeError("ps exploded"),
+            ),
+            patch.object(app_state.state.sockets, "notify_host_shutdown"),
+            caplog.at_level("CRITICAL"),
+        ):
+            await lc.graceful_shutdown(signal_num=signal_mod.SIGTERM)
+        mock_shutdown.assert_awaited_once()
+        assert any(
+            "could not verify containers are stopped" in r.message
+            and r.levelname == "CRITICAL"
+            for r in caplog.records
+        )
+
+    async def test_drain_phase_failure_does_not_block_exit(
+        self, app_state, caplog
+    ):
+        """An exception escaping the drain phase itself (e.g. the
+        baseline count raising) is logged and the exit proceeds —
+        never a wedged live server (V-222585)."""
+        import signal as signal_mod
+
+        app_state = _make_app_state()
+        lc = app_state.state.lifecycle
+        registry = app_state.state.container_registry
+        with (
+            patch.object(
+                registry,
+                "tracked_container_count",
+                side_effect=RuntimeError("states corrupted"),
+            ),
+            patch.object(
+                app_state.state.sockets, "notify_host_shutdown"
+            ) as mock_notify,
+            caplog.at_level("WARNING"),
+        ):
+            await lc.graceful_shutdown(signal_num=signal_mod.SIGTERM)
+        mock_notify.assert_called_once()
+        assert any("drain phase failed" in r.message for r in caplog.records)
 
     async def test_sighup_ignored_during_shutdown(self, app_state):
         """A HUP racing the shutdown is dropped, not scheduled —
@@ -1616,6 +1804,31 @@ class TestGracefulExitServer:
                         await asyncio.sleep(0)
                     server.handle_exit.assert_called_once_with(15, None)
                     assert lc._shutdown_tasks == set()
+
+    async def test_forced_exit_status_translates_to_systemexit(
+        self, app_state
+    ):
+        """A forced_exit_status set on the lifecycle (failed-recovery
+        path, V-222585) turns the context exit into SystemExit(1)
+        instead of re-raising the captured SIGTERM — death-by-signal
+        (143) reads as a "clean" exit to a Restart=on-failure
+        supervisor, which would leave the node down."""
+        import types as types_mod
+
+        app_state = _make_app_state()
+        app_state.state.lifecycle.forced_exit_status = 1
+        cls = self._server_cls(app_state)
+        server = types_mod.SimpleNamespace(
+            handle_exit=MagicMock(),
+            _captured_signals=[15],  # the self-SIGTERM, captured
+            force_exit=False,
+        )
+        with patch("signal.signal", return_value=MagicMock()):
+            gen = cls.capture_signals(server)
+            with pytest.raises(SystemExit) as excinfo:
+                with gen:
+                    pass
+        assert excinfo.value.code == 1
 
     async def test_hook_exception_logged_and_exit_still_fires(self, app_state):
         """A raising hook is logged by the done-callback (not swallowed
@@ -2187,38 +2400,8 @@ class TestMainEntryCallback2910:
     ):
         """An exception in one lifespan teardown step does not prevent
         the remaining steps from running (V-222585)."""
-        app = FastAPI()
-        app_state = _make_app_state()
-        app.state.container_registry = app_state.state.container_registry
-        app.state.sockets = app_state.state.sockets
-        app.state.settings = app_state.state.settings
-        app.state.ssl_trust = app_state.state.ssl_trust
-        app.state.db = app_state.state.db
-        app.state.model = app_state.state.model
-        app.state.proxy_watchdog = caddy_mod.CaddyWatchdog(app)
-        app.state.consent_sweeper = consent.EgressConsentSweeper(app)
-        app.state.inactivity_sweeper = inactivity.InactivitySweeper(app)
-        app.state.memory_evictor = container.eviction.MemoryPressureEvictor(
-            app
-        )
-        app.state.consent_deciders = consent.ConsentDeciderRegistry(app)
-        app.state.consent_coordinator = consent.ConsentCoordinator(app)
-        app.state.sidecar_connections = sidecar_connections.SidecarConnections(
-            app
-        )
-        app.state.oidc = oidc.OIDC(app)
-        app.state.features = features.Features(app)
-        app.state.hooks = app_state.state.hooks
-        app.state.workspaces = workspaces.Workspaces(app)
-        app.state.email = emailsvc_mod.EmailService(app)
-        app.state.util = util_mod.Util(app)
-        app.state.auth = auth_mod.Auth(app)
-        app.state.lifecycle = app_state.state.lifecycle
-        scheduler_stub = types.SimpleNamespace(
-            start=MagicMock(), stop=AsyncMock()
-        )
-        app.state.server_scheduler = scheduler_stub
-        registry = app_state.state.container_registry
+        app, wired = _lifespan_test_app()
+        registry = wired.state.container_registry
         with (
             patch.object(
                 registry,
@@ -2249,6 +2432,82 @@ class TestMainEntryCallback2910:
                 pass
         mock_shutdown.assert_awaited_once()
         mock_remove.assert_called_once()
+
+    @pytest.mark.parametrize(
+        ("break_step", "expected_exc"),
+        [
+            ("init_db", RuntimeError),
+            ("pid_conflict", SystemExit),
+            ("ssl_trust", RuntimeError),
+            ("logfire", RuntimeError),
+            ("seed", RuntimeError),
+            ("startup", RuntimeError),
+        ],
+    )
+    async def test_pre_yield_startup_failure_never_yields(
+        self, db, app_state, break_step, expected_exc
+    ):
+        """A failure at any pre-``yield`` lifespan step propagates
+        before the yield — the lifespan never starts serving, so
+        uvicorn's ``Server.startup`` marks the exit before creating any
+        listener: nothing is bound and no request is served (V-222585,
+        #3176 acceptance: fail secure on initialization failure)."""
+        app, wired = _lifespan_test_app()
+        registry = wired.state.container_registry
+        breaks = {
+            "init_db": lambda: patch.object(
+                app.state.model,
+                "init_db",
+                AsyncMock(side_effect=RuntimeError("db init failed")),
+            ),
+            "pid_conflict": lambda: patch.object(
+                util_mod.Util, "check_pid_file", return_value=999
+            ),
+            "ssl_trust": lambda: patch.object(
+                app.state.ssl_trust,
+                "apply_backend_ssl_trust",
+                MagicMock(side_effect=RuntimeError("ssl trust failed")),
+            ),
+            "logfire": lambda: patch(
+                "klangk.lifecycle.setup_logfire",
+                MagicMock(side_effect=RuntimeError("logfire failed")),
+            ),
+            "seed": lambda: patch(
+                "klangk.lifecycle.validate_and_seed",
+                AsyncMock(side_effect=RuntimeError("seed failed")),
+            ),
+            "startup": lambda: patch.object(
+                wired.state.lifecycle,
+                "startup",
+                AsyncMock(side_effect=RuntimeError("startup failed")),
+            ),
+        }
+        yielded = False
+        with (
+            patch.object(
+                registry,
+                "reap_instance_containers",
+                new_callable=AsyncMock,
+            ),
+            patch.object(
+                registry,
+                "reap_dead_owner_containers",
+                new_callable=AsyncMock,
+            ),
+            patch.object(registry, "start_cleanup_loop"),
+            patch.object(
+                util_mod.Util,
+                "check_pid_file",
+                return_value=None if break_step != "pid_conflict" else 999,
+            ),
+            patch.object(util_mod.Util, "write_pid_file"),
+            patch.object(util_mod.Util, "remove_pid_file"),
+            breaks[break_step](),
+        ):
+            with pytest.raises(expected_exc):
+                async with main.lifespan(app):
+                    yielded = True
+        assert not yielded
 
     async def test_recycle_runtime_runs_shutdown_then_startup(self, app_state):
         app_state = _make_app_state()
@@ -3102,6 +3361,7 @@ class TestMainEntryCallback2910:
             for _ in range(10):
                 await asyncio.sleep(0)
         mock_kill.assert_called_once_with(os.getpid(), signal.SIGTERM)
+        assert lc.forced_exit_status == 1
         assert any("recovery failed" in r.message for r in caplog.records)
 
     async def test_cancelled_restart_task_logs_quietly(self, app_state):

--- a/src/klangk/klangkd-tests/tests/test_main.py
+++ b/src/klangk/klangkd-tests/tests/test_main.py
@@ -1432,9 +1432,11 @@ class TestGracefulShutdown:
         assert not any("drain failed" in r.message for r in caplog.records)
         mock_drain.assert_awaited_once_with(reason="host shutdown")
 
-    async def test_drain_failure_does_not_block_exit(self, app_state, caplog):
-        """A drain exception is logged and the hook completes — the
-        process must still exit (never a wedged live server)."""
+    async def test_drain_failure_triggers_forced_backstop(
+        self, app_state, caplog
+    ):
+        """A drain exception triggers the forced backstop
+        (registry.shutdown) before exiting (V-222585)."""
         import signal as signal_mod
 
         app_state = _make_app_state()
@@ -1448,6 +1450,11 @@ class TestGracefulShutdown:
                 side_effect=RuntimeError("podman exploded"),
             ),
             patch.object(
+                registry,
+                "shutdown",
+                new_callable=AsyncMock,
+            ) as mock_shutdown,
+            patch.object(
                 app_state.state.sockets, "notify_host_shutdown"
             ) as mock_notify,
             caplog.at_level("WARNING"),
@@ -1455,6 +1462,43 @@ class TestGracefulShutdown:
             await lc.graceful_shutdown(signal_num=signal_mod.SIGINT)
         mock_notify.assert_called_once()
         assert any("drain failed" in r.message for r in caplog.records)
+        mock_shutdown.assert_awaited_once()
+        assert any(
+            "forced backstop completed" in r.message for r in caplog.records
+        )
+
+    async def test_drain_failure_backstop_also_fails_logs_critical(
+        self, app_state, caplog
+    ):
+        """When both the drain and the forced backstop fail, a CRITICAL
+        message warns operators of unsupervised containers (V-222585)."""
+        import signal as signal_mod
+
+        app_state = _make_app_state()
+        lc = app_state.state.lifecycle
+        registry = app_state.state.container_registry
+        with (
+            patch.object(
+                registry,
+                "drain_all_containers",
+                new_callable=AsyncMock,
+                side_effect=RuntimeError("drain exploded"),
+            ),
+            patch.object(
+                registry,
+                "shutdown",
+                new_callable=AsyncMock,
+                side_effect=RuntimeError("shutdown also exploded"),
+            ),
+            patch.object(app_state.state.sockets, "notify_host_shutdown"),
+            caplog.at_level("CRITICAL"),
+        ):
+            await lc.graceful_shutdown(signal_num=signal_mod.SIGTERM)
+        assert any(
+            "forced backstop also failed" in r.message
+            and r.levelname == "CRITICAL"
+            for r in caplog.records
+        )
 
     async def test_sighup_ignored_during_shutdown(self, app_state):
         """A HUP racing the shutdown is dropped, not scheduled —
@@ -2137,6 +2181,74 @@ class TestMainEntryCallback2910:
             await app_state.state.lifecycle.process_shutdown()
         mock_remove.assert_called_once()
         app_state.state.db.dispose_engine.assert_awaited_once()
+
+    async def test_teardown_step_failure_does_not_skip_remaining(
+        self, db, app_state
+    ):
+        """An exception in one lifespan teardown step does not prevent
+        the remaining steps from running (V-222585)."""
+        app = FastAPI()
+        app_state = _make_app_state()
+        app.state.container_registry = app_state.state.container_registry
+        app.state.sockets = app_state.state.sockets
+        app.state.settings = app_state.state.settings
+        app.state.ssl_trust = app_state.state.ssl_trust
+        app.state.db = app_state.state.db
+        app.state.model = app_state.state.model
+        app.state.proxy_watchdog = caddy_mod.CaddyWatchdog(app)
+        app.state.consent_sweeper = consent.EgressConsentSweeper(app)
+        app.state.inactivity_sweeper = inactivity.InactivitySweeper(app)
+        app.state.memory_evictor = container.eviction.MemoryPressureEvictor(
+            app
+        )
+        app.state.consent_deciders = consent.ConsentDeciderRegistry(app)
+        app.state.consent_coordinator = consent.ConsentCoordinator(app)
+        app.state.sidecar_connections = sidecar_connections.SidecarConnections(
+            app
+        )
+        app.state.oidc = oidc.OIDC(app)
+        app.state.features = features.Features(app)
+        app.state.hooks = app_state.state.hooks
+        app.state.workspaces = workspaces.Workspaces(app)
+        app.state.email = emailsvc_mod.EmailService(app)
+        app.state.util = util_mod.Util(app)
+        app.state.auth = auth_mod.Auth(app)
+        app.state.lifecycle = app_state.state.lifecycle
+        scheduler_stub = types.SimpleNamespace(
+            start=MagicMock(), stop=AsyncMock()
+        )
+        app.state.server_scheduler = scheduler_stub
+        registry = app_state.state.container_registry
+        with (
+            patch.object(
+                registry,
+                "reap_instance_containers",
+                new_callable=AsyncMock,
+            ),
+            patch.object(
+                registry,
+                "reap_dead_owner_containers",
+                new_callable=AsyncMock,
+            ),
+            patch.object(registry, "start_cleanup_loop"),
+            patch.object(
+                registry, "shutdown", new_callable=AsyncMock
+            ) as mock_shutdown,
+            patch.object(util_mod.Util, "check_pid_file", return_value=None),
+            patch.object(util_mod.Util, "write_pid_file"),
+            patch.object(util_mod.Util, "remove_pid_file") as mock_remove,
+            # Make stop_background_workers blow up — runtime_shutdown
+            # and process_shutdown must still run.
+            patch(
+                "klangk.lifecycle.stop_background_workers",
+                new_callable=AsyncMock,
+                side_effect=RuntimeError("sweeper exploded"),
+            ),
+        ):
+            async with main.lifespan(app):
+                pass
+        mock_shutdown.assert_awaited_once()
+        mock_remove.assert_called_once()
 
     async def test_recycle_runtime_runs_shutdown_then_startup(self, app_state):
         app_state = _make_app_state()
@@ -2964,9 +3076,10 @@ class TestMainEntryCallback2910:
         assert any("recycle failed" in r.message for r in caplog.records)
         assert lc._recycle_tasks == set()
 
-    async def test_failed_recovery_exits_process(self, app_state, caplog):
-        """Recovery that also fails exits the process (code 1) so the
-        service manager restarts us instead of a live zombie."""
+    async def test_failed_recovery_sends_sigterm(self, app_state, caplog):
+        """Recovery that also fails sends SIGTERM to self (not
+        os._exit) so the GracefulExitServer runs the hardened lifespan
+        teardown before the process exits (V-222585)."""
         app_state = _make_app_state()
         lc = app_state.state.lifecycle
         with (
@@ -2982,13 +3095,13 @@ class TestMainEntryCallback2910:
                 new_callable=AsyncMock,
                 side_effect=RuntimeError("startup also exploded"),
             ),
-            patch("klangk.lifecycle.os._exit") as mock_exit,
+            patch("os.kill") as mock_kill,
             caplog.at_level("CRITICAL"),
         ):
             lc.on_sighup()
-            for _ in range(6):
+            for _ in range(10):
                 await asyncio.sleep(0)
-        mock_exit.assert_called_once_with(1)
+        mock_kill.assert_called_once_with(os.getpid(), signal.SIGTERM)
         assert any("recovery failed" in r.message for r in caplog.records)
 
     async def test_cancelled_restart_task_logs_quietly(self, app_state):


### PR DESCRIPTION
## Summary

- Harden the lifespan `finally` teardown so each step (stop background workers, runtime shutdown, process shutdown) is wrapped individually — a failure in one never skips the rest
- Escalate graceful drain failures during SIGTERM/SIGINT: attempt a forced backstop (`registry.shutdown()`) before exiting; log CRITICAL if even the backstop fails
- Replace `os._exit(1)` in the SIGHUP recovery path with `os.kill(os.getpid(), signal.SIGTERM)` so the proxy child is cleaned up through the normal hardened teardown
- Document accepted residual risks (FIPS warn-only, podman prewarm warn-only) in `docs/deployment/signals.md`

Closes #3176

## Test plan

- [x] `test_teardown_step_failure_does_not_skip_remaining` — a failing `stop_background_workers` does not prevent `runtime_shutdown` and `process_shutdown` from running
- [x] `test_drain_failure_triggers_forced_backstop` — drain failure calls `registry.shutdown()` as backstop
- [x] `test_drain_failure_backstop_also_fails_logs_critical` — both drain and backstop failing logs CRITICAL
- [x] `test_failed_recovery_sends_sigterm` — failed recovery sends SIGTERM instead of `os._exit(1)`
- [x] Full backend suite (6980 tests) passes