### PR TITLE
Fix CI flake in test_detail_focus_defaults_to_own_list (#3188)

### DIFF
--- a/src/klangk/klangkc-tests/tests/test_tui.py
+++ b/src/klangk/klangkc-tests/tests/test_tui.py
@@ -8023,7 +8023,12 @@ async def test_detail_focus_defaults_to_own_list(monkeypatch):
     app = KlangkApp(st)
     async with app.run_test() as pilot:
         app.push_screen(WorkspaceDetailScreen("alpha"))
-        await pilot.pause()
+        # Settle the whole mount pipeline (mount worker → terminal loaders →
+        # _render_terminals → _focus_term_list re-grab) before clearing
+        # focus. A bare pause() let those land after set_focus(None) on a
+        # loaded runner, so the setup assert raced the screen's own focus
+        # reclaim (#3188) — same posture as the #2932 render races.
+        await _drain_workers(app, pilot)
         # Move focus off both lists, then reclaim. (Footer.focus() is a no-op
         # in textual, so clear focus directly to reach the reclaim branch.)
         app.screen.set_focus(None)


### PR DESCRIPTION
## Summary

`test_detail_focus_defaults_to_own_list` failed intermittently in the `test-backend` CI job ([failed run](https://github.com/mcdonc/klangk/actions/runs/33943126351/job/101244220210?pr=3183), gw2, `-n auto`): its **setup** assertion `assert app.screen.focused is None` tripped because the screen's own focus re-grab landed after the test's `pilot.pause()`.

Closes #3188.

## Root cause

The test pushed `WorkspaceDetailScreen`, settled with a single `pilot.pause()`, then called `set_focus(None)` and asserted nothing had re-grabbed focus. But `WorkspaceDetailScreen` re-asserts focus on `#term_list` asynchronously from several places (`cli/tui/screens/workspace_detail.py`): `on_mount`'s `call_after_refresh(self._focus_term_list)`, and `_render_terminals` behind the `_mount_async` worker's await chain and render lock. On a loaded runner (`-n auto`, shared CPU) those can complete after the test's pause, so `focused` was already back on `term_list` at the assertion — the setup raced the product's own reclaim logic.

## Fix

Use the suite's existing `_drain_workers(app, pilot)` helper (added for the same class of slow-runner races, #2932) to settle the whole mount pipeline — worker → terminal loaders → `_render_terminals` → focus re-grab — before clearing focus. The reclaim branch the test verifies is unchanged.

## Verification

- Targeted run: 1 passed.
- Stress: 15 consecutive runs of the test, all passed.
- Full `test_tui.py` file: 551 passed.
