### PR TITLE
Map raw connection exceptions to stable auth error messages (#3203)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -2291,6 +2291,12 @@ git-credential` (#1700).** `pig-latin` removed; `word-count` dormant.
 
 ### Fixed
 
+- **Auth error messages (#3203).** The web login, register, local-login,
+  resend-verification, and email-verification flows no longer show the raw
+  transport exception (which can include request URLs and endpoint paths)
+  on a connection failure. They now show a stable "Network error. Please
+  try again." message, with the underlying exception logged for debugging.
+
 - **Workspace-create error responses (#3215).** A host-side
   filesystem failure during workspace creation (unwritable data dir,
   disk full) no longer echoes the raw OS message — which names host

--- a/src/frontend/lib/auth/auth_service.dart
+++ b/src/frontend/lib/auth/auth_service.dart
@@ -410,6 +410,15 @@ class AuthService extends ChangeNotifier {
   /// disk without buffering it in memory).
   Map<String, String> get authHeaders => _authHeaders;
 
+  /// Stable user-facing text for a transport failure (#3203): the raw
+  /// exception (URLs, endpoint paths, transport messages) goes to the
+  /// log only — never into error UI. Mirrors the fixed wording the
+  /// standalone auth pages already use.
+  String _networkError(String action, Object error) {
+    debugPrint('[AuthService] $action request failed: $error');
+    return 'Network error. Please try again.';
+  }
+
   Future<String?> register(String email, String password) async {
     _loading = true;
     notifyListeners();
@@ -432,7 +441,7 @@ class AuthService extends ChangeNotifier {
       final error = jsonDecode(response.body);
       return error['detail'] ?? 'Registration failed';
     } catch (e) {
-      return 'Connection error: $e';
+      return _networkError('register', e);
     } finally {
       _loading = false;
       notifyListeners();
@@ -457,7 +466,7 @@ class AuthService extends ChangeNotifier {
       final error = jsonDecode(response.body);
       return error['detail'] ?? 'Login failed';
     } catch (e) {
-      return 'Connection error: $e';
+      return _networkError('login', e);
     } finally {
       _loading = false;
       notifyListeners();
@@ -482,7 +491,7 @@ class AuthService extends ChangeNotifier {
       final error = jsonDecode(response.body);
       return error['detail'] ?? 'Local login failed';
     } catch (e) {
-      return 'Connection error: $e';
+      return _networkError('local login', e);
     } finally {
       _loading = false;
       notifyListeners();
@@ -510,7 +519,7 @@ class AuthService extends ChangeNotifier {
       final error = jsonDecode(response.body);
       return error['detail'] ?? 'Failed to resend';
     } catch (e) {
-      return 'Connection error: $e';
+      return _networkError('resend verification', e);
     }
   }
 

--- a/src/frontend/lib/auth/verify_page.dart
+++ b/src/frontend/lib/auth/verify_page.dart
@@ -38,9 +38,13 @@ class _VerifyPageState extends State<VerifyPage> {
       final auth = context.read<AuthService>();
       final response =
           await auth.authGet('/api/v1/auth/verify?token=${widget.token}');
+      // The await above can straddle an unmount (e.g. the router's
+      // refreshListenable redirecting a already-tokened user off this
+      // public route) — bail before touching state (#3203).
+      if (!mounted) return;
       if (response.statusCode == 200) {
         final data = jsonDecode(response.body);
-        if (data['access_token'] != null && mounted) {
+        if (data['access_token'] != null) {
           await auth.saveTokenFromVerification(data['access_token']);
           return; // GoRouter redirect handles navigation
         }
@@ -60,6 +64,7 @@ class _VerifyPageState extends State<VerifyPage> {
       // Raw exception detail goes to the log only — the user sees a
       // stable message (#3203).
       debugPrint('[VerifyPage] verification request failed: $e');
+      if (!mounted) return;
       setState(() {
         _loading = false;
         _message = 'Network error. Please try again.';

--- a/src/frontend/lib/auth/verify_page.dart
+++ b/src/frontend/lib/auth/verify_page.dart
@@ -57,9 +57,12 @@ class _VerifyPageState extends State<VerifyPage> {
         });
       }
     } catch (e) {
+      // Raw exception detail goes to the log only — the user sees a
+      // stable message (#3203).
+      debugPrint('[VerifyPage] verification request failed: $e');
       setState(() {
         _loading = false;
-        _message = 'Connection error: $e';
+        _message = 'Network error. Please try again.';
       });
     }
   }

--- a/src/frontend/test/auth_service_test.dart
+++ b/src/frontend/test/auth_service_test.dart
@@ -541,7 +541,8 @@ void main() {
       await Future.delayed(Duration.zero);
 
       final error = await service.login('user', 'pass');
-      expect(error, contains('Connection error'));
+      expect(error, 'Network error. Please try again.');
+      expect(error, isNot(contains('Network unreachable')));
       expect(service.isLoggedIn, isFalse);
     });
 
@@ -800,7 +801,8 @@ void main() {
       await Future.delayed(Duration.zero);
 
       final error = await service.localLogin();
-      expect(error, contains('Connection error'));
+      expect(error, 'Network error. Please try again.');
+      expect(error, isNot(contains('Network unreachable')));
       expect(service.isLoggedIn, isFalse);
     });
   });
@@ -858,7 +860,8 @@ void main() {
       await Future.delayed(Duration.zero);
 
       final error = await service.register('user', 'pass');
-      expect(error, contains('Connection error'));
+      expect(error, 'Network error. Please try again.');
+      expect(error, isNot(contains('Network unreachable')));
       expect(service.isLoggedIn, isFalse);
       expect(service.loading, isFalse);
     });
@@ -1030,7 +1033,8 @@ void main() {
         'user@example.com',
         'pass',
       );
-      expect(error, contains('Connection error'));
+      expect(error, 'Network error. Please try again.');
+      expect(error, isNot(contains('Network unreachable')));
     });
   });
 

