### PR TITLE
Replace str(e) in files API error responses with generic messages (#3150)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -2223,6 +2223,13 @@ git-credential` (#1700).** `pig-latin` removed; `word-count` dormant.
 
 ### Fixed
 
+- **Files API error responses (#3150).** The workspace files routes
+  (list/read/delete/rename/upload/download) no longer echo raw
+  exception text — podman stderr, container paths, library messages —
+  in 400/403/500 response bodies. They return generic messages
+  ("Invalid path", "Permission denied", "Internal server error") and
+  log the underlying error server-side instead.
+
 - **Parallel image-build tasks tolerate transient rootless-podman failures
   (#3168).** `klangk:build-workspace-image` and `klangk:build-network-sidecar`
   run in parallel and are a fresh machine's first rootless podman invocations;

--- a/src/klangk/klangk/api/resources.py
+++ b/src/klangk/klangk/api/resources.py
@@ -60,13 +60,18 @@ def _files_http_error(
 ) -> HTTPException:
     """Translate a files-layer exception to its HTTP response (#2553).
 
-    The shared except-ladder of the file routes: ValueError -> 400 (the
-    caller's message), FileNotFoundError -> 404 (*not_found* wording
-    varies per route), FileExistsError -> 409, OSError -> 500. Routes
+    The shared except-ladder of the file routes: ValueError -> 400,
+    FileNotFoundError -> 404 (*not_found* wording varies per route),
+    FileExistsError -> 409, PermissionError -> 403, anything else ->
+    500. Response details are generic (#3150): the files layer's
+    exception messages carry podman stderr and container paths, which
+    must reach the operator's log, not the client — so each branch
+    logs the underlying error and returns a fixed wording. Routes
     with an extra case (or none of these) keep their own handling.
     """
     if isinstance(e, ValueError):
-        return HTTPException(status_code=400, detail=str(e))
+        logger.debug("files route rejected input: %s: %s", type(e).__name__, e)
+        return HTTPException(status_code=400, detail="Invalid path")
     if isinstance(e, FileNotFoundError):
         return HTTPException(status_code=404, detail=not_found)
     if isinstance(e, FileExistsError):
@@ -74,8 +79,10 @@ def _files_http_error(
             status_code=409, detail="Destination already exists"
         )
     if isinstance(e, PermissionError):
-        return HTTPException(status_code=403, detail=str(e))
-    return HTTPException(status_code=500, detail=str(e))
+        logger.debug("files route denied: %s", e)
+        return HTTPException(status_code=403, detail="Permission denied")
+    logger.error("files route failed: %s", e, exc_info=True)
+    return HTTPException(status_code=500, detail="Internal server error")
 
 
 @router.get("/workspaces/{workspace_id}/files")
@@ -106,7 +113,7 @@ async def read_file(
     try:
         content = await app.state.files.read_file(cid, path)
     except ValueError as e:
-        raise HTTPException(status_code=400, detail=str(e))
+        raise _files_http_error(e) from None
     if content is None:
         raise HTTPException(
             status_code=404, detail="File not found or too large"
@@ -171,7 +178,7 @@ async def download_file(
     try:
         info = await app.state.files.stat_path(cid, path)
     except ValueError as e:
-        raise HTTPException(status_code=400, detail=str(e))
+        raise _files_http_error(e) from None
     if info is None:
         raise HTTPException(status_code=404, detail="Path not found")
     name = sanitize_disposition_name(posixpath.basename(path) or "download")

--- a/src/klangk/klangk/api/resources.py
+++ b/src/klangk/klangk/api/resources.py
@@ -65,9 +65,12 @@ def _files_http_error(
     FileExistsError -> 409, PermissionError -> 403, anything else ->
     500. Response details are generic (#3150): the files layer's
     exception messages carry podman stderr and container paths, which
-    must reach the operator's log, not the client — so each branch
-    logs the underlying error and returns a fixed wording. Routes
-    with an extra case (or none of these) keep their own handling.
+    must reach the operator's log, not the client. The branches whose
+    exceptions can carry raised-in text (400/403/500) log the
+    underlying error and return a fixed wording; the 404/409 branches
+    don't log — the files layer raises those with fixed server-
+    composed strings, so there is nothing to diagnose. Routes with an
+    extra case (or none of these) keep their own handling.
     """
     if isinstance(e, ValueError):
         logger.debug("files route rejected input: %s: %s", type(e).__name__, e)
@@ -79,7 +82,7 @@ def _files_http_error(
             status_code=409, detail="Destination already exists"
         )
     if isinstance(e, PermissionError):
-        logger.debug("files route denied: %s", e)
+        logger.info("files route denied: %s", e)
         return HTTPException(status_code=403, detail="Permission denied")
     logger.error("files route failed: %s", e, exc_info=True)
     return HTTPException(status_code=500, detail="Internal server error")

--- a/src/klangk/klangkd-tests/tests/test_api.py
+++ b/src/klangk/klangkd-tests/tests/test_api.py
@@ -8852,13 +8852,13 @@ class TestFileRoutes:
                     headers=headers,
                 )
             assert resp.status_code == 403
-            assert "Permission denied" in resp.json()["detail"]
+            assert resp.json()["detail"] == "Permission denied"
         finally:
             self._cleanup(ws_id)
 
     async def test_list_files_find_error_returns_500(self, client, user):
-        """A non-permission find failure maps to 500 with the stderr text
-        (#2766)."""
+        """A non-permission find failure maps to 500 with a generic
+        body — the stderr text stays in the server log (#3150)."""
         headers = await _auth_headers(client)
         ws_id = await self._create_workspace(client, headers)
         try:
@@ -8873,7 +8873,7 @@ class TestFileRoutes:
                     headers=headers,
                 )
             assert resp.status_code == 500
-            assert "Too many levels" in resp.json()["detail"]
+            assert resp.json()["detail"] == "Internal server error"
         finally:
             self._cleanup(ws_id)
 
@@ -9041,7 +9041,7 @@ class TestFileRoutes:
                 },
             )
             assert resp.status_code == 400
-            assert "limit" in resp.json()["detail"]
+            assert resp.json()["detail"] == "Invalid path"
         finally:
             self._cleanup(ws_id)
 
@@ -9112,7 +9112,7 @@ class TestFileRoutes:
                     headers=headers,
                 )
             assert resp.status_code == 500
-            assert "Permission denied" in resp.json()["detail"]
+            assert resp.json()["detail"] == "Internal server error"
         finally:
             self._cleanup(ws_id)
 
@@ -9203,7 +9203,7 @@ class TestFileRoutes:
                     },
                 )
             assert resp.status_code == 500
-            assert "Permission denied" in resp.json()["detail"]
+            assert resp.json()["detail"] == "Internal server error"
         finally:
             self._cleanup(ws_id)
 
@@ -9806,7 +9806,7 @@ class TestFileRoutes:
                     files={"file": ("evil", b"bad", "text/plain")},
                 )
             assert resp.status_code == 500
-            assert "Read-only" in resp.json()["detail"]
+            assert resp.json()["detail"] == "Internal server error"
         finally:
             self._cleanup(ws_id)
 


### PR DESCRIPTION
## Summary

Fixes #3150. The workspace files API routes (`list`/`read`/`delete`/`rename`/`upload`/`download` in `api/resources.py`) put `str(e)` into error response bodies — leaking podman stderr (container paths, OS error text, library messages) to clients. `files.py` deliberately embeds that stderr into its exception messages as operator diagnostics; the leak happened at the API boundary, which copied those messages into 400/403/500 `detail` bodies verbatim.

The boundary now returns fixed wordings and logs the underlying error server-side:

- `ValueError` → 400 `"Invalid path"` (debug log)
- `PermissionError` → 403 `"Permission denied"` (info log)
- anything else → 500 `"Internal server error"` (`logger.error` with `exc_info`)
- 404/409 branches unchanged (already fixed server-composed text)

The two standalone `ValueError` handlers (`read_file`, `download_file`) route through the shared `_files_http_error` ladder. The files layer keeps its rich messages — they are the operator diagnostics; only the API boundary decides what a client sees.

## Tests

Updated assertions in `test_api.py` that codified the leak (`"Too many levels" in detail`, `"Read-only" in detail`, 500s asserting podman stderr) to equality asserts on the fixed generic wordings — each fixture's exception text differs from the asserted wording, so a regression to `str(e)` fails them. Full suite green: 7287 passed, 100% branch coverage; xenon passed.

## Notes

- Verified no other consumer of the files layer surfaces its messages to clients (only `api/resources.py` calls `app.state.files.*`; streaming paths can't carry a detail body after headers are sent).
- Verified nothing in `cli/` or `frontend/lib` branches on the old detail strings (the CLI/TUI/frontend display `detail` verbatim; the frontend path classifier keys on status code).
- Fresh-eyes review: APPROVE; its two actionable findings (docstring overclaim, 403 log level) are addressed in the follow-up commit.
