### PR TITLE
Map raw exceptions to stable messages in file listing and WebSocket error paths (#3227)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -2313,6 +2313,14 @@ git-credential` (#1700).** `pig-latin` removed; `word-count` dormant.
 
 ### Fixed
 
+- **File listing and WebSocket error messages (#3227).** A transport
+  failure while listing a workspace directory, and socket/parse errors
+  on the workspace WebSocket, no longer show the raw exception (which
+  can include request URLs and host names) in the file viewer's error
+  view or the restart-failure notice. They now show stable wording
+  ("Network error. Please try again.", "Connection failed. Please try
+  again."), with the underlying exception logged for debugging.
+
 - **Auth error messages (#3203).** The web login, register, local-login,
   resend-verification, and email-verification flows no longer show the raw
   transport exception (which can include request URLs and endpoint paths)

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -2313,13 +2313,14 @@ git-credential` (#1700).** `pig-latin` removed; `word-count` dormant.
 
 ### Fixed
 
-- **File listing and WebSocket error messages (#3227).** A transport
-  failure while listing a workspace directory, and socket/parse errors
-  on the workspace WebSocket, no longer show the raw exception (which
-  can include request URLs and host names) in the file viewer's error
-  view or the restart-failure notice. They now show stable wording
-  ("Network error. Please try again.", "Connection failed. Please try
-  again."), with the underlying exception logged for debugging.
+- **File viewer and WebSocket error messages (#3227).** A transport
+  failure while listing a workspace directory or opening a file, and
+  socket/parse errors on the workspace WebSocket, no longer show the
+  raw exception (which can include request URLs and host names) in the
+  file viewer's error views or the restart-failure notice. They now
+  show stable wording ("Network error. Please try again.",
+  "Connection failed. Please try again."), with the underlying
+  exception logged for debugging.
 
 - **Auth error messages (#3203).** The web login, register, local-login,
   resend-verification, and email-verification flows no longer show the raw

--- a/src/frontend/lib/file_viewer/file_viewer_panel.dart
+++ b/src/frontend/lib/file_viewer/file_viewer_panel.dart
@@ -248,6 +248,20 @@ class FileViewerPanelState extends State<FileViewerPanel> {
     }
   }
 
+  /// GET a file endpoint, mapping a transport failure to a stable
+  /// exception (#3227). Renderers surface the thrown message verbatim
+  /// in their error view, and a raw `ClientException` stringifies the
+  /// full request URL (host, endpoint path, query) — so the raw error
+  /// goes to the log only.
+  Future<http.Response> _getFile(Uri uri) async {
+    try {
+      return await _client.get(uri, headers: _headers);
+    } catch (e) {
+      debugPrint('File read request failed: $e');
+      throw Exception('Network error. Please try again.');
+    }
+  }
+
   /// Reads a file's decoded text via the `/files/content` endpoint. Injected
   /// into [RenderableFile.readText] for the renderer to call lazily.
   Future<String> _readFileText(String path) async {
@@ -256,11 +270,10 @@ class FileViewerPanelState extends State<FileViewerPanel> {
       // reader endpoint is gated like the download endpoint.
       throw Exception('Download not permitted');
     }
-    final response = await _client.get(
+    final response = await _getFile(
       Uri.parse(
         '$_baseUrl/api/v1/workspaces/${widget.workspaceId}/files/content?path=${Uri.encodeComponent(path)}',
       ),
-      headers: _headers,
     );
     if (response.statusCode == 404) {
       // The file no longer exists (e.g. deleted in the terminal since the
@@ -286,11 +299,10 @@ class FileViewerPanelState extends State<FileViewerPanel> {
       // renderers cannot fetch raw bytes.
       throw Exception('Download not permitted');
     }
-    final response = await _client.get(
+    final response = await _getFile(
       Uri.parse(
         '$_baseUrl/api/v1/workspaces/${widget.workspaceId}/files/download?path=${Uri.encodeComponent(path)}',
       ),
-      headers: _headers,
     );
     if (response.statusCode == 404) {
       // The file no longer exists since the listing was cached; invalidate

--- a/src/frontend/lib/file_viewer/file_viewer_panel.dart
+++ b/src/frontend/lib/file_viewer/file_viewer_panel.dart
@@ -236,7 +236,9 @@ class FileViewerPanelState extends State<FileViewerPanel> {
       if (mounted) {
         setState(() {
           _entries = [];
-          _listError = '$e';
+          // #3227: the raw exception (request URLs, transport detail)
+          // goes to the log only — the screen shows stable wording.
+          _listError = 'Network error. Please try again.';
         });
       }
     } finally {

--- a/src/frontend/lib/ws/ws_client.dart
+++ b/src/frontend/lib/ws/ws_client.dart
@@ -479,7 +479,13 @@ class WsClient extends ChangeNotifier {
 
           _handlers[type]?.call(json);
         } catch (e) {
-          _errorController.add(WsError(message: 'Parse error: $e'));
+          // #3227: the raw parse failure goes to the log; the stream
+          // carries stable wording only (it can reach the restart
+          // SnackBar on screen).
+          debugPrint('[WsClient] message parse error: $e');
+          _errorController.add(
+            const WsError(message: 'Could not read a server message.'),
+          );
         }
       },
       onDone: () {
@@ -521,7 +527,12 @@ class WsClient extends ChangeNotifier {
         }
       },
       onError: (e) {
-        _errorController.add(WsError(message: 'WebSocket error: $e'));
+        // #3227: log the raw socket error, emit the same stable
+        // wording the channel.ready failure uses.
+        debugPrint('[WsClient] WebSocket error: $e');
+        _errorController.add(
+          const WsError(message: 'Connection failed. Please try again.'),
+        );
         _stopHeartbeat();
         _connected = false;
         // #3000: same invariant as onDone — readiness does not survive the

--- a/src/frontend/lib/ws/ws_client.dart
+++ b/src/frontend/lib/ws/ws_client.dart
@@ -479,10 +479,11 @@ class WsClient extends ChangeNotifier {
 
           _handlers[type]?.call(json);
         } catch (e) {
-          // #3227: the raw parse failure goes to the log; the stream
-          // carries stable wording only (it can reach the restart
-          // SnackBar on screen).
-          debugPrint('[WsClient] message parse error: $e');
+          // #3227: the raw failure goes to the log; the stream carries
+          // stable wording only (it can reach the restart SnackBar on
+          // screen). The catch wraps handler dispatch as well as
+          // jsonDecode, so say "handling", not "parse".
+          debugPrint('[WsClient] message handling error: $e');
           _errorController.add(
             const WsError(message: 'Could not read a server message.'),
           );

--- a/src/frontend/test/file_viewer_panel_test.dart
+++ b/src/frontend/test/file_viewer_panel_test.dart
@@ -511,6 +511,61 @@ void main() {
       client.close();
     });
 
+    testWidgets('file read exception shows a stable error message',
+        (tester) async {
+      // #3227 review: the content reader had no transport catch, so a
+      // ClientException (whose toString carries the full request URL)
+      // propagated to the renderer's 'Failed to load file: <error>' view.
+      testHttpClientOverride = MockClient((request) async {
+        if (request.url.path.contains('/files/content')) {
+          throw http.ClientException(
+            'Connection refused',
+            Uri.parse(
+              'http://localhost:8997/api/v1/workspaces/ws-1/files/content?path=/home/tester/readme.txt',
+            ),
+          );
+        }
+        if (request.url.path.contains('/files')) {
+          return http.Response(
+            jsonEncode([
+              {
+                'name': 'readme.txt',
+                'path': '/home/tester/readme.txt',
+                'is_dir': false,
+                'size': 11
+              },
+            ]),
+            200,
+          );
+        }
+        return http.Response('Not found', 404);
+      });
+      final client = _MockWsClient();
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: SizedBox(
+              width: 800,
+              height: 600,
+              child: buildPanel(wsClient: client),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('readme.txt'));
+      await tester.pumpAndSettle();
+
+      expect(
+        find.textContaining('Network error. Please try again.'),
+        findsOneWidget,
+      );
+      expect(find.textContaining('localhost:8997'), findsNothing);
+      expect(find.textContaining('ClientException'), findsNothing);
+      client.close();
+    });
+
     testWidgets('delete file via context menu', (tester) async {
       var deleteCalled = false;
       testHttpClientOverride = MockClient((request) async {

--- a/src/frontend/test/file_viewer_panel_test.dart
+++ b/src/frontend/test/file_viewer_panel_test.dart
@@ -437,9 +437,17 @@ void main() {
       client.close();
     });
 
-    testWidgets('file listing exception shows debug message', (tester) async {
+    testWidgets('file listing exception shows a stable error message',
+        (tester) async {
+      // #3227: a transport failure must render stable wording, not the
+      // raw exception (a ClientException stringifies the request URL).
       testHttpClientOverride = MockClient((request) async {
-        throw Exception('Network error');
+        throw http.ClientException(
+          'Connection refused',
+          Uri.parse(
+            'http://localhost:8997/api/v1/workspaces/ws-1/files?path=/home/tester',
+          ),
+        );
       });
       final client = _MockWsClient();
       await tester.pumpWidget(
@@ -450,7 +458,12 @@ void main() {
         ),
       );
       await tester.pumpAndSettle();
-      expect(find.byType(FileViewerPanel), findsOneWidget);
+      expect(
+        find.textContaining('Network error. Please try again.'),
+        findsOneWidget,
+      );
+      expect(find.textContaining('localhost:8997'), findsNothing);
+      expect(find.textContaining('ClientException'), findsNothing);
       client.close();
     });
 

--- a/src/frontend/test/workspace_connector_test.dart
+++ b/src/frontend/test/workspace_connector_test.dart
@@ -306,6 +306,47 @@ void main() {
       ws.close();
     });
 
+    test('client-side stable errors route to onRestartError (#3227)', () async {
+      // The socket onError / parse-catch wording must never drift into
+      // the _messageLooksLike* heuristics (capacity / refusal text
+      // matching), which would reroute a plain connection failure to
+      // the page-level error view.
+      final ws = _MockWsClient();
+      final pageErrors = <WsError>[];
+      final restartErrors = <WsError>[];
+
+      final connector = WorkspaceConnector(
+        wsClient: ws,
+        workspaceId: 'ws-1',
+        featureRegistry: ToolPluginRegistry(),
+        onConnected: ({required connected, error}) {},
+        onContainerEvent: (_, __) => {},
+        onSharedTerminalDeleted: (_) => {},
+        onPageError: (e) => pageErrors.add(e),
+        onRestartError: (e) => restartErrors.add(e),
+      );
+
+      await connector.connect();
+
+      ws.emitError(
+        const WsError(message: 'Connection failed. Please try again.'),
+      );
+      ws.emitError(const WsError(message: 'Could not read a server message.'));
+      await Future<void>.delayed(Duration.zero);
+
+      expect(pageErrors, isEmpty);
+      expect(
+        restartErrors.map((e) => e.message),
+        [
+          'Connection failed. Please try again.',
+          'Could not read a server message.',
+        ],
+      );
+
+      connector.dispose();
+      ws.close();
+    });
+
     test('capacity refusals surface as page errors (#2525)', () async {
       final ws = _MockWsClient();
       final pageErrors = <WsError>[];

--- a/src/frontend/test/ws_client_test.dart
+++ b/src/frontend/test/ws_client_test.dart
@@ -1679,7 +1679,6 @@ void main() {
       // #3227: stable wording only — the raw exception (which can
       // embed frame content) goes to the log, not the stream.
       expect(errors[0].message, 'Could not read a server message.');
-      expect(errors[0].message.contains('FormatException'), isFalse);
     });
 
     test('server close resets connected state', () async {
@@ -1759,7 +1758,6 @@ void main() {
       // #3227: stable wording only — the raw socket error goes to the
       // log, not the stream.
       expect(errors[0].message, 'Connection failed. Please try again.');
-      expect(errors[0].message.contains('boom'), isFalse);
       expect(client.connected, isFalse);
     });
   });

--- a/src/frontend/test/ws_client_test.dart
+++ b/src/frontend/test/ws_client_test.dart
@@ -1676,7 +1676,10 @@ void main() {
       await Future.delayed(Duration.zero);
 
       expect(errors.length, 1);
-      expect(errors[0].message, startsWith('Parse error:'));
+      // #3227: stable wording only — the raw exception (which can
+      // embed frame content) goes to the log, not the stream.
+      expect(errors[0].message, 'Could not read a server message.');
+      expect(errors[0].message.contains('FormatException'), isFalse);
     });
 
     test('server close resets connected state', () async {
@@ -1753,7 +1756,10 @@ void main() {
       await Future.delayed(Duration.zero);
 
       expect(errors.length, 1);
-      expect(errors[0].message, contains('WebSocket error'));
+      // #3227: stable wording only — the raw socket error goes to the
+      // log, not the stream.
+      expect(errors[0].message, 'Connection failed. Please try again.');
+      expect(errors[0].message.contains('boom'), isFalse);
       expect(client.connected, isFalse);
     });
   });


### PR DESCRIPTION
## Summary

Implements #3227 — the follow-up to #3223 (the auth-flow fix for #3203): the same
leak class, raw exception `.toString()` interpolated into user-facing error UI,
survived outside `auth/`. A `ClientException.toString()` includes the full
request URI, so the rendered text could disclose endpoint paths and host names.

- **`file_viewer_panel.dart` (listing)** — a transport failure during a
  directory listing stored `'$e'` in `_listError` and rendered it verbatim under
  "Cannot list this directory:". It now stores the stable `'Network error.
  Please try again.'` wording (matching #3223's auth wording); the raw exception
  stays in the `debugPrint` one line above, log-only. The HTTP-detail arm
  (status line or server-authored `detail`) is unchanged — server strings are
  deliberate UI.
- **`file_viewer_panel.dart` (content reads)** — fresh-eyes review finding:
  `_readFileText` / `_readFileBytes` had no transport catch, so opening a file
  during a transport failure propagated the raw `ClientException` into every
  renderer's "Failed to load file: \<error\>" view. Both readers now fetch
  through a shared `_getFile` helper that logs the raw exception and throws the
  same stable wording.
- **`ws_client.dart`** — the socket `onError` and JSON-parse catches emitted
  `'WebSocket error: $e'` / `'Parse error: $e'` on the error stream, which
  `workspace_page` surfaces as `'Restart failed: <message>'` when a restart is
  in flight. They now `debugPrint` the raw exception and emit stable wording:
  `'Connection failed. Please try again.'` (the exact message the
  `channel.ready` failure already uses) and `'Could not read a server
  message.'`. Neither string trips the connector's capacity/refusal message
  heuristics, so routing is unchanged (pinned by a new connector test).

The borderline site the issue called out (`browser_delegate.dart` sending
`'fetch failed: $e'` over the WS bridge to the backend) is left as-is —
diagnostics-by-design, never rendered on screen.

## Testing

- Strengthened `file_viewer_panel_test.dart`: the transport-failure tests
  (listing and file-open) throw a real `http.ClientException` carrying a
  distinctive request URL and assert the stable message shows while neither the
  URL nor `ClientException` reaches the widget tree.
- Updated `ws_client_test.dart`: both error-stream tests assert the exact
  stable wording.
- New `workspace_connector_test.dart` case: the stable client-side `WsError`s
  route to `onRestartError`, guarding against wording drift into the
  `_messageLooksLike*` page-error heuristics.
- Full frontend suite green with 100% coverage (the CI way:
  `flutter test --coverage`).
