### PR TITLE
Replace str(e) in workspace-create OSError response with generic 500 (#3215)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -2223,6 +2223,12 @@ git-credential` (#1700).** `pig-latin` removed; `word-count` dormant.
 
 ### Fixed
 
+- **Workspace-create error responses (#3215).** A host-side
+  filesystem failure during workspace creation (unwritable data dir,
+  disk full) no longer echoes the raw OS message — which names host
+  paths — in a 400 body. It is now a 500 "Internal server error"
+  with the underlying error logged server-side.
+
 - **Files API error responses (#3150).** The workspace files routes
   (list/read/delete/rename/upload/download) no longer echo raw
   exception text — podman stderr, container paths, library messages —

--- a/src/klangk/klangk/api/workspaces.py
+++ b/src/klangk/klangk/api/workspaces.py
@@ -383,7 +383,7 @@ async def create_workspace(
     except OSError as e:
         # Host-side failure (data-dir mkdir, disk full) — not bad client
         # input. Generic body + server-side log, the _files_http_error
-        # posture (#3215): the raw message names host paths.
+        # posture (#3150): the raw message names host paths.
         logger.error("workspace create failed: %s", e, exc_info=True)
         raise HTTPException(
             status_code=500, detail="Internal server error"

--- a/src/klangk/klangk/api/workspaces.py
+++ b/src/klangk/klangk/api/workspaces.py
@@ -381,7 +381,13 @@ async def create_workspace(
             detail=f"A workspace named {body.name!r} already exists",
         )
     except OSError as e:
-        raise HTTPException(status_code=400, detail=str(e))
+        # Host-side failure (data-dir mkdir, disk full) — not bad client
+        # input. Generic body + server-side log, the _files_http_error
+        # posture (#3215): the raw message names host paths.
+        logger.error("workspace create failed: %s", e, exc_info=True)
+        raise HTTPException(
+            status_code=500, detail="Internal server error"
+        ) from None
 
     # Eagerly start the container so it's running by the time the
     # user connects.  Errors are logged but don't fail the create.

--- a/src/klangk/klangkd-tests/tests/test_api.py
+++ b/src/klangk/klangkd-tests/tests/test_api.py
@@ -17349,10 +17349,13 @@ class TestTestModeEndpoints:
 
 
 class TestNoCoverAudit2910Part3:
-    async def test_create_workspace_oserror_maps_500(self):
+    async def test_create_workspace_oserror_maps_500(self, caplog):
         """create_workspace raising OSError (host-side mkdir failure) is a
         500 with a generic body, not a 400 echoing the OS message
-        (#3215; direct handler call, Depends bypassed)."""
+        (#3215; direct handler call, Depends bypassed). The log record
+        is the operator's only diagnostic — pin it."""
+        import logging
+
         from fastapi import HTTPException
 
         from klangk.api.workspaces import (
@@ -17367,7 +17370,10 @@ class TestNoCoverAudit2910Part3:
             ),
         )
         app.state.settings.default_image = None
-        with pytest.raises(HTTPException) as caught:
+        with (
+            caplog.at_level(logging.ERROR, logger="klangk.api.workspaces"),
+            pytest.raises(HTTPException) as caught,
+        ):
             await create_endpoint(
                 CreateWorkspaceRequest(name="os-fail"),
                 user={"id": "u1", "email": "u@x.com"},
@@ -17375,6 +17381,7 @@ class TestNoCoverAudit2910Part3:
             )
         assert caught.value.status_code == 500
         assert caught.value.detail == "Internal server error"
+        assert "No space left on device" in caplog.text
 
     async def test_duplicate_workspace_collection_acl_false_403(self):
         """The in-handler defense-in-depth collection-create check (#2569):

--- a/src/klangk/klangkd-tests/tests/test_api.py
+++ b/src/klangk/klangkd-tests/tests/test_api.py
@@ -17349,9 +17349,10 @@ class TestTestModeEndpoints:
 
 
 class TestNoCoverAudit2910Part3:
-    async def test_create_workspace_oserror_maps_400(self):
-        """create_workspace raising OSError (bad mount source etc.) is a
-        400, not a 500 (direct handler call, Depends bypassed)."""
+    async def test_create_workspace_oserror_maps_500(self):
+        """create_workspace raising OSError (host-side mkdir failure) is a
+        500 with a generic body, not a 400 echoing the OS message
+        (#3215; direct handler call, Depends bypassed)."""
         from fastapi import HTTPException
 
         from klangk.api.workspaces import (
@@ -17361,7 +17362,9 @@ class TestNoCoverAudit2910Part3:
 
         app = MagicMock()
         app.state.workspaces.create_workspace = AsyncMock(
-            side_effect=OSError("mount source missing")
+            side_effect=OSError(
+                "[Errno 28] No space left on device: '/var/lib/klangk/...'"
+            ),
         )
         app.state.settings.default_image = None
         with pytest.raises(HTTPException) as caught:
@@ -17370,8 +17373,8 @@ class TestNoCoverAudit2910Part3:
                 user={"id": "u1", "email": "u@x.com"},
                 app=app,
             )
-        assert caught.value.status_code == 400
-        assert "mount source missing" in caught.value.detail
+        assert caught.value.status_code == 500
+        assert caught.value.detail == "Internal server error"
 
     async def test_duplicate_workspace_collection_acl_false_403(self):
         """The in-handler defense-in-depth collection-create check (#2569):


### PR DESCRIPTION
## Summary

Fixes #3215. The workspace-create route had `except OSError → 400, detail=str(e)` — echoing host-side OS error text (which names host paths, e.g. an ENOSPC on the data dir) to clients. Same leak class as #3150/#3207.

The OSError source is the service layer's host-side `home.mkdir` (`workspaces.py` create_workspace), not client input — the old test docstring claimed "bad mount source", but mounts are validated earlier by `_check_mounts` (ValueError → 400, before the try block). A host-side failure is a server failure, so the route now returns **500 "Internal server error"** and logs the underlying error with `exc_info` — the exact `_files_http_error` 500-branch posture.

The rewritten test pins the contract: status, generic body, and the log record (the operator's only diagnostic).

## Review-verified claims

- No client-caused OSError is swallowed into the 500: every input-validation path (`_check_mounts`, `_check_image`, `_check_autostart`, settings/domains/banner) runs in `_validate_create_fields` before the try; inside the try only the DB model (ValueError/SAError), host mkdir, and a hook-swallowing path run.
- No consumer couples on the old 400: CLI prints `detail` generically and retries only 502/503/504; TUI and the frontend dialog render `detail` verbatim; no e2e asserts the old behavior.

## Notes

- Fresh-eyes review: APPROVE; its two nits (caplog pin, comment attribution) are addressed in the follow-up commit.
- The reviewer flagged a **pre-existing** bug worth a follow-up: `create_workspace_with_acl` commits the DB row *before* `home.mkdir` runs, and the existing rollback only covers `allocate_ports` failure — so an mkdir failure leaves an orphaned workspace row whose name then 409s on retry. Not introduced here; will be filed separately.