--- a/src/frontend/test/verify_page_test.dart
+++ b/src/frontend/test/verify_page_test.dart
@@ -1,10 +1,11 @@
 import 'dart:async';
 import 'dart:convert';
 
+import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
 import 'package:http/http.dart' as http;
 import 'package:http/testing.dart';
-import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:klangk_frontend/auth/auth_service.dart';
@@ -23,18 +24,125 @@ void main() {
     testAuthHttpClientOverride = null;
   });
 
-  Widget buildVerifyPage(String token) {
+  GoRouter buildRouter({String token = 'some-token'}) => GoRouter(
+        initialLocation: '/verify?token=$token',
+        routes: [
+          GoRoute(
+            path: '/verify',
+            builder: (context, state) =>
+                VerifyPage(token: state.uri.queryParameters['token'] ?? ''),
+          ),
+          GoRoute(
+            path: '/login',
+            builder: (context, state) =>
+                const Scaffold(body: Center(child: Text('login-marker'))),
+          ),
+        ],
+      );
+
+  Widget buildVerifyPage({String token = 'some-token'}) {
     return ChangeNotifierProvider(
       create: (_) => AuthService(),
-      child: MaterialApp(home: VerifyPage(token: token)),
+      child: MaterialApp.router(routerConfig: buildRouter(token: token)),
     );
   }
 
+  /// Answers config/permissions so AuthService post-login bookkeeping
+  /// completes; `verify` responses are supplied per test.
+  http.Client clientFor(http.Response Function() verify) {
+    return MockClient((request) async {
+      if (request.url.path.contains('/api/v1/auth/verify')) {
+        return verify();
+      }
+      if (request.url.path.contains('/api/v1/config')) {
+        return http.Response('{}', 200);
+      }
+      if (request.url.path.contains('/api/v1/my-permissions')) {
+        return http.Response(
+          jsonEncode({
+            'user_id': 'u',
+            'email': 'u',
+            'permissions': {},
+            'groups': [],
+          }),
+          200,
+        );
+      }
+      return http.Response('Not found', 404);
+    });
+  }
+
   testWidgets('empty token shows a stable message', (tester) async {
-    await tester.pumpWidget(buildVerifyPage(''));
+    await tester.pumpWidget(buildVerifyPage(token: ''));
     await tester.pumpAndSettle();
 
     expect(find.text('Missing verification token.'), findsOneWidget);
+  });
+
+  testWidgets('200 with token logs the user in', (tester) async {
+    testAuthHttpClientOverride = clientFor(
+      () => http.Response(jsonEncode({'access_token': 'verified-token'}), 200),
+    );
+
+    final auth = AuthService();
+    await tester.pumpWidget(
+      ChangeNotifierProvider<AuthService>.value(
+        value: auth,
+        child: MaterialApp.router(routerConfig: buildRouter()),
+      ),
+    );
+    // Fixed pumps, not pumpAndSettle: the page keeps its progress spinner
+    // until the router redirect fires, and the spinner animates forever.
+    await tester.pump();
+    await tester.pump();
+
+    expect(auth.token, 'verified-token');
+    expect(auth.isLoggedIn, isTrue);
+  });
+
+  testWidgets('200 without token shows the success message', (tester) async {
+    testAuthHttpClientOverride = clientFor(
+      () => http.Response(jsonEncode({}), 200),
+    );
+
+    await tester.pumpWidget(buildVerifyPage());
+    await tester.pumpAndSettle();
+
+    expect(
+      find.text('Your email has been verified. You can now log in.'),
+      findsOneWidget,
+    );
+  });
+
+  testWidgets('non-200 shows the server detail', (tester) async {
+    testAuthHttpClientOverride = clientFor(
+      () => http.Response(
+        jsonEncode({'detail': 'Invalid or expired token'}),
+        403,
+      ),
+    );
+
+    await tester.pumpWidget(buildVerifyPage());
+    await tester.pumpAndSettle();
+
+    expect(find.text('Invalid or expired token'), findsOneWidget);
+  });
+
+  testWidgets('Go to Login navigates to /login', (tester) async {
+    testAuthHttpClientOverride = clientFor(
+      () => http.Response(
+        jsonEncode({'detail': 'Invalid or expired token'}),
+        403,
+      ),
+    );
+
+    await tester.pumpWidget(buildVerifyPage());
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Go to Login'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('login-marker'), findsOneWidget);
   });
 
   testWidgets(
@@ -46,7 +154,7 @@ void main() {
         );
       });
 
