### PR TITLE
Keep session token in sessionStorage on web (#3193)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -312,8 +312,9 @@ operators or integrators to act when upgrading.
   JWT in browser `sessionStorage` instead of `localStorage`, so closing
   the tab or the browser ends the session instead of leaving a usable
   token on disk. A token persisted by an older build is migrated on the
-  next load and removed from `localStorage`. Users must sign in again
-  after a browser restart.
+  next load and removed from `localStorage`. Signing in again is needed
+  after a browser restart, a session-restore reopen, or opening the app
+  in a new tab.
 
 - **Consent-decider sockets are closed on token revocation (#3162).**
   The `/ws/consent-decider` connection now shares the #3152 revocation

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -308,6 +308,13 @@ operators or integrators to act when upgrading.
 
 ### Security
 
+- **Session token storage (#3193).** The frontend now keeps the session
+  JWT in browser `sessionStorage` instead of `localStorage`, so closing
+  the tab or the browser ends the session instead of leaving a usable
+  token on disk. A token persisted by an older build is migrated on the
+  next load and removed from `localStorage`. Users must sign in again
+  after a browser restart.
+
 - **Consent-decider sockets are closed on token revocation (#3162).**
   The `/ws/consent-decider` connection now shares the #3152 revocation
   story: logging out, being evicted by the per-user session limit, or

--- a/src/frontend/e2e-tests/e2e/session-storage.spec.ts
+++ b/src/frontend/e2e-tests/e2e/session-storage.spec.ts
@@ -1,0 +1,87 @@
+import { test, expect } from "@playwright/test";
+import {
+  registerUser,
+  loginViaUI,
+  waitForFlutter,
+  TEST_PASSWORD,
+} from "./helpers";
+
+// #3193: the session JWT must live in sessionStorage (dies with the
+// tab/browser), never localStorage (survives browser close). These specs
+// pin the web token-store behavior the VM unit suite cannot reach — the
+// widget tests exercise the SharedPreferences stub, while this is the
+// production path.
+test.describe("session token storage (#3193)", () => {
+  test("login stores the JWT in sessionStorage, not localStorage", async ({
+    page,
+    request,
+  }) => {
+    const email = `ss-place-${Date.now()}@test.example.com`;
+    await registerUser(request, email, { admin: false });
+
+    await loginViaUI(page, email, TEST_PASSWORD);
+
+    // Raw JWT in sessionStorage (not the JSON-quoted form the old
+    // shared_preferences persistence wrote).
+    const ssToken = await page.evaluate(() =>
+      sessionStorage.getItem("klangk_jwt"),
+    );
+    expect(ssToken).toBeTruthy();
+    expect(ssToken!.startsWith("eyJ")).toBe(true);
+
+    // Nothing token-shaped may persist in localStorage.
+    const lsKeys = await page.evaluate(() => Object.keys(localStorage));
+    expect(lsKeys.some((k) => k.toLowerCase().includes("jwt"))).toBe(false);
+    expect(
+      await page.evaluate(() => localStorage.getItem("flutter.klangk_jwt")),
+    ).toBeNull();
+  });
+
+  test("legacy localStorage token is migrated and scrubbed on load", async ({
+    page,
+    request,
+  }) => {
+    const email = `ss-migrate-${Date.now()}@test.example.com`;
+    const { token } = await registerUser(request, email, { admin: false });
+
+    // Seed the exact form an older build left behind: the shared_preferences
+    // web backend stores values JSON-encoded under the flutter. prefix.
+    await page.goto("/");
+    await waitForFlutter(page);
+    await page.evaluate((t) => {
+      localStorage.setItem("flutter.klangk_jwt", JSON.stringify(t));
+    }, token);
+    await page.reload();
+    await waitForFlutter(page);
+
+    // The migrated token restores the session…
+    await expect(page).toHaveTitle(/Workspaces/i, { timeout: 30_000 });
+    // …in decoded (raw JWT) form, in sessionStorage…
+    const ssToken = await page.evaluate(() =>
+      sessionStorage.getItem("klangk_jwt"),
+    );
+    expect(ssToken).toBe(token);
+    // …and the persistent copy is gone.
+    expect(
+      await page.evaluate(() => localStorage.getItem("flutter.klangk_jwt")),
+    ).toBeNull();
+  });
+
+  test("a fresh tab starts unauthenticated (session dies with the tab)", async ({
+    page,
+    request,
+  }) => {
+    const email = `ss-newtab-${Date.now()}@test.example.com`;
+    await registerUser(request, email, { admin: false });
+    await loginViaUI(page, email, TEST_PASSWORD);
+
+    const tab2 = await page.context().newPage();
+    await tab2.goto("/");
+    await waitForFlutter(tab2);
+    await expect(tab2).toHaveTitle(/Login/i, { timeout: 10_000 });
+    expect(
+      await tab2.evaluate(() => sessionStorage.getItem("klangk_jwt")),
+    ).toBeNull();
+    await tab2.close();
+  });
+});

--- a/src/frontend/e2e-tests/playwright.config.ts
+++ b/src/frontend/e2e-tests/playwright.config.ts
@@ -81,6 +81,7 @@ export default defineConfig({
         "branding.spec.ts",
         "features.spec.ts",
         "password-history.spec.ts",
+        "session-storage.spec.ts",
         "token-expiry.spec.ts",
       ],
       use: chromiumUse,

--- a/src/frontend/lib/auth/auth_service.dart
+++ b/src/frontend/lib/auth/auth_service.dart
@@ -9,12 +9,12 @@ import 'package:klangk_plugin_api/klangk_plugin_api.dart';
 import '../branding.dart';
 import 'password_policy.dart';
 import 'pending_redirect.dart';
+import 'token_store.dart';
 
 /// Override for testing — set to intercept all HTTP calls in AuthService.
 http.Client? testAuthHttpClientOverride;
 
 class AuthService extends ChangeNotifier {
-  static const _tokenKey = 'klangk_jwt';
   String get _baseUrl => baseUrl;
 
   http.Client get _client => testAuthHttpClientOverride ?? http.Client();
@@ -271,8 +271,9 @@ class AuthService extends ChangeNotifier {
   }
 
   Future<void> _loadToken() async {
-    final prefs = await SharedPreferences.getInstance();
-    _token = prefs.getString(_tokenKey);
+    // #3193: sessionStorage on the web (dies with the tab/browser),
+    // SharedPreferences elsewhere.
+    _token = await readToken();
 
     await _loadConfig();
 
@@ -283,6 +284,7 @@ class AuthService extends ChangeNotifier {
         // stored hash (#1544).
         _bannerAccepted = false;
       } else {
+        final prefs = await SharedPreferences.getInstance();
         final acceptedHash = prefs.getString('klangk_banner_accepted');
         _bannerAccepted = acceptedHash == _bannerText.hashCode.toString();
       }
@@ -353,8 +355,7 @@ class AuthService extends ChangeNotifier {
 
   Future<void> _saveToken(String token) async {
     _token = token;
-    final prefs = await SharedPreferences.getInstance();
-    await prefs.setString(_tokenKey, token);
+    await writeToken(token);
     // Re-fetch config now that we have a token, so authenticated-only
     // fields (e.g. the netfilter deploy allow-list, #1365) are picked up
     // without an app restart.
@@ -384,8 +385,7 @@ class AuthService extends ChangeNotifier {
     // same-user "resume where you were" behavior after a token expiry.
     pendingRedirect = null;
     _stopPermissionRefresh();
-    final prefs = await SharedPreferences.getInstance();
-    await prefs.remove(_tokenKey);
+    await clearToken();
     notifyListeners();
   }
 

--- a/src/frontend/lib/auth/token_store.dart
+++ b/src/frontend/lib/auth/token_store.dart
@@ -1,0 +1,7 @@
+/// Session-token persistence (#3193).
+///
+/// On the web the token is kept in browser sessionStorage — closing the
+/// tab or the browser destroys the session — while other targets use
+/// SharedPreferences via the stub implementation.
+export 'token_store_stub.dart'
+    if (dart.library.js_interop) 'token_store_web.dart';

--- a/src/frontend/lib/auth/token_store_stub.dart
+++ b/src/frontend/lib/auth/token_store_stub.dart
@@ -1,0 +1,22 @@
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// Default (non-web) token store: the JWT persists in SharedPreferences.
+/// Swapped for a sessionStorage-backed implementation on the web via the
+/// conditional export in `token_store.dart` (#3193).
+
+const tokenKey = 'klangk_jwt';
+
+Future<String?> readToken() async {
+  final prefs = await SharedPreferences.getInstance();
+  return prefs.getString(tokenKey);
+}
+
+Future<void> writeToken(String token) async {
+  final prefs = await SharedPreferences.getInstance();
+  await prefs.setString(tokenKey, token);
+}
+
+Future<void> clearToken() async {
+  final prefs = await SharedPreferences.getInstance();
+  await prefs.remove(tokenKey);
+}

--- a/src/frontend/lib/auth/token_store_web.dart
+++ b/src/frontend/lib/auth/token_store_web.dart
@@ -1,0 +1,33 @@
+import 'package:web/web.dart' as web;
+
+/// Web token store (#3193): the session JWT lives in sessionStorage, so
+/// closing the tab or the browser destroys it. shared_preferences maps to
+/// localStorage on the web — which survives a browser close — so this
+/// implementation talks to `window.sessionStorage` directly.
+///
+/// A token left in localStorage by an older build (shared_preferences
+/// writes it under the `flutter.` prefix) is migrated into sessionStorage
+/// on first read and scrubbed, so an upgraded deployment stops carrying
+/// the persistent copy around.
+
+const tokenKey = 'klangk_jwt';
+const legacyLocalStorageKey = 'flutter.klangk_jwt';
+
+Future<String?> readToken() async {
+  final token = web.window.sessionStorage.getItem(tokenKey);
+  if (token != null) return token;
+  final legacy = web.window.localStorage.getItem(legacyLocalStorageKey);
+  if (legacy == null) return null;
+  web.window.localStorage.removeItem(legacyLocalStorageKey);
+  web.window.sessionStorage.setItem(tokenKey, legacy);
+  return legacy;
+}
+
+Future<void> writeToken(String token) async {
+  web.window.sessionStorage.setItem(tokenKey, token);
+}
+
+Future<void> clearToken() async {
+  web.window.sessionStorage.removeItem(tokenKey);
+  web.window.localStorage.removeItem(legacyLocalStorageKey);
+}

--- a/src/frontend/lib/auth/token_store_web.dart
+++ b/src/frontend/lib/auth/token_store_web.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:web/web.dart' as web;
 
 /// Web token store (#3193): the session JWT lives in sessionStorage, so
@@ -13,21 +15,58 @@ import 'package:web/web.dart' as web;
 const tokenKey = 'klangk_jwt';
 const legacyLocalStorageKey = 'flutter.klangk_jwt';
 
-Future<String?> readToken() async {
-  final token = web.window.sessionStorage.getItem(tokenKey);
-  if (token != null) return token;
-  final legacy = web.window.localStorage.getItem(legacyLocalStorageKey);
-  if (legacy == null) return null;
+/// Undo shared_preferences' JSON encoding (it stores strings via
+/// `json.encode`, so the legacy value arrives double-quoted). Falls back
+/// to the raw value for anything that isn't a JSON string.
+String? decodeLegacyToken(String? raw) {
+  if (raw == null) return null;
+  try {
+    final decoded = jsonDecode(raw);
+    if (decoded is String) return decoded;
+  } catch (_) {
+    // Not JSON — treat as a raw token.
+  }
+  return raw;
+}
+
+/// Scrub a token left in localStorage by an older build. Safe to call on
+/// every write/clear: a fresh login supersedes any legacy token, and the
+/// key simply may not exist.
+void scrubLegacyToken() {
   web.window.localStorage.removeItem(legacyLocalStorageKey);
-  web.window.sessionStorage.setItem(tokenKey, legacy);
-  return legacy;
+}
+
+/// Storage access throws when the browser blocks site data (cookies
+/// policy, privacy modes). A failure here must degrade to "logged out",
+/// not brick startup — `_loadToken` runs fire-and-forget from the
+/// AuthService constructor, so an exception would leave the splash
+/// spinner up forever.
+Future<String?> readToken() async {
+  try {
+    final token = web.window.sessionStorage.getItem(tokenKey);
+    if (token != null) return token;
+    final legacy = decodeLegacyToken(
+      web.window.localStorage.getItem(legacyLocalStorageKey),
+    );
+    if (legacy == null) return null;
+    // Write the replacement BEFORE removing the original, so a storage
+    // failure can't destroy the only copy.
+    web.window.sessionStorage.setItem(tokenKey, legacy);
+    web.window.localStorage.removeItem(legacyLocalStorageKey);
+    return legacy;
+  } catch (_) {
+    return null;
+  }
 }
 
 Future<void> writeToken(String token) async {
   web.window.sessionStorage.setItem(tokenKey, token);
+  // #3193 review: a fresh login supersedes any legacy token — don't let
+  // one linger in localStorage until the next logout.
+  scrubLegacyToken();
 }
 
 Future<void> clearToken() async {
   web.window.sessionStorage.removeItem(tokenKey);
-  web.window.localStorage.removeItem(legacyLocalStorageKey);
+  scrubLegacyToken();
 }

--- a/src/frontend/test/auth_service_test.dart
+++ b/src/frontend/test/auth_service_test.dart
@@ -506,6 +506,9 @@ void main() {
       expect(service.token, 'new-token');
       expect(service.isLoggedIn, isTrue);
       expect(service.loading, isFalse);
+      // #3193: the token must be persisted through the token store.
+      final prefs = await SharedPreferences.getInstance();
+      expect(prefs.getString('klangk_jwt'), 'new-token');
     });
 
     test('failed login returns error message', () async {
@@ -871,6 +874,9 @@ void main() {
       await service.logout();
       expect(service.isLoggedIn, isFalse);
       expect(service.token, isNull);
+      // #3193: logout must destroy the persisted token.
+      final prefs = await SharedPreferences.getInstance();
+      expect(prefs.getString('klangk_jwt'), isNull);
     });
 
     test('skips server call when already logged out (#2687)', () async {


### PR DESCRIPTION
## Summary

- The session JWT was persisted via `SharedPreferences`, which maps to `localStorage` on the web — so the token survived browser close and stayed usable on disk (#3193).
- Token persistence now goes through a small token store (`src/frontend/lib/auth/token_store.dart`, conditional export): **`sessionStorage` on the web** (dies with the tab/browser) and SharedPreferences elsewhere. Login, logout, refresh, and verification flows all route through it.
- A token left in `localStorage` by an older build (`flutter.klangk_jwt`, stored JSON-quoted by `shared_preferences_web`) is decoded, migrated into `sessionStorage` on first read, and scrubbed — from every write too, so it can't linger past a fresh login. Storage access failures degrade to logged-out rather than a stuck splash.
- New Playwright specs pin the web behavior (`session-storage.spec.ts`): placement after login, legacy migration + scrub, and per-tab isolation. VM widget tests keep covering the stub path; frontend coverage stays 100%.
- Changelog entry under `[Unreleased]` → Security.

Behavior change: signing in again is required after a browser restart, a session-restore reopen, or opening the app in a new tab.

## Verification

- `flutter test --coverage` — 1238 passing, 100% coverage maintained.
- `npx playwright test session-storage --project=chromium-api` — 3 passing against the real built app.
- Runtime-verified in a real browser via the fmtk harness: login stores only in `sessionStorage`; a JSON-quoted legacy `localStorage` token migrates (still authenticated, raw JWT, localStorage scrubbed); a new tab starts unauthenticated; logout clears storage.

Closes #3193
