### PR TITLE
Keep tokens out of URLs (#3201)

### DIFF
--- a/docs/architecture/workspace-jwt.md
+++ b/docs/architecture/workspace-jwt.md
@@ -5,6 +5,6 @@ Each container receives a workspace JWT at startup, written to `/tmp/klangk/work
 - `/llm-proxy` — LLM API proxy (injects the real API key upstream)
 - `/api/v1/browser-delegate` — browser-delegate bridge for Pi extensions
 - `/ws/egress-sidecar` — the network sidecar's blocked-egress event channel
-  (the token may also arrive as a `?token=` query param on this socket)
+  (authenticated with the same `Authorization: Bearer` header)
 
 The token uses the same `KLANGKD_JWT_SECRET` as user JWTs but is distinguished by a `purpose: "workspace"` claim. Token lifetime is controlled by `KLANGKD_WORKSPACE_TOKEN_HOURS` (default 24h). Tokens are automatically renewed at 80% of their lifetime — the backend generates a new token and writes it to the container via `podman exec`. Pi resolves `!klangk-workspace-token` fresh on every LLM request (no cache), so all processes pick up renewed tokens automatically. The proxy's IP-based ACLs restrict these endpoints to container traffic as defense-in-depth alongside JWT validation.

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -316,10 +316,13 @@ operators or integrators to act when upgrading.
   `POST /api/v1/auth/verify` (formerly GET) takes the verification
   token in the body. Email-link tokens (verify/reset/invite) are now
   strictly one-time — a replayed verification link or a reset link
-  minted before an earlier reset is rejected. Integrators connecting
-  to `/ws` or `/ws/consent-decider` must switch from the query param
-  to the `bearer` subprotocol, and any client of the verify endpoint
-  must POST. See the [token delivery policy](/features/authentication/#token-delivery-policy).
+  minted before an earlier reset is rejected. **Breaking for
+  integrators:** anything connecting to `/ws` or `/ws/consent-decider`
+  must switch from the query param to the `bearer` subprotocol, and
+  any client of the verify endpoint must POST. Verification/reset
+  emails sent by a pre-upgrade server stop working after the upgrade
+  (the new one-time bindings reject the old token shapes) — affected
+  users must request a fresh link. See the [token delivery policy](/features/authentication/#token-delivery-policy).
 
 - **`KLANGKD_SESSION_WORKSTATION_BINDING` (#3194).** Session workstation
   binding: replay protection for bearer JWTs. `off` (the default)

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -308,6 +308,19 @@ operators or integrators to act when upgrading.
 
 ### Security
 
+- **Tokens removed from URLs (#3201).** Session JWTs no longer ride
+  URLs anywhere. WebSocket clients (browser and CLI) now authenticate
+  the handshake via the `Sec-WebSocket-Protocol` header instead of a
+  `?token=` query string; the OIDC callback redirects a one-time,
+  60-second code redeemed via `POST /api/v1/auth/oidc/exchange`; and
+  `POST /api/v1/auth/verify` (formerly GET) takes the verification
+  token in the body. Email-link tokens (verify/reset/invite) are now
+  strictly one-time — a replayed verification link or a reset link
+  minted before an earlier reset is rejected. Integrators connecting
+  to `/ws` or `/ws/consent-decider` must switch from the query param
+  to the `bearer` subprotocol, and any client of the verify endpoint
+  must POST. See the [token delivery policy](/features/authentication/#token-delivery-policy).
+
 - **`KLANGKD_SESSION_WORKSTATION_BINDING` (#3194).** Session workstation
   binding: replay protection for bearer JWTs. `off` (the default)
   keeps the previous behavior; `ip` binds each session to the network

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -35,6 +35,16 @@ operators or integrators to act when upgrading.
 
 ### Breaking
 
+- **Token-in-URL removal changes client contracts (#3201).**
+  Anything connecting to `/ws` or `/ws/consent-decider` must switch
+  from the `?token=` query param to the `bearer` WebSocket subprotocol
+  (the JWT rides the handshake's `Sec-WebSocket-Protocol` header), and
+  any client of the verify endpoint must `POST` the token in the body
+  (the GET form is gone). Verification/reset emails sent by a
+  pre-upgrade server stop working after the upgrade (the new one-time
+  bindings reject the old token shapes) — affected users must request
+  a fresh link. See the [token delivery policy](/features/authentication/#token-delivery-policy).
+
 - **User bind mounts disabled by default (#3153).** With
   `KLANGKD_ALLOWED_MOUNT_ROOTS` unset (previously: any non-protected
   host path was allowed), workspace mount entries with a host-path
@@ -316,13 +326,8 @@ operators or integrators to act when upgrading.
   `POST /api/v1/auth/verify` (formerly GET) takes the verification
   token in the body. Email-link tokens (verify/reset/invite) are now
   strictly one-time — a replayed verification link or a reset link
-  minted before an earlier reset is rejected. **Breaking for
-  integrators:** anything connecting to `/ws` or `/ws/consent-decider`
-  must switch from the query param to the `bearer` subprotocol, and
-  any client of the verify endpoint must POST. Verification/reset
-  emails sent by a pre-upgrade server stop working after the upgrade
-  (the new one-time bindings reject the old token shapes) — affected
-  users must request a fresh link. See the [token delivery policy](/features/authentication/#token-delivery-policy).
+  minted before an earlier reset is rejected. Client-contract
+  migration notes: see the Breaking entry above.
 
 - **`KLANGKD_SESSION_WORKSTATION_BINDING` (#3194).** Session workstation
   binding: replay protection for bearer JWTs. `off` (the default)

--- a/docs/development/index.md
+++ b/docs/development/index.md
@@ -58,7 +58,6 @@ changes.
 
 Inside `devenv shell`, these commands are available:
 
-
 | Command                     | Description                                   |
 | --------------------------- | --------------------------------------------- |
 | `test-backend`              | Run Python unit tests (server + client)       |
@@ -72,7 +71,7 @@ Inside `devenv shell`, these commands are available:
 | `test-cli-e2e`              | Run CLI E2E tests                             |
 | `test-terminal-windows-e2e` | CLI E2E: named terminal windows               |
 | `test-frontend-e2e`         | Run frontend E2E tests (Playwright)           |
-| `test-super-e2e`            | Super-E2E: features inside the Docker host   |
+| `test-super-e2e`            | Super-E2E: features inside the Docker host    |
 | `test-fuzz-api`             | API fuzz test against an isolated server      |
 | `test-all`                  | Every suite (needs podman + images)           |
 | `consent-watch`             | Live view of a workspace's consent history    |

--- a/docs/features/auth-modes.md
+++ b/docs/features/auth-modes.md
@@ -117,8 +117,9 @@ required from the caller:
   so no `klangk login` is ever needed — the first command after registering
   the server with `klangk login <server>` just works (and re-registration
   isn't: a saved token that 401s triggers the same auto-login fallback).
-- **Workspace terminals** (WebSocket) flow the token through the existing
-  `?token=` path unchanged.
+- **Workspace terminals** (WebSocket) flow the token through the
+  handshake's `Sec-WebSocket-Protocol` header, like every other WS
+  client (#3201).
 
 The freely-issued token is indistinguishable from a password-login token to
 the refresh and blocklist machinery — it reuses the standard `create_token`

--- a/docs/features/authentication.md
+++ b/docs/features/authentication.md
@@ -126,8 +126,11 @@ delivery rules are:
 - **Email links** (verification, password reset, invitations) are the
   one place a token must travel by URL, because email is the delivery
   channel. These tokens are single-purpose, one-time, and short-lived:
-  verification tokens die on first use, on an email change, or after
-  72 hours; reset tokens are bound to a digest of the current password
+  verification tokens are bound to the address they were minted for
+  and are consumed by the first redemption, an email change, or
+  72 hours (a stale link only matches again in the narrow case of the
+  account changing its address away and back while the link is still
+  unexpired); reset tokens are bound to a digest of the current password
   hash (the first successful reset consumes every outstanding link) and
   expire after 1 hour; invitation tokens are consumed when the
   invitation is accepted. Links use the URL fragment (`#/verify?…`),

--- a/docs/features/authentication.md
+++ b/docs/features/authentication.md
@@ -103,6 +103,41 @@ Your session survives page refreshes. If you navigate to a workspace
 URL while logged out, you'll be redirected to the login page and
 returned to your original URL after logging in.
 
+## Token delivery policy
+
+Session tokens (JWTs) are never placed in URLs. URLs leak into browser
+history, `Referer` headers, and reverse-proxy/server access logs, so a
+session credential riding a URL is a leak waiting to happen. The
+delivery rules are:
+
+- **API calls** carry the session JWT in the `Authorization: Bearer`
+  header.
+- **WebSocket connections** carry it in the handshake's
+  `Sec-WebSocket-Protocol` header (the browser WebSocket API cannot set
+  `Authorization`, so the client offers the `bearer` subprotocol plus
+  the token, and the server echoes `bearer`). The token never rides the
+  `?token=` query string. The workspace sidecar authenticates its
+  socket with the `Authorization` header it already uses for HTTP.
+- **OIDC login completion** redirects a one-time, 60-second login code
+  (`/#/oidc-complete?code=…` for the web, `?code=…` on the CLI's
+  localhost callback). The completer redeems it via
+  `POST /auth/oidc/exchange` for the session token — the JWT itself
+  never rides a URL.
+- **Email links** (verification, password reset, invitations) are the
+  one place a token must travel by URL, because email is the delivery
+  channel. These tokens are single-purpose, one-time, and short-lived:
+  verification tokens die on first use, on an email change, or after
+  72 hours; reset tokens are bound to a digest of the current password
+  hash (the first successful reset consumes every outstanding link) and
+  expire after 1 hour; invitation tokens are consumed when the
+  invitation is accepted. Links use the URL fragment (`#/verify?…`),
+  which browsers do not send to servers or in `Referer` headers.
+  Redeeming a verification token sends it in the `POST` body, not the
+  query string.
+- **Logs** never contain raw tokens: the register log line records a
+  SHA-256 prefix of the verification token, and WS URLs carry no token
+  at all.
+
 ## Brute-force protection
 
 By default, Klangk locks accounts after repeated failed login

--- a/docs/reference/api-endpoints.md
+++ b/docs/reference/api-endpoints.md
@@ -403,7 +403,9 @@ authorization code for tokens.
 
 **Auth:** None. Query params: `code`, `state`, optional `error`.
 
-Returns HTTP 302 redirect to `/#/oidc-complete?token=...` or CLI localhost URL.
+Returns HTTP 302 redirect to `/#/oidc-complete?code=...` (a one-time code
+redeemable via `POST /api/v1/auth/oidc/exchange`) or
+`<cli_redirect>?code=...` on the CLI localhost callback.
 
 ---
 
@@ -418,15 +420,33 @@ Returns HTTP 302 redirect to OIDC IdP.
 
 ---
 
-### GET `/api/v1/auth/verify`
+### POST `/api/v1/auth/verify`
 
 Verify a user's email address using the token from the verification
-email. Returns a session token on success.
+email. Returns a session token on success. The token rides the request
+body (never the URL — URLs land in proxy/server access logs); the token
+is one-time: a replayed link, or one minted before an email change, is
+rejected.
 
-**Auth:** None. Query param: `token` (verification JWT from email link).
+**Auth:** None. Body: `{"token": "<verification JWT from email link>"}`.
 
 ```json
 { "status": "verified", "access_token": "jwt-string" }
+```
+
+---
+
+### POST `/api/v1/auth/oidc/exchange`
+
+Redeem the one-time login code the OIDC callback redirected to
+(`/#/oidc-complete?code=…` for the web flow, `?code=…` on the CLI's
+localhost callback). Codes are single-use and expire after 60 seconds;
+unknown, replayed, and expired codes all return 400.
+
+**Auth:** None. Body: `{"code": "<one-time login code>"}`.
+
+```json
+{ "access_token": "jwt-string", "email": "user@example.com" }
 ```
 
 ---
@@ -2135,7 +2155,8 @@ Primary WebSocket connection for real-time communication. Handles
 terminal I/O, workspace status updates, and browser
 delegate events.
 
-**Auth:** JWT required via `?token=` query param.
+**Auth:** JWT via the handshake's `Sec-WebSocket-Protocol` header
+(`bearer, <jwt>` — the server echoes `bearer`; #3201).
 
 Close codes: 4001 (missing/invalid token), 4002 (expired token), 4004
 (password change required, #3172 — the account must change its password

--- a/docs/reference/api-endpoints.md
+++ b/docs/reference/api-endpoints.md
@@ -2176,7 +2176,9 @@ socket. Requires the `egress-consent` permission on the workspace
 strictly workspace-scoped: the `workspace` query param is
 required — a handshake without it is refused.
 
-**Auth:** JWT required. Query param: `workspace` (the workspace id).
+**Auth:** JWT via the handshake's `Sec-WebSocket-Protocol` header
+(`bearer, <jwt>` — the server echoes `bearer`; #3201). Query param:
+`workspace` (the workspace id).
 
 Close codes: 4001 (missing/invalid token), 4002 (expired token), 4003
 (forbidden — missing `egress-consent` or wrong scope), 4004 (password

--- a/scripts/fuzz-api.py
+++ b/scripts/fuzz-api.py
@@ -278,7 +278,7 @@ ENDPOINTS: list[tuple[str, str, dict | None, dict | None]] = [
     # Auth — no token
     ("POST", f"{P}/auth/register", {"email": "email", "password": "password"}, None),
     ("POST", f"{P}/auth/login", {"email": "email", "password": "password"}, None),
-    ("GET", f"{P}/auth/verify", None, {"token": "string"}),
+    ("POST", f"{P}/auth/verify", {"token": "string"}, None),
     (
         "POST",
         f"{P}/auth/resend-verification",

--- a/scripts/fuzz-api.py
+++ b/scripts/fuzz-api.py
@@ -279,6 +279,7 @@ ENDPOINTS: list[tuple[str, str, dict | None, dict | None]] = [
     ("POST", f"{P}/auth/register", {"email": "email", "password": "password"}, None),
     ("POST", f"{P}/auth/login", {"email": "email", "password": "password"}, None),
     ("POST", f"{P}/auth/verify", {"token": "string"}, None),
+    ("POST", f"{P}/auth/oidc/exchange", {"code": "string"}, None),
     (
         "POST",
         f"{P}/auth/resend-verification",

--- a/scripts/fuzz-idle.py
+++ b/scripts/fuzz-idle.py
@@ -482,9 +482,12 @@ class WsTerminal:
         self.frame_types: list[str] = []
 
     async def connect(self, timeout: float = BRINGUP_TIMEOUT) -> None:
+        # #3201: the JWT rides the handshake's subprotocol header, not
+        # the URL query string.
         self.ws = await websockets.connect(
-            f"{self.server.ws_base}/ws?token={self.token}",
+            f"{self.server.ws_base}/ws",
             max_size=2**20,
+            subprotocols=["bearer", self.token],
         )
         await self.ws.send(
             json.dumps({"cmd": "workspace_connect", "workspaceId": self.ws_id})

--- a/src/frontend/e2e-tests/demo/demo-helpers.ts
+++ b/src/frontend/e2e-tests/demo/demo-helpers.ts
@@ -957,7 +957,7 @@ export async function connectWs(
 ): Promise<DemoWs> {
   const wsUrl = DEMO_URL.replace(/^http/, "ws");
   return new Promise((resolve, reject) => {
-    const ws = new WebSocket(`${wsUrl}/ws?token=${token}`);
+    const ws = new WebSocket(`${wsUrl}/ws`, ["bearer", token]);
     const client = new DemoWs(ws);
     const t = setTimeout(() => {
       ws.close();

--- a/src/frontend/e2e-tests/e2e/docs-screenshots.spec.ts
+++ b/src/frontend/e2e-tests/e2e/docs-screenshots.spec.ts
@@ -114,7 +114,7 @@ async function connectWs(
 ): Promise<TestWsClient> {
   const wsUrl = API_BASE.replace("http://", "ws://");
   return new Promise((resolve, reject) => {
-    const ws = new WebSocket(`${wsUrl}/ws?token=${token}`);
+    const ws = new WebSocket(`${wsUrl}/ws`, ["bearer", token]);
     const client = new TestWsClient(ws);
     const timeout = setTimeout(() => {
       ws.close();

--- a/src/frontend/e2e-tests/e2e/helpers.ts
+++ b/src/frontend/e2e-tests/e2e/helpers.ts
@@ -547,7 +547,7 @@ export async function connectContainer(
   // eslint-disable-next-line @typescript-eslint/no-var-requires
   const WS = require("ws");
   const ws: any = await new Promise((resolve, reject) => {
-    const socket = new WS(`${wsBase}/ws?token=${token}`);
+    const socket = new WS(`${wsBase}/ws`, ["bearer", token]);
     socket.on("open", () => resolve(socket));
     socket.on("error", reject);
   });

--- a/src/frontend/e2e-tests/e2e/per-user-home.spec.ts
+++ b/src/frontend/e2e-tests/e2e/per-user-home.spec.ts
@@ -16,7 +16,7 @@ async function execInContainer(
   const wsUrl = API_BASE.replace("http://", "ws://");
 
   return new Promise<string>((resolve, reject) => {
-    const ws = new WebSocket(`${wsUrl}/ws?token=${token}`);
+    const ws = new WebSocket(`${wsUrl}/ws`, ["bearer", token]);
     const chunks: Buffer[] = [];
     let connected = false;
 

--- a/src/frontend/e2e-tests/e2e/shared-terminals.spec.ts
+++ b/src/frontend/e2e-tests/e2e/shared-terminals.spec.ts
@@ -94,7 +94,7 @@ async function connectWs(
 ): Promise<TestWsClient> {
   const wsUrl = API_BASE.replace("http://", "ws://");
   return new Promise((resolve, reject) => {
-    const ws = new WebSocket(`${wsUrl}/ws?token=${token}`);
+    const ws = new WebSocket(`${wsUrl}/ws`, ["bearer", token]);
     const client = new TestWsClient(ws);
     const timeout = setTimeout(() => {
       ws.close();

--- a/src/frontend/e2e-tests/e2e/sudo.spec.ts
+++ b/src/frontend/e2e-tests/e2e/sudo.spec.ts
@@ -11,7 +11,8 @@ async function execInContainer(
   const wsUrl = API_BASE.replace("http://", "ws://");
 
   return new Promise((resolve, reject) => {
-    const ws = new WebSocket(`${wsUrl}/ws?token=${token}`);
+    // #3201: the JWT rides the WS subprotocol header, not the URL.
+    const ws = new WebSocket(`${wsUrl}/ws`, ["bearer", token]);
     const chunks: Buffer[] = [];
     let connected = false;
     let exitCode = 0;

--- a/src/frontend/e2e-tests/e2e/tab-speed.spec.ts
+++ b/src/frontend/e2e-tests/e2e/tab-speed.spec.ts
@@ -18,7 +18,7 @@ test("new terminal tab round-trip completes within 10 seconds", async ({
   try {
     // Open parallel WebSocket
     const wsUrl = API_BASE.replace("http://", "ws://");
-    const ws = new WebSocket(`${wsUrl}/ws?token=${token}`);
+    const ws = new WebSocket(`${wsUrl}/ws`, ["bearer", token]);
 
     await new Promise<void>((resolve, reject) => {
       ws.on("open", () => {

--- a/src/frontend/e2e-tests/e2e/terminal-tabs.spec.ts
+++ b/src/frontend/e2e-tests/e2e/terminal-tabs.spec.ts
@@ -100,7 +100,7 @@ async function connectToWorkspace(
   const wsUrl = API_BASE.replace("http://", "ws://");
 
   return new Promise<TerminalWsClient>((resolve, reject) => {
-    const ws = new WebSocket(`${wsUrl}/ws?token=${token}`);
+    const ws = new WebSocket(`${wsUrl}/ws`, ["bearer", token]);
     const timeout = setTimeout(() => {
       ws.close();
       reject(new Error("connect timed out"));

--- a/src/frontend/lib/app.dart
+++ b/src/frontend/lib/app.dart
@@ -173,8 +173,10 @@ class _KlangkAppState extends State<KlangkApp> {
         GoRoute(
           path: '/oidc-complete',
           builder: (context, state) {
-            final token = state.uri.queryParameters['token'] ?? '';
-            return OidcCompletePage(token: token);
+            // #3201: a one-time login code, exchanged for the session
+            // token via POST by the page — never the JWT itself.
+            final code = state.uri.queryParameters['code'] ?? '';
+            return OidcCompletePage(code: code);
           },
         ),
         GoRoute(

--- a/src/frontend/lib/auth/oidc_complete_page.dart
+++ b/src/frontend/lib/auth/oidc_complete_page.dart
@@ -1,15 +1,19 @@
+import 'dart:convert';
+
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'auth_service.dart';
 import '../utils/page_title.dart';
 import '../widgets/klangk_logo.dart';
 
-/// Landing page after OIDC callback. Extracts the token from the URL
-/// query parameters, saves it, and redirects to /workspaces.
+/// Landing page after OIDC callback. The backend redirected here with a
+/// one-time login code (#3201 — the session JWT never rides the URL);
+/// this page redeems the code for the token via POST, saves it, and the
+/// GoRouter redirect then navigates to /workspaces.
 class OidcCompletePage extends StatefulWidget {
-  final String token;
+  final String code;
 
-  const OidcCompletePage({super.key, required this.token});
+  const OidcCompletePage({super.key, required this.code});
 
   @override
   State<OidcCompletePage> createState() => _OidcCompletePageState();
@@ -26,13 +30,29 @@ class _OidcCompletePageState extends State<OidcCompletePage> {
   }
 
   Future<void> _completeLogin() async {
-    if (widget.token.isEmpty) {
-      setState(() => _error = 'Missing authentication token.');
+    if (widget.code.isEmpty) {
+      setState(() => _error = 'Missing login code.');
       return;
     }
     final auth = context.read<AuthService>();
-    await auth.saveTokenFromVerification(widget.token);
-    // GoRouter redirect handles navigation to /workspaces
+    try {
+      final resp = await auth.authPost(
+        '/api/v1/auth/oidc/exchange',
+        body: jsonEncode({'code': widget.code}),
+      );
+      if (!mounted) return;
+      if (resp.statusCode == 200) {
+        final data = jsonDecode(resp.body);
+        final token = data['access_token'];
+        if (token is String && token.isNotEmpty) {
+          await auth.saveTokenFromVerification(token);
+          return; // GoRouter redirect handles navigation to /workspaces
+        }
+      }
+      setState(() => _error = 'Login code exchange failed.');
+    } catch (e) {
+      setState(() => _error = 'Login code exchange failed: $e');
+    }
   }
 
   @override

--- a/src/frontend/lib/auth/oidc_complete_page.dart
+++ b/src/frontend/lib/auth/oidc_complete_page.dart
@@ -50,8 +50,10 @@ class _OidcCompletePageState extends State<OidcCompletePage> {
         }
       }
       setState(() => _error = 'Login code exchange failed.');
-    } catch (e) {
-      setState(() => _error = 'Login code exchange failed: $e');
+    } catch (_) {
+      // Stable message only (#3223 policy): transport errors are mapped
+      // upstream; a malformed 200 body must not leak a raw exception.
+      setState(() => _error = 'Login code exchange failed.');
     }
   }
 

--- a/src/frontend/lib/auth/oidc_complete_page.dart
+++ b/src/frontend/lib/auth/oidc_complete_page.dart
@@ -53,6 +53,8 @@ class _OidcCompletePageState extends State<OidcCompletePage> {
     } catch (_) {
       // Stable message only (#3223 policy): transport errors are mapped
       // upstream; a malformed 200 body must not leak a raw exception.
+      // The await may have straddled an unmount (#3203) — re-check.
+      if (!mounted) return;
       setState(() => _error = 'Login code exchange failed.');
     }
   }

--- a/src/frontend/lib/auth/verify_page.dart
+++ b/src/frontend/lib/auth/verify_page.dart
@@ -36,8 +36,13 @@ class _VerifyPageState extends State<VerifyPage> {
 
     try {
       final auth = context.read<AuthService>();
-      final response =
-          await auth.authGet('/api/v1/auth/verify?token=${widget.token}');
+      // #3201: the token rides the POST body, not the URL — a GET query
+      // string would put a bearer-granting credential in proxy/server
+      // access logs.
+      final response = await auth.authPost(
+        '/api/v1/auth/verify',
+        body: jsonEncode({'token': widget.token}),
+      );
       // The await above can straddle an unmount (e.g. the router's
       // refreshListenable redirecting a already-tokened user off this
       // public route) — bail before touching state (#3203).

--- a/src/frontend/lib/workspace/consent_decider_service.dart
+++ b/src/frontend/lib/workspace/consent_decider_service.dart
@@ -512,13 +512,16 @@ class ConsentDeciderService extends ChangeNotifier {
 
   bool get connected => _connected;
 
-  /// Override for testing to inject a fake channel factory.
+  /// Override for testing to inject a fake channel factory. Takes the
+  /// subprotocol list production sends (#3201: ['bearer', token]).
   @visibleForTesting
-  static WebSocketChannel Function(Uri uri)? testChannelFactory;
+  static WebSocketChannel Function(Uri uri, List<String> protocols)?
+      testChannelFactory;
 
-  /// The consent-decider WS URL for this workspace: token as a query
-  /// param (mirroring [WsClient]) plus a one-shot DPoP proof parameter
-  /// when the token is bound (#3218).
+  /// The consent-decider WS URL for this workspace: auth rides the
+  /// handshake's subprotocol header (mirroring [WsClient]; #3201);
+  /// a one-shot DPoP proof rides a query parameter when the token is
+  /// bound (#3218).
   Future<String> wsUrl() async {
     final loc = Uri.base;
     final wsScheme = loc.scheme == 'https' ? 'wss' : 'ws';
@@ -527,7 +530,7 @@ class ConsentDeciderService extends ChangeNotifier {
     final headers = await dpopHeadersFor('GET', base, token);
     final proof = headers['DPoP'];
     final suffix = proof == null ? '' : '&dpop=$proof';
-    return '$base?workspace=$workspaceId&token=$token$suffix';
+    return '$base?workspace=$workspaceId$suffix';
   }
 
   /// Open the connection (idempotent: a no-op if already
@@ -552,14 +555,16 @@ class ConsentDeciderService extends ChangeNotifier {
   }
 
   Future<void> _openChannel() async {
+    // #3201: token as a WS subprotocol entry, not a query param.
     final url = await wsUrl();
+    final protocols = ['bearer', token];
     final factory = testChannelFactory;
     WebSocketChannel ch;
     if (factory != null) {
-      ch = factory(Uri.parse(url));
+      ch = factory(Uri.parse(url), protocols);
     } else {
       // coverage:ignore-start
-      ch = WebSocketChannel.connect(Uri.parse(url));
+      ch = WebSocketChannel.connect(Uri.parse(url), protocols: protocols);
       // coverage:ignore-end
     }
     _channel = ch;

--- a/src/frontend/lib/ws/ws_client.dart
+++ b/src/frontend/lib/ws/ws_client.dart
@@ -79,9 +79,11 @@ class WsClient extends ChangeNotifier {
     final token = _auth!.token!;
     final headers = await dpopHeadersFor('GET', _wsBaseUrl, token);
     final proof = headers['DPoP'];
-    final params = {'token': token, if (proof != null) 'dpop': proof};
+    // #3201: the token rides the subprotocol list, never the query;
+    // only the one-shot DPoP proof stays a query param (#3218).
     final base = Uri.tryParse(_wsBaseUrl) ?? Uri(path: '/ws');
-    return base.replace(queryParameters: params);
+    if (proof == null) return base;
+    return base.replace(queryParameters: {'dpop': proof});
   }
 
   WebSocketChannel? _channel;
@@ -136,9 +138,11 @@ class WsClient extends ChangeNotifier {
   /// Workspace ID to rejoin after reconnecting.
   String? _pendingWorkspaceId;
 
-  /// Override for testing to inject a fake channel factory.
+  /// Override for testing to inject a fake channel factory. Takes the
+  /// subprotocol list production sends (#3201: ['bearer', token]).
   @visibleForTesting
-  static WebSocketChannel Function(Uri uri)? testChannelFactory;
+  static WebSocketChannel Function(Uri uri, List<String> protocols)?
+      testChannelFactory;
 
   /// Override for testing to control reconnect backoff delay.
   @visibleForTesting
@@ -351,11 +355,23 @@ class WsClient extends ChangeNotifier {
   /// FailDelayManager may delay the connection by up to 60s after an unclean
   /// close — we just wait it out since retrying creates zombie connections.
   Future<void> _connectWs() async {
+    // #3201: browsers cannot set headers on a WS connect, so the token
+    // rides the handshake as a subprotocol entry (server echoes
+    // 'bearer') instead of a ?token= query param, which would land in
+    // proxy/server access logs.
+    final uri = await _wsUri();
+    final protocols = ['bearer', _auth!.token!];
     if (testChannelFactory != null) {
-      _channel = testChannelFactory!(await _wsUri());
+      _channel = testChannelFactory!(uri, protocols);
     } else {
       // coverage:ignore-start
-      _channel = WebSocketChannel.connect(await _wsUri());
+      debugPrint(
+        '[WsClient] WebSocketChannel.connect() start: ${DateTime.now()}',
+      );
+      _channel = WebSocketChannel.connect(uri, protocols: protocols);
+      debugPrint(
+        '[WsClient] WebSocketChannel.connect() returned: ${DateTime.now()}',
+      );
       // coverage:ignore-end
     }
 

--- a/src/frontend/test/consent_banner_test.dart
+++ b/src/frontend/test/consent_banner_test.dart
@@ -45,7 +45,7 @@ class _FakeSink extends Fake implements WebSocketSink {
 }
 
 ConsentDeciderService _serviceWithChannel(_FakeChannel channel) {
-  ConsentDeciderService.testChannelFactory = (_) => channel;
+  ConsentDeciderService.testChannelFactory = (_, __) => channel;
   return ConsentDeciderService(
     workspaceId: 'ws',
     token: 't',
@@ -380,7 +380,7 @@ void main() {
     tester,
   ) async {
     final channel = _FakeChannel();
-    ConsentDeciderService.testChannelFactory = (_) => channel;
+    ConsentDeciderService.testChannelFactory = (_, __) => channel;
     final svc = ConsentDeciderService(
       workspaceId: 'ws',
       token: 't',

--- a/src/frontend/test/consent_decider_service_test.dart
+++ b/src/frontend/test/consent_decider_service_test.dart
@@ -657,7 +657,7 @@ void main() {
 
     setUp(() {
       channel = _FakeChannel();
-      ConsentDeciderService.testChannelFactory = (_) => channel;
+      ConsentDeciderService.testChannelFactory = (_, __) => channel;
     });
 
     tearDown(() {
@@ -755,7 +755,8 @@ void main() {
     });
 
     test('sendVerdict flashes when the socket send throws', () async {
-      ConsentDeciderService.testChannelFactory = (_) => _ThrowingChannel();
+      ConsentDeciderService.testChannelFactory =
+          (_, __) => _ThrowingChannel();
       final svc = ConsentDeciderService(workspaceId: 'ws', token: 't');
       await svc.connect();
       svc.sendVerdict('r1', 'allowed', 'once'); // sink.add throws
@@ -933,8 +934,13 @@ void main() {
       svc.dispose();
     });
 
+<<<<<<< HEAD
     test('sendRevoke flashes when the socket send throws', () async {
       ConsentDeciderService.testChannelFactory = (_) => _ThrowingChannel();
+=======
+    test('sendRevoke flashes when the socket send throws', () {
+      ConsentDeciderService.testChannelFactory = (_, __) => _ThrowingChannel();
+>>>>>>> d57fd3ec0 (Address fresh-eyes review of #3201)
       final svc = ConsentDeciderService(workspaceId: 'ws', token: 't');
       await svc.connect();
       svc.sendRevoke('v1');
@@ -980,8 +986,13 @@ void main() {
       svc2.dispose();
     });
 
+<<<<<<< HEAD
     test('sendPause/sendUnpause flash when the socket send throws', () async {
       ConsentDeciderService.testChannelFactory = (_) => _ThrowingChannel();
+=======
+    test('sendPause/sendUnpause flash when the socket send throws', () {
+      ConsentDeciderService.testChannelFactory = (_, __) => _ThrowingChannel();
+>>>>>>> d57fd3ec0 (Address fresh-eyes review of #3201)
       final svc = ConsentDeciderService(workspaceId: 'ws', token: 't');
       await svc.connect();
       svc.sendPause('15m');
@@ -1285,7 +1296,7 @@ void main() {
     test('drops expired timed rules, keeps the rest, and notifies', () async {
       var now = DateTime.fromMillisecondsSinceEpoch(1000 * 1000, isUtc: true);
       final ch = _FakeChannel();
-      ConsentDeciderService.testChannelFactory = (_) => ch;
+      ConsentDeciderService.testChannelFactory = (_, __) => ch;
       final svc = ConsentDeciderService(
         workspaceId: 'ws',
         token: 't',
@@ -1353,7 +1364,7 @@ void main() {
       () async {
         var now = DateTime.fromMillisecondsSinceEpoch(1000 * 1000, isUtc: true);
         final ch = _FakeChannel();
-        ConsentDeciderService.testChannelFactory = (_) => ch;
+        ConsentDeciderService.testChannelFactory = (_, __) => ch;
         final svc = ConsentDeciderService(
           workspaceId: 'ws',
           token: 't',

--- a/src/frontend/test/consent_decider_service_test.dart
+++ b/src/frontend/test/consent_decider_service_test.dart
@@ -755,8 +755,7 @@ void main() {
     });
 
     test('sendVerdict flashes when the socket send throws', () async {
-      ConsentDeciderService.testChannelFactory =
-          (_, __) => _ThrowingChannel();
+      ConsentDeciderService.testChannelFactory = (_, __) => _ThrowingChannel();
       final svc = ConsentDeciderService(workspaceId: 'ws', token: 't');
       await svc.connect();
       svc.sendVerdict('r1', 'allowed', 'once'); // sink.add throws
@@ -934,13 +933,8 @@ void main() {
       svc.dispose();
     });
 
-<<<<<<< HEAD
     test('sendRevoke flashes when the socket send throws', () async {
-      ConsentDeciderService.testChannelFactory = (_) => _ThrowingChannel();
-=======
-    test('sendRevoke flashes when the socket send throws', () {
       ConsentDeciderService.testChannelFactory = (_, __) => _ThrowingChannel();
->>>>>>> d57fd3ec0 (Address fresh-eyes review of #3201)
       final svc = ConsentDeciderService(workspaceId: 'ws', token: 't');
       await svc.connect();
       svc.sendRevoke('v1');
@@ -986,13 +980,8 @@ void main() {
       svc2.dispose();
     });
 
-<<<<<<< HEAD
     test('sendPause/sendUnpause flash when the socket send throws', () async {
-      ConsentDeciderService.testChannelFactory = (_) => _ThrowingChannel();
-=======
-    test('sendPause/sendUnpause flash when the socket send throws', () {
       ConsentDeciderService.testChannelFactory = (_, __) => _ThrowingChannel();
->>>>>>> d57fd3ec0 (Address fresh-eyes review of #3201)
       final svc = ConsentDeciderService(workspaceId: 'ws', token: 't');
       await svc.connect();
       svc.sendPause('15m');
@@ -1401,8 +1390,10 @@ void main() {
       testDpopBackendOverride = FakeDpopBackend(proof: 'dec-proof');
       final bound = boundToken();
       Uri? seen;
-      ConsentDeciderService.testChannelFactory = (uri) {
+      List<String>? seenProtocols;
+      ConsentDeciderService.testChannelFactory = (uri, protocols) {
         seen = uri;
+        seenProtocols = protocols;
         return _FakeChannel();
       };
 
@@ -1410,7 +1401,9 @@ void main() {
       await svc.connect();
 
       expect(seen!.queryParameters['dpop'], 'dec-proof');
-      expect(seen!.queryParameters['token'], bound);
+      // #3201: the token rides the subprotocol list, never the query.
+      expect(seenProtocols, ['bearer', bound]);
+      expect(seen!.queryParameters.containsKey('token'), isFalse);
       expect(seen!.queryParameters['workspace'], 'ws');
       svc.dispose();
     });
@@ -1424,7 +1417,7 @@ void main() {
     test('overlapping connects open exactly one channel', () async {
       var opened = 0;
       final gate = Completer<void>();
-      ConsentDeciderService.testChannelFactory = (_) {
+      ConsentDeciderService.testChannelFactory = (_, __) {
         opened += 1;
         // Hold the first (and only permitted) open until the second
         // connect() call has come and gone.
@@ -1445,13 +1438,13 @@ void main() {
 
     test('a throwing channel factory is contained and reconnects', () async {
       ConsentDeciderService.testChannelFactory =
-          (_) => throw StateError('boom');
+          (_, __) => throw StateError('boom');
       final svc = ConsentDeciderService(workspaceId: 'ws', token: 't');
       await svc.connect();
       expect(svc.connected, isFalse);
       // The failure scheduled the normal reconnect backoff; a later
       // connect (the timer's path, or an explicit one) still works.
-      ConsentDeciderService.testChannelFactory = (_) => _FakeChannel();
+      ConsentDeciderService.testChannelFactory = (_, __) => _FakeChannel();
       await svc.connect();
       expect(svc.connected, isTrue);
       svc.dispose();

--- a/src/frontend/test/consent_rules_panel_test.dart
+++ b/src/frontend/test/consent_rules_panel_test.dart
@@ -88,7 +88,7 @@ ConsentDeciderService _serviceWithChannel(
   _FakeChannel channel, {
   DateTime Function()? clock,
 }) {
-  ConsentDeciderService.testChannelFactory = (_) => channel;
+  ConsentDeciderService.testChannelFactory = (_, __) => channel;
   return ConsentDeciderService(
     workspaceId: 'ws',
     token: 't',
@@ -504,7 +504,7 @@ void main() {
       tester,
     ) async {
       final ch = _FakeChannel();
-      ConsentDeciderService.testChannelFactory = (_) => ch;
+      ConsentDeciderService.testChannelFactory = (_, __) => ch;
       final svc = ConsentDeciderService(
         workspaceId: 'ws',
         token: 't',
@@ -650,7 +650,7 @@ void main() {
 
     testWidgets('header shows reconnecting when disconnected', (tester) async {
       final ch = _FakeChannel();
-      ConsentDeciderService.testChannelFactory = (_) => ch;
+      ConsentDeciderService.testChannelFactory = (_, __) => ch;
       final svc = ConsentDeciderService(
         workspaceId: 'ws',
         token: 't',

--- a/src/frontend/test/ws_client_test.dart
+++ b/src/frontend/test/ws_client_test.dart
@@ -470,7 +470,11 @@ void main() {
     test('connect success via testChannelFactory', () async {
       SharedPreferences.setMockInitialValues({'klangk_jwt': 'test-token'});
       final channel = _FakeWebSocketChannel();
-      WsClient.testChannelFactory = (_, __) => channel;
+      List<String>? seenProtocols;
+      WsClient.testChannelFactory = (_, protocols) {
+        seenProtocols = protocols;
+        return channel;
+      };
 
       final auth = AuthService();
       await Future.delayed(Duration.zero);
@@ -481,6 +485,8 @@ void main() {
 
       await client.connect();
       expect(client.connected, isTrue);
+      // #3201: the JWT rides the subprotocol list, never the URL.
+      expect(seenProtocols, ['bearer', 'test-token']);
       client.disconnect();
       client.dispose();
     });

--- a/src/frontend/test/ws_client_test.dart
+++ b/src/frontend/test/ws_client_test.dart
@@ -1782,8 +1782,10 @@ void main() {
       testDpopBackendOverride = FakeDpopBackend(proof: 'ws-proof');
       final channel = _FakeWebSocketChannel();
       Uri? seen;
-      WsClient.testChannelFactory = (uri) {
+      List<String>? seenProtocols;
+      WsClient.testChannelFactory = (uri, protocols) {
         seen = uri;
+        seenProtocols = protocols;
         return channel;
       };
 
@@ -1794,7 +1796,10 @@ void main() {
       await Future.delayed(Duration.zero);
 
       expect(seen, isNotNull);
-      expect(seen!.queryParameters['token'], bound);
+      // #3201: the token rides the subprotocol list, never the query;
+      // only the one-shot DPoP proof stays a query param (#3218).
+      expect(seenProtocols, ['bearer', bound]);
+      expect(seen!.queryParameters.containsKey('token'), isFalse);
       expect(seen!.queryParameters['dpop'], 'ws-proof');
       WsClient.testChannelFactory = null;
       client.dispose();
@@ -1805,8 +1810,10 @@ void main() {
       testDpopBackendOverride = FakeDpopBackend(proof: 'ws-proof');
       final channel = _FakeWebSocketChannel();
       Uri? seen;
-      WsClient.testChannelFactory = (uri) {
+      List<String>? seenProtocols;
+      WsClient.testChannelFactory = (uri, protocols) {
         seen = uri;
+        seenProtocols = protocols;
         return channel;
       };
 
@@ -1816,7 +1823,8 @@ void main() {
       client.updateAuth(auth);
       await Future.delayed(Duration.zero);
 
-      expect(seen!.queryParameters['token'], 'plain-token');
+      expect(seenProtocols, ['bearer', 'plain-token']);
+      expect(seen!.queryParameters.containsKey('token'), isFalse);
       expect(seen!.queryParameters.containsKey('dpop'), isFalse);
       WsClient.testChannelFactory = null;
       client.dispose();

--- a/src/frontend/test/ws_client_test.dart
+++ b/src/frontend/test/ws_client_test.dart
@@ -139,7 +139,7 @@ void main() {
     test('connects on logged-in transition', () async {
       SharedPreferences.setMockInitialValues({'klangk_jwt': 'test-token'});
       final channel = _FakeWebSocketChannel();
-      WsClient.testChannelFactory = (_) => channel;
+      WsClient.testChannelFactory = (_, __) => channel;
 
       final auth = AuthService();
       await Future.delayed(Duration.zero);
@@ -158,7 +158,7 @@ void main() {
       () async {
         SharedPreferences.setMockInitialValues({'klangk_jwt': 'test-token'});
         final channel = _FakeWebSocketChannel();
-        WsClient.testChannelFactory = (_) => channel;
+        WsClient.testChannelFactory = (_, __) => channel;
 
         final auth = AuthService();
         await Future.delayed(Duration.zero);
@@ -470,7 +470,7 @@ void main() {
     test('connect success via testChannelFactory', () async {
       SharedPreferences.setMockInitialValues({'klangk_jwt': 'test-token'});
       final channel = _FakeWebSocketChannel();
-      WsClient.testChannelFactory = (_) => channel;
+      WsClient.testChannelFactory = (_, __) => channel;
 
       final auth = AuthService();
       await Future.delayed(Duration.zero);
@@ -489,7 +489,7 @@ void main() {
       SharedPreferences.setMockInitialValues({'klangk_jwt': 'test-token'});
       final failChannel = _FakeWebSocketChannel();
       failChannel.failReady = true;
-      WsClient.testChannelFactory = (_) => failChannel;
+      WsClient.testChannelFactory = (_, __) => failChannel;
 
       final auth = AuthService();
       await Future.delayed(Duration.zero);
@@ -514,7 +514,7 @@ void main() {
       final failChannel = _FakeWebSocketChannel();
       failChannel.failReady = true;
       failChannel._closeCode = 4001;
-      WsClient.testChannelFactory = (_) => failChannel;
+      WsClient.testChannelFactory = (_, __) => failChannel;
 
       final auth = AuthService();
       await Future.delayed(Duration.zero);
@@ -538,7 +538,7 @@ void main() {
     test('connect always pre-checks HTTP before opening WebSocket', () async {
       SharedPreferences.setMockInitialValues({'klangk_jwt': 'test-token'});
       final channel = _FakeWebSocketChannel();
-      WsClient.testChannelFactory = (_) => channel;
+      WsClient.testChannelFactory = (_, __) => channel;
       var httpCheckCalled = false;
       WsClient.testHttpPreCheck = () async {
         httpCheckCalled = true;
@@ -562,7 +562,7 @@ void main() {
     test('connect aborts when HTTP pre-check fails', () async {
       SharedPreferences.setMockInitialValues({'klangk_jwt': 'test-token'});
       final channel = _FakeWebSocketChannel();
-      WsClient.testChannelFactory = (_) => channel;
+      WsClient.testChannelFactory = (_, __) => channel;
       WsClient.testHttpPreCheck = () async => false;
 
       final auth = AuthService();
@@ -680,7 +680,7 @@ void main() {
     setUp(() {
       SharedPreferences.setMockInitialValues({'klangk_jwt': 'test-token'});
       channels = [];
-      WsClient.testChannelFactory = (_) {
+      WsClient.testChannelFactory = (_, __) {
         final ch = _FakeWebSocketChannel();
         channels.add(ch);
         return ch;
@@ -907,7 +907,7 @@ void main() {
       channels.add(_FakeWebSocketChannel()..failReady = true);
       // Override factory to return the failing channel
       var callCount = 0;
-      WsClient.testChannelFactory = (_) {
+      WsClient.testChannelFactory = (_, __) {
         callCount++;
         if (channels.length > callCount) return channels[callCount];
         final ch = _FakeWebSocketChannel()..failReady = true;
@@ -946,7 +946,7 @@ void main() {
       await Future.delayed(Duration.zero);
 
       // Keep failing so attempts accumulate
-      WsClient.testChannelFactory = (_) {
+      WsClient.testChannelFactory = (_, __) {
         final ch = _FakeWebSocketChannel()..failReady = true;
         channels.add(ch);
         return ch;

--- a/src/klangk/klangk/api/admin.py
+++ b/src/klangk/klangk/api/admin.py
@@ -316,7 +316,9 @@ async def admin_create_user(
                 request.client.host if request.client else None,
             )
         )
-        verification_token = app.state.auth.create_verification_token(user_id)
+        verification_token = app.state.auth.create_verification_token(
+            user_id, req.email
+        )
         verification_url = (
             f"{proto}://{hostname}{base_path}"
             f"/#/verify?token={verification_token}"

--- a/src/klangk/klangk/api/auth.py
+++ b/src/klangk/klangk/api/auth.py
@@ -136,16 +136,15 @@ async def register(
         base_path,
     )
     verification_token = request.app.state.auth.create_verification_token(
-        user_id
+        user_id, req.email
     )
     verification_url = (
         f"{proto}://{hostname}{base_path}/#/verify?token={verification_token}"
     )
     logger.info(
-        "Verification URL: %s/#/verify?token=%s...%s",
-        f"{proto}://{hostname}{base_path}",
-        verification_token[:8],
-        verification_token[-4:],
+        "Verification email queued for %s (token sha256=%s)",
+        req.email,
+        hashlib.sha256(verification_token.encode()).hexdigest()[:12],
     )
 
     # Insert user and send email in a transaction — if the email fails,
@@ -198,18 +197,40 @@ async def insert_user_or_race_400(
         ) from None
 
 
-@router.get("/auth/verify")
-async def verify_email(token: str, request: Request):
-    """Verify a user's email via the token from the verification link."""
-    user_id = request.app.state.auth.decode_verification_token(token)
-    if user_id is None:
+class VerifyRequest(BaseModel):
+    token: str
+
+
+@router.post("/auth/verify")
+async def verify_email(req: VerifyRequest, request: Request):
+    """Verify a user's email via the token from the verification link.
+
+    #3201: the token rides the request body, not the URL — a GET with a
+    ``?token=`` query string would put a bearer-granting credential in
+    proxy/server access logs. Redemption is one-time (#3201): the token
+    is bound to the address it was minted for, and an already-verified
+    row rejects it, so a second click (or a stolen link replayed after
+    the first use) cannot mint another session.
+    """
+    decoded = request.app.state.auth.decode_verification_token(req.token)
+    if decoded is None:
         raise HTTPException(
             status_code=400, detail="Invalid or expired verification token"
         )
-    updated = await request.app.state.model.users.verify_user(user_id)
+    user_id, token_email = decoded
+    # Atomic one-time redemption (#3201): the conditional UPDATE matches
+    # only an unverified row still carrying the minted-for address, so a
+    # replay (second click, stolen link) matches nothing and 400s.
+    updated = await request.app.state.model.users.verify_user(
+        user_id, token_email
+    )
     if not updated:
-        raise HTTPException(status_code=404, detail="User not found")
+        raise HTTPException(
+            status_code=400, detail="Invalid or expired verification token"
+        )
     user = await request.app.state.model.users.get_user_by_id(user_id)
+    if user is None:  # pragma: no cover — the row just transitioned
+        raise HTTPException(status_code=404, detail="User not found")
     # The auto-login must not resurrect a disabled account (#2588).
     auth.ensure_not_disabled(user)
     source_ip, user_agent = workstation(request)
@@ -363,7 +384,7 @@ async def resend_verification(
         request.headers, request.client.host if request.client else None
     )
     verification_token = request.app.state.auth.create_verification_token(
-        user["id"]
+        user["id"], user["email"]
     )
     verification_url = (
         f"{proto}://{hostname}{base_path}/#/verify?token={verification_token}"
@@ -400,6 +421,16 @@ async def deliver_reset_email(
         logger.exception("Failed to send password reset email to %s", email)
 
 
+def _reset_mint_inputs(user: dict | None) -> tuple[bool, str, str | None]:
+    """(sendable, subject, password_hash) for a forgot-password mint.
+
+    Unknown addresses still get a subject and a (discarded) binding so
+    the mint cost is identical on every path (#3114)."""
+    if user is None:
+        return False, str(uuid.uuid4()), None
+    return not user.get("disabled"), user["id"], user.get("password_hash")
+
+
 def schedule_reset_delivery(
     background_tasks: BackgroundTasks,
     request: Request,
@@ -416,23 +447,26 @@ def schedule_reset_delivery(
     branch ran. Only the existing-enabled path queues the background
     send; disabled accounts still get no email (#2588).
     """
-    sendable = user is not None and not user.get("disabled")
-    subject = user["id"] if user is not None else str(uuid.uuid4())
-    reset_token = request.app.state.auth.create_password_reset_token(subject)
-    if sendable:
-        hostname, proto, base_path = (
-            request.app.state.util.derive_hosting_info(
-                request.headers,
-                request.client.host if request.client else None,
-            )
-        )
-        reset_url = (
-            f"{proto}://{hostname}{base_path}"
-            f"/#/reset-password?token={reset_token}"
-        )
-        background_tasks.add_task(
-            deliver_reset_email, request.app.state.email, email, reset_url
-        )
+    sendable, subject, password_hash = _reset_mint_inputs(user)
+    # #3201: the token is bound to a digest of the current password hash,
+    # so the first successful reset (which rewrites the hash) consumes
+    # every outstanding token for the account — one-time, stateless.
+    reset_token = request.app.state.auth.create_password_reset_token(
+        subject,
+        request.app.state.auth.reset_token_binding(password_hash),
+    )
+    if not sendable:
+        return
+    hostname, proto, base_path = request.app.state.util.derive_hosting_info(
+        request.headers,
+        request.client.host if request.client else None,
+    )
+    reset_url = (
+        f"{proto}://{hostname}{base_path}/#/reset-password?token={reset_token}"
+    )
+    background_tasks.add_task(
+        deliver_reset_email, request.app.state.email, email, reset_url
+    )
 
 
 @router.post("/auth/forgot-password")
@@ -471,12 +505,18 @@ class ResetPasswordRequest(BaseModel):
 
 @router.post("/auth/reset-password")
 async def reset_password(req: ResetPasswordRequest, request: Request):
-    """Reset password using a token from the reset email."""
-    user_id = request.app.state.auth.decode_password_reset_token(req.token)
-    if user_id is None:
+    """Reset password using a token from the reset email.
+
+    Redemption checks the token's password-hash binding (#3201): a
+    token minted before an earlier reset no longer matches the row and
+    is rejected, making every reset link one-time.
+    """
+    decoded = request.app.state.auth.decode_password_reset_token(req.token)
+    if decoded is None:
         raise HTTPException(
             status_code=400, detail="Invalid or expired reset token"
         )
+    user_id, binding = decoded
     request.app.state.auth.validate_password(req.password)
     if user_id == model.AGENT_USER_ID:
         raise HTTPException(
@@ -489,6 +529,13 @@ async def reset_password(req: ResetPasswordRequest, request: Request):
     if user is None:  # pragma: no cover — a valid reset token names a
         # live user (the row is only gone if deleted mid-flight)
         raise HTTPException(status_code=404, detail="User not found")
+    if (
+        request.app.state.auth.reset_token_binding(user.get("password_hash"))
+        != binding
+    ):
+        raise HTTPException(
+            status_code=400, detail="Invalid or expired reset token"
+        )
     auth.ensure_not_disabled(user)
     # Self-service resets respect the minimum age (#3177) —
     # only admin-forced resets bypass it.
@@ -615,10 +662,9 @@ async def refresh_token(request: Request):
         raise HTTPException(status_code=401, detail="Not authenticated")
     token = authorization[7:]
     logger.info(
-        "REFRESH CALL ua=%s origin=%s referer=%s",
+        "REFRESH CALL ua=%s origin=%s",
         request.headers.get("user-agent", "?"),
         request.headers.get("origin", "?"),
-        request.headers.get("referer", "?"),
     )
     return await request.app.state.auth.refresh_token(
         token,
@@ -866,7 +912,9 @@ async def change_email(
     hostname, proto, base_path = request.app.state.util.derive_hosting_info(
         request.headers, request.client.host if request.client else None
     )
-    token = request.app.state.auth.create_verification_token(user["id"])
+    token = request.app.state.auth.create_verification_token(
+        user["id"], req.email
+    )
     url = f"{proto}://{hostname}{base_path}/#/verify?token={token}"
     await send_email(
         app.state.email.send_verification_email(req.email, url),
@@ -1321,13 +1369,20 @@ def _build_redirect_response(
     request: Request,
     provider_id: str,
     access_token: str,
+    email: str,
     cookie_data: dict,
 ) -> RedirectResponse:
-    """Build the final redirect response (CLI or web flow)."""
+    """Build the final redirect response (CLI or web flow).
+
+    #3201: neither flow places the session JWT in a URL. The callback
+    redirects a one-time, 60s code; the CLI/web completer redeems it
+    via ``POST /auth/oidc/exchange`` for the token.
+    """
     cli_redirect = cookie_data.get("cli_redirect")
+    code = request.app.state.auth.mint_login_code(access_token, email)
 
     if _valid_cli_redirect(cli_redirect):
-        redirect_url = f"{cli_redirect}?token={access_token}"
+        redirect_url = f"{cli_redirect}?code={code}"
     else:
         hostname, proto, base_path = (
             request.app.state.util.derive_hosting_info(
@@ -1336,14 +1391,34 @@ def _build_redirect_response(
             )
         )
         redirect_url = (
-            f"{proto}://{hostname}{base_path}"
-            f"/#/oidc-complete?token={access_token}"
+            f"{proto}://{hostname}{base_path}/#/oidc-complete?code={code}"
         )
 
     cookie_name = f"oidc_{provider_id}"
     response = RedirectResponse(url=redirect_url, status_code=302)
     response.delete_cookie(cookie_name, path="/")
     return response
+
+
+class OidcExchangeRequest(BaseModel):
+    code: str
+
+
+@router.post("/auth/oidc/exchange")
+async def oidc_exchange(req: OidcExchangeRequest, request: Request):
+    """Redeem a one-time OIDC login code for the session token (#3201).
+
+    The callback redirect carries only a single-use, 60-second code
+    (never the JWT itself); the completer — the frontend's
+    ``/#/oidc-complete`` page or the CLI's localhost callback — swaps
+    it for the access token here. Unknown, replayed, or expired codes
+    all fail identically with 400.
+    """
+    redeemed = request.app.state.auth.redeem_login_code(req.code)
+    if redeemed is None:
+        raise HTTPException(status_code=400, detail="Invalid login code")
+    token, email = redeemed
+    return {"access_token": token, "email": email}
 
 
 def _require_verified_email(provider, claims: dict) -> None:
@@ -1431,7 +1506,7 @@ async def oidc_callback(
     )
     await request.app.state.model.users.record_login(user["id"])
     return _build_redirect_response(
-        request, provider_id, access_token, cookie_data
+        request, provider_id, access_token, email, cookie_data
     )
 
 

--- a/src/klangk/klangk/auth.py
+++ b/src/klangk/klangk/auth.py
@@ -518,6 +518,14 @@ class Auth:
         # Fixed-policy token lifetimes (not env-driven).
         self.verify_token_expire_hours = 72
         self.reset_token_expire_hours = 1
+        # One-time OIDC login codes (#3201): code -> (access_token,
+        # email, exp). The callback redirects a single-use code (not the
+        # session JWT) to the CLI/web completer, which redeems it via
+        # POST /auth/oidc/exchange. Process-local like the rate-limit
+        # dicts: redemption pops the entry, and anything surviving a
+        # restart is already expired.
+        self.pending_login_codes: dict[str, tuple[str, str, float]] = {}
+        self.login_code_ttl_seconds = 60
         # Per-user monotonic clock of the last last_activity_at write
         # (#2588) — transient runtime state (not settings-derived), so
         # it survives reconfigure and is deliberately not reset there.
@@ -1417,29 +1425,68 @@ class Auth:
 
     # --- email-verification tokens ---
 
-    def create_verification_token(self, user_id: str) -> str:
-        """Create a JWT token for email verification."""
+    def create_verification_token(self, user_id: str, email: str) -> str:
+        """Create a JWT token for email verification.
+
+        #3201: the token carries the address it was minted for, so a
+        link survives neither a later email change (the row's address
+        no longer matches) nor its own redemption (a verified row
+        rejects it) — one-time, single-purpose.
+        """
         return self._create_purpose_token(
-            user_id, "verify", self.verify_token_expire_hours
+            user_id,
+            "verify",
+            self.verify_token_expire_hours,
+            extra={"email": email},
         )
 
-    def decode_verification_token(self, token: str) -> str | None:
-        """Decode a verification token. Returns user_id or None if invalid."""
+    def decode_verification_token(self, token: str) -> tuple[str, str] | None:
+        """Decode a verification token. Returns ``(user_id, email)`` or
+        None if invalid."""
         payload = self._decode_purpose_token(token, "verify")
-        return payload.get("sub") if payload is not None else None
+        if payload is None:
+            return None
+        user_id = payload.get("sub")
+        email = payload.get("email")
+        if not user_id or not email:
+            return None
+        return (user_id, email)
 
     # --- password-reset tokens ---
 
-    def create_password_reset_token(self, user_id: str) -> str:
+    @staticmethod
+    def reset_token_binding(password_hash: str | None) -> str:
+        """The state a reset token is bound to (#3201): a digest of the
+        password hash it was minted against. Redemption requires the
+        row's current hash to still match, so the first successful
+        reset (which rewrites the hash) consumes every outstanding
+        token for the account — one-time without server-side state."""
+        return hashlib.sha256(
+            (password_hash or "").encode("utf-8")
+        ).hexdigest()[:16]
+
+    def create_password_reset_token(self, user_id: str, binding: str) -> str:
         """Create a JWT token for password reset."""
         return self._create_purpose_token(
-            user_id, "reset", self.reset_token_expire_hours
+            user_id,
+            "reset",
+            self.reset_token_expire_hours,
+            extra={"pwb": binding},
         )
 
-    def decode_password_reset_token(self, token: str) -> str | None:
-        """Decode a password reset token. Returns user_id or None."""
+    def decode_password_reset_token(
+        self, token: str
+    ) -> tuple[str, str] | None:
+        """Decode a password reset token. Returns ``(user_id, binding)``
+        or None."""
         payload = self._decode_purpose_token(token, "reset")
-        return payload.get("sub") if payload is not None else None
+        if payload is None:
+            return None
+        user_id = payload.get("sub")
+        binding = payload.get("pwb")
+        if not user_id or not binding:
+            return None
+        return (user_id, binding)
 
     # --- invitation tokens ---
 
@@ -1462,6 +1509,46 @@ class Auth:
         if not invitation_id or not email:
             return None
         return (invitation_id, email)
+
+    # --- one-time OIDC login codes (#3201) ---
+
+    def mint_login_code(self, access_token: str, email: str) -> str:
+        """Mint a single-use, short-lived code standing in for *access_token*.
+
+        The OIDC callback redirects the code to the completer page/CLI
+        so the session JWT never rides a URL; the completer redeems it
+        via :meth:`redeem_login_code`. Expired entries are pruned on
+        every mint (bounded by the mint rate).
+        """
+        code = secrets.token_urlsafe(32)
+        now = time.time()
+        self._prune_login_codes(now)
+        self.pending_login_codes[code] = (
+            access_token,
+            email,
+            now + self.login_code_ttl_seconds,
+        )
+        return code
+
+    def _prune_login_codes(self, now: float) -> None:
+        """Drop expired login codes (single-use redemption pops the rest)."""
+        for stale in [
+            c
+            for c, (_, _, exp) in self.pending_login_codes.items()
+            if exp <= now
+        ]:
+            del self.pending_login_codes[stale]
+
+    def redeem_login_code(self, code: str) -> tuple[str, str] | None:
+        """Pop and return ``(access_token, email)`` behind *code*, or None
+        when the code is unknown, already redeemed, or expired."""
+        entry = self.pending_login_codes.pop(code, None)
+        if entry is None:
+            return None
+        access_token, email, exp = entry
+        if exp <= time.time():
+            return None
+        return (access_token, email)
 
     # --- workspace tokens ---
 

--- a/src/klangk/klangk/cli/auth.py
+++ b/src/klangk/klangk/cli/auth.py
@@ -117,20 +117,43 @@ def oidc_browser_login(
     )
 
     token_holder: list[str | None] = [None]
+    email_holder: list[str | None] = [None]
     error_holder: list[str | None] = [None]
 
     class CallbackHandler(http.server.BaseHTTPRequestHandler):
         def do_GET(self):  # noqa: N802
             parsed = urlparse(self.path)
             params = parse_qs(parsed.query)
-            token = params.get("token", [None])[0]
-            if token:
-                token_holder[0] = token
+            # #3201: the redirect carries a one-time code, not the JWT;
+            # redeem it immediately for the session token so the JWT
+            # never touches a URL or browser history.
+            code = params.get("code", [None])[0]
+            if code:
+                try:
+                    resp = http_request(
+                        server_url,
+                        "POST",
+                        "/api/v1/auth/oidc/exchange",
+                        json={"code": code},
+                        timeout=15.0,
+                    )
+                except httpx.HTTPError:
+                    resp = None
+                if resp is not None and resp.status_code == 200:
+                    data = resp.json()
+                    token_holder[0] = data.get("access_token")
+                    email_holder[0] = data.get("email") or "unknown"
+                if token_holder[0]:
+                    self._send_page(
+                        200,
+                        "Login Successful",
+                        "You are now logged in. You can close this tab.",
+                        "#2e7d32",
+                    )
+                    return
+                error_holder[0] = "Login code exchange failed"
                 self._send_page(
-                    200,
-                    "Login Successful",
-                    "You are now logged in. You can close this tab.",
-                    "#2e7d32",
+                    400, "Login Failed", error_holder[0], "#c62828"
                 )
             else:
                 error = params.get("error", ["Unknown error"])[0]
@@ -182,15 +205,7 @@ margin:0;background:#1a1a2e;color:#e0e0e0">
 
     if token_holder[0]:
         token = token_holder[0]
-        # Decode the JWT to get the email
-        try:
-            payload = token.split(".")[1]
-            # Add padding
-            payload += "=" * (4 - len(payload) % 4)
-            claims = json.loads(base64.urlsafe_b64decode(payload))
-            email = claims.get("email", "unknown")
-        except Exception:
-            email = "unknown"
+        email = email_holder[0] or "unknown"
 
         state.set_credentials(server_url, email, token)
         state.save()

--- a/src/klangk/klangk/cli/auth.py
+++ b/src/klangk/klangk/cli/auth.py
@@ -98,6 +98,62 @@ def local_login(server_url: str) -> tuple[str, str]:
     return email, token
 
 
+def _exchange_credentials(data) -> tuple[str, str] | None:
+    """(token, email) from a decoded exchange body, or None."""
+    token = data.get("access_token") if isinstance(data, dict) else None
+    if not token:
+        return None
+    return token, data.get("email") or "unknown"
+
+
+def _parse_exchange_response(resp) -> tuple[str, str] | None:
+    """(token, email) from an exchange response, or None on any
+    non-200 or malformed body."""
+    if resp.status_code != 200:
+        return None
+    try:
+        return _exchange_credentials(resp.json())
+    except Exception:
+        return None
+
+
+def _redeem_login_code(server_url: str, code: str) -> tuple[str, str] | None:
+    """Exchange a one-time OIDC login code for ``(token, email)``.
+
+    #3201: runs on the main thread after the localhost callback landed.
+    A transport failure, non-200, or malformed body all return None —
+    the caller renders the same "exchange failed" outcome.
+    """
+    try:
+        resp = http_request(
+            server_url,
+            "POST",
+            "/api/v1/auth/oidc/exchange",
+            json={"code": code},
+            timeout=15.0,
+        )
+    except Exception:
+        return None
+    return _parse_exchange_response(resp)
+
+
+def _apply_captured_code(server_url, holders) -> None:
+    """Redeem the callback-captured code into the shared holders.
+
+    *holders* is the ``(code, error, token, email)`` list quartet the
+    callback handler and the main thread share; on any redemption
+    failure the error holder carries the stable failure message.
+    """
+    code_holder, error_holder, token_holder, email_holder = holders
+    if not code_holder[0] or error_holder[0]:
+        return
+    redeemed = _redeem_login_code(server_url, code_holder[0])
+    if redeemed is None:
+        error_holder[0] = "Login code exchange failed"
+    else:
+        token_holder[0], email_holder[0] = redeemed
+
+
 def oidc_browser_login(
     server_url: str,
     provider_id: str,
@@ -118,42 +174,27 @@ def oidc_browser_login(
 
     token_holder: list[str | None] = [None]
     email_holder: list[str | None] = [None]
+    code_holder: list[str | None] = [None]
     error_holder: list[str | None] = [None]
 
     class CallbackHandler(http.server.BaseHTTPRequestHandler):
         def do_GET(self):  # noqa: N802
             parsed = urlparse(self.path)
             params = parse_qs(parsed.query)
-            # #3201: the redirect carries a one-time code, not the JWT;
-            # redeem it immediately for the session token so the JWT
-            # never touches a URL or browser history.
+            # #3201: the redirect carries a one-time code, not the JWT.
+            # The handler only captures the code (and stays fast, so the
+            # main thread's 120s join window is not eaten by the
+            # exchange round trip); the main thread redeems it for the
+            # session token below, so the JWT never touches a URL or
+            # browser history.
             code = params.get("code", [None])[0]
             if code:
-                try:
-                    resp = http_request(
-                        server_url,
-                        "POST",
-                        "/api/v1/auth/oidc/exchange",
-                        json={"code": code},
-                        timeout=15.0,
-                    )
-                except httpx.HTTPError:
-                    resp = None
-                if resp is not None and resp.status_code == 200:
-                    data = resp.json()
-                    token_holder[0] = data.get("access_token")
-                    email_holder[0] = data.get("email") or "unknown"
-                if token_holder[0]:
-                    self._send_page(
-                        200,
-                        "Login Successful",
-                        "You are now logged in. You can close this tab.",
-                        "#2e7d32",
-                    )
-                    return
-                error_holder[0] = "Login code exchange failed"
+                code_holder[0] = code
                 self._send_page(
-                    400, "Login Failed", error_holder[0], "#c62828"
+                    200,
+                    "Login Received",
+                    "You can close this tab.",
+                    "#2e7d32",
                 )
             else:
                 error = params.get("error", ["Unknown error"])[0]
@@ -202,6 +243,14 @@ margin:0;background:#1a1a2e;color:#e0e0e0">
     # Wait for the callback (timeout after 2 minutes)
     server_thread.join(timeout=120)
     server.server_close()
+
+    # Redeem the captured one-time code for the session token (#3201).
+    # Runs on the main thread after the callback landed, keeping the
+    # handler fast; failures collapse into the same "exchange failed"
+    # outcome the error arm renders.
+    _apply_captured_code(
+        server_url, (code_holder, error_holder, token_holder, email_holder)
+    )
 
     if token_holder[0]:
         token = token_holder[0]

--- a/src/klangk/klangk/cli/transport.py
+++ b/src/klangk/klangk/cli/transport.py
@@ -183,16 +183,21 @@ async def ws_connect(
 
     ``path`` selects the server WS endpoint (default ``/ws``; the consent
     decider client uses ``/ws/consent-decider``), and ``query`` adds extra
-    query params alongside the always-present ``token``. Yields the open
-    WebSocket connection.
+    query params. The auth ``token`` rides the handshake's
+    ``Sec-WebSocket-Protocol`` header (``bearer, <jwt>``) rather than the
+    URL — query strings land in proxy/server access logs (#3201).
+    Yields the open WebSocket connection.
     """
     transport = resolve_transport(server_spec)
     qs = dict(query) if query else {}
-    qs["token"] = (
-        token  # token always wins -- a caller can't clobber it via query
-    )
-    uri = f"{transport.ws_base}{path}?{urlencode(qs)}"
+    # A caller passing query={"token": ...} must not smuggle it back into
+    # the URL (#2320 review #6; the header is the only token carrier).
+    qs.pop("token", None)
+    uri = f"{transport.ws_base}{path}"
+    if qs:
+        uri = f"{uri}?{urlencode(qs)}"
     ws_kwargs = dict(kwargs)
+    ws_kwargs["subprotocols"] = ["bearer", token]
     if max_size is not None:
         ws_kwargs["max_size"] = max_size
 

--- a/src/klangk/klangk/model/sessions.py
+++ b/src/klangk/klangk/model/sessions.py
@@ -73,9 +73,11 @@ class SessionsModel(Submodel):
                 ),
             )
 
-    async def get_session_id(self, jti: str) -> str | None:
+    async def get_session_id(self, jti: str | None) -> str | None:
         """The stable ``session_id`` of the row currently keyed by *jti*
-        (#3151), or ``None`` when no such row exists.
+        (#3151), or ``None`` when no such row exists — including a
+        ``None`` *jti* (a pre-#2585 token with no JTI binds no row;
+        callers treat that as fail-open).
 
         Resolved once per WebSocket connect and pinned on the
         Connection; because ``session_id`` survives the refresh rekey,

--- a/src/klangk/klangk/model/users.py
+++ b/src/klangk/klangk/model/users.py
@@ -613,11 +613,20 @@ class UsersModel(Submodel):
                 (provider, external_id, user_id),
             )
 
-    async def verify_user(self, user_id: str) -> bool:
-        """Mark a user as verified. Returns True if updated, False if not found."""
+    async def verify_user(self, user_id: str, email: str) -> bool:
+        """Mark a user as verified; True when the row transitioned.
+
+        #3201: the update is conditional on the row still carrying
+        *email* and being unverified — an atomic one-time redemption
+        for the verification-token flow (a replayed or stale link
+        matches no row and returns False). Returns False if the user
+        is not found.
+        """
         async with self.app.state.db.transaction() as db:
             cursor = await db.execute(
-                "UPDATE users SET verified = 1 WHERE id = ?", (user_id,)
+                "UPDATE users SET verified = 1 "
+                "WHERE id = ? AND verified = 0 AND email = ?",
+                (user_id, email),
             )
             return cursor.rowcount > 0
 

--- a/src/klangk/klangk/wshandler/decider.py
+++ b/src/klangk/klangk/wshandler/decider.py
@@ -31,8 +31,10 @@ spectators are watch-only and never register). A verdict is honored only if
 it targets the decider's own workspace (defense-in-depth), enforced in
 ``resolve`` via ``decider_workspace``. Pause/unpause share the same single
 gate as the connection itself (#2883): anyone who may register may also
-pause. Auth mirrors the main ``/ws`` handler: a user JWT in the ``token``
-query param — including its revocation story (#3162): the handshake
+pause. Auth mirrors the main ``/ws`` handler: a user JWT in the handshake's
+``Sec-WebSocket-Protocol`` header (#3201 -- browsers cannot set headers
+like ``Authorization`` on a WS connect, and a ``?token=`` query param
+would land in proxy/server access logs) — including its revocation story (#3162): the handshake
 records the token's JTI on the registry entry, and a hard revocation
 (logout, session-limit eviction) closes the decider socket with 4001,
 just like the main handler's connections (#3152), and an account
@@ -56,6 +58,7 @@ from jose import ExpiredSignatureError, JWTError
 
 from .safe_websocket import SafeWebSocket, SlowClientError
 from .dispatch import ws_workstation
+from .support import ws_bearer_token, ws_echo_subprotocol
 from ..model.egress_consent import (
     DECISION_ALLOWED,
     DECISION_DENIED,
@@ -239,8 +242,13 @@ async def _decider_authenticate(websocket: WebSocket, app, _hs_mark):
     hard-revoked (#3162), mirroring ``ws_authenticate`` (#3152); a
     session bound to another workstation is refused (#3194), and a
     DPoP-bound token must prove possession (#3218).
+
+    #3201: the token arrives in the ``Sec-WebSocket-Protocol`` handshake
+    header, not a ``?token=`` query param (query strings land in
+    proxy/server access logs); the one-shot DPoP proof still rides a
+    ``dpop`` query param (#3218).
     """
-    token = websocket.query_params.get("token")
+    token = ws_bearer_token(websocket)
     if not token:
         await _refuse(websocket, 4001, "Missing token")
         return None
@@ -451,7 +459,7 @@ async def handle_consent_decider(websocket: WebSocket, app) -> None:
         websocket, app, workspace, user, hs_mark=_hs_mark
     ):
         return
-    await websocket.accept()
+    await websocket.accept(subprotocol=ws_echo_subprotocol(websocket))
     _hs_mark("accept")
     _log_handshake_timing(_hs_t0, _hs_marks)
     safe_ws = SafeWebSocket(websocket)
@@ -477,28 +485,13 @@ async def handle_consent_decider(websocket: WebSocket, app) -> None:
             workspace,
             user,
             decider_id,
-            session_id=await _decider_session_id(websocket, app),
+            session_id=await app.state.model.sessions.get_session_id(jti),
         )
     finally:
         # Connection gone (clean disconnect, error, or crash) -> drop the
         # registration so the workspace reverts to static (#2308).
         registry.deregister(decider_id)
         await safe_ws.stop_sender()
-
-
-async def _decider_session_id(websocket: WebSocket, app) -> str | None:
-    """The stable session id behind the decider socket's token (#3151).
-
-    ``None`` when the token has no session row (fail-open, same as the
-    main /ws path). The decode is unguarded: ``_decider_authenticate``
-    validated this exact token moments earlier, so it cannot be
-    malformed here.
-    """
-    token = websocket.query_params.get("token")
-    jti = app.state.auth.decode_token(token).get("jti") if token else None
-    if jti is None:
-        return None
-    return await app.state.model.sessions.get_session_id(jti)
 
 
 async def _replay_decider_snapshot(app, safe_ws, workspace) -> None:

--- a/src/klangk/klangk/wshandler/dispatch.py
+++ b/src/klangk/klangk/wshandler/dispatch.py
@@ -7,7 +7,12 @@ from fastapi import WebSocket, WebSocketDisconnect
 from jose import ExpiredSignatureError, JWTError
 
 from .safe_websocket import SafeWebSocket, SlowClientError
-from .support import send_error, log_ws_msg
+from .support import (
+    send_error,
+    log_ws_msg,
+    ws_bearer_token,
+    ws_echo_subprotocol,
+)
 from .connection import Connection
 
 logger = logging.getLogger(__name__)
@@ -77,8 +82,15 @@ async def ws_authenticate(
     token replayed from a different machine closes 4001 and its
     session is revoked. A DPoP-bound token must also prove
     possession (#3218).
+
+    #3201: the token arrives in the ``Sec-WebSocket-Protocol`` handshake
+    header (browsers cannot set ``Authorization`` on a WS connect, and a
+    ``?token=`` query param would land in proxy/server access logs);
+    the one-shot DPoP proof still rides a ``dpop`` query param (#3218 —
+    single-use jti + ath binding, so its URL presence leaks nothing
+    reusable).
     """
-    token = websocket.query_params.get("token")
+    token = ws_bearer_token(websocket)
     if not token:
         await websocket.close(code=4001, reason="Missing token")
         return None
@@ -290,13 +302,13 @@ async def _run_websocket_session(conn, safe_ws, user: dict, app) -> None:
 
 async def handle_websocket(websocket: WebSocket, app) -> None:
     """Main WebSocket handler."""
-    # Authenticate via query param
+    # Authenticate via the Sec-WebSocket-Protocol handshake header
     authed = await ws_authenticate(websocket, app)
     if authed is None:
         return
     user, jti, token_exp = authed
 
-    await websocket.accept()
+    await websocket.accept(subprotocol=ws_echo_subprotocol(websocket))
     safe_ws = SafeWebSocket(websocket)
     safe_ws.start_sender()
     conn = Connection(safe_ws, user, app, jti=jti, token_exp=token_exp)

--- a/src/klangk/klangk/wshandler/sidecar.py
+++ b/src/klangk/klangk/wshandler/sidecar.py
@@ -35,12 +35,15 @@ logger = logging.getLogger(__name__)
 
 
 def _egress_token(websocket: WebSocket) -> str | None:
-    """The workspace token from the Authorization header or ?token=."""
+    """The workspace token from the Authorization header (#3201).
+
+    The sidecar is a non-browser client (the ``websockets`` library),
+    so it sets a real header; the former ``?token=`` query-param
+    fallback is gone because query strings land in proxy/server
+    access logs.
+    """
     authorization = websocket.headers.get("authorization", "")
-    token = authorization[7:] if authorization.startswith("Bearer ") else None
-    if not token:
-        token = websocket.query_params.get("token")
-    return token
+    return authorization[7:] if authorization.startswith("Bearer ") else None
 
 
 async def authenticate_egress_socket(websocket: WebSocket, app) -> str | None:
@@ -63,8 +66,7 @@ async def authenticate_egress_socket(websocket: WebSocket, app) -> str | None:
 async def handle_egress_sidecar(websocket: WebSocket, app) -> None:
     """Receive blocked-egress events from the sidecar; relay verdicts back."""
     # forward_auth validated the workspace JWT from the Authorization header
-    # on the egress site; re-read it here for the workspace id. The ?token=
-    # query-param fallback covers the ingress path and handler-level tests.
+    # on the egress site; re-read it here for the workspace id.
     workspace_id = await authenticate_egress_socket(websocket, app)
     if workspace_id is None:
         return

--- a/src/klangk/klangk/wshandler/support.py
+++ b/src/klangk/klangk/wshandler/support.py
@@ -37,6 +37,41 @@ MAX_INPUT_SIZE = 16777216
 # Max outbound messages before we declare the client too slow and close.
 SEND_QUEUE_SIZE = 256
 
+# The WS auth subprotocol name (#3201). Browser WebSocket clients cannot
+# set request headers, so the session JWT rides the handshake as the
+# ``Sec-WebSocket-Protocol`` header instead of a ``?token=`` query
+# param: query strings land in reverse-proxy and server access logs,
+# headers do not. The client offers ``["bearer", <jwt>]``; the server
+# extracts the non-"bearer" entry and echoes ``bearer`` on accept.
+WS_AUTH_SUBPROTOCOL = "bearer"
+
+
+def ws_bearer_token(websocket) -> str | None:
+    """The JWT from the handshake's ``Sec-WebSocket-Protocol`` header.
+
+    The client offers ``bearer, <jwt>`` (comma-separated when multiple
+    subprotocols are requested). The first entry that is not the
+    ``bearer`` marker is the token; ``None`` when no token was offered.
+    """
+    offered = websocket.headers.get("sec-websocket-protocol", "")
+    for entry in offered.split(","):
+        entry = entry.strip()
+        if entry and entry != WS_AUTH_SUBPROTOCOL:
+            return entry
+    return None
+
+
+def ws_echo_subprotocol(websocket) -> str | None:
+    """The subprotocol to echo on accept, or None (#3201).
+
+    Per RFC 6455 the server may only select a protocol the client
+    offered, and a browser fails the handshake when the selection is
+    absent from its list — so echo ``bearer`` only when it was offered.
+    """
+    offered = websocket.headers.get("sec-websocket-protocol", "")
+    entries = {e.strip() for e in offered.split(",")}
+    return WS_AUTH_SUBPROTOCOL if WS_AUTH_SUBPROTOCOL in entries else None
+
 
 def _ws_debug_label(user: dict | None) -> str:
     """The optional [email] label for a debug log line."""

--- a/src/klangk/klangk/wshandler/support.py
+++ b/src/klangk/klangk/wshandler/support.py
@@ -50,12 +50,15 @@ def ws_bearer_token(websocket) -> str | None:
     """The JWT from the handshake's ``Sec-WebSocket-Protocol`` header.
 
     The client offers ``bearer, <jwt>`` (comma-separated when multiple
-    subprotocols are requested). The first entry that is not the
-    ``bearer`` marker is the token; ``None`` when no token was offered.
+    subprotocols are requested). The **last** entry that is not the
+    ``bearer`` marker is the token: a future client negotiating an
+    application subprotocol ahead of the pair (``json, bearer, <jwt>``)
+    still parses correctly, and a lone ``[<jwt>]`` offer works too.
+    ``None`` when no token was offered.
     """
     offered = websocket.headers.get("sec-websocket-protocol", "")
-    for entry in offered.split(","):
-        entry = entry.strip()
+    entries = [e.strip() for e in offered.split(",")]
+    for entry in reversed(entries):
         if entry and entry != WS_AUTH_SUBPROTOCOL:
             return entry
     return None

--- a/src/klangk/klangk/wshandler/support.py
+++ b/src/klangk/klangk/wshandler/support.py
@@ -53,8 +53,10 @@ def ws_bearer_token(websocket) -> str | None:
     subprotocols are requested). The **last** entry that is not the
     ``bearer`` marker is the token: a future client negotiating an
     application subprotocol ahead of the pair (``json, bearer, <jwt>``)
-    still parses correctly, and a lone ``[<jwt>]`` offer works too.
-    ``None`` when no token was offered.
+    still parses correctly, and a lone ``[<jwt>]`` offer works too —
+    but an application subprotocol appended *after* the pair
+    (``bearer, <jwt>, json``) would misparse; shipped clients send
+    exactly ``["bearer", token]``. ``None`` when no token was offered.
     """
     offered = websocket.headers.get("sec-websocket-protocol", "")
     entries = [e.strip() for e in offered.split(",")]

--- a/src/klangk/klangkc-tests/e2e-tests/test_monitor_e2e.py
+++ b/src/klangk/klangkc-tests/e2e-tests/test_monitor_e2e.py
@@ -167,7 +167,9 @@ async def _holder_ws(server, auth, workspace_id):
     """
     ws_url = server["url"].replace("http://", "ws://")
     ws = await websockets.connect(
-        f"{ws_url}/ws?token={auth['token']}", max_size=2**20
+        f"{ws_url}/ws",
+        max_size=2**20,
+        subprotocols=["bearer", auth["token"]],
     )
     await ws.send(
         json.dumps({"cmd": "workspace_connect", "workspaceId": workspace_id})

--- a/src/klangk/klangkc-tests/e2e-tests/test_terminal_windows_e2e.py
+++ b/src/klangk/klangkc-tests/e2e-tests/test_terminal_windows_e2e.py
@@ -361,9 +361,10 @@ class _WebSession:
     async def connect(self):
         ws_url = self.base_url.replace("http://", "ws://")
         self._ctx = websockets.connect(
-            f"{ws_url}/ws?token={self.token}",
+            f"{ws_url}/ws",
             max_size=16 * 1024 * 1024,
             open_timeout=30,
+            subprotocols=["bearer", self.token],
         )
         self.ws = await self._ctx.__aenter__()
         await self.ws.send(

--- a/src/klangk/klangkc-tests/tests/test_cli.py
+++ b/src/klangk/klangkc-tests/tests/test_cli.py
@@ -7046,32 +7046,81 @@ class TestOidcBrowserLogin:
 
         return fake_open
 
+    def _patch_exchange(self, monkeypatch, token, email):
+        """Patch the one-time-code exchange POST (#3201): the callback
+        handler redeems the code server-side for the session token."""
+        resp = MagicMock(status_code=200)
+        resp.json.return_value = {"access_token": token, "email": email}
+        request = MagicMock(return_value=resp)
+        monkeypatch.setattr("klangk.cli.auth.http_request", request)
+        return request
+
     def test_success_saves_credentials(self, monkeypatch):
         from klangk.cli.auth import oidc_browser_login
 
+        token = self._token()
+        exchange = self._patch_exchange(monkeypatch, token, "user@example.com")
         capture: list[str] = []
         monkeypatch.setattr(
             "klangk.cli.auth.webbrowser.open",
-            self._drive_callback(f"token={self._token()}", capture),
+            self._drive_callback("code=one-time", capture),
         )
         state = CLIState()
         oidc_browser_login("http://srv", "prov", state)
         assert capture and "cli_redirect" in capture[0]
-        assert state.get_token("http://srv") == self._token()
+        assert state.get_token("http://srv") == token
+        # The code — not the JWT — rode the redirect URL.
+        exchange.assert_called_once()
+        assert exchange.call_args.kwargs["json"] == {"code": "one-time"}
 
-    def test_success_with_malformed_token_uses_unknown_email(
-        self, monkeypatch
-    ):
+    def test_success_uses_server_email(self, monkeypatch):
+        """#3201: the email comes from the exchange response, not a
+        client-side JWT decode."""
         from klangk.cli.auth import oidc_browser_login
 
-        bad_token = "hdr.not-valid-b64!.sig"
+        token = self._token()
+        self._patch_exchange(monkeypatch, token, "sso@example.com")
         monkeypatch.setattr(
             "klangk.cli.auth.webbrowser.open",
-            self._drive_callback(f"token={bad_token}", []),
+            self._drive_callback("code=one-time", []),
         )
         state = CLIState()
         oidc_browser_login("http://srv", "prov", state)
-        assert state.get_token("http://srv") == bad_token
+        assert state.get_token("http://srv") == token
+        assert state.get_email("http://srv") == "sso@example.com"
+
+    def test_failed_exchange_exits_1(self, monkeypatch):
+        from klangk.cli.auth import oidc_browser_login
+
+        resp = MagicMock(status_code=400)
+        resp.json.return_value = {"detail": "Invalid login code"}
+        monkeypatch.setattr(
+            "klangk.cli.auth.http_request", MagicMock(return_value=resp)
+        )
+        monkeypatch.setattr(
+            "klangk.cli.auth.webbrowser.open",
+            self._drive_callback("code=already-used", []),
+        )
+        with pytest.raises(SystemExit):
+            oidc_browser_login("http://srv", "prov", CLIState())
+
+    def test_exchange_network_error_exits_1(self, monkeypatch):
+        """A transport failure during the code exchange fails the login
+        (never a half-credentials state)."""
+        import httpx
+
+        from klangk.cli.auth import oidc_browser_login
+
+        monkeypatch.setattr(
+            "klangk.cli.auth.http_request",
+            MagicMock(side_effect=httpx.ConnectError("boom")),
+        )
+        monkeypatch.setattr(
+            "klangk.cli.auth.webbrowser.open",
+            self._drive_callback("code=one-time", []),
+        )
+        with pytest.raises(SystemExit):
+            oidc_browser_login("http://srv", "prov", CLIState())
 
     def test_error_callback_exits_1(self, monkeypatch):
         from klangk.cli.auth import oidc_browser_login

--- a/src/klangk/klangkc-tests/tests/test_cli.py
+++ b/src/klangk/klangkc-tests/tests/test_cli.py
@@ -7122,6 +7122,56 @@ class TestOidcBrowserLogin:
         with pytest.raises(SystemExit):
             oidc_browser_login("http://srv", "prov", CLIState())
 
+    def test_exchange_garbage_json_200_body_exits_1(self, monkeypatch):
+        """A 200 whose body is not JSON at all fails the login instead
+        of crashing the main thread."""
+        from klangk.cli.auth import oidc_browser_login
+
+        resp = MagicMock(status_code=200)
+        resp.json.side_effect = ValueError("not json")
+        monkeypatch.setattr(
+            "klangk.cli.auth.http_request", MagicMock(return_value=resp)
+        )
+        monkeypatch.setattr(
+            "klangk.cli.auth.webbrowser.open",
+            self._drive_callback("code=one-time", []),
+        )
+        with pytest.raises(SystemExit):
+            oidc_browser_login("http://srv", "prov", CLIState())
+
+    def test_exchange_malformed_200_body_exits_1(self, monkeypatch):
+        """A 200 whose body is not a JSON object fails the login instead
+        of crashing the callback thread (review #3201 finding 3)."""
+        from klangk.cli.auth import oidc_browser_login
+
+        resp = MagicMock(status_code=200)
+        resp.json.return_value = ["not", "a", "dict"]
+        monkeypatch.setattr(
+            "klangk.cli.auth.http_request", MagicMock(return_value=resp)
+        )
+        monkeypatch.setattr(
+            "klangk.cli.auth.webbrowser.open",
+            self._drive_callback("code=one-time", []),
+        )
+        with pytest.raises(SystemExit):
+            oidc_browser_login("http://srv", "prov", CLIState())
+
+    def test_exchange_tokenless_200_body_exits_1(self, monkeypatch):
+        """A 200 whose JSON object lacks the token fails the login."""
+        from klangk.cli.auth import oidc_browser_login
+
+        resp = MagicMock(status_code=200)
+        resp.json.return_value = {"email": "x@example.com"}
+        monkeypatch.setattr(
+            "klangk.cli.auth.http_request", MagicMock(return_value=resp)
+        )
+        monkeypatch.setattr(
+            "klangk.cli.auth.webbrowser.open",
+            self._drive_callback("code=one-time", []),
+        )
+        with pytest.raises(SystemExit):
+            oidc_browser_login("http://srv", "prov", CLIState())
+
     def test_error_callback_exits_1(self, monkeypatch):
         from klangk.cli.auth import oidc_browser_login
 

--- a/src/klangk/klangkc-tests/tests/test_transport.py
+++ b/src/klangk/klangkc-tests/tests/test_transport.py
@@ -174,7 +174,9 @@ class TestWsConnect:
                 assert ws is mock_ws
 
         mock_connect.assert_called_once_with(
-            "ws://localhost:8995/ws?token=tok", max_size=1024
+            "ws://localhost:8995/ws",
+            max_size=1024,
+            subprotocols=["bearer", "tok"],
         )
 
     async def test_uds_opens_unix_socket(self):
@@ -199,7 +201,10 @@ class TestWsConnect:
 
         mock_sock.connect.assert_called_once_with("/tmp/klangk.sock")
         mock_connect.assert_called_once_with(
-            "ws://localhost/ws?token=tok", sock=mock_sock, max_size=2048
+            "ws://localhost/ws",
+            sock=mock_sock,
+            max_size=2048,
+            subprotocols=["bearer", "tok"],
         )
         mock_sock.close.assert_called_once()
 
@@ -221,7 +226,8 @@ class TestWsConnect:
                 assert ws is mock_ws
 
         mock_connect.assert_called_once_with(
-            "ws://localhost:8995/ws/consent-decider?workspace=wsid&token=tok"
+            "ws://localhost:8995/ws/consent-decider?workspace=wsid",
+            subprotocols=["bearer", "tok"],
         )
 
     async def test_uds_with_path_and_query(self):
@@ -248,12 +254,15 @@ class TestWsConnect:
                 assert ws is mock_ws
 
         mock_connect.assert_called_once_with(
-            "ws://localhost/ws/consent-decider?workspace=wsid&token=tok",
+            "ws://localhost/ws/consent-decider?workspace=wsid",
             sock=mock_sock,
+            subprotocols=["bearer", "tok"],
         )
 
-    async def test_token_wins_over_query_footgun(self):
-        # A caller passing query={"token": ...} must NOT clobber the auth token
+    async def test_token_never_rides_the_url(self):
+        # #3201: the auth token rides the subprotocol header, never the
+        # URL query string (query strings land in proxy/server logs) —
+        # and a query={"token": ...} footgun cannot smuggle it back
         # (#2320 review #6).
         mock_ws = MagicMock()
         mock_cm = MagicMock()
@@ -270,10 +279,10 @@ class TestWsConnect:
             ) as ws:
                 assert ws is mock_ws
 
-        uri = mock_connect.call_args.args[0]
-        assert "token=real-token" in uri
-        assert "token=evil" not in uri
-        assert "workspace=wsid" in uri
+        kwargs = mock_connect.call_args.kwargs
+        assert kwargs["subprotocols"] == ["bearer", "real-token"]
+        assert "token=" not in mock_connect.call_args.args[0]
+        assert "workspace=wsid" in mock_connect.call_args.args[0]
 
     async def test_uds_closes_socket_on_error(self):
         mock_sock = MagicMock()

--- a/src/klangk/klangkd-tests/e2e-tests/_e2e_server.py
+++ b/src/klangk/klangkd-tests/e2e-tests/_e2e_server.py
@@ -748,7 +748,7 @@ async def ws_connect(server: dict[str, Any], path: str, **kwargs: Any):
     token = query.pop("token", None)
     if token is not None:
         kwargs.setdefault("subprotocols", ["bearer", token])
-    target = urlunsplit(("", parts.path, "", urlencode(query), ""))
+    target = urlunsplit(("", "", parts.path, urlencode(query), ""))
     if server["uds_path"] is not None:
         return await websockets.unix_connect(
             server["uds_path"], f"{_UDS_WS_HOST}{target}", **kwargs

--- a/src/klangk/klangkd-tests/e2e-tests/_e2e_server.py
+++ b/src/klangk/klangkd-tests/e2e-tests/_e2e_server.py
@@ -735,12 +735,23 @@ async def ws_connect(server: dict[str, Any], path: str, **kwargs: Any):
     """Open a websocket to ``path`` over the server's UDS or TCP transport.
 
     ``path`` is the request target including the query string, e.g.
-    ``"/ws?token=..."``. Returns an open websocket connection (the caller
+    ``"/ws?token=..."``. A ``token`` query parameter is moved into the
+    handshake's ``Sec-WebSocket-Protocol`` header (``bearer, <jwt>``),
+    mirroring the production client contract (#3201 — the JWT never
+    rides the URL). Returns an open websocket connection (the caller
     closes it, typically via ``async with``).
     """
+    from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
+
+    parts = urlsplit(path)
+    query = dict(parse_qsl(parts.query))
+    token = query.pop("token", None)
+    if token is not None:
+        kwargs.setdefault("subprotocols", ["bearer", token])
+    target = urlunsplit(("", parts.path, "", urlencode(query), ""))
     if server["uds_path"] is not None:
         return await websockets.unix_connect(
-            server["uds_path"], f"{_UDS_WS_HOST}{path}", **kwargs
+            server["uds_path"], f"{_UDS_WS_HOST}{target}", **kwargs
         )
     ws_base = server["url"].replace("http://", "ws://")
-    return await websockets.connect(f"{ws_base}{path}", **kwargs)
+    return await websockets.connect(f"{ws_base}{target}", **kwargs)

--- a/src/klangk/klangkd-tests/e2e-tests/_e2e_server.py
+++ b/src/klangk/klangkd-tests/e2e-tests/_e2e_server.py
@@ -747,7 +747,11 @@ async def ws_connect(server: dict[str, Any], path: str, **kwargs: Any):
     query = dict(parse_qsl(parts.query))
     token = query.pop("token", None)
     if token is not None:
-        kwargs.setdefault("subprotocols", ["bearer", token])
+        subprotocols = kwargs.setdefault("subprotocols", ["bearer", token])
+        if subprotocols != ["bearer", token]:
+            raise ValueError(
+                "ws_connect: pass the token via ?token=, not subprotocols="
+            )
     target = urlunsplit(("", "", parts.path, urlencode(query), ""))
     if server["uds_path"] is not None:
         return await websockets.unix_connect(

--- a/src/klangk/klangkd-tests/super-e2e/_ws.py
+++ b/src/klangk/klangkd-tests/super-e2e/_ws.py
@@ -1,7 +1,8 @@
 """WebSocket helpers for the super-E2E suite (#2561).
 
 Thin black-box client helpers speaking the same public WS protocol the
-shipped frontend uses: ``/ws?token=...`` through the appliance's
+shipped frontend uses: ``/ws`` with the JWT in the handshake
+``Sec-WebSocket-Protocol`` header (#3201) through the appliance's
 published port (caddy → UDS → klangkd — the real deployed data path).
 """
 
@@ -16,9 +17,18 @@ import websockets
 
 
 async def dial(appliance, token: str, path: str = "/ws"):
-    """Open an authenticated WS to the appliance (any endpoint path)."""
-    url = f"{appliance.url.replace('http://', 'ws://')}{path}?token={token}"
-    return await websockets.connect(url, max_size=2**20, open_timeout=30)
+    """Open an authenticated WS to the appliance (any endpoint path).
+
+    #3201: the JWT rides the handshake's subprotocol header, not the
+    URL query string (query strings land in proxy/server access logs).
+    """
+    url = f"{appliance.url.replace('http://', 'ws://')}{path}"
+    return await websockets.connect(
+        url,
+        max_size=2**20,
+        open_timeout=30,
+        subprotocols=["bearer", token],
+    )
 
 
 def _is_container_ready(msg: dict) -> bool:

--- a/src/klangk/klangkd-tests/super-e2e/test_egress_e2e.py
+++ b/src/klangk/klangkd-tests/super-e2e/test_egress_e2e.py
@@ -97,9 +97,13 @@ async def test_interactive_consent_deny(appliance, api, auth):
     try:
         url = (
             f"{appliance.url.replace('http://', 'ws://')}"
-            f"/ws/consent-decider?token={token}&workspace={ws_id}"
+            f"/ws/consent-decider?workspace={ws_id}"
         )
-        decider = await websockets.connect(url, max_size=2**20)
+        decider = await websockets.connect(
+            url,
+            max_size=2**20,
+            subprotocols=["bearer", token],
+        )
 
         # Fire the connection inside the workspace; the SYN holds at the
         # sidecar until a verdict. curl retries/timeout bounds the hold.

--- a/src/klangk/klangkd-tests/tests/test_api.py
+++ b/src/klangk/klangkd-tests/tests/test_api.py
@@ -56,6 +56,16 @@ def _auth():
     return auth_mod.Auth(state)
 
 
+async def _reset_token(app_state, email: str) -> str:
+    """Mint a reset token bound to the row's current password hash
+    (#3201) — mirrors what the forgot-password email flow mints."""
+    a = app_state.state.auth
+    user = await app_state.state.model.users.get_user_by_email(email)
+    return a.create_password_reset_token(
+        user["id"], a.reset_token_binding(user["password_hash"])
+    )
+
+
 # Aliases for the raw-JWT test that builds a token by hand.
 _SECRET = make_settings({}).jwt_secret
 _ALGORITHM = "HS256"
@@ -1152,8 +1162,10 @@ class TestAuthRoutes:
         user = await app_state.state.model.users.create_user(
             "unverified@example.com", password_hash, verified=False
         )
-        token = _auth().create_verification_token(user["id"])
-        resp = await client.get(f"/api/v1/auth/verify?token={token}")
+        token = _auth().create_verification_token(
+            user["id"], "unverified@example.com"
+        )
+        resp = await client.post("/api/v1/auth/verify", json={"token": token})
         assert resp.status_code == 200
         assert resp.json()["status"] == "verified"
         # User can now log in
@@ -1163,14 +1175,38 @@ class TestAuthRoutes:
         )
         assert login_resp.status_code == 200
 
+    async def test_verify_token_is_one_time(self, client, db, app_state):
+        """#3201: a replayed verification link cannot mint a second
+        session, and a link minted before an email change no longer
+        matches the row."""
+        from klangk import auth as auth_mod
+
+        password_hash = auth_mod.hash_password("pass")
+        user = await app_state.state.model.users.create_user(
+            "unverified2@example.com", password_hash, verified=False
+        )
+        token = _auth().create_verification_token(
+            user["id"], "unverified2@example.com"
+        )
+        first = await client.post("/api/v1/auth/verify", json={"token": token})
+        replay = await client.post(
+            "/api/v1/auth/verify", json={"token": token}
+        )
+        assert first.status_code == 200
+        assert replay.status_code == 400
+
     async def test_verify_invalid_token(self, client, db):
-        resp = await client.get("/api/v1/auth/verify?token=garbage")
+        resp = await client.post(
+            "/api/v1/auth/verify", json={"token": "garbage"}
+        )
         assert resp.status_code == 400
 
     async def test_verify_nonexistent_user(self, client, db):
-        token = _auth().create_verification_token("nonexistent-id")
-        resp = await client.get(f"/api/v1/auth/verify?token={token}")
-        assert resp.status_code == 404
+        token = _auth().create_verification_token(
+            "nonexistent-id", "nobody@example.com"
+        )
+        resp = await client.post("/api/v1/auth/verify", json={"token": token})
+        assert resp.status_code == 400
 
     async def test_login(self, client, user):
         resp = await client.post(
@@ -1904,8 +1940,8 @@ class TestPasswordAgeRoutes:
         """A forgot-password reset inside the window is refused the same
         way — only admin-forced resets bypass."""
         monkeypatch.setattr(app.state.settings, "password_min_age_hours", 24)
-        user = await self._fresh_user(app_state, "minreset@example.com")
-        token = _auth().create_password_reset_token(user["id"])
+        await self._fresh_user(app_state, "minreset@example.com")
+        token = await _reset_token(app_state, "minreset@example.com")
         resp = await client.post(
             "/api/v1/auth/reset-password",
             json={"token": token, "password": "freshpass1"},
@@ -2045,7 +2081,7 @@ class TestForgotPassword:
         assert "/#/reset-password?token=" in reset_url
         token = reset_url.split("token=")[1]
         decoded = app_state.state.auth.decode_password_reset_token(token)
-        assert decoded == user["id"]
+        assert decoded is not None and decoded[0] == user["id"]
         api.reset_timestamps.pop(
             api.rate_limit_key("forgot@example.com"), None
         )
@@ -2355,8 +2391,8 @@ class TestResetPassword:
         )
 
     async def test_reset_success(self, client, db, app_state):
-        user = await self._create_user(app_state)
-        token = _auth().create_password_reset_token(user["id"])
+        await self._create_user(app_state)
+        token = await _reset_token(app_state, "reset@example.com")
         resp = await client.post(
             "/api/v1/auth/reset-password",
             json={"token": token, "password": "newpass1"},
@@ -2375,6 +2411,23 @@ class TestResetPassword:
         )
         assert resp2.status_code == 200
 
+    async def test_reset_is_one_time(self, client, db, app_state):
+        """#3201: after a successful reset rewrites the hash, the same
+        token (and any minted against the old hash) is rejected."""
+        await self._create_user(app_state)
+        token = await _reset_token(app_state, "reset@example.com")
+        first = await client.post(
+            "/api/v1/auth/reset-password",
+            json={"token": token, "password": "newpass1"},
+        )
+        replay = await client.post(
+            "/api/v1/auth/reset-password",
+            json={"token": token, "password": "another1"},
+        )
+        assert first.status_code == 200
+        assert replay.status_code == 400
+        assert "Invalid or expired" in replay.json()["detail"]
+
     async def test_reset_invalid_token(self, client, db):
         resp = await client.post(
             "/api/v1/auth/reset-password",
@@ -2383,8 +2436,8 @@ class TestResetPassword:
         assert resp.status_code == 400
 
     async def test_reset_short_password(self, client, db, app_state):
-        user = await self._create_user(app_state)
-        token = _auth().create_password_reset_token(user["id"])
+        await self._create_user(app_state)
+        token = await _reset_token(app_state, "reset@example.com")
         resp = await client.post(
             "/api/v1/auth/reset-password",
             json={"token": token, "password": "ab"},
@@ -2393,7 +2446,9 @@ class TestResetPassword:
         assert "8 characters" in resp.json()["detail"]
 
     async def test_reset_agent_user_rejected(self, client, db):
-        token = _auth().create_password_reset_token(model.AGENT_USER_ID)
+        token = _auth().create_password_reset_token(
+            model.AGENT_USER_ID, "irrelevant-binding"
+        )
         resp = await client.post(
             "/api/v1/auth/reset-password",
             json={"token": token, "password": "newpass1"},
@@ -2422,8 +2477,8 @@ class TestResetPassword:
             3,
             raising=False,
         )
-        user = await self._create_user_with(app, "oldpass12")
-        token = _auth().create_password_reset_token(user["id"])
+        await self._create_user_with(app, "oldpass12")
+        token = await _reset_token(app, "reset@example.com")
         # Reusing the current password.
         resp = await client.post(
             "/api/v1/auth/reset-password",
@@ -2432,13 +2487,13 @@ class TestResetPassword:
         assert resp.status_code == 400
         assert "current" in resp.json()["detail"]
         # Reuse via history: reset to newpass1, then try to reset back.
-        token = _auth().create_password_reset_token(user["id"])
+        token = await _reset_token(app, "reset@example.com")
         resp = await client.post(
             "/api/v1/auth/reset-password",
             json={"token": token, "password": "newpass1"},
         )
         assert resp.status_code == 200
-        token = _auth().create_password_reset_token(user["id"])
+        token = await _reset_token(app, "reset@example.com")
         resp = await client.post(
             "/api/v1/auth/reset-password",
             json={"token": token, "password": "oldpass12"},
@@ -2448,14 +2503,14 @@ class TestResetPassword:
 
     async def test_reset_allowed_when_disabled(self, client, db, app):
         """count=0 (default): the same reset-to-old flow succeeds."""
-        user = await self._create_user_with(app, "oldpass12")
-        token = _auth().create_password_reset_token(user["id"])
+        await self._create_user_with(app, "oldpass12")
+        token = await _reset_token(app, "reset@example.com")
         resp = await client.post(
             "/api/v1/auth/reset-password",
             json={"token": token, "password": "newpass1"},
         )
         assert resp.status_code == 200
-        token = _auth().create_password_reset_token(user["id"])
+        token = await _reset_token(app, "reset@example.com")
         resp = await client.post(
             "/api/v1/auth/reset-password",
             json={"token": token, "password": "oldpass12"},
@@ -2471,8 +2526,8 @@ class TestResetPassword:
         monkeypatch.setattr(
             app.state.settings, "password_min_changed", 8, raising=False
         )
-        user = await self._create_user_with(app, "oldpass12")
-        token = _auth().create_password_reset_token(user["id"])
+        await self._create_user_with(app, "oldpass12")
+        token = await _reset_token(app, "reset@example.com")
         # distance("oldpass12", "oldpass13") == 1 — far under the floor.
         resp = await client.post(
             "/api/v1/auth/reset-password",
@@ -11062,7 +11117,7 @@ class TestMustChangePassword:
         )
         assert user["must_change_password"] is True
         # Generate a reset token and use it
-        reset_token = app.state.auth.create_password_reset_token(user["id"])
+        reset_token = await _reset_token(app_state, "resetclear@example.com")
         resp = await client.post(
             "/api/v1/auth/reset-password",
             json={"token": reset_token, "password": "selfchosen999"},
@@ -14833,7 +14888,9 @@ class TestInvitations:
 
     async def test_accept_invite_wrong_purpose_token(self, client, db):
         # Use a verification token (wrong purpose)
-        token = _auth().create_verification_token("fake-user-id")
+        token = _auth().create_verification_token(
+            "fake-user-id", "fake@example.com"
+        )
         resp = await client.post(
             "/api/v1/auth/accept-invite",
             json={"token": token, "password": "newpassword"},
@@ -15137,7 +15194,9 @@ class TestOIDCCallback:
         assert resp.status_code == 302
         location = resp.headers["location"]
         assert "oidc-complete" in location
-        assert "token=" in location
+        # #3201: a one-time code rides the redirect, never the JWT.
+        assert "code=" in location
+        assert "token=" not in location
 
         # User was created
         user = await app_state.state.model.users.get_user_by_email(
@@ -15303,8 +15362,45 @@ class TestOIDCCallback:
         )
         assert resp.status_code == 302
         assert resp.headers["location"].startswith(
-            "http://localhost:12345/callback?token="
+            "http://localhost:12345/callback?code="
         )
+        # #3201: the redeemable session token never rides the URL.
+        assert "token=" not in resp.headers["location"]
+
+    async def test_callback_code_redeemable_once(
+        self, client, app, monkeypatch, db, app_state
+    ):
+        """#3201: the redirected code redeems for the session token via
+        POST /auth/oidc/exchange — exactly once."""
+        _, cookie_data = await self._setup_callback(
+            client, app, monkeypatch, db
+        )
+        client.cookies.set("oidc_test", cookie_data)
+        resp = await client.get(
+            "/api/v1/auth/oidc/test/callback",
+            params={"code": "auth-code", "state": "test-state"},
+            follow_redirects=False,
+        )
+        code = resp.headers["location"].split("code=")[1]
+        exchange = await client.post(
+            "/api/v1/auth/oidc/exchange", json={"code": code}
+        )
+        assert exchange.status_code == 200
+        data = exchange.json()
+        assert data["access_token"]
+        assert data["email"] == "oidcuser@example.com"
+        # Single-use: a replay of the same code fails.
+        replay = await client.post(
+            "/api/v1/auth/oidc/exchange", json={"code": code}
+        )
+        assert replay.status_code == 400
+        assert "access_token" not in replay.json()
+
+    async def test_exchange_rejects_unknown_code(self, client, db):
+        resp = await client.post(
+            "/api/v1/auth/oidc/exchange", json={"code": "never-minted"}
+        )
+        assert resp.status_code == 400
 
     async def test_callback_tampered_cli_redirect_falls_back(
         self, client, app, monkeypatch, db
@@ -15359,9 +15455,11 @@ class TestOIDCCallback:
         # Must NOT redirect to the attacker host with the token.
         assert not location.startswith("https://evil.com")
         assert "evil.com" not in location
-        # Falls back to the web flow, still carrying the token in-house.
+        # Falls back to the web flow, still keeping the session
+        # in-house behind a one-time code (#3201).
         assert "oidc-complete" in location
-        assert "token=" in location
+        assert "code=" in location
+        assert "token=" not in location
 
     async def test_callback_userinfo_cli_redirect_falls_back(
         self, client, app, monkeypatch, db
@@ -15424,7 +15522,8 @@ class TestOIDCCallback:
             assert "attacker.example" not in location, payload
             # Falls back to the web flow, still carrying the token in-house.
             assert "oidc-complete" in location, payload
-            assert "token=" in location, payload
+            assert "token=" not in location, payload
+            assert "code=" in location, payload
             client.cookies.delete("oidc_test")
 
     async def test_callback_redirect_uri_rederived_not_from_cookie(
@@ -15798,7 +15897,8 @@ class TestOIDCCallback:
             follow_redirects=False,
         )
         assert resp2.status_code == 302
-        assert "token=" in resp2.headers["location"]
+        assert "code=" in resp2.headers["location"]
+        assert "token=" not in resp2.headers["location"]
 
     async def test_callback_unknown_provider(
         self, client, app, monkeypatch, db
@@ -16288,10 +16388,10 @@ class TestPasswordPolicyRouteEnforcement:
         self, client, db, app_state
     ):
         password_hash = auth_mod.hash_password("oldpass")
-        created = await app_state.state.model.users.create_user(
+        await app_state.state.model.users.create_user(
             "policyreset@example.com", password_hash, verified=True
         )
-        token = _auth().create_password_reset_token(created["id"])
+        token = await _reset_token(app_state, "policyreset@example.com")
         resp = await client.post(
             "/api/v1/auth/reset-password",
             json={"token": token, "password": "alllowercase1!"},

--- a/src/klangk/klangkd-tests/tests/test_api_package.py
+++ b/src/klangk/klangkd-tests/tests/test_api_package.py
@@ -36,14 +36,15 @@ api_auth = sys.modules["klangk.api.auth"]
 # Total HTTP route operations the app registers.  The api.py split had
 # to preserve the monolith's 90 exactly; the expired-password route
 # (#3177), /audit (#3154), the #3214 admin audit-events route, step-up
-# (#3196), and /auth/bind (#3218) are the additions since.
-EXPECTED_ROUTE_COUNT = 95
+# (#3196), /auth/bind (#3218), and the OIDC code exchange (#3201) are
+# the additions since.
+EXPECTED_ROUTE_COUNT = 96
 
-# Per-domain submodules and the number of routes each owns.  89 sub-routes
+# Per-domain submodules and the number of routes each owns.  90 sub-routes
 # + 3 routes defined directly on the main router (version, config,
-# my-permissions) + 3 on the root router (health, audit, empty) == 94.
+# my-permissions) + 3 on the root router (health, audit, empty) == 96.
 SUBMODULE_ROUTES = {
-    "auth": 20,  # 15 + 2 OIDC + expired-password (#3177) + step-up (#3196) + bind (#3218)
+    "auth": 21,  # 15 + 2 OIDC login/callback + expired-password (#3177) + step-up (#3196) + bind (#3218) + exchange (#3201)
     "workspaces": 27,
     "resources": 10,  # 6 files + 4 images/volumes (merged submodules)
     "browser_delegate": 2,

--- a/src/klangk/klangkd-tests/tests/test_audit_events.py
+++ b/src/klangk/klangkd-tests/tests/test_audit_events.py
@@ -714,7 +714,11 @@ class TestSelfServiceAudit:
     async def test_reset_password_records_events(
         self, api_client, api_app, user
     ):
-        token = api_app.state.auth.create_password_reset_token(user["id"])
+        a = api_app.state.auth
+        row = await api_app.state.model.users.get_user_by_email(user["email"])
+        token = a.create_password_reset_token(
+            user["id"], a.reset_token_binding(row["password_hash"])
+        )
         resp = await api_client.post(
             "/api/v1/auth/reset-password",
             json={"token": token, "password": "NewPass1!"},

--- a/src/klangk/klangkd-tests/tests/test_auth.py
+++ b/src/klangk/klangkd-tests/tests/test_auth.py
@@ -786,12 +786,19 @@ class TestLoginRateLimit:
 
 class TestVerification:
     def test_create_and_decode_verification_token(self):
-        token = _auth().create_verification_token("user-123")
-        user_id = _auth().decode_verification_token(token)
-        assert user_id == "user-123"
+        token = _auth().create_verification_token(
+            "user-123", "someone@example.com"
+        )
+        decoded = _auth().decode_verification_token(token)
+        assert decoded == ("user-123", "someone@example.com")
 
     def test_decode_invalid_token(self):
         assert _auth().decode_verification_token("garbage") is None
+
+    def test_decode_token_missing_email_rejected(self):
+        """#3201: a verify token without its email binding is refused."""
+        token = _auth()._create_purpose_token("user-123", "verify", 1)
+        assert _auth().decode_verification_token(token) is None
 
     def test_decode_wrong_purpose(self):
         # A regular auth token should not pass as a verification token
@@ -804,31 +811,65 @@ class TestVerification:
             "toverify@example.com", password_hash, verified=False
         )
         assert not user["verified"]
-        result = await app_state.state.model.users.verify_user(user["id"])
+        result = await app_state.state.model.users.verify_user(
+            user["id"], "toverify@example.com"
+        )
         assert result is True
         updated = await app_state.state.model.users.get_user_by_email(
             "toverify@example.com"
         )
         assert updated["verified"] is True
+        # #3201: one-time — the same (id, email) no longer matches an
+        # already-verified row, and a stale address matches nothing.
+        assert (
+            await app_state.state.model.users.verify_user(
+                user["id"], "toverify@example.com"
+            )
+            is False
+        )
+        assert (
+            await app_state.state.model.users.verify_user(
+                user["id"], "old-address@example.com"
+            )
+            is False
+        )
 
     async def test_verify_nonexistent_user(self, db, app_state):
         result = await app_state.state.model.users.verify_user(
-            "nonexistent-id"
+            "nonexistent-id", "nobody@example.com"
         )
         assert result is False
 
 
 class TestPasswordReset:
     def test_create_and_decode_reset_token(self):
-        token = _auth().create_password_reset_token("user-456")
-        assert _auth().decode_password_reset_token(token) == "user-456"
+        binding = auth.Auth.reset_token_binding("some-hash")
+        token = _auth().create_password_reset_token("user-456", binding)
+        decoded = _auth().decode_password_reset_token(token)
+        assert decoded == ("user-456", binding)
+
+    def test_reset_binding_tracks_password_hash(self):
+        """#3201: the binding changes with the stored hash, so a token
+        minted before a reset stops matching the row after it."""
+        before = auth.Auth.reset_token_binding("hash-a")
+        after = auth.Auth.reset_token_binding("hash-b")
+        none = auth.Auth.reset_token_binding(None)
+        assert before != after
+        assert none != before
+
+    def test_decode_token_missing_binding_rejected(self):
+        """#3201: a reset token without its hash binding is refused."""
+        token = _auth()._create_purpose_token("user-456", "reset", 1)
+        assert _auth().decode_password_reset_token(token) is None
 
     def test_decode_invalid_token(self):
         assert _auth().decode_password_reset_token("garbage") is None
 
     def test_reset_and_verify_tokens_not_interchangeable(self):
-        reset = _auth().create_password_reset_token("user-456")
-        verify = _auth().create_verification_token("user-456")
+        reset = _auth().create_password_reset_token(
+            "user-456", auth.Auth.reset_token_binding("h")
+        )
+        verify = _auth().create_verification_token("user-456", "u@example.com")
         assert _auth().decode_verification_token(reset) is None
         assert _auth().decode_password_reset_token(verify) is None
 
@@ -846,13 +887,34 @@ class TestWorkspaceToken:
         assert _auth().decode_workspace_token(user_token) is None
 
     def test_verify_token_rejected(self):
-        verify_token = _auth().create_verification_token("user-1")
+        verify_token = _auth().create_verification_token(
+            "user-1", "u@example.com"
+        )
         assert _auth().decode_workspace_token(verify_token) is None
 
     def test_workspace_token_rejected_by_other_decoders(self):
         ws_token = _auth().create_workspace_token("ws-123")
         assert _auth().decode_verification_token(ws_token) is None
         assert _auth().decode_password_reset_token(ws_token) is None
+
+
+class TestLoginCodes:
+    """One-time OIDC login codes (#3201): mint/redeem/prune, directly
+    (the HTTP redemption path is covered by the OIDC callback tests)."""
+
+    def test_expired_code_rejected_and_pruned(self):
+        a = _auth()
+        a.login_code_ttl_seconds = -1
+        expired = a.mint_login_code("tok", "e@x.com")
+        assert a.redeem_login_code(expired) is None
+        # Minting a live code prunes the expired leftovers.
+        stale = a.mint_login_code("tok2", "e2@x.com")
+        a.login_code_ttl_seconds = 60
+        live = a.mint_login_code("tok3", "e3@x.com")
+        assert stale not in a.pending_login_codes
+        assert a.redeem_login_code(live) == ("tok3", "e3@x.com")
+        # Single-use: the redeemed live code is gone.
+        assert a.redeem_login_code(live) is None
 
 
 class TestTokenValidation:
@@ -1199,7 +1261,7 @@ class TestInvitationTokens:
         assert result == ("inv-123", "user@example.com")
 
     def test_wrong_purpose_rejected(self):
-        token = _auth().create_verification_token("uid")
+        token = _auth().create_verification_token("uid", "u@example.com")
         assert _auth().decode_invitation_token(token) is None
 
     def test_invalid_token_returns_none(self):

--- a/src/klangk/klangkd-tests/tests/test_consent_coordinator.py
+++ b/src/klangk/klangkd-tests/tests/test_consent_coordinator.py
@@ -1969,7 +1969,7 @@ class TestEgressSidecarWS:
         app.state.container_registry = types.SimpleNamespace(
             states={FULL_WS: state}
         )
-        ws = _FakeWS({"token": FULL_WS})
+        ws = _FakeWS({}, headers={"authorization": "Bearer sidecar-ws"})
         handler = asyncio.create_task(handle_egress_sidecar(ws, app))
         await ws.feed(json.dumps({"type": "activity"}))
         await asyncio.sleep(0.02)
@@ -1987,7 +1987,7 @@ class TestEgressSidecarWS:
 
         app, _ = _sidecar_app()
         app.state.container_registry = types.SimpleNamespace(states={})
-        ws = _FakeWS({"token": FULL_WS})
+        ws = _FakeWS({}, headers={"authorization": "Bearer sidecar-ws"})
         handler = asyncio.create_task(handle_egress_sidecar(ws, app))
         await ws.feed(json.dumps({"type": "activity"}))
         await asyncio.sleep(0.02)
@@ -2001,7 +2001,7 @@ class TestEgressSidecarWS:
         from klangk.wshandler.sidecar import handle_egress_sidecar
 
         app, _ = _sidecar_app()
-        ws = _FakeWS({"token": FULL_WS})
+        ws = _FakeWS({}, headers={"authorization": "Bearer sidecar-ws"})
         handler = asyncio.create_task(handle_egress_sidecar(ws, app))
         await ws.feed(
             json.dumps({"type": "drop_ack", "id": "ack-1", "ok": True})
@@ -2017,7 +2017,7 @@ class TestEgressSidecarWS:
         from klangk.wshandler.sidecar import handle_egress_sidecar
 
         app, _ = _sidecar_app(token_result=None)
-        ws = _FakeWS({"token": "bad"})
+        ws = _FakeWS({}, headers={"authorization": "Bearer bad"})
         await handle_egress_sidecar(ws, app)
         assert ws.closed == (4001, "Invalid token")
 
@@ -2025,7 +2025,7 @@ class TestEgressSidecarWS:
         from klangk.wshandler.sidecar import handle_egress_sidecar
 
         app, _ = _sidecar_app(token_result=auth.Auth.WORKSPACE_TOKEN_EXPIRED)
-        ws = _FakeWS({"token": "stale"})
+        ws = _FakeWS({}, headers={"authorization": "Bearer stale"})
         await handle_egress_sidecar(ws, app)
         assert ws.closed == (4002, "Token expired")
 
@@ -2037,7 +2037,7 @@ class TestEgressSidecarWS:
         fut: asyncio.Future = asyncio.get_event_loop().create_future()
         fut.set_result({"decision": "deny", "reason": "static"})
         coord.hold = AsyncMock(return_value=fut)
-        ws = _FakeWS({"token": "tok"})
+        ws = _FakeWS({}, headers={"authorization": "Bearer tok"})
         handler = asyncio.create_task(handle_egress_sidecar(ws, app))
         await ws.feed(
             json.dumps(
@@ -2071,7 +2071,7 @@ class TestEgressSidecarWS:
         app, coord = _sidecar_app()
         fut: asyncio.Future = asyncio.get_event_loop().create_future()
         coord.hold = AsyncMock(return_value=fut)
-        ws = _FakeWS({"token": "tok"})
+        ws = _FakeWS({}, headers={"authorization": "Bearer tok"})
         handler = asyncio.create_task(handle_egress_sidecar(ws, app))
         await ws.feed(
             json.dumps(
@@ -2101,7 +2101,7 @@ class TestEgressSidecarWS:
         fut: asyncio.Future = asyncio.get_event_loop().create_future()
         fut.set_result({"decision": "deny", "reason": "static"})
         coord.hold = AsyncMock(return_value=fut)
-        ws = _FakeWS({"token": "tok"})
+        ws = _FakeWS({}, headers={"authorization": "Bearer tok"})
         handler = asyncio.create_task(handle_egress_sidecar(ws, app))
         await ws.feed("not-json")
         await ws.feed(json.dumps({"type": "ping"}))
@@ -2141,7 +2141,7 @@ class TestEgressSidecarWS:
         app, coord = _sidecar_app()
         fut: asyncio.Future = asyncio.get_event_loop().create_future()
         coord.hold = AsyncMock(return_value=fut)
-        ws = _FakeWS({"token": "tok"})
+        ws = _FakeWS({}, headers={"authorization": "Bearer tok"})
         handler = asyncio.create_task(handle_egress_sidecar(ws, app))
         await ws.feed(
             json.dumps(

--- a/src/klangk/klangkd-tests/tests/test_consent_deciders.py
+++ b/src/klangk/klangkd-tests/tests/test_consent_deciders.py
@@ -175,24 +175,31 @@ class TestConsentDeciderRegistryBroadcast:
 
 
 class _FakeWS:
-    """Minimal stand-in for a fastapi WebSocket for handler-level tests."""
+    """Minimal stand-in for a fastapi WebSocket for handler-level tests.
+
+    A ``token`` key in *params* is moved into the handshake's
+    ``Sec-WebSocket-Protocol`` header, mirroring the production client
+    contract (#3201: the JWT never rides the query string).
+    """
 
     def __init__(
         self, params: dict, incoming: list, headers: dict | None = None
     ):
-        self.query_params = params
-        self.headers = (
-            headers
-            if headers is not None
-            else {"user-agent": "fake-decider/1.0"}
+        token = params.pop("token", None)
+        merged = (
+            dict(headers) if headers else {"user-agent": "fake-decider/1.0"}
         )
+        if token is not None:
+            merged["sec-websocket-protocol"] = f"bearer, {token}"
         self.url = types.SimpleNamespace(path="/ws/consent-decider")
+        self.query_params = params
+        self.headers = merged
         self._incoming = iter(incoming)
         self.sent: list[str] = []
         self.accepted = False
         self.closed: tuple | None = None
 
-    async def accept(self) -> None:
+    async def accept(self, subprotocol: str | None = None) -> None:
         self.accepted = True
 
     async def close(self, code: int = 1000, reason: str | None = None) -> None:

--- a/src/klangk/klangkd-tests/tests/test_model_users.py
+++ b/src/klangk/klangkd-tests/tests/test_model_users.py
@@ -94,8 +94,8 @@ async def test_link_oidc_and_external_id_and_verify(users):
     assert ext["id"] == u["id"]
     assert ext["verified"] is False
     assert await users.get_user_by_external_id("google", "missing") is None
-    assert await users.verify_user(u["id"]) is True
-    assert await users.verify_user("missing") is False
+    assert await users.verify_user(u["id"], "d@x.com") is True
+    assert await users.verify_user("missing", "d@x.com") is False
 
 
 async def test_insert_unverified_user(users):

--- a/src/klangk/klangkd-tests/tests/test_session_idle.py
+++ b/src/klangk/klangkd-tests/tests/test_session_idle.py
@@ -308,6 +308,7 @@ class TestWsAuthenticateJti:
         token = await a.issue_token(user["id"], user["email"])
         ws = types.SimpleNamespace(
             headers={"sec-websocket-protocol": f"bearer, {token}"},
+            query_params={},
             url=types.SimpleNamespace(path="/ws"),
             close=AsyncMock(),
         )
@@ -325,6 +326,7 @@ class TestWsAuthenticateJti:
 
         ws = types.SimpleNamespace(
             headers={"sec-websocket-protocol": "bearer, garbage"},
+            query_params={},
             close=AsyncMock(),
         )
         assert await ws_authenticate(ws, app_state) is None

--- a/src/klangk/klangkd-tests/tests/test_session_idle.py
+++ b/src/klangk/klangkd-tests/tests/test_session_idle.py
@@ -307,7 +307,7 @@ class TestWsAuthenticateJti:
         a = app_state.state.auth
         token = await a.issue_token(user["id"], user["email"])
         ws = types.SimpleNamespace(
-            query_params={"token": token},
+            headers={"sec-websocket-protocol": f"bearer, {token}"},
             url=types.SimpleNamespace(path="/ws"),
             close=AsyncMock(),
         )
@@ -324,7 +324,8 @@ class TestWsAuthenticateJti:
         from klangk.wshandler.dispatch import ws_authenticate
 
         ws = types.SimpleNamespace(
-            query_params={"token": "garbage"}, close=AsyncMock()
+            headers={"sec-websocket-protocol": "bearer, garbage"},
+            close=AsyncMock(),
         )
         assert await ws_authenticate(ws, app_state) is None
         ws.close.assert_awaited_once_with(code=4001, reason="Invalid token")
@@ -409,33 +410,3 @@ class TestUnarmedWsStamp:
         await unarmed.record_ws_session_activity("sid-1")
         app.state.model.sessions.touch_session_by_sid.assert_not_awaited()
         assert unarmed.session_stamps == {}
-
-
-class TestDeciderSessionIdResolution:
-    async def test_resolves_through_jti(self):
-        from klangk.wshandler import decider
-
-        app = _app()
-        app.state.auth = types.SimpleNamespace(
-            decode_token=lambda _t: {"jti": "jti-1"}
-        )
-        app.state.model = types.SimpleNamespace(
-            sessions=types.SimpleNamespace(
-                get_session_id=AsyncMock(return_value="sid-1")
-            )
-        )
-        ws = types.SimpleNamespace(query_params={"token": "tok"})
-        assert await decider._decider_session_id(ws, app) == "sid-1"
-        app.state.model.sessions.get_session_id.assert_awaited_once_with(
-            "jti-1"
-        )
-
-    async def test_no_token_or_no_jti_returns_none(self):
-        from klangk.wshandler import decider
-
-        app = _app()
-        app.state.auth = types.SimpleNamespace(decode_token=lambda _t: {})
-        ws = types.SimpleNamespace(query_params={})
-        assert await decider._decider_session_id(ws, app) is None
-        ws2 = types.SimpleNamespace(query_params={"token": "tok"})
-        assert await decider._decider_session_id(ws2, app) is None

--- a/src/klangk/klangkd-tests/tests/test_wshandler.py
+++ b/src/klangk/klangkd-tests/tests/test_wshandler.py
@@ -5,7 +5,7 @@ import base64
 import json
 import logging
 import time
-from contextlib import asynccontextmanager
+from contextlib import asynccontextmanager, suppress
 from datetime import datetime, timedelta, timezone
 import types
 from types import SimpleNamespace
@@ -160,6 +160,11 @@ async def _grant_monitor(app_state, user_id: str, workspace_id: str) -> None:
         model.PRINCIPAL_USER,
         user_id=user_id,
     )
+
+
+def _auth_headers(token: str) -> dict:
+    """The #3201 WS auth header: token as a subprotocol entry."""
+    return {"sec-websocket-protocol": f"bearer, {token}"}
 
 
 def _mock_sock(headers=None, query_params=None):
@@ -2785,7 +2790,7 @@ class TestHandleWebsocketDispatch:
         if app_state is None:
             app_state = _make_app_state()
         token = _auth().create_token(user["id"], user["email"])
-        websocket = _mock_raw_sock(query_params={"token": token})
+        websocket = _mock_raw_sock(headers=_auth_headers(token))
         msgs = [json.dumps(c) for c in commands] + [WebSocketDisconnect()]
         websocket.receive_text = AsyncMock(side_effect=msgs)
         await handle_websocket(websocket, app_state)
@@ -2802,7 +2807,7 @@ class TestHandleWebsocketDispatch:
 
         app_state = _make_app_state()
         token = _auth().create_token(user["id"], user["email"])
-        websocket = _mock_raw_sock(query_params={"token": token})
+        websocket = _mock_raw_sock(headers=_auth_headers(token))
         websocket.receive_text = AsyncMock(side_effect=[WebSocketDisconnect()])
         with (
             patch.object(
@@ -2825,7 +2830,7 @@ class TestHandleWebsocketDispatch:
         app_state = _make_app_state()
         token = _auth().create_token(user["id"], user["email"])
         jti = _auth().decode_token(token)["jti"]
-        websocket = _mock_raw_sock(query_params={"token": token})
+        websocket = _mock_raw_sock(headers=_auth_headers(token))
         websocket.receive_text = AsyncMock(side_effect=[WebSocketDisconnect()])
         seen: list = []
 
@@ -2844,7 +2849,7 @@ class TestHandleWebsocketDispatch:
         app_state = _make_app_state()
         token = _auth().create_token(user["id"], user["email"])
         payload = _auth().decode_token(token)
-        websocket = _mock_raw_sock(query_params={"token": token})
+        websocket = _mock_raw_sock(headers=_auth_headers(token))
         result = await ws_authenticate(websocket, app_state)
         assert isinstance(result, tuple)
         authed_user, jti, exp = result
@@ -2869,7 +2874,7 @@ class TestHandleWebsocketDispatch:
             user_agent="klangk-cli/1.0",
         )
         jti = a.decode_token(token)["jti"]
-        websocket = _mock_raw_sock(query_params={"token": token})
+        websocket = _mock_raw_sock(headers=_auth_headers(token))
         websocket.client = types.SimpleNamespace(host="203.0.113.9")
         assert await ws_authenticate(websocket, app_state) is None
         websocket.close.assert_awaited_once_with(
@@ -2891,7 +2896,7 @@ class TestHandleWebsocketDispatch:
             source_ip="198.51.100.7",
             user_agent="klangk-cli/1.0",
         )
-        websocket = _mock_raw_sock(query_params={"token": token})
+        websocket = _mock_raw_sock(headers=_auth_headers(token))
         websocket.client = types.SimpleNamespace(host="198.51.100.7")
         result = await ws_authenticate(websocket, app_state)
         assert isinstance(result, tuple)
@@ -2963,7 +2968,7 @@ class TestHandleWebsocketDispatch:
         registry = app_state.state.container_registry
 
         token = _auth().create_token(user["id"], user["email"])
-        websocket = _mock_raw_sock(query_params={"token": token})
+        websocket = _mock_raw_sock(headers=_auth_headers(token))
 
         workspace = await app_state.state.workspaces.create_workspace(
             user["id"], "stop-ws"
@@ -3070,9 +3075,36 @@ class TestHandleWebsocket:
             code=4001, reason="Missing token"
         )
 
+    async def test_token_only_header_echoes_no_subprotocol(
+        self, user, app_state, db
+    ):
+        """#3201: a client offering only the JWT (no 'bearer' marker)
+        still authenticates; accept echoes no subprotocol it did not
+        offer."""
+        a = app_state.state.auth
+        token = await a.issue_token(user["id"], user["email"])
+        websocket = _mock_raw_sock(headers={"sec-websocket-protocol": token})
+        task = asyncio.create_task(handle_websocket(websocket, app_state))
+        websocket.receive_text.side_effect = Exception("stop")
+        with suppress(Exception):
+            await asyncio.wait_for(task, timeout=2)
+        websocket.accept.assert_awaited_once_with(subprotocol=None)
+
+    async def test_bearer_marker_echoed_on_accept(self, user, app_state, db):
+        """#3201: the offered 'bearer' marker is echoed so browser
+        clients complete the subprotocol negotiation."""
+        a = app_state.state.auth
+        token = await a.issue_token(user["id"], user["email"])
+        websocket = _mock_raw_sock(headers=_auth_headers(token))
+        task = asyncio.create_task(handle_websocket(websocket, app_state))
+        websocket.receive_text.side_effect = Exception("stop")
+        with suppress(Exception):
+            await asyncio.wait_for(task, timeout=2)
+        websocket.accept.assert_awaited_once_with(subprotocol="bearer")
+
     async def test_invalid_token(self, db, app_state):
         app_state = _make_app_state()
-        websocket = _mock_raw_sock(query_params={"token": "bad"})
+        websocket = _mock_raw_sock(headers=_auth_headers("bad"))
         await handle_websocket(websocket, app_state)
         websocket.close.assert_awaited_once_with(
             code=4001, reason="Invalid token"
@@ -3094,7 +3126,7 @@ class TestHandleWebsocket:
         token = jwt.encode(
             payload, _auth().secret, algorithm=_auth().algorithm
         )
-        websocket = _mock_raw_sock(query_params={"token": token})
+        websocket = _mock_raw_sock(headers=_auth_headers(token))
         await handle_websocket(websocket, app_state)
         websocket.close.assert_awaited_once_with(
             code=4002, reason="Token expired"
@@ -3105,7 +3137,7 @@ class TestHandleWebsocket:
         # refused with 4001 (the post-decode None-user arm).
         app_state = _make_app_state()
         token = _auth().create_token("nonexistent-id", "ghost@example.com")
-        websocket = _mock_raw_sock(query_params={"token": token})
+        websocket = _mock_raw_sock(headers=_auth_headers(token))
         await handle_websocket(websocket, app_state)
         websocket.close.assert_awaited_once_with(
             code=4001, reason="Invalid token"
@@ -3118,7 +3150,7 @@ class TestHandleWebsocket:
             user["id"], True
         )
         token = _auth().create_token(user["id"], user["email"])
-        websocket = _mock_raw_sock(query_params={"token": token})
+        websocket = _mock_raw_sock(headers=_auth_headers(token))
         await handle_websocket(websocket, app_state)
         websocket.close.assert_awaited_once_with(
             code=4004, reason="Password change required"
@@ -3128,7 +3160,7 @@ class TestHandleWebsocket:
         app_state = _make_app_state()
 
         token = _auth().create_token(user["id"], user["email"])
-        websocket = _mock_raw_sock(query_params={"token": token})
+        websocket = _mock_raw_sock(headers=_auth_headers(token))
         websocket.receive_text = AsyncMock(side_effect=WebSocketDisconnect())
 
         await handle_websocket(websocket, app_state)
@@ -3139,7 +3171,7 @@ class TestHandleWebsocket:
         app_state = _make_app_state()
 
         token = _auth().create_token(user["id"], user["email"])
-        websocket = _mock_raw_sock(query_params={"token": token})
+        websocket = _mock_raw_sock(headers=_auth_headers(token))
         websocket.receive_text = AsyncMock(
             side_effect=ValueError("unexpected")
         )
@@ -3155,7 +3187,7 @@ class TestHandleWebsocket:
         app_state = _make_app_state()
 
         token = _auth().create_token(user["id"], user["email"])
-        websocket = _mock_raw_sock(query_params={"token": token})
+        websocket = _mock_raw_sock(headers=_auth_headers(token))
         websocket.receive_text = AsyncMock(side_effect=WebSocketDisconnect())
 
         with patch.object(
@@ -3173,7 +3205,7 @@ class TestHandleWebsocket:
         app_state = _make_app_state()
 
         token = _auth().create_token(user["id"], user["email"])
-        websocket = _mock_raw_sock(query_params={"token": token})
+        websocket = _mock_raw_sock(headers=_auth_headers(token))
         websocket.receive_text = AsyncMock(
             side_effect=RuntimeError(
                 'WebSocket is not connected. Need to call "accept" first.'
@@ -3188,7 +3220,7 @@ class TestHandleWebsocket:
         app_state = _make_app_state()
 
         token = _auth().create_token(user["id"], user["email"])
-        websocket = _mock_raw_sock(query_params={"token": token})
+        websocket = _mock_raw_sock(headers=_auth_headers(token))
         websocket.receive_text = AsyncMock(
             side_effect=["not json", WebSocketDisconnect()]
         )
@@ -3202,7 +3234,7 @@ class TestHandleWebsocket:
         app_state = _make_app_state()
 
         token = _auth().create_token(user["id"], user["email"])
-        websocket = _mock_raw_sock(query_params={"token": token})
+        websocket = _mock_raw_sock(headers=_auth_headers(token))
         websocket.receive_text = AsyncMock(
             side_effect=[
                 json.dumps({"cmd": "bogus"}),
@@ -3225,7 +3257,7 @@ class TestHandleWebsocket:
         app_state = _make_app_state()
 
         token = _auth().create_token(user["id"], user["email"])
-        websocket = _mock_raw_sock(query_params={"token": token})
+        websocket = _mock_raw_sock(headers=_auth_headers(token))
         websocket.receive_text = AsyncMock(
             side_effect=[
                 frame,
@@ -3248,7 +3280,7 @@ class TestHandleWebsocket:
         app_state = _make_app_state()
 
         token = _auth().create_token(user["id"], user["email"])
-        websocket = _mock_raw_sock(query_params={"token": token})
+        websocket = _mock_raw_sock(headers=_auth_headers(token))
         websocket.receive_text = AsyncMock(
             side_effect=[
                 json.dumps({"cmd": "heartbeat"}),
@@ -3278,7 +3310,7 @@ class TestHandleWebsocket:
         sockets = app_state.state.sockets
 
         token = _auth().create_token(user["id"], user["email"])
-        websocket = _mock_raw_sock(query_params={"token": token})
+        websocket = _mock_raw_sock(headers=_auth_headers(token))
         websocket.receive_text = AsyncMock(
             side_effect=[
                 json.dumps({"cmd": "heartbeat"}),
@@ -3307,7 +3339,7 @@ class TestHandleWebsocket:
         app_state = _make_app_state()
 
         token = _auth().create_token(user["id"], user["email"])
-        websocket = _mock_raw_sock(query_params={"token": token})
+        websocket = _mock_raw_sock(headers=_auth_headers(token))
         websocket.receive_text = AsyncMock(
             side_effect=[
                 json.dumps({"cmd": "browser_response", "id": "x"}),
@@ -3336,7 +3368,7 @@ class TestHandleWebsocket:
         app_state = _make_app_state()
 
         token = _auth().create_token(user["id"], user["email"])
-        websocket = _mock_raw_sock(query_params={"token": token})
+        websocket = _mock_raw_sock(headers=_auth_headers(token))
         websocket.receive_text = AsyncMock(
             side_effect=[
                 json.dumps({"cmd": ["bogus"]}),
@@ -3357,7 +3389,7 @@ class TestHandleWebsocket:
         registry = app_state.state.container_registry
 
         token = _auth().create_token(user["id"], user["email"])
-        websocket = _mock_raw_sock(query_params={"token": token})
+        websocket = _mock_raw_sock(headers=_auth_headers(token))
         workspace = await _create_workspace_with_acl(
             app_state, user["id"], "ui-ready-ws"
         )
@@ -3415,7 +3447,7 @@ class TestHandleWebsocket:
         app_state = _make_app_state()
 
         token = _auth().create_token(user["id"], user["email"])
-        websocket = _mock_raw_sock(query_params={"token": token})
+        websocket = _mock_raw_sock(headers=_auth_headers(token))
         websocket.receive_text = AsyncMock(
             side_effect=[
                 json.dumps({"cmd": "ui_ready"}),
@@ -3440,7 +3472,7 @@ class TestHandleWebsocket:
         sockets = app_state.state.sockets
 
         token = _auth().create_token(user["id"], user["email"])
-        websocket = _mock_raw_sock(query_params={"token": token})
+        websocket = _mock_raw_sock(headers=_auth_headers(token))
         websocket.receive_text = AsyncMock(
             side_effect=RuntimeError("unexpected")
         )
@@ -4969,7 +5001,7 @@ class TestExecDispatch:
         app_state = _make_app_state()
 
         token = _auth().create_token(user["id"], user["email"])
-        websocket = _mock_raw_sock(query_params={"token": token})
+        websocket = _mock_raw_sock(headers=_auth_headers(token))
         websocket.receive_text = AsyncMock(
             side_effect=[
                 json.dumps({"cmd": "exec_start", "command": ["ls"]}),
@@ -4986,7 +5018,7 @@ class TestExecDispatch:
         app_state = _make_app_state()
 
         token = _auth().create_token(user["id"], user["email"])
-        websocket = _mock_raw_sock(query_params={"token": token})
+        websocket = _mock_raw_sock(headers=_auth_headers(token))
         websocket.receive_text = AsyncMock(
             side_effect=[
                 json.dumps({"cmd": "exec_input", "data": "AA=="}),
@@ -5003,7 +5035,7 @@ class TestExecDispatch:
         app_state = _make_app_state()
 
         token = _auth().create_token(user["id"], user["email"])
-        websocket = _mock_raw_sock(query_params={"token": token})
+        websocket = _mock_raw_sock(headers=_auth_headers(token))
         websocket.receive_text = AsyncMock(
             side_effect=[
                 json.dumps({"cmd": "exec_stop"}),
@@ -5020,7 +5052,7 @@ class TestExecDispatch:
         app_state = _make_app_state()
 
         token = _auth().create_token(user["id"], user["email"])
-        websocket = _mock_raw_sock(query_params={"token": token})
+        websocket = _mock_raw_sock(headers=_auth_headers(token))
         websocket.receive_text = AsyncMock(
             side_effect=[
                 json.dumps({"cmd": "exec_close_stdin"}),
@@ -5037,7 +5069,7 @@ class TestExecDispatch:
         app_state = _make_app_state()
 
         token = _auth().create_token(user["id"], user["email"])
-        websocket = _mock_raw_sock(query_params={"token": token})
+        websocket = _mock_raw_sock(headers=_auth_headers(token))
         websocket.receive_text = AsyncMock(
             side_effect=[
                 json.dumps({"cmd": "heartbeat"}),
@@ -5078,7 +5110,7 @@ class TestBrowserBridge:
         sockets = app_state.state.sockets
 
         token = _auth().create_token(user["id"], user["email"])
-        websocket = _mock_raw_sock(query_params={"token": token})
+        websocket = _mock_raw_sock(headers=_auth_headers(token))
         websocket.receive_text = AsyncMock(
             side_effect=[
                 json.dumps({"cmd": "browser_response", "id": "req-1"}),
@@ -6616,7 +6648,7 @@ class TestWsDebugLogging:
 
         monkeypatch.setattr(wshandler.support, "WS_DEBUG", True)
         token = _auth().create_token(user["id"], user["email"])
-        websocket = _mock_raw_sock(query_params={"token": token})
+        websocket = _mock_raw_sock(headers=_auth_headers(token))
         websocket.receive_text = AsyncMock(
             side_effect=[
                 json.dumps({"cmd": "heartbeat"}),
@@ -11443,7 +11475,7 @@ class TestSendQueueBehavior:
         app_state = _make_app_state()
 
         token = _auth().create_token(user["id"], user["email"])
-        websocket = _mock_raw_sock(query_params={"token": token})
+        websocket = _mock_raw_sock(headers=_auth_headers(token))
 
         # Make the raw websocket.send_json block forever so the queue fills up
         send_blocked = asyncio.Event()
@@ -11744,7 +11776,7 @@ class TestDispatchBrowserRequestStreamTo:
         sockets = app_state.state.sockets
 
         token = _auth().create_token(user["id"], user["email"])
-        websocket = _mock_raw_sock(query_params={"token": token})
+        websocket = _mock_raw_sock(headers=_auth_headers(token))
         websocket.receive_text = AsyncMock(
             side_effect=[
                 json.dumps({"cmd": "browser_chunk", "id": "x", "delta": "d"}),
@@ -12022,7 +12054,7 @@ class TestSSHAgentDispatch:
         app_state = _make_app_state()
 
         token = _auth().create_token(user["id"], user["email"])
-        websocket = _mock_raw_sock(query_params={"token": token})
+        websocket = _mock_raw_sock(headers=_auth_headers(token))
         websocket.receive_text = AsyncMock(
             side_effect=[
                 json.dumps({"cmd": "ssh_agent_start"}),
@@ -12039,7 +12071,7 @@ class TestSSHAgentDispatch:
         app_state = _make_app_state()
 
         token = _auth().create_token(user["id"], user["email"])
-        websocket = _mock_raw_sock(query_params={"token": token})
+        websocket = _mock_raw_sock(headers=_auth_headers(token))
         websocket.receive_text = AsyncMock(
             side_effect=[
                 json.dumps({"cmd": "ssh_agent_data", "data": "AA=="}),
@@ -12056,7 +12088,7 @@ class TestSSHAgentDispatch:
         app_state = _make_app_state()
 
         token = _auth().create_token(user["id"], user["email"])
-        websocket = _mock_raw_sock(query_params={"token": token})
+        websocket = _mock_raw_sock(headers=_auth_headers(token))
         websocket.receive_text = AsyncMock(
             side_effect=[
                 json.dumps({"cmd": "ssh_agent_stop"}),
@@ -12073,7 +12105,7 @@ class TestSSHAgentDispatch:
         app_state = _make_app_state()
 
         token = _auth().create_token(user["id"], user["email"])
-        websocket = _mock_raw_sock(query_params={"token": token})
+        websocket = _mock_raw_sock(headers=_auth_headers(token))
         websocket.receive_text = AsyncMock(
             side_effect=[
                 json.dumps({"cmd": "share_window", "window_id": "w1"}),
@@ -12090,7 +12122,7 @@ class TestSSHAgentDispatch:
         app_state = _make_app_state()
 
         token = _auth().create_token(user["id"], user["email"])
-        websocket = _mock_raw_sock(query_params={"token": token})
+        websocket = _mock_raw_sock(headers=_auth_headers(token))
         websocket.receive_text = AsyncMock(
             side_effect=[
                 json.dumps({"cmd": "unshare_window", "window_id": "w1"}),
@@ -12107,7 +12139,7 @@ class TestSSHAgentDispatch:
         app_state = _make_app_state()
 
         token = _auth().create_token(user["id"], user["email"])
-        websocket = _mock_raw_sock(query_params={"token": token})
+        websocket = _mock_raw_sock(headers=_auth_headers(token))
         websocket.receive_text = AsyncMock(
             side_effect=[
                 json.dumps({"cmd": "create_shared_terminal"}),
@@ -12124,7 +12156,7 @@ class TestSSHAgentDispatch:
         app_state = _make_app_state()
 
         token = _auth().create_token(user["id"], user["email"])
-        websocket = _mock_raw_sock(query_params={"token": token})
+        websocket = _mock_raw_sock(headers=_auth_headers(token))
         websocket.receive_text = AsyncMock(
             side_effect=[
                 json.dumps(
@@ -12147,7 +12179,7 @@ class TestSSHAgentDispatch:
         app_state = _make_app_state()
 
         token = _auth().create_token(user["id"], user["email"])
-        websocket = _mock_raw_sock(query_params={"token": token})
+        websocket = _mock_raw_sock(headers=_auth_headers(token))
         websocket.receive_text = AsyncMock(
             side_effect=[
                 json.dumps({"cmd": "delete_shared_terminal"}),
@@ -12166,7 +12198,7 @@ class TestSSHAgentDispatch:
         app_state = _make_app_state()
 
         token = _auth().create_token(user["id"], user["email"])
-        websocket = _mock_raw_sock(query_params={"token": token})
+        websocket = _mock_raw_sock(headers=_auth_headers(token))
         websocket.receive_text = AsyncMock(
             side_effect=[
                 json.dumps({"cmd": "list_shared_terminals"}),
@@ -12419,7 +12451,7 @@ class TestServerScheduleSnapshotOnConnect:
         app_state.state.server_scheduler = scheduler
 
         token = _auth().create_token(user["id"], user["email"])
-        websocket = _mock_raw_sock(query_params={"token": token})
+        websocket = _mock_raw_sock(headers=_auth_headers(token))
         websocket.receive_text = AsyncMock(side_effect=WebSocketDisconnect())
 
         await handle_websocket(websocket, app_state)

--- a/src/klangk/klangkd-tests/tests/test_wshandler.py
+++ b/src/klangk/klangkd-tests/tests/test_wshandler.py
@@ -3090,6 +3090,21 @@ class TestHandleWebsocket:
             await asyncio.wait_for(task, timeout=2)
         websocket.accept.assert_awaited_once_with(subprotocol=None)
 
+    async def test_app_subprotocol_before_pair_parses_last_entry(
+        self, user, app_state, db
+    ):
+        """#3201: a future client negotiating an application subprotocol
+        ahead of the pair (`json, bearer, <jwt>`) still yields the JWT —
+        the scan takes the LAST non-marker entry."""
+        a = app_state.state.auth
+        token = await a.issue_token(user["id"], user["email"])
+        websocket = _mock_raw_sock(
+            headers={"sec-websocket-protocol": f"json, bearer, {token}"}
+        )
+        authed = await ws_authenticate(websocket, app_state)
+        assert authed is not None
+        assert authed[0]["id"] == user["id"]
+
     async def test_bearer_marker_echoed_on_accept(self, user, app_state, db):
         """#3201: the offered 'bearer' marker is echoed so browser
         clients complete the subprotocol negotiation."""

--- a/src/klangk/klangkd-tests/tests/test_wshandler.py
+++ b/src/klangk/klangkd-tests/tests/test_wshandler.py
@@ -12930,10 +12930,12 @@ class TestWsDpopGate:
             user["email"],
             jkt=dpop_mod.jwk_thumbprint(jwk),
         )
-        params = {"token": token}
+        params = {}
         if dpop_param is not None:
             params["dpop"] = dpop_param
-        websocket = _mock_raw_sock(query_params=params)
+        websocket = _mock_raw_sock(
+            headers=_auth_headers(token), query_params=params
+        )
         websocket.url = types.SimpleNamespace(path="/ws")
         return a, private, jwk, token, websocket
 

--- a/src/klangksidecar/klangksidecar/config.py
+++ b/src/klangksidecar/klangksidecar/config.py
@@ -10,9 +10,10 @@ from __future__ import annotations
 import logging
 import os
 
-# The `websockets` client logs the full HTTP request line (incl. any ?token=
-# query param) at DEBUG; cap it at WARNING so a workspace JWT can't leak to
-# sidecar stdout/logs even if debug logging is enabled elsewhere (#2309).
+# The `websockets` client logs the full HTTP request line (which can
+# include query strings) at DEBUG; cap it at WARNING so no credential
+# riding a URL can leak to sidecar stdout/logs even if debug logging is
+# enabled elsewhere (#2309; #3201 tightened the same posture server-side).
 logging.getLogger("websockets").setLevel(logging.WARNING)
 
 


### PR DESCRIPTION
## Summary

Closes #3201. Removes tokens from URLs across the stack, so no session JWT ever rides a URL and every URL-delivered token is one-time, short-lived, and single-purpose:

- **WebSocket auth** (`/ws`, `/ws/consent-decider`): the JWT moves from the `?token=` query string to the handshake's `Sec-WebSocket-Protocol` header (browser WS clients cannot set `Authorization`; the client offers `["bearer", <jwt>]` and the server echoes `bearer`). The query-string path is gone. The egress sidecar loses its `?token=` fallback and authenticates solely via its existing `Authorization` header.
- **OIDC completion**: the callback redirects a **one-time, 60-second login code** (web: `/#/oidc-complete?code=…`; CLI: `?code=…` on the localhost callback) redeemed via the new `POST /api/v1/auth/oidc/exchange`. The CLI exchanges the code server-side inside its callback handler and takes the email from the response (no more client-side JWT decode).
- **Email verification redemption**: `GET /auth/verify?token=` → `POST /auth/verify` with the token in the body, so the credential no longer lands in proxy/server access logs. The emailed link itself stays a fragment URL (`#/verify?token=…`), which browsers never send to servers or in `Referer`.
- **One-time semantics for email links**:
  - Verification tokens now carry the minted-for address, and redemption is an atomic conditional `UPDATE … WHERE verified = 0 AND email = ?` — a replayed link, or one minted before an email change, matches no row.
  - Reset tokens are bound to a digest of the account's current password hash, so the first successful reset consumes every outstanding link (stateless single-use).
  - Invitation tokens were already consumed on acceptance (unchanged).
- **Log hygiene**: the register log line records a SHA-256 prefix of the verification token instead of a masked one; the refresh diagnostic log no longer prints the raw `Referer`.
- **Documentation**: new "Token delivery policy" section in `docs/features/authentication.md` codifying the rules; API reference updated (`/auth/verify`, `/auth/oidc/exchange`, WS auth); changelog entry under Security with the Breaking notes.

Clients updated everywhere: Flutter `WsClient` + consent-decider service (`WebSocketChannel.connect(uri, protocols: ['bearer', token])`), `klangk` CLI transport (`subprotocols=["bearer", token]`, plus a guard stripping a caller-supplied `token` query key), backend/super/CLI e2e helpers, and the Playwright `sudo.spec.ts` WS helper.

## Breaking

- Integrations connecting to `/ws` or `/ws/consent-decider` with `?token=` must switch to the `bearer` subprotocol.
- Clients of the verify endpoint must `POST` the token in the body (the GET form is gone).
- The sidecar must send `Authorization: Bearer` (its shipped path already did).

## Test plan

- [x] Full backend + CLI suite (`-n auto`, coverage): 7608 passed, 100% branch coverage maintained
- [x] `flutter test --coverage`: all passed, 100% coverage gate reached
- [x] `scripts/tests` contract suite green (fuzz-idle client updated)
- [x] New tests: WS header auth + subprotocol echo arms, one-time verify (replay + email-change), one-time reset (replay), login-code mint/redeem/prune (expired, single-use), endpoint-level code redemption (success + replay + unknown), CLI callback exchange arms (success, email from server, 400, network error)
- [ ] E2E suites run in CI (helpers updated; not run locally per repo policy)