-      await tester.pumpWidget(buildVerifyPage('some-token'));
+      await tester.pumpWidget(buildVerifyPage());
       await tester.pumpAndSettle();
 
       expect(find.text('Network error. Please try again.'), findsOneWidget);
@@ -57,7 +165,7 @@ void main() {
   );
 
   // The authGet await can straddle an unmount (the router redirects an
-  // already-tokened user off this public route mid-request); every arm
+  // already-tokened user off the public /verify route mid-request); every arm
   // below the await must bail instead of calling setState on a disposed
   // state (#3203 review finding).
   testWidgets('token response after unmount does not touch state',
@@ -73,7 +181,7 @@ void main() {
       return completer.future;
     });
 
-    await tester.pumpWidget(buildVerifyPage('some-token'));
+    await tester.pumpWidget(buildVerifyPage());
     await tester.pump();
     await tester.pumpWidget(const MaterialApp(home: SizedBox()));
     completer.complete(
@@ -92,7 +200,7 @@ void main() {
       return completer.future;
     });
 
-    await tester.pumpWidget(buildVerifyPage('some-token'));
+    await tester.pumpWidget(buildVerifyPage());
     await tester.pump();
     await tester.pumpWidget(const MaterialApp(home: SizedBox()));
     completer.completeError(Exception('Network unreachable'));

--- a/src/frontend/test/verify_page_test.dart
+++ b/src/frontend/test/verify_page_test.dart
@@ -1,3 +1,6 @@
+import 'dart:async';
+import 'dart:convert';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:http/http.dart' as http;
 import 'package:http/testing.dart';
@@ -52,4 +55,47 @@ void main() {
       expect(find.textContaining('localhost:8997'), findsNothing);
     },
   );
