### PR TITLE
Settle delayed focus re-grab in detail-focus test (#3224)

### DIFF
--- a/src/klangk/klangkc-tests/tests/test_tui.py
+++ b/src/klangk/klangkc-tests/tests/test_tui.py
@@ -223,10 +223,45 @@ async def _drain_workers(app, pilot) -> None:
     the render pipelines' ``clear()`` transiently resets the ListView index
     to None before the re-seed, and on slow runners (macOS CI, #2932) a bare
     ``pilot.pause()`` can observe that window.
+
+    Legs covered: the mount worker → terminal/shared loaders →
+    ``_render_terminals`` → pre-clear ``_focus_term_list`` re-grab chain,
+    plus one screen update-timer tick of pending UI messages. Legs NOT
+    covered: ``on_mount``'s ``call_after_refresh(_focus_term_list)`` can
+    still be one hop away (widget queue → ``screen._callbacks`` → update
+    tick; each ``pause()`` drives a single hop, #3224) — clear focus via
+    ``_settle_cleared_focus`` when the assertion that follows needs focus
+    to stay cleared.
     """
     while len(app.workers):
         await app.workers.wait_for_complete()
     await pilot.pause()
+
+
+async def _settle_cleared_focus(app, pilot, attempts: int = 8) -> None:
+    """Clear screen focus and wait out every delayed focus re-grab (#3224).
+
+    The detail screen re-asserts ``#term_list`` focus from legs a single
+    ``pilot.pause()`` cannot flush: ``on_mount``'s
+    ``call_after_refresh(_focus_term_list)`` hops widget queue →
+    ``screen._callbacks`` → the screen's update-timer tick, so the re-grab
+    can land on the pause *after* ``set_focus(None)`` — the exact #3224
+    macOS flake (recurring past #3188's pre-clear drain). Re-clear and
+    re-drain until a full worker drain + pause completes with focus still
+    cleared: each delayed leg fires at most once, so the loop converges.
+    If it never settles, a periodic leg is re-asserting focus — fail with
+    that named so the next recurrence identifies the missing leg.
+    """
+    for _ in range(attempts):
+        app.screen.set_focus(None)
+        await _drain_workers(app, pilot)
+        if app.screen.focused is None:
+            return
+    raise AssertionError(
+        "focus was re-grabbed after clearing for "
+        f"{attempts} settle attempts; a periodic leg is re-asserting "
+        "#term_list focus (#3224)"
+    )
 
 
 def _attach_notify_spy(app) -> list:
@@ -8031,8 +8066,10 @@ async def test_detail_focus_defaults_to_own_list(monkeypatch):
         await _drain_workers(app, pilot)
         # Move focus off both lists, then reclaim. (Footer.focus() is a no-op
         # in textual, so clear focus directly to reach the reclaim branch.)
-        app.screen.set_focus(None)
-        await pilot.pause()
+        # #3224: the drain above settles the pre-clear legs, but
+        # on_mount's call_after_refresh re-grab can still be a hop away —
+        # re-clear + re-drain until focus stays cleared.
+        await _settle_cleared_focus(app, pilot)
         assert app.screen.focused is None
         app.screen._focus_term_list()
         await pilot.pause()

--- a/src/klangk/klangkc-tests/tests/test_tui.py
+++ b/src/klangk/klangkc-tests/tests/test_tui.py
@@ -239,18 +239,27 @@ async def _drain_workers(app, pilot) -> None:
 
 
 async def _settle_cleared_focus(app, pilot, attempts: int = 8) -> None:
-    """Clear screen focus and wait out every delayed focus re-grab (#3224).
+    """Clear screen focus and settle the delayed ``#term_list`` re-grabs
+    (#3224).
 
-    The detail screen re-asserts ``#term_list`` focus from legs a single
-    ``pilot.pause()`` cannot flush: ``on_mount``'s
-    ``call_after_refresh(_focus_term_list)`` hops widget queue →
-    ``screen._callbacks`` → the screen's update-timer tick, so the re-grab
-    can land on the pause *after* ``set_focus(None)`` — the exact #3224
-    macOS flake (recurring past #3188's pre-clear drain). Re-clear and
-    re-drain until a full worker drain + pause completes with focus still
-    cleared: each delayed leg fires at most once, so the loop converges.
-    If it never settles, a periodic leg is re-asserting focus — fail with
-    that named so the next recurrence identifies the missing leg.
+    The detail screen re-asserts ``#term_list`` focus from one-shot legs
+    a single ``pilot.pause()`` cannot flush: ``on_mount``'s
+    ``call_after_refresh(_focus_term_list)`` chains widget queue →
+    ``screen._callbacks`` → the update tick's trailing ``call_next`` →
+    ``Widget.focus()``'s ``app.call_later(set_focus)`` — and the last hop
+    can land on the pause *after* ``set_focus(None)`` (the #3224 macOS
+    flake, recurring past #3188's pre-clear drain). So this polls focus
+    instead of counting hops: re-clear and re-drain until a full worker
+    drain + pause completes with focus still cleared.
+
+    Contract: returns at a no-await point with focus observed cleared —
+    a straggler one-shot leg may still be in flight. Callers are safe
+    when they assert before their next await (nothing can interleave) or
+    when stragglers are idempotent with their own reclaim (a straggler
+    targets the same widget the reclaim just focused). ``attempts``
+    bounds the loop well above the worst case (~4 one-shot legs × a few
+    hops each); exhausting it means a periodic leg — not a one-shot —
+    is re-asserting focus, named in the failure for the next recurrence.
     """
     for _ in range(attempts):
         app.screen.set_focus(None)
@@ -259,8 +268,8 @@ async def _settle_cleared_focus(app, pilot, attempts: int = 8) -> None:
             return
     raise AssertionError(
         "focus was re-grabbed after clearing for "
-        f"{attempts} settle attempts; a periodic leg is re-asserting "
-        "#term_list focus (#3224)"
+        f"{attempts} settle attempts; a periodic leg (not one of the "
+        "one-shot legs) is re-asserting #term_list focus (#3224)"
     )
 
 


### PR DESCRIPTION
## Summary

`test_detail_focus_defaults_to_own_list` now waits out the delayed focus re-grabs that survive #3188's pre-clear drain, closing the macOS CI flake at the setup assert (`app.screen.focused is None` after `set_focus(None)` + one `pilot.pause()`).

## Mechanism

`WorkspaceDetailScreen.on_mount` schedules `_focus_term_list` via `call_after_refresh`. In textual 8.x that callback travels a multi-hop chain — `InvokeLater` message in the widget's queue → appended to `screen._callbacks` → invoked on the screen's update-timer tick — and each `pilot.pause()` drives only one hop (it ends with a single manual `_on_timer_update`). So a settle that looks complete can still have the re-grab one hop away; it then lands on the *test's own* pause right after `set_focus(None)`, which is exactly what the failing run observed. Under CPU load the first hop lands late, which is why the race shows on loaded darwin runners and not on Linux.

## The fix

A new `_settle_cleared_focus(app, pilot)` helper clears focus and re-drains (worker drain + pause) until a full drain completes with focus still cleared:

- Each delayed re-grab leg fires at most once, so the loop converges — typically in two iterations.
- If it never settles, the helper raises with the cause named ("a periodic leg is re-asserting `#term_list` focus"), so a future recurrence of this race family identifies its missing leg by name (the issue's second acceptance criterion).
- `_drain_workers`' docstring now documents which async legs it covers and which it leaves to `_settle_cleared_focus`.

The production code is unchanged: the focus re-assertions are intended behavior; the test was observing an unquiesced screen.

## Verification

- Target test: 10 consecutive runs unloaded and 10 under 8-way synthetic CPU contention — 20/20 pass.
- Full `test_tui.py` with `-n auto` (CI invocation, scoped to the file): 551 passed, twice.

Closes #3224.
