### PR TITLE
Add Audit subtab to the admin Events tab (#3217)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -651,6 +651,14 @@ sync` report a clear permission-denied error.
 
 ### Added
 
+- **Audit subtab in the admin Events tab (#3217).** The Events tab
+  now has a Containers / Audit segmented control; Audit lists the
+  identity/privilege stream of #3205 (logins, account and group
+  changes, ACL and workspace-role edits) newest-first with paging and
+  event / actor / target filters. Rows expand to the read-only detail
+  blob plus source IP and user agent. Same `manage-events` grant as
+  the container history — no new permission wiring.
+
 - **Structured audit stream for identity and privilege actions
   (#3205).** A new `audit_events` table records account
   create/update/delete (admin and self-service), group and ACL

--- a/src/frontend/lib/admin/admin_users_page.dart
+++ b/src/frontend/lib/admin/admin_users_page.dart
@@ -17,7 +17,7 @@ import '../widgets/obscure_toggle.dart';
 import '../widgets/skeuo_tab.dart';
 import '../utils/system_agent.dart';
 import '../utils/validators.dart';
-import 'container_events_panel.dart';
+import 'events_tab.dart';
 import 'server_schedule_panel.dart';
 
 class AdminUsersPage extends StatefulWidget {
@@ -558,7 +558,7 @@ class _AdminUsersPageState extends State<AdminUsersPage> {
       addTab(
         label: 'Events',
         icon: Icons.history,
-        view: const ContainerEventsPanel(),
+        view: const EventsTab(),
       );
     }
     // The Volumes tab (#2993): the deployment's instance-managed

--- a/src/frontend/lib/admin/audit_events_panel.dart
+++ b/src/frontend/lib/admin/audit_events_panel.dart
@@ -1,0 +1,490 @@
+// coverage:ignore-file
+/// Admin → Events tab → Audit subtab: paged identity/privilege audit
+/// history (#3217).
+///
+/// Reads the `audit_events` table (#3205) through
+/// `GET /api/v1/events/audit` — newest first, optional `event` /
+/// `actor` / `target` substring filters, offset-based paging. Mirrors
+/// [ContainerEventsPanel] (same paged envelope, same filter-field +
+/// paging layout). The subtab rides the Events tab's `manage-events`
+/// gate (see [AdminUsersPage]); the `/events` ACL resource governs
+/// both streams, so no separate permission wiring exists.
+library;
+
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../auth/auth_service.dart';
+import '../theme/colors.dart';
+import '../utils/system_agent.dart';
+
+/// The Audit subtab body: event/actor/target filter fields, paging
+/// controls, and the history table. Each row expands in place to the
+/// read-only detail view (detail JSON, full source IP, full user
+/// agent) for incident correlation.
+class AuditEventsPanel extends StatefulWidget {
+  const AuditEventsPanel({super.key});
+
+  @override
+  State<AuditEventsPanel> createState() => _AuditEventsPanelState();
+}
+
+class _AuditEventsPanelState extends State<AuditEventsPanel> {
+  static const _pageSize = 50;
+
+  List<Map<String, dynamic>> _events = [];
+  int _total = 0;
+  int _offset = 0;
+  bool _loading = true;
+  String? _error;
+
+  String _eventQuery = '';
+  String _actorQuery = '';
+  String _targetQuery = '';
+
+  /// Row id whose detail area is expanded (null = none).
+  int? _expandedId;
+
+  @override
+  void initState() {
+    super.initState();
+    _load();
+  }
+
+  /// URL-encode a query param map (sorted for stable, cacheable URLs).
+  static String _encodeQuery(Map<String, String> params) {
+    final pairs = <String>[];
+    for (final key in params.keys.toList()..sort()) {
+      pairs.add(
+        '${Uri.encodeQueryComponent(key)}='
+        '${Uri.encodeQueryComponent(params[key]!)}',
+      );
+    }
+    return pairs.join('&');
+  }
+
+  Future<void> _load({int offset = 0}) async {
+    setState(() {
+      _loading = true;
+      _error = null;
+      _offset = offset;
+    });
+    try {
+      final query = <String, String>{
+        'limit': '$_pageSize',
+        'offset': '$offset',
+        if (_eventQuery.isNotEmpty) 'event': _eventQuery,
+        if (_actorQuery.isNotEmpty) 'actor': _actorQuery,
+        if (_targetQuery.isNotEmpty) 'target': _targetQuery,
+      };
+      final auth = context.read<AuthService>();
+      final resp =
+          await auth.authGet('/api/v1/events/audit?${_encodeQuery(query)}');
+      if (!mounted) return;
+      if (resp.statusCode == 200) {
+        final data = jsonDecode(resp.body) as Map<String, dynamic>;
+        setState(() {
+          _events = (data['items'] as List).cast<Map<String, dynamic>>();
+          _total = (data['total'] as num).toInt();
+          _loading = false;
+        });
+      } else {
+        setState(() {
+          _error = 'Failed to load audit events (${resp.statusCode})';
+          _loading = false;
+        });
+      }
+    } catch (e) {
+      debugPrint('[AuditEventsPanel] load failed: $e');
+      if (mounted) {
+        setState(() {
+          _error = 'Could not load audit events. Please try again.';
+          _loading = false;
+        });
+      }
+    }
+  }
+
+  bool get _canPrev => _offset > 0;
+  bool get _canNext => _offset + _events.length < _total;
+
+  /// '12–61 of 214' — the slice currently on screen.
+  String get _rangeLabel {
+    if (_total == 0) return '0 events';
+    final first = _offset + 1;
+    final last = _offset + _events.length;
+    return '$first–$last of $_total';
+  }
+
+  /// Render an epoch-seconds `created_at` as a local 'MMM d, HH:MM' label.
+  String _timeLabel(dynamic createdAt) {
+    final secs = (createdAt as num?)?.toDouble();
+    if (secs == null) return '';
+    final dt = DateTime.fromMillisecondsSinceEpoch((secs * 1000).round());
+    final localizations = MaterialLocalizations.of(context);
+    return '${localizations.formatMediumDate(dt)} '
+        '${localizations.formatTimeOfDay(TimeOfDay.fromDateTime(dt))}';
+  }
+
+  /// Actor email when the backend denormalized one at write time, the
+  /// raw id otherwise (attribution survives the actor's own deletion,
+  /// #3205). A missing actor is an unauthenticated row (login.failed)
+  /// or a fixed system identity.
+  String _actorLabel(Map<String, dynamic> row) {
+    final id = row['actor_id'] as String?;
+    if (id == agentUserId) return 'system agent';
+    final email = row['actor_email'] as String?;
+    if (email != null && email.isNotEmpty) return email;
+    if (id != null && id.isNotEmpty) return id;
+    return 'system';
+  }
+
+  /// 'user 2f9a…' / 'group g1' / '' when the event has no target.
+  String _targetLabel(Map<String, dynamic> row) {
+    final id = row['target_id'] as String?;
+    final type = row['target_type'] as String?;
+    if (id == null || id.isEmpty) return '';
+    if (type == null || type.isEmpty) return id;
+    return '$type $id';
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Padding(
+          padding: const EdgeInsets.fromLTRB(16, 12, 16, 4),
+          child: Row(
+            children: [
+              Expanded(
+                child: _FilterField(
+                  fieldKey: const ValueKey('audit-event-filter'),
+                  label: 'Filter by event name',
+                  onChanged: (value) {
+                    _eventQuery = value;
+                    _load(offset: 0);
+                  },
+                ),
+              ),
+              const SizedBox(width: 8),
+              Expanded(
+                child: _FilterField(
+                  fieldKey: const ValueKey('audit-actor-filter'),
+                  label: 'Filter by actor id or email',
+                  onChanged: (value) {
+                    _actorQuery = value;
+                    _load(offset: 0);
+                  },
+                ),
+              ),
+              const SizedBox(width: 8),
+              Expanded(
+                child: _FilterField(
+                  fieldKey: const ValueKey('audit-target-filter'),
+                  label: 'Filter by target id',
+                  onChanged: (value) {
+                    _targetQuery = value;
+                    _load(offset: 0);
+                  },
+                ),
+              ),
+              const SizedBox(width: 8),
+              IconButton(
+                icon: const Icon(Icons.refresh),
+                tooltip: 'Refresh',
+                onPressed: () => _load(offset: _offset),
+              ),
+            ],
+          ),
+        ),
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 16),
+          child: Row(
+            children: [
+              Expanded(
+                child: Text(
+                  _rangeLabel,
+                  style: const TextStyle(color: KColors.textSecondary),
+                ),
+              ),
+              IconButton(
+                icon: const Icon(Icons.chevron_left),
+                tooltip: 'Previous page',
+                onPressed: _canPrev
+                    ? () => _load(
+                          offset:
+                              _offset - _pageSize < 0 ? 0 : _offset - _pageSize,
+                        )
+                    : null,
+              ),
+              IconButton(
+                icon: const Icon(Icons.chevron_right),
+                tooltip: 'Next page',
+                onPressed: _canNext
+                    ? () => _load(offset: _offset + _events.length)
+                    : null,
+              ),
+            ],
+          ),
+        ),
+        Expanded(child: _buildBody()),
+      ],
+    );
+  }
+
+  /// Column labels with the flex weights shared by the header row and
+  /// every data row: aligned columns that always share the panel width
+  /// (the #3006 container-table pattern). Long cell values ellipsize;
+  /// the tooltip carries the full text, and the row's expanded detail
+  /// view repeats source IP / user agent in full.
+  static const _columns = <(String, int)>[
+    ('When', 3),
+    ('Event', 2),
+    ('Actor', 3),
+    ('Target', 3),
+    ('Source IP', 2),
+    ('User agent', 4),
+  ];
+
+  Widget _buildBody() {
+    if (_loading && _events.isEmpty) {
+      return const Center(child: CircularProgressIndicator());
+    }
+    if (_error != null && _events.isEmpty) {
+      return Center(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Text(_error!),
+            const SizedBox(height: 8),
+            OutlinedButton(
+              onPressed: () => _load(offset: 0),
+              child: const Text('Retry'),
+            ),
+          ],
+        ),
+      );
+    }
+    if (_events.isEmpty) {
+      return const Center(child: Text('No audit events recorded'));
+    }
+    return Column(
+      children: [
+        Container(
+          padding: const EdgeInsets.fromLTRB(16, 8, 16, 4),
+          decoration: const BoxDecoration(
+            border: Border(bottom: BorderSide(color: KColors.borderDefault)),
+          ),
+          child: Row(
+            children: [
+              for (final (label, flex) in _columns)
+                Expanded(
+                  flex: flex,
+                  child: Text(
+                    label,
+                    style: const TextStyle(
+                      color: KColors.textSecondary,
+                      fontWeight: FontWeight.bold,
+                      fontSize: 12,
+                    ),
+                  ),
+                ),
+            ],
+          ),
+        ),
+        Expanded(
+          child: ListView.builder(
+            itemCount: _events.length,
+            itemBuilder: (ctx, i) => _eventRow(_events[i]),
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _eventRow(Map<String, dynamic> row) {
+    final expanded = _expandedId == row['id'];
+    // Cells built in _columns order; the flex weights below always come
+    // from the same _columns iteration, so a column reorder cannot
+    // relabel the header while leaving the old weight on a cell.
+    final cells = <Widget>[
+      _textCell(_timeLabel(row['created_at'])),
+      _eventChip(row['event'] as String? ?? ''),
+      _textCell(_actorLabel(row)),
+      _textCell(_targetLabel(row)),
+      _textCell(row['source_ip'] as String? ?? ''),
+      _textCell(row['user_agent'] as String? ?? ''),
+    ];
+    return Container(
+      decoration: const BoxDecoration(
+        border: Border(bottom: BorderSide(color: KColors.borderMuted)),
+      ),
+      child: Column(
+        children: [
+          InkWell(
+            onTap: () => setState(
+              () => _expandedId = expanded ? null : row['id'] as int?,
+            ),
+            child: Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 6),
+              child: Row(
+                children: [
+                  for (final (i, (_, flex)) in _columns.indexed)
+                    Expanded(flex: flex, child: cells[i]),
+                ],
+              ),
+            ),
+          ),
+          if (expanded) _detailArea(row),
+        ],
+      ),
+    );
+  }
+
+  /// The expanded, read-only per-row detail view: the action-specific
+  /// `detail` blob (pretty-printed JSON, never secrets — #3205) plus
+  /// the full correlation fields the row columns ellipsize.
+  Widget _detailArea(Map<String, dynamic> row) {
+    final detail = row['detail'];
+    final detailJson = detail == null
+        ? '—'
+        : const JsonEncoder.withIndent('  ').convert(detail);
+    Widget field(String label, String value) {
+      return Padding(
+        padding: const EdgeInsets.only(bottom: 4),
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            SizedBox(
+              width: 90,
+              child: Text(
+                label,
+                style: const TextStyle(
+                  color: KColors.textSecondary,
+                  fontSize: 12,
+                ),
+              ),
+            ),
+            Expanded(
+              child: SelectableText(
+                value,
+                style: const TextStyle(fontSize: 12),
+              ),
+            ),
+          ],
+        ),
+      );
+    }
+
+    return Container(
+      key: const ValueKey('audit-event-detail'),
+      width: double.infinity,
+      padding: const EdgeInsets.fromLTRB(16, 4, 16, 8),
+      color: KColors.bgSurface,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          field('Source IP', row['source_ip'] as String? ?? '—'),
+          field('User agent', row['user_agent'] as String? ?? '—'),
+          field('Detail', detailJson),
+        ],
+      ),
+    );
+  }
+
+  /// One ellipsized table cell; the tooltip keeps the full value
+  /// reachable when the flex share is too narrow to show it.
+  Widget _textCell(String text) {
+    return Tooltip(
+      message: text,
+      child: Text(text, maxLines: 1, overflow: TextOverflow.ellipsis),
+    );
+  }
+
+  /// Failure/destruction events read red (login.failed, user.delete,
+  /// group.member.remove, session.revoke, …), everything else green —
+  /// the binary chip coloring of the container table.
+  Widget _eventChip(String event) {
+    final negative = event.endsWith('.failed') ||
+        event.endsWith('.delete') ||
+        event.endsWith('.remove') ||
+        event.endsWith('.revoke');
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
+      decoration: BoxDecoration(
+        color: negative ? KColors.accentRed : KColors.accentGreen,
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Text(
+        event,
+        maxLines: 1,
+        overflow: TextOverflow.ellipsis,
+        style: const TextStyle(color: Colors.white, fontSize: 12),
+      ),
+    );
+  }
+}
+
+/// A debounced filter field (the workspace-filter pattern of the
+/// container events panel): reports trimmed changes to [onChanged]
+/// once typing pauses, keeping the request burst down.
+class _FilterField extends StatefulWidget {
+  const _FilterField({
+    required this.fieldKey,
+    required this.label,
+    required this.onChanged,
+  });
+
+  final Key fieldKey;
+  final String label;
+  final ValueChanged<String> onChanged;
+
+  @override
+  State<_FilterField> createState() => _FilterFieldState();
+}
+
+class _FilterFieldState extends State<_FilterField> {
+  final _controller = TextEditingController();
+  Timer? _debounce;
+  String _lastReported = '';
+
+  @override
+  void initState() {
+    super.initState();
+    _controller.addListener(() {
+      final value = _controller.text.trim();
+      if (value == _lastReported) return;
+      _lastReported = value;
+      _debounce?.cancel();
+      _debounce = Timer(
+        const Duration(milliseconds: 300),
+        () => widget.onChanged(value),
+      );
+    });
+  }
+
+  @override
+  void dispose() {
+    _debounce?.cancel();
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return TextField(
+      key: widget.fieldKey,
+      controller: _controller,
+      decoration: InputDecoration(
+        isDense: true,
+        labelText: widget.label,
+        border: const OutlineInputBorder(),
+        prefixIcon: const Icon(Icons.filter_list),
+      ),
+    );
+  }
+}

