### PR TITLE
Extend prose-writing rule to issue and PR bodies/comments (#3225)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -333,16 +333,16 @@ backend only over HTTP/WebSocket. Don't refactor `cli/` to import a shared
 helper from `klangk.*`; duplicate the small bit of logic instead, or put the
 shared code somewhere both can import without crossing the boundary.
 
-## Documentation writing: state what the feature does
+## Prose writing: state what the feature does
 
-In docs, docstrings, and config comments that document
-operator-facing behavior, describe what a mode or setting **does**,
-not a list of what it lacks. "No public name needed, no ACME account,
-no ports 80/443, no redirect" is negative parallelism — the reader
-must reconstruct the behavior from its absences, and the list drifts
-into jargon compression ("no ACME account" instead of "klangkd does
-not contact a certificate authority"). Write the positive statements
-instead:
+In docs, docstrings, config comments, GitHub issue and PR bodies, and
+review or issue comments that document operator-facing behavior,
+describe what a mode or setting **does**, not a list of what it lacks.
+"No public name needed, no ACME account, no ports 80/443, no
+redirect" is negative parallelism — the reader must reconstruct the
+behavior from its absences, and the list drifts into jargon
+compression ("no ACME account" instead of "klangkd does not contact a
+certificate authority"). Write the positive statements instead:
 
 ```markdown
 Wrong: - **No HTTP→HTTPS redirect** — the outer proxy owns port 80
@@ -360,9 +360,10 @@ setting that is unused), state it as a fact and give the reason —
 not as a headline "No X" bullet. Use concrete nouns over shorthand:
 "certificates are stored in `<state_dir>/caddy-storage`", not
 "leaves live under the storage path". Applies to `docs/` prose, the
-env-var reference rows, and the first-run config template comments
-alike. Docs-chapter diffs that introduce a run of "No …" bullets are
-a review flag — rewrite before merging.
+env-var reference rows, the first-run config template comments, and
+issue/PR bodies and comments alike. Docs-chapter diffs and PR
+descriptions that introduce a run of "No …" bullets are a review
+flag — rewrite before merging.
 
 ## Changelog (`docs/changes.md`)
 


### PR DESCRIPTION
## Summary

The AGENTS.md section "Documentation writing: state what the feature does" now governs agent-written GitHub issue and PR bodies and comments as well. It is retitled "Prose writing: state what the feature does" to match the broader scope.

Specifically:

- The scope line names docs, docstrings, config comments, **GitHub issue and PR bodies, and review or issue comments** that document operator-facing behavior.
- The "applies to" list and the review-flag guidance now cover PR descriptions too: a run of "No …" bullets in a PR description is a rewrite-before-merge flag, same as in docs-chapter diffs.

The rule itself is unchanged: describe what a mode or setting **does**, state absences as facts with reasons, use concrete nouns over shorthand.

Closes #3225.