+
+  // The authGet await can straddle an unmount (the router redirects an
+  // already-tokened user off this public route mid-request); every arm
+  // below the await must bail instead of calling setState on a disposed
+  // state (#3203 review finding).
+  testWidgets('token response after unmount does not touch state',
+      (tester) async {
+    final completer = Completer<http.Response>();
+    // Config resolves immediately so AuthService init finishes while
+    // still mounted; only the verification request parks on the
+    // completer.
+    testAuthHttpClientOverride = MockClient((request) async {
+      if (request.url.path.contains('/api/v1/config')) {
+        return http.Response('{}', 200);
+      }
+      return completer.future;
+    });
+
+    await tester.pumpWidget(buildVerifyPage('some-token'));
+    await tester.pump();
+    await tester.pumpWidget(const MaterialApp(home: SizedBox()));
+    completer.complete(
+      http.Response(jsonEncode({'access_token': 't'}), 200),
+    );
+    await tester.pumpAndSettle();
+  });
+
+  testWidgets('network failure after unmount does not touch state',
+      (tester) async {
+    final completer = Completer<http.Response>();
+    testAuthHttpClientOverride = MockClient((request) async {
+      if (request.url.path.contains('/api/v1/config')) {
+        return http.Response('{}', 200);
+      }
+      return completer.future;
+    });
+
+    await tester.pumpWidget(buildVerifyPage('some-token'));
+    await tester.pump();
+    await tester.pumpWidget(const MaterialApp(home: SizedBox()));
+    completer.completeError(Exception('Network unreachable'));
+    await tester.pumpAndSettle();
+  });
 }

--- a/src/frontend/test/verify_page_test.dart
+++ b/src/frontend/test/verify_page_test.dart
@@ -1,0 +1,55 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:klangk_frontend/auth/auth_service.dart';
+import 'package:klangk_frontend/auth/verify_page.dart';
+import 'package:klangk_plugin_api/klangk_plugin_api.dart';
+
+void main() {
+  setUp(() {
+    testBaseUrlOverride = 'http://localhost:8997';
+    SharedPreferences.setMockInitialValues({});
+    testAuthHttpClientOverride = null;
+  });
+
+  tearDown(() {
+    testBaseUrlOverride = null;
+    testAuthHttpClientOverride = null;
+  });
+
+  Widget buildVerifyPage(String token) {
+    return ChangeNotifierProvider(
+      create: (_) => AuthService(),
+      child: MaterialApp(home: VerifyPage(token: token)),
+    );
+  }
+
+  testWidgets('empty token shows a stable message', (tester) async {
+    await tester.pumpWidget(buildVerifyPage(''));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Missing verification token.'), findsOneWidget);
+  });
+
+  testWidgets(
+    'network failure shows a stable message, not the raw exception (#3203)',
+    (tester) async {
+      testAuthHttpClientOverride = MockClient((request) async {
+        throw Exception(
+          'Network unreachable: GET http://localhost:8997/api/v1/auth/verify',
+        );
+      });
+
+      await tester.pumpWidget(buildVerifyPage('some-token'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Network error. Please try again.'), findsOneWidget);
+      expect(find.textContaining('Network unreachable'), findsNothing);
+      expect(find.textContaining('Connection error'), findsNothing);
+      expect(find.textContaining('localhost:8997'), findsNothing);
+    },
+  );
+}


### PR DESCRIPTION
## Summary

Fixes #3203 — frontend auth flows interpolated the caught exception directly into user-facing error UI (`'Connection error: $e'`), so a failed connection showed raw transport detail (request URLs, endpoint paths, transport messages) on screen.

Changes:

- **`src/frontend/lib/auth/auth_service.dart`** — the four catch arms (`register`, `login`, `localLogin`, `resendVerification`) now return the stable `'Network error. Please try again.'` wording the standalone auth pages already use (`forgot_password_page.dart` et al.), via a shared `_networkError` helper that sends the raw exception to `debugPrint` only.
- **`src/frontend/lib/auth/verify_page.dart`** — the verification-failure catch shows the same stable message; the raw exception is logged.

Server-provided `detail` strings on non-200 responses are unchanged — only the transport-failure path (where the client-side exception is ours to leak) is remapped.

## Testing

- `src/frontend/test/auth_service_test.dart` — the four connection-error tests now assert the stable message and that the raw exception text (`Network unreachable`) does **not** reach the caller.
- `src/frontend/test/verify_page_test.dart` (new) — pumps `VerifyPage` against a throwing client; asserts the stable message renders and neither the raw exception, `Connection error`, nor the request URL appears in the widget tree.
- Full frontend suite green (`flutter test --coverage`, 1264 tests).

## Changelog

`docs/changes.md` → Fixed, under `[Unreleased]`.
