### PR TITLE
Revoke sessions when an admin deletes a user (#3195)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,6 +58,7 @@ Thumbs.db
 # Claude
 .claude/
 .coverage
+.coverage.*
 # pytest-testmon line->test map (local iteration only, #2288). Written to
 # the pytest rootdir (src/klangk/.testmondata).
 .testmondata

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -2244,6 +2244,11 @@ git-credential` (#1700).** `pig-latin` removed; `word-count` dormant.
   ("Invalid path", "Permission denied", "Internal server error") and
   log the underlying error server-side instead.
 
+- **Admin user deletion now revokes sessions (#3195).** `DELETE
+  /api/v1/users/{user_id}` now blocklists every token the deleted user
+  held and cuts their live WebSocket and consent-decider connections.
+  Previously sessions stayed alive until their natural expiry.
+
 - **Parallel image-build tasks tolerate transient rootless-podman failures
   (#3168).** `klangk:build-workspace-image` and `klangk:build-network-sidecar`
   run in parallel and are a fresh machine's first rootless podman invocations;

--- a/src/klangk/klangk/api/admin.py
+++ b/src/klangk/klangk/api/admin.py
@@ -353,7 +353,18 @@ async def delete_user(
     # rows, so the per-workspace registry entries can be pruned after the
     # delete (#2912).
     ws_ids = await app.state.model.workspaces.get_user_workspace_ids(user_id)
+    # Revoke every session while the rows still exist to read the JTIs
+    # from (#3195): each token is blocklisted (401 "Token has been
+    # revoked" on its next use) and the live sockets it opened are cut.
+    await app.state.auth.revoke_all_user_sessions(
+        user_id, reason="user deletion"
+    )
     deleted = await app.state.model.users.delete_user(user_id)
+    # Cut what remains by user id, after the row is gone (#3195): a
+    # connect that raced in between the revoke and the delete must hit
+    # the missing user row and die, and sockets from pre-session-registry
+    # tokens carry no session row for the revoke to reach.
+    await _kick_user_sockets(app, user_id, "deleted", "Account deleted")
     # Prune the per-user activity-throttle stamp (#2914): placed before
     # the not-deleted race check so even a lost race (user already gone)
     # does not leave a stale entry behind.
@@ -479,23 +490,27 @@ def _reject_self_disable(
         )
 
 
-async def _kick_disabled_user_sockets(app, user_id: str) -> None:
-    """Cut a just-disabled user's live sockets (#2588, #3162).
+async def _kick_user_sockets(
+    app, user_id: str, action: str, reason: str
+) -> None:
+    """Cut a user's live sockets (#2588, #3162).
 
     The main /ws connections (the terminal/control data plane) and the
     consent-decider sockets (egress-consent authority) alike; 4001 ->
-    the clients log out rather than reconnect-looping.
+    the clients log out rather than reconnect-looping. *action* names
+    the trigger in the log line ("disabled", "deleted").
     """
     kicked = await wshandler.disconnect_user(
-        app.state.sockets, user_id, reason="Account disabled"
+        app.state.sockets, user_id, reason=reason
     )
     deciders_kicked = await wshandler.disconnect_deciders_by_user(
-        app, user_id, reason="Account disabled"
+        app, user_id, reason=reason
     )
     if kicked or deciders_kicked:
         logger.info(
-            "admin: disabled user %s; closed %d live connection(s)"
+            "admin: %s user %s; closed %d live connection(s)"
             " and %d consent decider(s)",
+            action,
             user_id,
             kicked,
             deciders_kicked,
@@ -517,7 +532,7 @@ async def _update_user_disabled(
     if not updated:  # pragma: no cover — race between get and update
         raise HTTPException(status_code=404, detail="User not found")
     if req.disabled:
-        await _kick_disabled_user_sockets(app, user_id)
+        await _kick_user_sockets(app, user_id, "disabled", "Account disabled")
 
 
 @router.post("/users/{user_id}/unlockout")

--- a/src/klangk/klangk/auth.py
+++ b/src/klangk/klangk/auth.py
@@ -1063,17 +1063,21 @@ class Auth:
         if deciders is not None:
             await deciders.disconnect_by_jti(jti, reason="Token revoked")
 
-    async def revoke_all_user_sessions(self, user_id: str) -> None:
+    async def revoke_all_user_sessions(
+        self, user_id: str, *, reason: str = "password change"
+    ) -> None:
         """Blocklist and delete every session for *user_id* (#3152).
 
-        Called after a password change: the old credential is invalid, so
-        every session minted with it must be forcibly ended — both the
-        HTTP side (blocklist → 401) and the WebSocket side (kick).
+        Called after a password change (the old credential is invalid, so
+        every session minted with it must be forcibly ended) and on user
+        deletion (#3195) — both the HTTP side (blocklist → 401) and the
+        WebSocket side (kick). *reason* names the trigger in the log.
         """
         rows = await self.app.state.model.sessions.list_sessions(user_id)
         for row in rows:
             logger.info(
-                "password change: revoking session jti=%s (user %s)",
+                "%s: revoking session jti=%s (user %s)",
+                reason,
                 row["jti"],
                 user_id,
             )

--- a/src/klangk/klangkd-tests/tests/test_api.py
+++ b/src/klangk/klangkd-tests/tests/test_api.py
@@ -10296,6 +10296,95 @@ class TestAdminEndpoints:
         emails = [u["email"] for u in resp.json()["users"]]
         assert "testuser@example.com" not in emails
 
+    async def test_delete_user_revokes_sessions(
+        self, client, app, admin_user, user, registry, app_state
+    ):
+        """#3195: deletion blocklists the victim's tokens — the old JWT
+        dies as "revoked" (not merely "user not found"), so nothing
+        issued before the delete stays usable until natural expiry."""
+        login = await client.post(
+            "/api/v1/auth/login",
+            json={
+                "identifier": "testuser@example.com",
+                "password": "testpass",
+            },
+        )
+        victim_headers = {
+            "Authorization": f"Bearer {login.json()['access_token']}"
+        }
+        jti = app.state.auth.decode_token(login.json()["access_token"])["jti"]
+        headers = await self._admin_headers(client)
+        with (
+            patch.object(
+                registry,
+                "stop_user_containers",
+                new_callable=AsyncMock,
+            ),
+            patch.object(
+                app.state.workspaces,
+                "archive_user_data",
+                new_callable=AsyncMock,
+            ),
+        ):
+            resp = await client.delete(
+                f"/api/v1/users/{user['id']}", headers=headers
+            )
+        assert resp.status_code == 200
+        # The token is blocklisted, so it 401s as revoked (the check
+        # runs before the user lookup — a deleted-but-unrevoked token
+        # would say "User not found" instead).
+        resp = await client.get("/api/v1/auth/me", headers=victim_headers)
+        assert resp.status_code == 401
+        assert resp.json()["detail"] == "Token has been revoked"
+        # The blocklist assert is the real check: the session rows would
+        # also vanish via the user-delete cascade without the revoke.
+        assert await app_state.state.model.tokens.is_token_blocklisted(jti)
+
+    async def test_delete_user_kicks_sockets(
+        self, client, app, admin_user, user, registry
+    ):
+        """#3195: deletion cuts the victim's live /ws connections
+        (4001, "Account deleted") — a deleted user's data plane must not
+        outlive the delete. The victim's fake connection has no session
+        row, so it is the by-user kick (not the jti revoke) that closes
+        it — exactly the pre-session-registry-token case. Another user's
+        socket is untouched."""
+        closed: list[tuple[int, str]] = []
+
+        class FakeSock:
+            async def close(self, code=1000, reason=""):
+                closed.append((code, reason))
+
+        victim_conn = types.SimpleNamespace(
+            user={"id": user["id"], "email": user["email"]}
+        )
+        other_conn = types.SimpleNamespace(
+            user={"id": "someone-else", "email": "other@example.com"}
+        )
+        app.state.sockets.connections[FakeSock()] = other_conn
+        app.state.sockets.connections[FakeSock()] = victim_conn
+        headers = await self._admin_headers(client)
+        try:
+            with (
+                patch.object(
+                    registry,
+                    "stop_user_containers",
+                    new_callable=AsyncMock,
+                ),
+                patch.object(
+                    app.state.workspaces,
+                    "archive_user_data",
+                    new_callable=AsyncMock,
+                ),
+            ):
+                resp = await client.delete(
+                    f"/api/v1/users/{user['id']}", headers=headers
+                )
+            assert resp.status_code == 200
+            assert closed == [(4001, "Account deleted")]
+        finally:
+            app.state.sockets.connections.clear()
+
     async def test_delete_user_prunes_activity_stamp(
         self, client, app, admin_user, user, registry
     ):


### PR DESCRIPTION
## Summary

Admin user deletion left the deleted user's authentication material alive:
`DELETE /api/v1/users/{user_id}` stopped containers, archived data, and pruned
registry entries, but never touched the session surface. Live WebSocket (and
consent-decider) connections survived the delete, and issued JWTs were never
blocklisted — the blocklist is what the auth choke points check first, so a
held token's fate hung on downstream user-row lookups instead of an explicit
revocation (#3195).

The route now revokes every session **before** the DB cascade removes the rows
(the cascade would make the JTIs unreadable):

- `revoke_all_user_sessions(user_id, reason="user deletion")` — blocklists each
  session's JTI (next HTTP use → `401 Token has been revoked`), cuts the live
  sockets each token opened (4001 → client logout), and drops the rows. This
  runs **before** the DB delete, while the session rows (which cascade away
  with the user) still carry the JTIs to blocklist.
- `_kick_user_sockets(...)` (the disable-path kicker, generalized) then runs
  **after** the user row is gone and cuts anything left by user id — sockets
  authenticated by pre-session-registry tokens that carry no session row to
  revoke, and any connect that raced in between the revoke and the delete
  (it hits the missing user row and is rejected). Reason: `Account deleted`.
- `revoke_all_user_sessions` gained a keyword-only `reason` param so the log
  line no longer claims "password change" on the delete path.

## Tests

- `test_delete_user_revokes_sessions` — logs in as the victim, deletes via
  admin, asserts the old token now 401s as **revoked** (the pre-fix behavior
  was 401 "User not found"; the detail proves the blocklist), the JTI is on
  the blocklist, and the session row is gone.
- `test_delete_user_kicks_sockets` — the victim's live `/ws` connections close
  with `(4001, "Account deleted")`; another user's socket is untouched.

Full suite: 7289 passed locally; the only coverage delta observed
(`container/idle.py` throttle arms) is machine-load flakiness in pre-existing
timing tests — this box was running three other full suites concurrently
(load avg >200) during local runs; CI's dedicated runner is the authority.

Fixes #3195.