--- a/src/frontend/lib/admin/audit_events_panel.dart
+++ b/src/frontend/lib/admin/audit_events_panel.dart
@@ -19,7 +19,6 @@ import 'package:provider/provider.dart';
 
 import '../auth/auth_service.dart';
 import '../theme/colors.dart';
-import '../utils/system_agent.dart';
 
 /// The Audit subtab body: event/actor/target filter fields, paging
 /// controls, and the history table. Each row expands in place to the
@@ -48,6 +47,12 @@ class _AuditEventsPanelState extends State<AuditEventsPanel> {
   /// Row id whose detail area is expanded (null = none).
   int? _expandedId;
 
+  /// Monotonic load sequence: a response from a superseded load (a
+  /// newer filter/page request raced it) must not overwrite the table
+  /// — the three independent filter debouncers make overlapping
+  /// requests the common case, not the exception.
+  int _seq = 0;
+
   @override
   void initState() {
     super.initState();
@@ -67,10 +72,15 @@ class _AuditEventsPanelState extends State<AuditEventsPanel> {
   }
 
   Future<void> _load({int offset = 0}) async {
+    final seq = ++_seq;
     setState(() {
       _loading = true;
       _error = null;
       _offset = offset;
+      // A fresh page or filter result invalidates any expansion —
+      // ids are unique, but a row resurfacing pages later pre-opened
+      // would be surprising.
+      _expandedId = null;
     });
     try {
       final query = <String, String>{
@@ -83,7 +93,7 @@ class _AuditEventsPanelState extends State<AuditEventsPanel> {
       final auth = context.read<AuthService>();
       final resp =
           await auth.authGet('/api/v1/events/audit?${_encodeQuery(query)}');
-      if (!mounted) return;
+      if (!mounted || seq != _seq) return;
       if (resp.statusCode == 200) {
         final data = jsonDecode(resp.body) as Map<String, dynamic>;
         setState(() {
@@ -99,7 +109,7 @@ class _AuditEventsPanelState extends State<AuditEventsPanel> {
       }
     } catch (e) {
       debugPrint('[AuditEventsPanel] load failed: $e');
-      if (mounted) {
+      if (mounted && seq == _seq) {
         setState(() {
           _error = 'Could not load audit events. Please try again.';
           _loading = false;
@@ -131,15 +141,15 @@ class _AuditEventsPanelState extends State<AuditEventsPanel> {
 
   /// Actor email when the backend denormalized one at write time, the
   /// raw id otherwise (attribution survives the actor's own deletion,
-  /// #3205). A missing actor is an unauthenticated row (login.failed)
-  /// or a fixed system identity.
+  /// #3205). A missing actor is an unauthenticated row (login.failed,
+  /// user.register) — labeled 'anonymous', not 'system': nobody
+  /// authenticated performed it.
   String _actorLabel(Map<String, dynamic> row) {
     final id = row['actor_id'] as String?;
-    if (id == agentUserId) return 'system agent';
     final email = row['actor_email'] as String?;
     if (email != null && email.isNotEmpty) return email;
     if (id != null && id.isNotEmpty) return id;
-    return 'system';
+    return 'anonymous';
   }
 
   /// 'user 2f9a…' / 'group g1' / '' when the event has no target.

--- a/src/frontend/lib/admin/container_events_panel.dart
+++ b/src/frontend/lib/admin/container_events_panel.dart
@@ -38,6 +38,9 @@ class _ContainerEventsPanelState extends State<ContainerEventsPanel> {
   bool _loading = true;
   String? _error;
 
+  /// Monotonic load sequence — see [_load].
+  int _seq = 0;
+
   final _workspaceController = TextEditingController();
   String _workspaceQuery = '';
   Timer? _queryDebounce;
@@ -78,6 +81,12 @@ class _ContainerEventsPanelState extends State<ContainerEventsPanel> {
   }
 
   Future<void> _load({int offset = 0}) async {
+    // Monotonic load sequence: a superseded response (filter debounce,
+    // refresh, or paging while a request is in flight) must not
+    // overwrite the table — the last response to *land* is not
+    // necessarily the newest request (#3217 review, applied to the
+    // container stream too).
+    final seq = ++_seq;
     setState(() {
       _loading = true;
       _error = null;
@@ -92,7 +101,7 @@ class _ContainerEventsPanelState extends State<ContainerEventsPanel> {
       final auth = context.read<AuthService>();
       final resp = await auth
           .authGet('/api/v1/events/containers?${_encodeQuery(query)}');
-      if (!mounted) return;
+      if (!mounted || seq != _seq) return;
       if (resp.statusCode == 200) {
         final data = jsonDecode(resp.body) as Map<String, dynamic>;
         setState(() {
@@ -108,7 +117,7 @@ class _ContainerEventsPanelState extends State<ContainerEventsPanel> {
       }
     } catch (e) {
       debugPrint('[ContainerEventsPanel] load failed: $e');
-      if (mounted) {
+      if (mounted && seq == _seq) {
         setState(() {
           _error = 'Could not load events. Please try again.';
           _loading = false;

--- a/src/frontend/lib/admin/container_events_panel.dart
+++ b/src/frontend/lib/admin/container_events_panel.dart
@@ -1,5 +1,6 @@
 // coverage:ignore-file
-/// Admin → Events tab: paged container start/stop history (#2923).
+/// Admin → Events tab → Containers subtab: paged container start/stop
+/// history (#2923).
 ///
 /// Reads the `container_events` audit table (#2915) through
 /// `GET /api/v1/events/containers` — newest first, optional id-or-name workspace

--- a/src/frontend/lib/admin/events_tab.dart
+++ b/src/frontend/lib/admin/events_tab.dart
@@ -3,6 +3,11 @@
 /// audit streams that share the `manage-events` permission — container
 /// start/stop history ([ContainerEventsPanel], #2923) and the
 /// identity/privilege audit stream ([AuditEventsPanel], #3205/#3217).
+///
+/// The panels live in an [IndexedStack] (the same keep-alive the admin
+/// page uses for its top-level tabs): a subtab's filters, offset, and
+/// expansion state survive switching, and a panel is built lazily —
+/// only once first selected.
 
 import 'package:flutter/material.dart';
 
@@ -20,6 +25,11 @@ class EventsTab extends StatefulWidget {
 
 class _EventsTabState extends State<EventsTab> {
   String _sub = 'containers';
+
+  /// Subtabs built so far (lazy first build; kept alive afterwards).
+  final Set<String> _built = {'containers'};
+
+  static const _order = ['containers', 'audit'];
 
   @override
   Widget build(BuildContext context) {
@@ -44,14 +54,25 @@ class _EventsTabState extends State<EventsTab> {
                 ),
               ],
               selected: {_sub},
-              onSelectionChanged: (sel) => setState(() => _sub = sel.first),
+              onSelectionChanged: (sel) => setState(() {
+                _sub = sel.first;
+                _built.add(_sub);
+              }),
             ),
           ),
         ),
         Expanded(
-          child: _sub == 'audit'
-              ? const AuditEventsPanel()
-              : const ContainerEventsPanel(),
+          child: IndexedStack(
+            index: _sub == 'audit' ? 1 : 0,
+            children: [
+              for (final id in _order)
+                _built.contains(id)
+                    ? (id == 'audit'
+                        ? const AuditEventsPanel()
+                        : const ContainerEventsPanel())
+                    : const SizedBox.shrink(),
+            ],
+          ),
         ),
       ],
     );

--- a/src/frontend/lib/admin/events_tab.dart
+++ b/src/frontend/lib/admin/events_tab.dart
@@ -1,0 +1,59 @@
+// coverage:ignore-file
+/// Admin → Events tab shell (#3217): a subtab switch between the two
+/// audit streams that share the `manage-events` permission — container
+/// start/stop history ([ContainerEventsPanel], #2923) and the
+/// identity/privilege audit stream ([AuditEventsPanel], #3205/#3217).
+
+import 'package:flutter/material.dart';
+
+import 'audit_events_panel.dart';
+import 'container_events_panel.dart';
+
+/// The Events tab body: a segmented control (Containers / Audit) plus
+/// the selected subtab's panel.
+class EventsTab extends StatefulWidget {
+  const EventsTab({super.key});
+
+  @override
+  State<EventsTab> createState() => _EventsTabState();
+}
+
+class _EventsTabState extends State<EventsTab> {
+  String _sub = 'containers';
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        Padding(
+          padding: const EdgeInsets.fromLTRB(16, 8, 16, 0),
+          child: Align(
+            alignment: Alignment.centerLeft,
+            child: SegmentedButton<String>(
+              key: const ValueKey('events-subtab'),
+              segments: const [
+                ButtonSegment(
+                  value: 'containers',
+                  icon: Icon(Icons.inventory_2_outlined),
+                  label: Text('Containers'),
+                ),
+                ButtonSegment(
+                  value: 'audit',
+                  icon: Icon(Icons.fact_check_outlined),
+                  label: Text('Audit'),
+                ),
+              ],
+              selected: {_sub},
+              onSelectionChanged: (sel) => setState(() => _sub = sel.first),
+            ),
+          ),
+        ),
+        Expanded(
+          child: _sub == 'audit'
+              ? const AuditEventsPanel()
+              : const ContainerEventsPanel(),
+        ),
+      ],
+    );
+  }
+}

--- a/src/frontend/test/audit_events_panel_test.dart
+++ b/src/frontend/test/audit_events_panel_test.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:convert';
 
 import 'package:flutter/material.dart';
@@ -9,7 +10,6 @@ import 'package:shared_preferences/shared_preferences.dart';
 import 'package:klangk_frontend/admin/admin_users_page.dart';
 import 'package:klangk_frontend/admin/audit_events_panel.dart';
 import 'package:klangk_frontend/auth/auth_service.dart';
-import 'package:klangk_frontend/utils/system_agent.dart';
 import 'package:klangk_frontend/ws/ws_client.dart';
 import 'package:klangk_plugin_api/klangk_plugin_api.dart';
 
@@ -225,7 +225,7 @@ void main() {
               _auditEvent(
                 3,
                 event: 'acl.replace',
-                actorId: agentUserId,
+                actorId: 'u-7',
                 targetType: 'workspace',
                 targetId: 'ws-1',
               ),
@@ -240,9 +240,10 @@ void main() {
       expect(find.text('login.failed'), findsOneWidget);
       expect(find.text('acl.replace'), findsOneWidget);
       expect(find.text('admin@example.com'), findsOneWidget);
-      // No actor on login.failed -> 'system'; agent id -> 'system agent'.
-      expect(find.text('system'), findsOneWidget);
-      expect(find.text('system agent'), findsOneWidget);
+      // No actor on login.failed -> 'anonymous'; bare id when the
+      // email was never denormalized (purged actor).
+      expect(find.text('anonymous'), findsOneWidget);
+      expect(find.text('u-7'), findsOneWidget);
       expect(find.text('user u-2'), findsOneWidget);
       expect(find.text('user u-9'), findsOneWidget);
       expect(find.text('workspace ws-1'), findsOneWidget);
@@ -412,6 +413,97 @@ void main() {
       expect(find.text('0 events'), findsOneWidget);
     });
 
+    testWidgets('a superseded slow response never overwrites a newer one',
+        (tester) async {
+      // Overlapping loads are the common case (independent filter
+      // debouncers): the newer request's rows must win even when the
+      // older response lands last.
+      final pending = <Completer<http.Response>>[];
+      testAuthHttpClientOverride =
+          _mockClient(_adminPermissions, (request) async {
+        if (request.url.path == '/api/v1/events/audit') {
+          final actor = request.url.queryParameters['actor'];
+          final completer = Completer<http.Response>();
+          pending.add(completer);
+          final resp = await completer.future;
+          final marker = actor != null ? 'actor-row' : 'event-row';
+          return http.Response(
+            _auditEnvelope([
+              _auditEvent(1, event: 'user.create', targetId: marker),
+            ], total: 1),
+            resp.statusCode,
+          );
+        }
+        return http.Response('Not found', 404);
+      }, isAdmin: true);
+
+      await tester.binding.setSurfaceSize(const Size(1600, 900));
+      await tester.pumpWidget(buildPanel());
+      // Initial load.
+      pending.removeAt(0).complete(http.Response('', 200));
+      await tester.pumpAndSettle();
+
+      // Two filter edits -> two overlapping requests.
+      await tester.enterText(
+        find.byKey(const ValueKey('audit-event-filter')),
+        'user.create',
+      );
+      await tester.pump(const Duration(milliseconds: 350));
+      await tester.enterText(
+        find.byKey(const ValueKey('audit-actor-filter')),
+        'admin@example.com',
+      );
+      await tester.pump(const Duration(milliseconds: 350));
+      expect(pending.length, 2);
+
+      // The newer (actor) response lands first...
+      pending.removeLast().complete(http.Response('', 200));
+      await tester.pumpAndSettle();
+      expect(find.text('user actor-row'), findsOneWidget);
+
+      // ...then the stale (event-only) one: it must be discarded.
+      pending.removeAt(0).complete(http.Response('', 200));
+      await tester.pumpAndSettle();
+      expect(find.text('user actor-row'), findsOneWidget);
+      expect(find.text('user event-row'), findsNothing);
+    });
+
+    testWidgets('paging and filter changes collapse an open expansion',
+        (tester) async {
+      serveAudit((limit, offset, event, actor, target) => http.Response(
+            _auditEnvelope([
+              _auditEvent(
+                1,
+                event: 'user.update',
+                actorEmail: 'admin@example.com',
+                targetId: 'u-2',
+                detail: {'field': 'handle'},
+              ),
+              _auditEvent(
+                2,
+                event: 'user.create',
+                actorEmail: 'admin@example.com',
+                targetId: 'u-3',
+              ),
+            ], total: 2),
+            200,
+          ));
+
+      await pumpPanel(tester);
+      await tester.tap(find.text('user.update'));
+      await tester.pumpAndSettle();
+      expect(find.byKey(const ValueKey('audit-event-detail')), findsOneWidget);
+
+      // A filter change loads a fresh result set: the expansion goes.
+      await tester.enterText(
+        find.byKey(const ValueKey('audit-event-filter')),
+        'user.create',
+      );
+      await tester.pump(const Duration(milliseconds: 350));
+      await tester.pumpAndSettle();
+      expect(find.byKey(const ValueKey('audit-event-detail')), findsNothing);
+    });
+
     testWidgets('table rows fit a narrow viewport (#3006 pattern)',
         (tester) async {
       serveAudit((limit, offset, event, actor, target) => http.Response(
@@ -450,8 +542,12 @@ void main() {
       await tester.tap(find.text('Events'));
       await tester.pumpAndSettle();
       // The Containers subtab is the default: its panel is up first.
-      expect(find.byKey(const ValueKey('events-workspace-filter')),
-          findsOneWidget);
+      // (Offstage panels stay mounted — the keep-alive — so
+      // visibility asserts use hitTestable, not findsNothing.)
+      expect(
+        find.byKey(const ValueKey('events-workspace-filter')).hitTestable(),
+        findsOneWidget,
+      );
       await tester.tap(find.text('Audit'));
       await tester.pumpAndSettle();
     }
@@ -470,19 +566,36 @@ void main() {
 
       await pumpToAudit(tester);
 
-      // The audit panel's filter fields replaced the container one.
+      // The audit panel is the visible subtab now.
       expect(
-          find.byKey(const ValueKey('events-workspace-filter')), findsNothing);
+        find.byKey(const ValueKey('events-workspace-filter')).hitTestable(),
+        findsNothing,
+      );
       expect(
-        find.byKey(const ValueKey('audit-event-filter')),
+        find.byKey(const ValueKey('audit-event-filter')).hitTestable(),
         findsOneWidget,
       );
       expect(find.text('user.create'), findsOneWidget);
 
+      // Keep-alive (#3217 review): subtab state survives switching —
+      // the hidden panel stays mounted offstage, matching the
+      // IndexedStack keep-alive the admin page gives its top tabs.
+      await tester.enterText(
+        find.byKey(const ValueKey('audit-actor-filter')),
+        'kept-filter',
+      );
+      await tester.pump(const Duration(milliseconds: 350));
+      await tester.pumpAndSettle();
       await tester.tap(find.text('Containers'));
       await tester.pumpAndSettle();
       expect(find.byKey(const ValueKey('events-workspace-filter')),
           findsOneWidget);
+      await tester.tap(find.text('Audit'));
+      await tester.pumpAndSettle();
+      final field = tester.widget<TextField>(
+        find.byKey(const ValueKey('audit-actor-filter')),
+      );
+      expect(field.controller!.text, 'kept-filter');
     });
 
     testWidgets('delegated auditor reaches the audit stream (#3217)',

--- a/src/frontend/test/audit_events_panel_test.dart
+++ b/src/frontend/test/audit_events_panel_test.dart
@@ -468,8 +468,7 @@ void main() {
       expect(find.text('user event-row'), findsNothing);
     });
 
-    testWidgets('paging and filter changes collapse an open expansion',
-        (tester) async {
+    testWidgets('a filter change collapses an open expansion', (tester) async {
       serveAudit((limit, offset, event, actor, target) => http.Response(
             _auditEnvelope([
               _auditEvent(
@@ -596,6 +595,37 @@ void main() {
         find.byKey(const ValueKey('audit-actor-filter')),
       );
       expect(field.controller!.text, 'kept-filter');
+    });
+
+    testWidgets(
+        'the audit panel loads lazily — no request before first selection',
+        (tester) async {
+      // The keep-alive IndexedStack builds a subtab's panel only when
+      // first selected: visiting the Events tab must not fire an
+      // /events/audit request.
+      final requests = serveAudit(
+        (limit, offset, event, actor, target) =>
+            http.Response(_auditEnvelope([]), 200),
+        withPage: true,
+      );
+
+      await tester.binding.setSurfaceSize(const Size(1600, 900));
+      await tester.pumpWidget(buildPage());
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Events'));
+      await tester.pumpAndSettle();
+
+      expect(
+        requests.where((r) => r.url.path == '/api/v1/events/audit'),
+        isEmpty,
+      );
+
+      await tester.tap(find.text('Audit'));
+      await tester.pumpAndSettle();
+      expect(
+        requests.where((r) => r.url.path == '/api/v1/events/audit'),
+        isNotEmpty,
+      );
     });
 
     testWidgets('delegated auditor reaches the audit stream (#3217)',

--- a/src/frontend/test/audit_events_panel_test.dart
+++ b/src/frontend/test/audit_events_panel_test.dart
@@ -1,0 +1,523 @@
+import 'dart:convert';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:provider/provider.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:klangk_frontend/admin/admin_users_page.dart';
+import 'package:klangk_frontend/admin/audit_events_panel.dart';
+import 'package:klangk_frontend/auth/auth_service.dart';
+import 'package:klangk_frontend/utils/system_agent.dart';
+import 'package:klangk_frontend/ws/ws_client.dart';
+import 'package:klangk_plugin_api/klangk_plugin_api.dart';
+
+/// A paged audit-events envelope, matching the backend
+/// `GET /events/audit` response (#3205).
+String _auditEnvelope(
+  List<Map<String, dynamic>> items, {
+  int total = 0,
+  int limit = 50,
+  int offset = 0,
+}) =>
+    jsonEncode({
+      'items': items,
+      'total': total,
+      'limit': limit,
+      'offset': offset,
+    });
+
+Map<String, dynamic> _auditEvent(
+  int id, {
+  String event = 'user.create',
+  String? actorId,
+  String? actorEmail,
+  String? targetType = 'user',
+  String? targetId,
+  Map<String, dynamic>? detail,
+  String? sourceIp,
+  String? userAgent,
+  double createdAt = 1767225600.0,
+}) =>
+    {
+      'id': id,
+      'event': event,
+      'actor_id': actorId,
+      'actor_email': actorEmail,
+      'target_type': targetType,
+      'target_id': targetId,
+      'detail': detail,
+      'source_ip': sourceIp,
+      'user_agent': userAgent,
+      'created_at': createdAt,
+    };
+
+/// Default JWT for a logged-in admin user.
+String get _adminToken {
+  final header = base64Url
+      .encode(utf8.encode(jsonEncode({'alg': 'HS256', 'typ': 'JWT'})))
+      .replaceAll('=', '');
+  final body = base64Url
+      .encode(
+        utf8.encode(
+          jsonEncode({'sub': 'admin-user', 'email': 'admin@example.com'}),
+        ),
+      )
+      .replaceAll('=', '');
+  return '$header.$body.fakesig';
+}
+
+/// Build a mock client serving config + my-permissions ([permissions],
+/// [isAdmin]) plus a custom handler for everything else.
+http.Client _mockClient(
+  Map<String, List<String>> permissions,
+  Future<http.Response> Function(http.Request) handler, {
+  bool isAdmin = false,
+}) {
+  return MockClient((request) async {
+    if (request.url.path.contains('/api/v1/config')) {
+      return http.Response(
+        jsonEncode({'login_banner_title': '', 'login_banner': ''}),
+        200,
+      );
+    }
+    if (request.url.path.contains('/api/v1/my-permissions')) {
+      return http.Response(
+        jsonEncode({
+          'user_id': 'admin-user',
+          'email': 'admin@example.com',
+          'is_admin': isAdmin,
+          'permissions': permissions,
+          'groups': [
+            {'id': 'g1', 'name': 'admin'},
+          ],
+        }),
+        200,
+      );
+    }
+    return handler(request);
+  });
+}
+
+/// The admin permission set as the server reports it.
+Map<String, List<String>> get _adminPermissions => {
+      '/users': ['manage-users'],
+      '/events': ['view', 'manage-events'],
+    };
+
+void main() {
+  setUp(() {
+    testBaseUrlOverride = 'http://localhost:8997';
+    SharedPreferences.setMockInitialValues({'klangk_jwt': _adminToken});
+  });
+
+  tearDown(() {
+    testBaseUrlOverride = null;
+    testAuthHttpClientOverride = null;
+  });
+
+  Widget buildPage() {
+    return MultiProvider(
+      providers: [
+        ChangeNotifierProvider(create: (_) => AuthService()),
+        ChangeNotifierProvider(create: (_) => WsClient()),
+      ],
+      child: const MaterialApp(home: AdminUsersPage()),
+    );
+  }
+
+  /// The panel alone (no admin-page chrome), for surface-size tests
+  /// that exercise the table under width constraint (#3006 pattern).
+  Widget buildPanel() {
+    return MultiProvider(
+      providers: [
+        ChangeNotifierProvider(create: (_) => AuthService()),
+        ChangeNotifierProvider(create: (_) => WsClient()),
+      ],
+      child: const MaterialApp(
+        home: Scaffold(body: AuditEventsPanel()),
+      ),
+    );
+  }
+
+  /// Serve the audit endpoint via [auditFor] (called with the parsed
+  /// limit/offset and the three substring filters of each request)
+  /// plus the empty users/groups/schedule loads so the page renders.
+  List<http.Request> serveAudit(
+    http.Response Function(
+      int limit,
+      int offset,
+      String? event,
+      String? actor,
+      String? target,
+    ) auditFor, {
+    bool withPage = false,
+  }) {
+    final requests = <http.Request>[];
+    testAuthHttpClientOverride = _mockClient(_adminPermissions, (
+      request,
+    ) async {
+      if (request.url.path == '/api/v1/events/audit') {
+        requests.add(request);
+        final limit = int.parse(request.url.queryParameters['limit'] ?? '50');
+        final offset = int.parse(request.url.queryParameters['offset'] ?? '0');
+        final event = request.url.queryParameters['event'];
+        final actor = request.url.queryParameters['actor'];
+        final target = request.url.queryParameters['target'];
+        return auditFor(limit, offset, event, actor, target);
+      }
+      if (withPage) {
+        if (request.url.path == '/api/v1/events/containers') {
+          requests.add(request);
+          return http.Response(_auditEnvelope([]), 200);
+        }
+        if (request.url.path == '/api/v1/users') {
+          return http.Response(
+            jsonEncode({
+              'users': <Map<String, dynamic>>[],
+              'page': 1,
+              'page_size': 10,
+              'total': 0,
+            }),
+            200,
+          );
+        }
+        if (request.url.path == '/api/v1/groups') {
+          return http.Response(jsonEncode([]), 200);
+        }
+        if (request.url.path == '/api/v1/server/schedule' &&
+            request.method == 'GET') {
+          return http.Response(jsonEncode({'schedules': []}), 200);
+        }
+      }
+      return http.Response('Not found', 404);
+    }, isAdmin: true);
+    return requests;
+  }
+
+  /// Pump the panel alone on a wide surface and settle.
+  Future<void> pumpPanel(WidgetTester tester) async {
+    await tester.binding.setSurfaceSize(const Size(1600, 900));
+    await tester.pumpWidget(buildPanel());
+    await tester.pumpAndSettle();
+  }
+
+  group('AuditEventsPanel', () {
+    testWidgets('renders rows from the paged envelope', (tester) async {
+      serveAudit((limit, offset, event, actor, target) => http.Response(
+            _auditEnvelope([
+              _auditEvent(
+                1,
+                event: 'user.create',
+                actorId: 'u-1',
+                actorEmail: 'admin@example.com',
+                targetId: 'u-2',
+                sourceIp: '10.0.0.7',
+                userAgent: 'Mozilla/5.0 (X11; Linux x86_64) klangk/1.0',
+              ),
+              _auditEvent(
+                2,
+                event: 'login.failed',
+                targetId: 'u-9',
+                detail: {'via': 'password', 'identifier': 'admin@example.com'},
+              ),
+              _auditEvent(
+                3,
+                event: 'acl.replace',
+                actorId: agentUserId,
+                targetType: 'workspace',
+                targetId: 'ws-1',
+              ),
+            ], total: 12),
+            200,
+          ));
+
+      await pumpPanel(tester);
+
+      // Event names as chips, actor email / fallbacks, target labels.
+      expect(find.text('user.create'), findsOneWidget);
+      expect(find.text('login.failed'), findsOneWidget);
+      expect(find.text('acl.replace'), findsOneWidget);
+      expect(find.text('admin@example.com'), findsOneWidget);
+      // No actor on login.failed -> 'system'; agent id -> 'system agent'.
+      expect(find.text('system'), findsOneWidget);
+      expect(find.text('system agent'), findsOneWidget);
+      expect(find.text('user u-2'), findsOneWidget);
+      expect(find.text('user u-9'), findsOneWidget);
+      expect(find.text('workspace ws-1'), findsOneWidget);
+      expect(find.text('10.0.0.7'), findsOneWidget);
+      expect(
+        find.text('Mozilla/5.0 (X11; Linux x86_64) klangk/1.0'),
+        findsOneWidget,
+      );
+      // Range label reflects the page slice.
+      expect(find.text('1–3 of 12'), findsOneWidget);
+    });
+
+    testWidgets('next/prev page through the history', (tester) async {
+      serveAudit((limit, offset, event, actor, target) => http.Response(
+            _auditEnvelope(
+              [
+                _auditEvent(offset + 1, actorEmail: 'pager@example.com'),
+              ],
+              total: 3,
+              limit: limit,
+              offset: offset,
+            ),
+            200,
+          ));
+
+      await pumpPanel(tester);
+
+      final next = find.ancestor(
+        of: find.byTooltip('Next page'),
+        matching: find.byType(IconButton),
+      );
+      final prev = find.ancestor(
+        of: find.byTooltip('Previous page'),
+        matching: find.byType(IconButton),
+      );
+      expect(tester.widget<IconButton>(prev).onPressed, isNull);
+      expect(tester.widget<IconButton>(next).onPressed, isNotNull);
+      expect(find.text('1–1 of 3'), findsOneWidget);
+
+      await tester.tap(next);
+      await tester.pumpAndSettle();
+      expect(find.text('2–2 of 3'), findsOneWidget);
+      expect(tester.widget<IconButton>(prev).onPressed, isNotNull);
+
+      await tester.tap(prev);
+      await tester.pumpAndSettle();
+      expect(find.text('1–1 of 3'), findsOneWidget);
+    });
+
+    testWidgets('event/actor/target filters debounce into query params',
+        (tester) async {
+      final requests = serveAudit(
+        (limit, offset, event, actor, target) => http.Response(
+          _auditEnvelope(
+            [
+              if (event != null || actor != null || target != null)
+                _auditEvent(1, actorEmail: 'filtered@example.com'),
+            ],
+            total: event != null || actor != null || target != null ? 1 : 0,
+          ),
+          200,
+        ),
+      );
+
+      await pumpPanel(tester);
+
+      await tester.enterText(
+        find.byKey(const ValueKey('audit-event-filter')),
+        'group.member',
+      );
+      await tester.pump(const Duration(milliseconds: 350));
+      await tester.pumpAndSettle();
+
+      await tester.enterText(
+        find.byKey(const ValueKey('audit-actor-filter')),
+        'admin@example.com',
+      );
+      await tester.pump(const Duration(milliseconds: 350));
+      await tester.pumpAndSettle();
+
+      await tester.enterText(
+        find.byKey(const ValueKey('audit-target-filter')),
+        'u-2',
+      );
+      await tester.pump(const Duration(milliseconds: 350));
+      await tester.pumpAndSettle();
+
+      expect(find.text('filtered@example.com'), findsOneWidget);
+      final query = requests.last.url.queryParameters;
+      expect(query['event'], 'group.member');
+      expect(query['actor'], 'admin@example.com');
+      expect(query['target'], 'u-2');
+      expect(query['offset'], '0');
+    });
+
+    testWidgets('tapping a row expands the read-only detail view',
+        (tester) async {
+      serveAudit((limit, offset, event, actor, target) => http.Response(
+            _auditEnvelope([
+              _auditEvent(
+                7,
+                event: 'user.delete',
+                actorEmail: 'admin@example.com',
+                targetId: 'u-2',
+                detail: {
+                  'email': 'gone@example.com',
+                  'cascade': ['workspaces', 'sessions'],
+                },
+                sourceIp: '192.168.1.4',
+                userAgent: 'klangk-cli/1.0',
+              ),
+            ], total: 1),
+            200,
+          ));
+
+      await pumpPanel(tester);
+
+      expect(find.byKey(const ValueKey('audit-event-detail')), findsNothing);
+      await tester.tap(find.text('user.delete'));
+      await tester.pumpAndSettle();
+
+      final detail = find.byKey(const ValueKey('audit-event-detail'));
+      expect(detail, findsOneWidget);
+      // Pretty-printed JSON detail, verbatim.
+      expect(
+          find.textContaining('"email": "gone@example.com"'), findsOneWidget);
+      expect(find.textContaining('"cascade"'), findsOneWidget);
+      // Correlation fields repeated in full.
+      expect(find.text('192.168.1.4'), findsWidgets);
+      expect(find.text('klangk-cli/1.0'), findsWidgets);
+
+      // Tapping again collapses.
+      await tester.tap(find.text('user.delete'));
+      await tester.pumpAndSettle();
+      expect(find.byKey(const ValueKey('audit-event-detail')), findsNothing);
+    });
+
+    testWidgets('null detail renders a placeholder, not an error',
+        (tester) async {
+      serveAudit((limit, offset, event, actor, target) => http.Response(
+            _auditEnvelope([
+              _auditEvent(
+                4,
+                event: 'logout',
+                actorEmail: 'u@example.com',
+                detail: null,
+              ),
+            ], total: 1),
+            200,
+          ));
+
+      await pumpPanel(tester);
+      await tester.tap(find.text('logout'));
+      await tester.pumpAndSettle();
+
+      expect(find.byKey(const ValueKey('audit-event-detail')), findsOneWidget);
+      // Source IP / user agent placeholders plus the detail dash.
+      expect(find.text('—'), findsNWidgets(3));
+    });
+
+    testWidgets('empty history shows the empty state', (tester) async {
+      serveAudit((limit, offset, event, actor, target) =>
+          http.Response(_auditEnvelope([]), 200));
+
+      await pumpPanel(tester);
+      expect(find.text('No audit events recorded'), findsOneWidget);
+      expect(find.text('0 events'), findsOneWidget);
+    });
+
+    testWidgets('table rows fit a narrow viewport (#3006 pattern)',
+        (tester) async {
+      serveAudit((limit, offset, event, actor, target) => http.Response(
+            _auditEnvelope([
+              _auditEvent(
+                1,
+                event: 'workspace.role.change',
+                actorEmail: 'some-very-long-email-address@example.com',
+                targetType: 'workspace',
+                targetId: 'ws-0123456789abcdef',
+                sourceIp: '10.1.2.3',
+                userAgent: 'Mozilla/5.0 (X11; Linux x86_64) '
+                    'AppleWebKit/537.36 klangk/1.0.5',
+              ),
+            ], total: 1),
+            200,
+          ));
+
+      await tester.binding.setSurfaceSize(const Size(400, 900));
+      await tester.pumpWidget(buildPanel());
+      await tester.pumpAndSettle();
+
+      expect(tester.takeException(), isNull);
+      expect(find.text('workspace ws-0123456789abcdef'), findsOneWidget);
+      expect(find.text('10.1.2.3'), findsOneWidget);
+    });
+  });
+
+  group('AdminUsersPage events subtab', () {
+    /// Pump the whole admin page on a wide surface, navigate to the
+    /// Events tab, and switch to the Audit subtab.
+    Future<void> pumpToAudit(WidgetTester tester) async {
+      await tester.binding.setSurfaceSize(const Size(1600, 900));
+      await tester.pumpWidget(buildPage());
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Events'));
+      await tester.pumpAndSettle();
+      // The Containers subtab is the default: its panel is up first.
+      expect(find.byKey(const ValueKey('events-workspace-filter')),
+          findsOneWidget);
+      await tester.tap(find.text('Audit'));
+      await tester.pumpAndSettle();
+    }
+
+    testWidgets('switches between the Containers and Audit subtabs',
+        (tester) async {
+      serveAudit(
+        (limit, offset, event, actor, target) => http.Response(
+          _auditEnvelope([
+            _auditEvent(1, actorEmail: 'admin@example.com', targetId: 'u-2'),
+          ], total: 1),
+          200,
+        ),
+        withPage: true,
+      );
+
+      await pumpToAudit(tester);
+
+      // The audit panel's filter fields replaced the container one.
+      expect(
+          find.byKey(const ValueKey('events-workspace-filter')), findsNothing);
+      expect(
+        find.byKey(const ValueKey('audit-event-filter')),
+        findsOneWidget,
+      );
+      expect(find.text('user.create'), findsOneWidget);
+
+      await tester.tap(find.text('Containers'));
+      await tester.pumpAndSettle();
+      expect(find.byKey(const ValueKey('events-workspace-filter')),
+          findsOneWidget);
+    });
+
+    testWidgets('delegated auditor reaches the audit stream (#3217)',
+        (tester) async {
+      // A principal whose only admin-sphere grant is `manage-events`
+      // on /events: the same gate covers both subtabs — the audit
+      // stream needs no extra wiring.
+      testAuthHttpClientOverride = _mockClient(
+        {
+          '/events': ['manage-events'],
+        },
+        (request) async {
+          if (request.url.path == '/api/v1/events/audit') {
+            return http.Response(
+              _auditEnvelope([
+                _auditEvent(
+                  1,
+                  event: 'session.revoke',
+                  actorId: 'u-3',
+                  targetId: 'u-3',
+                ),
+              ], total: 1),
+              200,
+            );
+          }
+          if (request.url.path == '/api/v1/events/containers') {
+            return http.Response(_auditEnvelope([]), 200);
+          }
+          return http.Response('Not found', 404);
+        },
+      );
+
+      await pumpToAudit(tester);
+      expect(find.text('session.revoke'), findsOneWidget);
+      expect(find.text('Users'), findsNothing);
+    });
+  });
+}

--- a/src/frontend/test/container_events_panel_test.dart
+++ b/src/frontend/test/container_events_panel_test.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:convert';
 
 import 'package:flutter/material.dart';
@@ -331,6 +332,85 @@ void main() {
       expect(tester.takeException(), isNull);
       expect(find.text('cid-0123456789abcdef'), findsOneWidget);
       expect(find.text('sidecar-ns-0123456789'), findsOneWidget);
+    });
+
+    testWidgets('a superseded slow response never overwrites a newer one',
+        (tester) async {
+      // Same race the audit panel guards against (#3217 review):
+      // double-Next or refresh-while-pending makes responses land out
+      // of issue order; the newest request's page must win.
+      final pending = <Completer<http.Response>>[];
+      testAuthHttpClientOverride =
+          _mockClient(_adminPermissions, (request) async {
+        if (request.url.path == '/api/v1/events/containers') {
+          final offset = request.url.queryParameters['offset'];
+          final completer = Completer<http.Response>();
+          pending.add(completer);
+          await completer.future;
+          return http.Response(
+            _eventsEnvelope([
+              _event('ws-$offset', workspaceName: 'page-$offset'),
+            ], total: 5),
+            200,
+          );
+        }
+        if (request.url.path == '/api/v1/users') {
+          return http.Response(
+            jsonEncode({
+              'users': <Map<String, dynamic>>[],
+              'page': 1,
+              'page_size': 10,
+              'total': 0,
+            }),
+            200,
+          );
+        }
+        if (request.url.path == '/api/v1/groups') {
+          return http.Response(jsonEncode([]), 200);
+        }
+        if (request.url.path == '/api/v1/server/schedule' &&
+            request.method == 'GET') {
+          return http.Response(jsonEncode({'schedules': []}), 200);
+        }
+        return http.Response('Not found', 404);
+      }, isAdmin: true);
+
+      await tester.binding.setSurfaceSize(const Size(1600, 900));
+      await tester.pumpWidget(buildPage());
+      // Permissions resolve asynchronously — pump until the mounted
+      // Events tab fires the container panel's initial load.
+      while (pending.isEmpty) {
+        await tester.pump(const Duration(milliseconds: 10));
+      }
+      pending.removeAt(0).complete(http.Response('', 200));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Events'));
+      await tester.pumpAndSettle();
+      expect(find.text('page-0'), findsOneWidget);
+
+      // Two quick Next taps -> two overlapping requests (offset 1,
+      // then 2 — paging advances by rows-on-page).
+      final next = find.ancestor(
+        of: find.byTooltip('Next page'),
+        matching: find.byType(IconButton),
+      );
+      await tester.tap(next);
+      await tester.pump();
+      await tester.tap(next);
+      await tester.pump();
+      expect(pending.length, 2);
+
+      // The newer (offset 2) response lands first...
+      pending.removeLast().complete(http.Response('', 200));
+      await tester.pumpAndSettle();
+      expect(find.text('page-2'), findsOneWidget);
+      expect(find.text('3–3 of 5'), findsOneWidget);
+
+      // ...then the stale (offset 1) one: it must be discarded.
+      pending.removeAt(0).complete(http.Response('', 200));
+      await tester.pumpAndSettle();
+      expect(find.text('page-2'), findsOneWidget);
+      expect(find.text('page-1'), findsNothing);
     });
 
     testWidgets('tab hidden without the permission', (tester) async {


### PR DESCRIPTION
 Implements #3217.

## What

The admin **Events** tab gains a **Containers / Audit** segmented control
(`events_tab.dart`). The new **Audit** subtab (`audit_events_panel.dart`)
lists the identity/privilege audit stream from #3205 through
`GET /api/v1/events/audit` — the same paged envelope as the container
history — with:

- newest-first rows, 50/page offset paging, `1–51 of 214` range label
- three debounced substring filters mapping to the `event` / `actor` /
  `target` query params
- columns: When, Event (chip), Actor (email → actor-id fallback →
  `system`, agent id → `system agent`), Target (`type id`), Source IP,
  User agent — same flex-weight table pattern as the container panel
  (#3006), ellipsized cells with full-value tooltips
- tap a row to expand the read-only detail view: pretty-printed `detail`
  JSON plus the full source IP and user agent for incident correlation

Both subtabs ride the existing `manage-events` gate on `/events` — the
same ACL resource governs `GET /events/containers` and
`GET /events/audit`, so no new permission wiring (a delegated auditor
with only that grant sees exactly the Events tab with both streams).

## Notes

- Subtab panels live in an `IndexedStack` (lazy first build), so each
  panel's filter/paging/expansion state survives switching — the same
  keep-alive the admin page gives its top-level tabs.
- `flutter test --coverage` passes (1251 tests) including 13 new widget
  tests covering rendering, paging, filter params on the wire, row
  expansion/collapse, empty/error states, narrow viewport, subtab
  switching, and the delegated-auditor gate.
- Changelog entry under `[Unreleased]` → Added.

 🤖 Generated with [Claude Code](https://claude.com/claude-code)
