### PR TITLE
Gate CLI --auto-start on the allow_autostart ceiling (#3184)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -1684,6 +1684,14 @@ stop)`) and a `server: stop at 23:00 (in 1h 12m)` status line in the
 /api/v1/volumes` now requires the owning `workspace` field; the CLI
   create command takes `--workspace`. Deleting a workspace removes its
   volumes (an orphan sweep reclaims stragglers).
+- **CLI `--auto-start` respects the `KLANGKD_ALLOW_AUTOSTART` ceiling
+  (#3184).** `klangk create --auto-start` and `klangk edit --auto-start`
+  now fail fast with a clear error when the server does not allow
+  auto-start — before any create/edit request is sent — matching the web
+  UI and TUI, which hide the Auto start control on such deployments.
+  `--no-auto-start` is unaffected, and a failed config probe no longer
+  blocks the request (the server still enforces the ceiling). See
+  [Auto-start](https://klangk.github.io/klangk/features/auto-start/).
 
 - **`klangk sandbox` `copy:` destinations are literal container paths
   (#3118).** Only a leading `~` is special (it expands to

--- a/docs/features/auto-start.md
+++ b/docs/features/auto-start.md
@@ -44,7 +44,9 @@ klangk edit my-service --no-auto-start
 
 On a server without `KLANGKD_ALLOW_AUTOSTART`, `--auto-start` is
 refused up front (before any request is sent) with a message naming
-the setting; `--no-auto-start` always works.
+the setting; `--no-auto-start` always works. The sandbox config's
+`auto-start: true` needs the server flag too — without it the sandbox
+create fails with the server's auto-start error.
 
 ### Sandbox config
 

--- a/docs/features/auto-start.md
+++ b/docs/features/auto-start.md
@@ -42,6 +42,10 @@ klangk edit my-service --auto-start
 klangk edit my-service --no-auto-start
 ```
 
+On a server without `KLANGKD_ALLOW_AUTOSTART`, `--auto-start` is
+refused up front (before any request is sent) with a message naming
+the setting; `--no-auto-start` always works.
+
 ### Sandbox config
 
 In `.klangk-sandbox.yaml`:

--- a/src/klangk/klangk/cli/edit.py
+++ b/src/klangk/klangk/cli/edit.py
@@ -23,7 +23,13 @@ from .options import (
     RejectOption,
     SudoOption,
 )
-from .workspaces import build_settings, parse_env_list, prompt, SENTINEL
+from .workspaces import (
+    build_settings,
+    ensure_autostart_allowed,
+    parse_env_list,
+    prompt,
+    SENTINEL,
+)
 from .mount import validate_allowed_domain_spec, validate_mount_spec
 
 # Body fields baked into the container at create time: changing one on a
@@ -581,7 +587,10 @@ def edit(
     auto_start: bool | None = typer.Option(
         None,
         "--auto-start/--no-auto-start",
-        help="Start container automatically on server boot",
+        help=(
+            "Start container automatically on server boot"
+            " (requires KLANGKD_ALLOW_AUTOSTART=1 on the server)"
+        ),
     ),
     per_handle_home: bool | None = typer.Option(
         None,
@@ -626,6 +635,9 @@ def edit(
         raise typer.Exit(code=1)
     context.require_auth()
     client = context.client()
+    # Only opting in is capped by the deploy ceiling; --no-auto-start
+    # is always below it (#3184).
+    ensure_autostart_allowed(client, auto_start)
     ws = context.resolve_or_exit(client, workspace)
 
     if has_any_flags(

--- a/src/klangk/klangk/cli/workspaces.py
+++ b/src/klangk/klangk/cli/workspaces.py
@@ -241,15 +241,17 @@ def ensure_autostart_allowed(client, requested) -> None:
     ``--no-auto-start``) returns without a config round trip. A
     config-fetch failure degrades to "allowed": the request itself
     reports the real error, and the server enforces the ceiling
-    regardless (``_check_autostart`` in ``api/workspaces.py``).
+    regardless (``_check_autostart`` in ``api/workspaces.py``). A
+    200 body that is not a JSON object is treated as "not allowed",
+    the same posture as the TUI's ``allow_autostart`` probe.
     """
     if not requested:
         return
     try:
-        allowed = client.config().get("allow_autostart") is True
+        cfg = client.config()
     except (httpx.HTTPError, AuthError, ValueError):
         return
-    if not allowed:
+    if not isinstance(cfg, dict) or cfg.get("allow_autostart") is not True:
         context.err.print(
             "[red]Auto-start is not enabled on this server"
             " (set KLANGKD_ALLOW_AUTOSTART=1)[/red]"
@@ -349,13 +351,14 @@ def create(
     """Create a new workspace."""
     context.require_auth()
     validate_create_specs(mount, allow, reject)
-    ensure_autostart_allowed(context.client(), auto_start)
+    client = context.client()
+    ensure_autostart_allowed(client, auto_start)
     env_dict = parse_env_list(env) if isinstance(env, list) else None
     settings = build_settings(
         idle_timeout, cpu_limit, memory_limit, pids_limit, allow_sudo
     )
     ws = create_workspace_or_exit(
-        context.client(),
+        client,
         name,
         image=image,
         command=command,

--- a/src/klangk/klangk/cli/workspaces.py
+++ b/src/klangk/klangk/cli/workspaces.py
@@ -25,7 +25,7 @@ from rich.progress import (
 from rich.table import Table
 
 from .client import KlangkClient  # noqa: F401 (type annotations)
-from .client import WorkspaceNotFoundError
+from .client import AuthError, WorkspaceNotFoundError
 from . import context
 from .mount import validate_allowed_domain_spec, validate_mount_spec
 from .options import (
@@ -229,6 +229,34 @@ def validate_create_specs(mount, allow, reject) -> None:
         )
 
 
+def ensure_autostart_allowed(client, requested) -> None:
+    """Refuse up front when the deploy forbids auto-start (#3184).
+
+    ``KLANGKD_ALLOW_AUTOSTART`` is a ceiling on per-workspace auto-start:
+    the web UI and the TUI forms hide their Auto start control when it
+    is off, so ``klangk create --auto-start`` / ``klangk edit
+    --auto-start`` check it too — before any create/edit request is
+    sent, so no workspace is created and no after-the-fact 400 surfaces.
+    Only opting in is capped: ``requested`` falsy (flag omitted, or
+    ``--no-auto-start``) returns without a config round trip. A
+    config-fetch failure degrades to "allowed": the request itself
+    reports the real error, and the server enforces the ceiling
+    regardless (``_check_autostart`` in ``api/workspaces.py``).
+    """
+    if not requested:
+        return
+    try:
+        allowed = client.config().get("allow_autostart") is True
+    except (httpx.HTTPError, AuthError, ValueError):
+        return
+    if not allowed:
+        context.err.print(
+            "[red]Auto-start is not enabled on this server"
+            " (set KLANGKD_ALLOW_AUTOSTART=1)[/red]"
+        )
+        raise typer.Exit(code=1)
+
+
 def create_workspace_or_exit(
     client,
     name,
@@ -276,7 +304,10 @@ def create(
     auto_start: bool = typer.Option(
         False,
         "--auto-start",
-        help="Start container automatically on server boot",
+        help=(
+            "Start container automatically on server boot"
+            " (requires KLANGKD_ALLOW_AUTOSTART=1 on the server)"
+        ),
     ),
     per_handle_home: bool | None = typer.Option(
         None,
@@ -318,6 +349,7 @@ def create(
     """Create a new workspace."""
     context.require_auth()
     validate_create_specs(mount, allow, reject)
+    ensure_autostart_allowed(context.client(), auto_start)
     env_dict = parse_env_list(env) if isinstance(env, list) else None
     settings = build_settings(
         idle_timeout, cpu_limit, memory_limit, pids_limit, allow_sudo

--- a/src/klangk/klangkc-tests/tests/test_cli_main.py
+++ b/src/klangk/klangkc-tests/tests/test_cli_main.py
@@ -3203,6 +3203,26 @@ class TestMainCLI:
         assert result.exit_code == 0
         client.create_workspace.assert_called_once()
 
+    def test_create_auto_start_refused_on_non_dict_config(
+        self, logged_in_cfg, monkeypatch
+    ):
+        """#3184: a 200 body that isn't a JSON object can't prove the
+        ceiling is off, so it is treated as not allowed — the same
+        posture as the TUI's allow_autostart probe."""
+        from klangk.cli import main
+
+        client = MagicMock()
+        client.config.return_value = "not-a-config-object"
+        monkeypatch.setattr(context_mod, "client", lambda: client)
+
+        from typer.testing import CliRunner
+
+        runner = CliRunner()
+        result = runner.invoke(main.app, ["create", "ws", "--auto-start"])
+        assert result.exit_code == 1
+        assert "Auto-start is not enabled" in result.output
+        client.create_workspace.assert_not_called()
+
     def test_create_with_reject_cidr_rejected(
         self, logged_in_cfg, monkeypatch
     ):

--- a/src/klangk/klangkc-tests/tests/test_cli_main.py
+++ b/src/klangk/klangkc-tests/tests/test_cli_main.py
@@ -844,7 +844,7 @@ class TestMainCLI:
             "Console",
             return_value=Console(file=buf, force_terminal=True),
         ):
-            main.create("new-ws")
+            main.create("new-ws", auto_start=False)
         assert "new-ws" in buf.getvalue()
 
     def test_create_workspace_error(self, logged_in_cfg, monkeypatch):
@@ -863,7 +863,10 @@ class TestMainCLI:
         monkeypatch.setattr(context_mod, "client", lambda: client)
 
         with pytest.raises(typer.Exit):
-            main.create("dup")
+            # auto_start pinned: a direct call skips click's default
+            # processing, and a raw OptionInfo default is truthy enough
+            # to trip the #3184 ceiling pre-flight.
+            main.create("dup", auto_start=False)
 
     def test_delete_workspace(self, logged_in_cfg, monkeypatch):
         from klangk.cli import main
@@ -3136,6 +3139,70 @@ class TestMainCLI:
         kwargs = client.create_workspace.call_args.kwargs
         assert kwargs["settings"] is None
 
+    def test_create_auto_start_allowed_by_deploy(
+        self, logged_in_cfg, monkeypatch
+    ):
+        """#3184: ``--auto-start`` pre-flights the deploy ceiling and
+        passes when the deploy allows auto-start."""
+        from klangk.cli import main
+
+        ws = Workspace(
+            id="new-id", name="ws", created_at="2025-01-01T00:00:00Z"
+        )
+        client = MagicMock()
+        client.create_workspace.return_value = ws
+        client.config.return_value = {"allow_autostart": True}
+        monkeypatch.setattr(context_mod, "client", lambda: client)
+
+        from typer.testing import CliRunner
+
+        runner = CliRunner()
+        result = runner.invoke(main.app, ["create", "ws", "--auto-start"])
+        assert result.exit_code == 0
+        assert client.create_workspace.call_args.kwargs["auto_start"] is True
+
+    def test_create_auto_start_refused_when_deploy_disallows(
+        self, logged_in_cfg, monkeypatch
+    ):
+        """#3184: allow_autostart is a ceiling — ``--auto-start`` fails
+        fast, before any create request is sent (no half-created
+        workspace, no after-the-fact 400)."""
+        from klangk.cli import main
+
+        client = MagicMock()
+        client.config.return_value = {"allow_autostart": False}
+        monkeypatch.setattr(context_mod, "client", lambda: client)
+
+        from typer.testing import CliRunner
+
+        runner = CliRunner()
+        result = runner.invoke(main.app, ["create", "ws", "--auto-start"])
+        assert result.exit_code == 1
+        assert "Auto-start is not enabled" in result.output
+        client.create_workspace.assert_not_called()
+
+    def test_create_auto_start_degrades_on_config_failure(
+        self, logged_in_cfg, monkeypatch
+    ):
+        """#3184: a failed ceiling pre-flight must not block the create —
+        the request goes through and the server enforces the ceiling."""
+        from klangk.cli import main
+
+        ws = Workspace(
+            id="new-id", name="ws", created_at="2025-01-01T00:00:00Z"
+        )
+        client = MagicMock()
+        client.create_workspace.return_value = ws
+        client.config.side_effect = httpx.ConnectError("boom")
+        monkeypatch.setattr(context_mod, "client", lambda: client)
+
+        from typer.testing import CliRunner
+
+        runner = CliRunner()
+        result = runner.invoke(main.app, ["create", "ws", "--auto-start"])
+        assert result.exit_code == 0
+        client.create_workspace.assert_called_once()
+
     def test_create_with_reject_cidr_rejected(
         self, logged_in_cfg, monkeypatch
     ):
@@ -3715,6 +3782,9 @@ class TestMainCLI:
         client = MagicMock()
         client.resolve_workspace.return_value = ws
         client.put.return_value = MagicMock(status_code=200)
+        # The deploy ceiling allows auto-start (#3184): the command
+        # pre-flights /config before sending the edit.
+        client.config.return_value = {"allow_autostart": True}
 
         with patch.object(context_mod, "client", return_value=client):
             from typer.testing import CliRunner
@@ -3725,6 +3795,51 @@ class TestMainCLI:
 
         body = client.put.call_args[1]["json"]
         assert body["auto_start"] is True
+
+    def test_edit_auto_start_refused_when_deploy_disallows(
+        self, logged_in_cfg, monkeypatch
+    ):
+        """#3184: allow_autostart is a ceiling — ``--auto-start`` fails
+        fast, before any edit request is sent."""
+        from klangk.cli import main
+
+        client = MagicMock()
+        client.config.return_value = {"allow_autostart": False}
+        monkeypatch.setattr(context_mod, "client", lambda: client)
+
+        from typer.testing import CliRunner
+
+        runner = CliRunner()
+        result = runner.invoke(main.app, ["edit", "my-ws", "--auto-start"])
+        assert result.exit_code == 1
+        assert "Auto-start is not enabled" in result.output
+        client.put.assert_not_called()
+
+    def test_edit_no_auto_start_skips_the_ceiling(
+        self, logged_in_cfg, monkeypatch
+    ):
+        """``--no-auto-start`` is always below the ceiling (#3184): the
+        edit proceeds without consulting /config at all."""
+        from klangk.cli import main
+
+        ws = Workspace(
+            id="ws1" + "0" * 52,
+            name="my-ws",
+            created_at="2025-01-01T00:00:00Z",
+        )
+        client = MagicMock()
+        client.resolve_workspace.return_value = ws
+        client.put.return_value = MagicMock(status_code=200)
+        monkeypatch.setattr(context_mod, "client", lambda: client)
+
+        from typer.testing import CliRunner
+
+        runner = CliRunner()
+        result = runner.invoke(main.app, ["edit", "my-ws", "--no-auto-start"])
+        assert result.exit_code == 0
+        client.config.assert_not_called()
+        body = client.put.call_args[1]["json"]
+        assert body["auto_start"] is False
 
     def test_create_with_home_layout_flags(self, logged_in_cfg, monkeypatch):
         # #2721: --per-handle-home / --shared-home thread the home layout


### PR DESCRIPTION
Makes `KLANGKD_ALLOW_AUTOSTART` a ceiling for the CLI's autostart controls, closing #3184.

## What changed

`klangk create --auto-start` and `klangk edit --auto-start` now pre-flight `/api/v1/config` and refuse up front — exit 1 with a message naming `KLANGKD_ALLOW_AUTOSTART=1` — **before** any create/edit request is sent. This matches the web UI and the TUI create/edit forms, which already hide their Auto start control when the deploy flag is off (#1115), and the docs, which say the option is "hidden in the web UI, CLI, and API" when the flag is unset.

Details:

- New `ensure_autostart_allowed(client, requested)` in `cli/workspaces.py`, called from the `create` command and `klangk edit`. Falsy `requested` (flag omitted, or `--no-auto-start`) returns without a config round trip — opting out is always below the ceiling.
- Graceful degradation: a failed config probe (transport error, expired session, malformed body) is treated as "allowed", so the gate never blocks a create/edit on a flaky transport — the request itself surfaces the real error, and the server's `_check_autostart` still enforces the ceiling regardless.
- Flag help text now states the server requirement; `docs/features/auto-start.md` notes the fail-fast behavior; changelog entry under `[Unreleased]` → Changed.

## What didn't change

- `--no-auto-start` on a deploy without autostart still works (it can only move a workspace below the ceiling).
- `klangk sandbox` auto-start config is untouched — its own safety classifier already refuses auto-start sandboxes, so that path never reaches a create with `auto_start` set.
- Server behavior is unchanged (it already 400'd a truthy `auto_start`); this PR only moves the failure earlier, client-side.

## Testing

New/updated tests in `klangkc-tests/tests/test_cli_main.py`:

- `--auto-start` refused on a disallowing deploy: exit 1, message shown, **no request sent** (`create_workspace` / `put` never called).
- `--auto-start` proceeds when the deploy allows it (both create and edit).
- `--no-auto-start` skips the ceiling check entirely (`config` never called).
- Config-probe failure (transport error) degrades to allowed; create proceeds.

Full suite: 6865 passed, 100% branch coverage; xenon rank A.
