### PR TITLE
fmtk e2e harness: programmatic runner with settings-swap + SIGHUP/restart driver (#3232)

### DIFF
--- a/.github/actions/e2e-suite/action.yml
+++ b/.github/actions/e2e-suite/action.yml
@@ -48,7 +48,7 @@ runs:
         "$retry" devenv shell -- true
 
     - name: Build images
-      if: inputs.run == 'true'
+      if: inputs.run == 'true' && inputs.build-tasks != ''
       shell: bash
       run: |
         . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh 2>/dev/null || true

--- a/.github/workflows/fmtk-e2e-tests.yml
+++ b/.github/workflows/fmtk-e2e-tests.yml
@@ -1,0 +1,85 @@
+name: "E2E: fmtk Frontend Tests"
+
+on:
+  workflow_dispatch:
+    inputs:
+      runner:
+        description: "Runner kind: stock (ubuntu-latest) or the self-hosted nix VM"
+        type: choice
+        options: [stock, nix]
+        default: stock
+  push:
+    branches: [release/**]
+  pull_request:
+    paths:
+      - "src/klangk/**"
+      - "src/frontend/e2e-tests/fmtk/**"
+      - "scripts/fmtk-up.sh"
+      - "scripts/fmtk-down.sh"
+      - "scripts/fmtk-chrome.sh"
+      - "scripts/fmtk-seed.py"
+      - "devenv.nix"
+      - "devenv.yaml"
+      - ".github/workflows/fmtk-e2e-tests.yml"
+      - ".github/actions/e2e-suite/**"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  # fmtk-driven browser e2e (#3232/#3231): boots the fmtk-up scratch stack
+  # (headless Chrome under CI — no DISPLAY) and drives the debug frontend
+  # through the fmtk CLI. No image build needed: the smoke-level suites
+  # compile from source via `flutter run --debug` and do not start
+  # workspace containers (suites that do will pass build-tasks).
+  test-fmtk-e2e:
+    runs-on: ${{ inputs.runner == 'nix' && 'nix' || 'ubuntu-latest' }}
+    timeout-minutes: 60
+    env:
+      # No cross-run reuse on CI: the self-hosted nix VM persists processes
+      # AND state between dispatches, and an adopted backend would be built
+      # from the PREVIOUS commit's code (silent false greens/reds). Stock
+      # runners are ephemeral anyway — fresh costs nothing there.
+      FMTK_E2E_FRESH: "1"
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: dorny/paths-filter@v4
+        id: filter
+        with:
+          filters: |
+            e2e:
+              - 'src/klangk/**'
+              - 'src/frontend/e2e-tests/fmtk/**'
+              - 'scripts/fmtk-up.sh'
+              - 'scripts/fmtk-down.sh'
+              - 'scripts/fmtk-chrome.sh'
+              - 'scripts/fmtk-seed.py'
+              - 'devenv.nix'
+              - 'devenv.yaml'
+              - '.github/workflows/fmtk-e2e-tests.yml'
+              - '.github/actions/e2e-suite/**'
+
+      # Stock runners only (see backend-e2e-tests.yml); skipped when the
+      # paths filter found no e2e-relevant changes.
+      - uses: ./.github/actions/devenv-setup
+        if: inputs.runner != 'nix' && steps.filter.outputs.e2e == 'true'
+
+      - uses: ./.github/actions/e2e-suite
+        with:
+          run: ${{ steps.filter.outputs.e2e }}
+          suite: test-fmtk-e2e
+          suite-name: fmtk
+          build-tasks: ""
+
+      - name: Upload harness logs
+        if: always() && steps.filter.outputs.e2e == 'true'
+        uses: actions/upload-artifact@v7
+        with:
+          name: fmtk-e2e-logs
+          retention-days: 7
+          path: |
+            .devenv/state/fmtk/klangkd.log
+            .devenv/state/fmtk/caddy.log
+            .devenv/state/fmtk/flutter-e2e.log

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -477,6 +477,20 @@ flutter compile time alone. `fmtk-down` stops the kept services
 (`--wipe` also deletes the scratch state; `fmtk-up --fresh` is
 `fmtk-down --wipe` + launch).
 
+The same stack backs an automated pytest suite (#3232):
+
+```bash
+devenv --quiet -O dotenv.enable:bool false shell -- test-fmtk-e2e
+```
+
+It boots the stack programmatically (headless Chrome under CI or
+without DISPLAY), drives the app via the fmtk CLI, and swaps server
+config through SIGHUP or a full restart — the library lives in
+`src/frontend/e2e-tests/fmtk/fmtkharness.py`. Use it when developing
+new fmtk-driven scenarios (CI re-runs it on the same hardware; do not
+run it as a routine pre-push gate). `FMTK_E2E_FRESH=1` wipes the
+scratch state first.
+
 The harness exists because the frontend is same-origin only: `baseUrl`
 derives from the page origin (klangk-plugin-api `backend_url`), so a
 debug app loaded straight from the flutter dev server calls its own

--- a/devenv.nix
+++ b/devenv.nix
@@ -709,6 +709,15 @@ in
   # Idempotent fixture seeding (also run by fmtk-up): sharer/acler/viewer
   # users + the fmtk-verify workspace against a running backend.
   scripts.fmtk-seed.exec = ''exec ${venvPython} "$DEVENV_ROOT/scripts/fmtk-seed.py" "$@"'';
+  # fmtk-driven frontend e2e suite (#3232): boots the fmtk-up scratch stack
+  # programmatically (headless under CI), drives the debug app through the
+  # fmtk CLI, and swaps server config via SIGHUP/restart. The first run in
+  # a cold worktree pays the flutter debug compile; the backend + proxy are
+  # kept across runs (fmtk-down stops them). FMTK_E2E_FRESH=1 wipes first.
+  scripts.test-fmtk-e2e.exec = ''
+    cd $DEVENV_ROOT
+    exec ${venvPython} -m pytest src/frontend/e2e-tests/fmtk -v --no-cov "$@"
+  '';
 
   scripts.serve-docs.exec = ''
     cd $DEVENV_ROOT

--- a/scripts/fmtk-chrome.sh
+++ b/scripts/fmtk-chrome.sh
@@ -31,11 +31,23 @@ if [[ -z $chrome_bin ]]; then
 fi
 
 args=()
+flutter_port="${FMTK_FLUTTER_PORT:-8125}"
+proxy_port="${FMTK_PROXY_PORT:-8124}"
 for arg in "$@"; do
   case "$arg" in
-  http://127.0.0.1:8125* | http://localhost:8125*) arg="http://127.0.0.1:8124/#/" ;;
+  http://127.0.0.1:${flutter_port}* | http://localhost:${flutter_port}*)
+    arg="http://127.0.0.1:${proxy_port}/#/"
+    ;;
   esac
   args+=("$arg")
 done
+
+# Extra flags for unattended runs (fmtk e2e harness, #3232): CI stock
+# runners have no DISPLAY, so the harness points FMTK_CHROME_FLAGS at
+# --headless=new (+ --no-sandbox etc) before launching flutter run.
+if [[ -n ${FMTK_CHROME_FLAGS:-} ]]; then
+  read -ra extra_flags <<<"$FMTK_CHROME_FLAGS"
+  args+=("${extra_flags[@]}")
+fi
 
 exec "$chrome_bin" --no-first-run --no-default-browser-check "${args[@]}"

--- a/scripts/fmtk-down.sh
+++ b/scripts/fmtk-down.sh
@@ -17,12 +17,13 @@ REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 DEVENV_STATE="${DEVENV_STATE:-$REPO_ROOT/.devenv/state}"
 STATE_DIR="${FMTK_STATE:-$DEVENV_STATE/fmtk}"
 FLUTTER_PORT="${FMTK_FLUTTER_PORT:-8125}"
+PROXY_PORT="${FMTK_PROXY_PORT:-8124}"
 
 log() { printf '\033[1m[fmtk-down]\033[0m %s\n' "$*"; }
 
 for pattern in \
   "run --debug -d chrome.*--web-port $FLUTTER_PORT" \
-  "[c]hrome.*127.0.0.1:8124" \
+  "[c]hrome.*127.0.0.1:$PROXY_PORT" \
   "klangk[.]main --config $STATE_DIR/klangkd.yaml" \
   "[c]addy run --config $STATE_DIR/proxy.Caddyfile"; do
   if pkill -TERM -f "$pattern" 2>/dev/null; then
@@ -32,7 +33,7 @@ done
 sleep 2
 for pattern in \
   "run --debug -d chrome.*--web-port $FLUTTER_PORT" \
-  "[c]hrome.*127.0.0.1:8124" \
+  "[c]hrome.*127.0.0.1:$PROXY_PORT" \
   "klangk[.]main --config $STATE_DIR/klangkd.yaml" \
   "[c]addy run --config $STATE_DIR/proxy.Caddyfile"; do
   pkill -KILL -f "$pattern" 2>/dev/null || true

--- a/scripts/fmtk-seed.py
+++ b/scripts/fmtk-seed.py
@@ -90,25 +90,52 @@ def login(base: str, email: str, password: str) -> str:
     return body["access_token"]
 
 
+def create_fixture_user(base: str, token: str, email: str) -> str:
+    """Create one fixture user via the admin API; returns its id."""
+    status, body = api(
+        base,
+        token,
+        "POST",
+        "/api/v1/users",
+        {"email": email, "password": FIXTURE_PASSWORD},
+    )
+    if status != 200:
+        sys.exit(f"create {email} failed ({status}): {body}")
+    print(f"created user {email}")
+    return body["id"]
+
+
+def clear_must_change(base: str, token: str, user_id: str, email: str) -> None:
+    """Clear the admin-created must-change-password flag (#3172)."""
+    status, body = api(
+        base,
+        token,
+        "PATCH",
+        f"/api/v1/users/{user_id}",
+        {"must_change_password": False},
+    )
+    if status != 200:
+        sys.exit(f"clear must-change for {email} failed ({status}): {body}")
+
+
 def ensure_users(base: str, token: str) -> dict[str, str]:
-    """Create missing fixture users; returns email -> user_id."""
-    _, listing = api(base, token, "GET", "/api/v1/users")
+    """Create missing fixture users; returns email -> user_id.
+
+    Admin-created users carry ``must_change_password`` (#3172), which
+    would refuse every API call but the change-password flow — pointless
+    for fixture accounts — so the flag is cleared for every fixture
+    user on every seed run (also fixing users created before this
+    clear-on-create behavior landed).
+    """
+    # page_size covers the fixture set (the bare listing defaults to a
+    # small page — fixtures falling off page 1 would 400 on re-create)
+    _, listing = api(base, token, "GET", "/api/v1/users?page_size=100")
     ids = {u["email"]: u["id"] for u in listing["users"]}
     for name in FIXTURES:
         email = f"{name}@example.com"
-        if email in ids:
-            continue
-        status, body = api(
-            base,
-            token,
-            "POST",
-            "/api/v1/users",
-            {"email": email, "password": FIXTURE_PASSWORD},
-        )
-        if status != 200:
-            sys.exit(f"create {email} failed ({status}): {body}")
-        ids[email] = body["id"]
-        print(f"created user {email}")
+        user_id = ids.get(email) or create_fixture_user(base, token, email)
+        clear_must_change(base, token, user_id, email)
+        ids[email] = user_id
     return ids
 
 

--- a/scripts/tests/test_fmtk_harness.py
+++ b/scripts/tests/test_fmtk_harness.py
@@ -110,12 +110,16 @@ def test_down_stops_the_right_processes():
     down = _DOWN.read_text()
     for pattern in (
         "run --debug -d chrome",
-        "[c]hrome.*127.0.0.1:8124",
+        "[c]hrome.*127.0.0.1:$PROXY_PORT",
         "klangk[.]main --config",
         "[c]addy run --config",
         "--wipe",
     ):
         assert pattern in down, f"fmtk-down must handle: {pattern}"
+    assert 'PROXY_PORT="${FMTK_PROXY_PORT:-8124}"' in down, (
+        "the chrome pattern must follow FMTK_PROXY_PORT (side-by-side "
+        "harnesses on overridden ports, #3232)"
+    )
 
 
 def assert_removed_fixtures_absent(seed: str) -> None:
@@ -149,7 +153,39 @@ def test_seed_matrix_wiring():
     )
 
 
+def test_seed_clears_must_change_password():
+    """Admin-created users carry must_change_password (#3172), which
+    refuses every API call but the change flow — the seed must clear it
+    for every fixture user on every run or fixture logins dead-end."""
+    seed = _SEED.read_text()
+    assert '"must_change_password": False' in seed, (
+        "the seed must PATCH must_change_password off for fixture users"
+    )
+
+
 def test_agents_documents_the_harness():
     agents = _AGENTS.read_text()
     assert "fmtk-up" in agents, "AGENTS.md must point at the fmtk-up harness"
     assert "fmtk-down" in agents, "AGENTS.md must document fmtk-down"
+    assert "test-fmtk-e2e" in agents, (
+        "AGENTS.md must document the automated fmtk e2e runner (#3232)"
+    )
+
+
+def assert_suite_files_present(suite_dir: Path) -> None:
+    """The pytest suite pieces must exist together (#3232)."""
+    for name in ("fmtkharness.py", "conftest.py", "test_smoke.py"):
+        assert (suite_dir / name).is_file(), f"{name} is missing from {suite_dir}"
+
+
+def test_e2e_suite_wiring():
+    """The fmtk-driven e2e suite (#3232): devenv script, library, tests,
+    and CI workflow must all exist together."""
+    nix = _DEVENV_NIX.read_text()
+    assert "scripts.test-fmtk-e2e.exec" in nix, (
+        "devenv.nix must define the test-fmtk-e2e script"
+    )
+    assert_suite_files_present(_REPO_ROOT / "src/frontend/e2e-tests/fmtk")
+    workflow = _REPO_ROOT / ".github/workflows/fmtk-e2e-tests.yml"
+    assert workflow.is_file(), "the fmtk e2e CI workflow is missing"
+    assert "test-fmtk-e2e" in workflow.read_text()

--- a/src/frontend/e2e-tests/fmtk/conftest.py
+++ b/src/frontend/e2e-tests/fmtk/conftest.py
@@ -1,0 +1,46 @@
+"""pytest wiring for the fmtk e2e suites (#3232).
+
+One session-scoped :class:`Harness` boots the scratch stack (backend +
+proxy are adopted/kept across runs, like ``fmtk-up``); tests get an
+``app`` (FmtkClient) bound to the running debug app. After every test the
+app-error drain asserts the toolkit saw zero uncaught Flutter errors —
+a suite-level invariant, so a scenario that "passes" while spewing errors
+is red (#3232 done-when). Attribution caveat: the toolkit's error monitor
+is a rolling, never-cleared window over the current app instance — an
+error surfacing in test B may originate in test A of the same session —
+and ``restart_app`` drains+raises *before* stopping so the outgoing
+instance cannot launder its errors away.
+
+Env knobs: FMTK_E2E_FRESH=1 wipes the scratch state before the session
+(fresh DB); FMTK_E2E_HEADLESS forces Chrome mode (default auto: headless
+under CI or without DISPLAY). Run via the ``test-fmtk-e2e`` devenv script.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from fmtkharness import Harness
+
+
+@pytest.fixture(scope="session")
+def harness() -> Harness:
+    instance = Harness()
+    instance.boot(fresh=os.environ.get("FMTK_E2E_FRESH") == "1")
+    yield instance
+    instance.teardown()
+
+
+@pytest.fixture(scope="session")
+def app(harness: Harness):
+    return harness.client
+
+
+@pytest.fixture(autouse=True)
+def no_app_errors(app):
+    """Every test must leave the app error-free (drained post-test)."""
+    yield
+    errors = app.app_errors()
+    assert not errors, f"uncaught app errors during test: {errors}"

--- a/src/frontend/e2e-tests/fmtk/fmtkharness.py
+++ b/src/frontend/e2e-tests/fmtk/fmtkharness.py
@@ -1,0 +1,764 @@
+"""Programmatic fmtk e2e harness (#3232).
+
+The library behind the fmtk-driven frontend e2e suites: it boots the same
+scratch stack ``fmtk-up`` builds (scratch klangkd + origin-splitting caddy
++ ``flutter run --debug -d chrome``), drives the running app through the
+``fmtk`` CLI, and swaps server configuration live (SIGHUP, #1587) or via a
+full restart — the capability every per-feature suite under this directory
+builds on (parent #3231).
+
+Reuse model, mirroring ``scripts/fmtk-up.sh``: the backend and proxy are
+KEPT across runs (adopted when healthy and provably ours — same config
+path), so re-runs pay only the flutter compile time. ``boot(fresh=True)``
+wipes the scratch state first (fresh DB).
+
+Stdlib + pyyaml (venv) only — it runs under the devenv venv python, like
+``scripts/fmtk-seed.py``.
+
+Env knobs (all optional, defaults match fmtk-up):
+
+  FMTK_BACKEND_PORT (8998), FMTK_EGRESS_PORT (8996),
+  FMTK_PROXY_PORT (8124), FMTK_FLUTTER_PORT (8125),
+  FMTK_STATE (<repo>/.devenv/state/fmtk),
+  FMTK_E2E_HEADLESS ("1" force headless Chrome, "0" force headed;
+                     default auto: headless when no DISPLAY or CI=true)
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import shutil
+import signal
+import subprocess
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+import yaml
+
+FIXTURE_PASSWORD = "fmtk-Pass123!"
+ADMIN_EMAIL = "fmtk-admin@example.com"
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+DEVENV_STATE = Path(os.environ.get("DEVENV_STATE") or REPO_ROOT / ".devenv/state")
+STATE_DIR = Path(os.environ.get("FMTK_STATE") or DEVENV_STATE / "fmtk")
+BACKEND_PORT = os.environ.get("FMTK_BACKEND_PORT", "8998")
+EGRESS_PORT = os.environ.get("FMTK_EGRESS_PORT", "8996")
+PROXY_PORT = os.environ.get("FMTK_PROXY_PORT", "8124")
+FLUTTER_PORT = os.environ.get("FMTK_FLUTTER_PORT", "8125")
+VENV_PYTHON = REPO_ROOT / ".devenv/state/venv/bin/python"
+
+# Default scratch config — the exact file scripts/fmtk-up.sh writes. The
+# harness owns this file once it boots the backend; swap_settings()
+# rewrites it from the in-memory dict.
+DEFAULT_CONFIG = {
+    "port": BACKEND_PORT,
+    "listen": "127.0.0.1",
+    "egress_port": EGRESS_PORT,
+    "idle_timeout_seconds": "300",
+    "auth_modes": "password",
+    "jwt_secret": "fmtk-scratch-secret",
+    "default_user": "admin@example.com",
+    "default_password": "admin123abc",
+    # fmtk drives machine-speed /api bursts from one IP
+    "api_rate_limit": "0",
+    "state_dir": str(STATE_DIR / "klangk"),
+    "data_dir": str(STATE_DIR / "klangk/data"),
+}
+
+# klangkd.yaml key -> /api/v1/config key is identity for every key the
+# harness swaps today (login_banner_title etc.); wait_config_reflects
+# relies on that identity and refuses keys /config does not expose.
+
+VM_URI_TIMEOUT = 600
+HTTP_TIMEOUT = 15
+
+
+class FmtkError(RuntimeError):
+    """A fmtk CLI call returned ok=false (message + details)."""
+
+
+class HarnessTimeout(FmtkError):
+    """A wait_for/boot deadline elapsed."""
+
+
+def http_get_json(url: str) -> dict:
+    with urllib.request.urlopen(url, timeout=HTTP_TIMEOUT) as resp:
+        return json.loads(resp.read().decode())
+
+
+def wait_http(url: str, name: str, timeout: float) -> None:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        try:
+            http_get_json(url)
+            return
+        except (urllib.error.URLError, OSError, ValueError):
+            time.sleep(1)
+    raise HarnessTimeout(f"timed out waiting for {name} at {url}")
+
+
+def pids_matching(pattern: str) -> list[int]:
+    out = subprocess.run(
+        ["pgrep", "-f", pattern], capture_output=True, text=True
+    ).stdout
+    return [int(p) for p in out.split() if p.strip()]
+
+
+def config_yaml_path() -> Path:
+    return STATE_DIR / "klangkd.yaml"
+
+
+def read_config_yaml() -> dict:
+    """Parse the scratch config (yaml.safe_load — the file fmtk-up.sh
+    writes carries inline comments a line-based parse would corrupt)."""
+    return yaml.safe_load(config_yaml_path().read_text()) or {}
+
+
+def write_config_yaml(cfg: dict) -> None:
+    """Write the scratch config back (order-preserving)."""
+    config_yaml_path().write_text(
+        yaml.safe_dump(cfg, sort_keys=False, default_flow_style=False)
+    )
+
+
+class Backend:
+    """Scratch klangkd lifecycle: launch/adopt, config swap, SIGHUP, restart."""
+
+    def __init__(self) -> None:
+        self.config: dict[str, object] = {}
+        self.log_path = STATE_DIR / "klangkd.log"
+
+    @property
+    def url(self) -> str:
+        return f"http://127.0.0.1:{BACKEND_PORT}"
+
+    def pgrep_pattern(self) -> str:
+        return f"klangk.main --config {config_yaml_path()}"
+
+    def pids(self) -> list[int]:
+        return pids_matching(self.pgrep_pattern())
+
+    def is_ours_and_healthy(self) -> bool:
+        if not self.pids():
+            return False
+        try:
+            http_get_json(f"{self.url}/api/v1/config")
+            return True
+        except (urllib.error.URLError, OSError, ValueError):
+            return False
+
+    def ensure(self) -> None:
+        """Adopt a healthy scratch backend or launch a fresh one."""
+        STATE_DIR.mkdir(parents=True, exist_ok=True)
+        if self.is_ours_and_healthy():
+            self.config = read_config_yaml()
+            return
+        if ports_busy([BACKEND_PORT, EGRESS_PORT]):
+            raise FmtkError(
+                f"port {BACKEND_PORT}/{EGRESS_PORT} in use by something else — "
+                "run fmtk-down or override FMTK_*_PORT"
+            )
+        self.config = dict(DEFAULT_CONFIG)
+        if config_yaml_path().exists():
+            self.config = read_config_yaml()
+        self.launch()
+
+    def launch(self) -> None:
+        write_config_yaml(self.config)
+        env = backend_env()
+        log = open(self.log_path, "ab")
+        subprocess.Popen(
+            [
+                str(VENV_PYTHON),
+                "-m",
+                "klangk.main",
+                "--config",
+                str(config_yaml_path()),
+            ],
+            cwd=REPO_ROOT,
+            env=env,
+            stdout=log,
+            stderr=log,
+            start_new_session=True,
+        )
+        wait_http(f"{self.url}/api/v1/config", "scratch klangkd", 240)
+
+    def api_config(self) -> dict:
+        return http_get_json(f"{self.url}/api/v1/config")
+
+    def sighup(self) -> None:
+        """Reload configuration in place (#1587): listener + DB stay up."""
+        pids = self.pids()
+        if not pids:
+            raise FmtkError("scratch klangkd is not running (SIGHUP target gone)")
+        os.kill(pids[0], signal.SIGHUP)
+
+    def wait_healthy(self, timeout: float = 240) -> None:
+        wait_http(f"{self.url}/api/v1/config", "scratch klangkd", timeout)
+
+    def restart(self) -> None:
+        """Stop the scratch klangkd and relaunch it (same state + config)."""
+        pids = self.pids()
+        if pids:
+            os.kill(pids[0], signal.SIGTERM)
+            self.wait_gone(pids[0], 30)
+        self.launch()
+
+    def wait_gone(self, pid: int, timeout: float) -> None:
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            if pid not in self.pids():
+                return
+            time.sleep(0.5)
+        try:
+            os.kill(pid, signal.SIGKILL)
+        except ProcessLookupError:
+            pass  # exited between the poll and the kill
+
+    def swap_settings(
+        self, changes: dict, apply: str = "sighup", timeout: float = 120
+    ) -> dict:
+        """Rewrite config keys and make the server pick them up.
+
+        ``apply``: "sighup" (reloadable settings — in-place reload),
+        "restart" (deploy-time settings — full process restart), or
+        "none" (write only — nothing is applied to the running server,
+        so nothing is awaited; the next boot reads the file). Returns the
+        current /api/v1/config payload.
+        """
+        self.config.update(changes)
+        write_config_yaml(self.config)
+        if apply == "sighup":
+            self.sighup()
+        elif apply == "restart":
+            self.restart()
+        else:
+            return self.api_config()
+        self.wait_healthy()
+        self.wait_config_reflects(changes, timeout)
+        return self.api_config()
+
+    def wait_config_reflects(self, changes: dict, timeout: float) -> None:
+        """Block until /api/v1/config carries the swapped values.
+
+        Every swapped key must appear in the payload — a key the endpoint
+        never exposes (e.g. jwt_secret) cannot be verified, and silently
+        passing on it would be a false "landed" signal, so it raises
+        instead. Note this is a settings-swap barrier, not a guarantee
+        that every subsystem has reconfigured against the new value.
+        """
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            cfg = self.api_config()
+            missing = [key for key in changes if key not in cfg]
+            if missing:
+                raise FmtkError(
+                    f"/api/v1/config does not expose {missing} — the swap "
+                    "cannot be verified; assert it another way"
+                )
+            stale = {
+                key: (cfg[key], value)
+                for key, value in changes.items()
+                if cfg[key] != value
+            }
+            if not stale:
+                return
+            time.sleep(1)
+        raise HarnessTimeout(f"/api/v1/config never reflected {changes}")
+
+
+def backend_env() -> dict:
+    """Hermetic env for the scratch klangkd: ambient KLANGKD_* is
+    scrubbed (env beats the yaml file in settings resolution — a stray
+    variable would silently override the config the harness writes,
+    #1526), and on stock CI runners system podman (SUID newuidmap) is
+    preferred over the nix one on PATH."""
+    env = {k: v for k, v in os.environ.items() if not k.startswith("KLANGKD_")}
+    if Path("/usr/bin/podman").exists():
+        env["KLANGKD_PODMAN_BIN"] = "/usr/bin/podman"
+    return env
+
+
+def ports_busy(ports: list[str]) -> bool:
+    out = subprocess.run(["ss", "-tln"], capture_output=True, text=True).stdout
+    return any(f":{port} " in line for port in ports for line in out.splitlines())
+
+
+class Proxy:
+    """The origin-splitting caddy fmtk-up fronts the debug run with."""
+
+    def __init__(self, backend: Backend) -> None:
+        self.backend = backend
+        self.config_path = STATE_DIR / "proxy.Caddyfile"
+
+    @property
+    def pattern(self) -> str:
+        return f"caddy run --config {self.config_path}"
+
+    def is_ours_and_healthy(self) -> bool:
+        if not pids_matching(self.pattern):
+            return False
+        try:
+            http_get_json(f"http://127.0.0.1:{PROXY_PORT}/api/v1/config")
+            return True
+        except (urllib.error.URLError, OSError, ValueError):
+            return False
+
+    def ensure(self) -> None:
+        if self.is_ours_and_healthy():
+            return
+        if ports_busy([PROXY_PORT]):
+            raise FmtkError(f"port {PROXY_PORT} in use — run fmtk-down")
+        self.config_path.write_text(
+            f"http://:{PROXY_PORT} {{\n"
+            "\tbind 127.0.0.1\n"
+            "\thandle /api/* {\n"
+            f"\t\treverse_proxy 127.0.0.1:{BACKEND_PORT}\n"
+            "\t}\n"
+            "\thandle /ws {\n"
+            f"\t\treverse_proxy 127.0.0.1:{BACKEND_PORT}\n"
+            "\t}\n"
+            "\thandle {\n"
+            f"\t\treverse_proxy 127.0.0.1:{FLUTTER_PORT}\n"
+            "\t}\n"
+            "}\n"
+        )
+        log = open(STATE_DIR / "caddy.log", "ab")
+        subprocess.Popen(
+            [
+                "caddy",
+                "run",
+                "--config",
+                str(self.config_path),
+                "--adapter",
+                "caddyfile",
+            ],
+            cwd=REPO_ROOT,
+            stdout=log,
+            stderr=log,
+            start_new_session=True,
+        )
+        wait_http(f"http://127.0.0.1:{PROXY_PORT}/api/v1/config", "caddy proxy", 30)
+
+
+def seed(url: str) -> None:
+    """Idempotently apply the fmtk fixture (users + fmtk-verify workspace)."""
+    subprocess.run(
+        [str(VENV_PYTHON), str(REPO_ROOT / "scripts/fmtk-seed.py"), "--url", url],
+        cwd=REPO_ROOT,
+        check=True,
+    )
+
+
+def headless_requested() -> bool:
+    forced = os.environ.get("FMTK_E2E_HEADLESS", "").lower()
+    if forced in ("1", "true", "yes"):
+        return True
+    if forced in ("0", "false", "no"):
+        return False
+    return bool(os.environ.get("CI")) or not os.environ.get("DISPLAY")
+
+
+class FlutterRun:
+    """``flutter run --debug -d chrome`` + VM-service/CDP discovery."""
+
+    def __init__(self) -> None:
+        self.proc: subprocess.Popen | None = None
+        self.log_path = STATE_DIR / "flutter-e2e.log"
+        self.vm_uri = ""
+        self.log_offset = 0
+
+    def chrome_env(self) -> dict:
+        env = dict(os.environ)
+        env["CHROME_EXECUTABLE"] = str(REPO_ROOT / "scripts/fmtk-chrome.sh")
+        if headless_requested():
+            env["FMTK_CHROME_FLAGS"] = (
+                "--headless=new --no-sandbox --disable-gpu "
+                "--disable-dev-shm-usage --window-size=1600,1000"
+            )
+        return env
+
+    def flutter_args(self) -> list[str]:
+        args = [
+            "run",
+            "--debug",
+            "-d",
+            "chrome",
+            "--web-hostname",
+            "127.0.0.1",
+            "--web-port",
+            FLUTTER_PORT,
+        ]
+        pkg_config = REPO_ROOT / "src/frontend/.dart_tool/package_config.json"
+        lock = REPO_ROOT / "src/frontend/pubspec.lock"
+        if pkg_config.exists() and not newer(pkg_config, lock):
+            args.append("--no-pub")
+        return args
+
+    def launch(self) -> None:
+        self.vm_uri = ""
+        # Append (restart_app must not truncate earlier phases out of the CI
+        # artifact), and remember where this launch's output starts —
+        # scanning the whole file would match the PREVIOUS run's VM URI.
+        self.log_offset = self.log_path.stat().st_size if self.log_path.exists() else 0
+        log = open(self.log_path, "ab")
+        self.proc = subprocess.Popen(
+            ["flutter", *self.flutter_args()],
+            cwd=REPO_ROOT / "src/frontend",
+            env=self.chrome_env(),
+            stdout=log,
+            stderr=log,
+            start_new_session=True,
+        )
+        try:
+            self.wait_vm_uri()
+        except FmtkError:
+            self.stop()  # a failed boot must not leak the flutter process
+            raise
+
+    def wait_vm_uri(self) -> None:
+        deadline = time.monotonic() + VM_URI_TIMEOUT
+        while time.monotonic() < deadline:
+            if self.proc and self.proc.poll() is not None:
+                raise FmtkError(
+                    f"flutter run exited before exposing a VM service — "
+                    f"tail of {self.log_path}:\n{self.tail()}"
+                )
+            if self.log_path.exists():
+                fresh = self.log_path.read_text(errors="replace")[self.log_offset :]
+                match = re.search(r"ws://\S+/ws", fresh)
+                if match:
+                    self.vm_uri = match.group(0)
+                    return
+            time.sleep(2)
+        raise HarnessTimeout(
+            f"no Dart VM Service in {self.log_path} after {VM_URI_TIMEOUT}s"
+        )
+
+    def tail(self, lines: int = 30) -> str:
+        if not self.log_path.exists():
+            return "(no log)"
+        return "\n".join(
+            self.log_path.read_text(errors="replace").splitlines()[-lines:]
+        )
+
+    def cdp_port(self) -> str:
+        out = subprocess.run(
+            ["pgrep", "-af", "chrome"], capture_output=True, text=True
+        ).stdout
+        for line in out.splitlines():
+            if "remote-debugging-port=" in line:
+                return line.split("remote-debugging-port=")[1].split()[0]
+        return ""
+
+    def stop(self) -> None:
+        if self.proc and self.proc.poll() is None:
+            os.killpg(self.proc.pid, signal.SIGTERM)
+            try:
+                self.proc.wait(timeout=15)
+            except subprocess.TimeoutExpired:
+                os.killpg(self.proc.pid, signal.SIGKILL)
+
+
+def newer(a: Path, b: Path) -> bool:
+    return a.stat().st_mtime > b.stat().st_mtime
+
+
+class FmtkClient:
+    """Thin Python wrapper over ``fmtk exec`` against one running app.
+
+    Holds the live :class:`FlutterRun` (not a snapshot URI) so it keeps
+    working across ``Harness.restart_app()`` relaunches.
+    """
+
+    def __init__(self, flutter: "FlutterRun") -> None:
+        self.flutter = flutter
+
+    @property
+    def vm_uri(self) -> str:
+        uri = self.flutter.vm_uri
+        if not uri:
+            raise FmtkError("flutter run not launched")
+        return uri
+
+    def exec(self, name: str, args: dict | None = None) -> object:
+        proc = subprocess.run(
+            [
+                "fmtk",
+                "exec",
+                "--name",
+                name,
+                "--vm-service-uri",
+                self.vm_uri,
+                "--args",
+                json.dumps(args or {}),
+            ],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+        envelope = self.parse_envelope(proc.stdout, name, proc.stderr)
+        if not envelope.get("ok"):
+            err = envelope.get("error") or {}
+            raise FmtkError(
+                f"fmtk {name} failed: {err.get('message')} ({err.get('details')})"
+            )
+        return envelope.get("data")
+
+    def parse_envelope(self, stdout: str, name: str, stderr: str) -> dict:
+        try:
+            return json.loads(stdout)
+        except ValueError:
+            raise FmtkError(
+                f"fmtk {name} printed no JSON envelope (stderr: {stderr[-500:]}; "
+                f"stdout: {stdout[-500:]})"
+            ) from None
+
+    # --- snapshot / interaction helpers ---------------------------------
+
+    def snapshot(self) -> object:
+        return self.exec("semantic_snapshot")
+
+    def wait_for_text(self, text: str, timeout_ms: int = 30000) -> object:
+        """Block until ``text`` appears anywhere in the semantic tree.
+
+        fmtk caps one wait_for at 30s (schema max), and the first debug
+        frame after dwds attach can take longer — so this loops 25s
+        slices until the outer deadline elapses.
+        """
+        deadline = time.monotonic() + max(timeout_ms, 1000) / 1000
+        while True:
+            remaining_ms = int((deadline - time.monotonic()) * 1000)
+            slice_ms = min(25000, max(remaining_ms, 1000))
+            try:
+                return self.exec(
+                    "wait_for",
+                    {
+                        "predicate": {"kind": "text", "text": text},
+                        "timeoutMs": slice_ms,
+                    },
+                )
+            except FmtkError:
+                if time.monotonic() >= deadline:
+                    raise
+
+    def has_text(self, text: str, timeout_ms: int = 2000) -> bool:
+        try:
+            self.wait_for_text(text, timeout_ms)
+            return True
+        except FmtkError:
+            return False
+
+    def tap(self, ref: str) -> None:
+        self.exec("tap_widget", {"ref": ref})
+
+    def enter_text(self, ref: str, text: str) -> None:
+        self.exec("enter_text", {"ref": ref, "text": text})
+
+    def tap_label(self, label: str, node_kind: str = "button") -> None:
+        """Tap the first ``node_kind`` (button by default) whose labels
+        contain ``label`` — the button filter matters because a page's
+        heading text often duplicates the button label ("Log In")."""
+        self.tap(self.ref_for_label(label, node_kind))
+
+    def ref_for_label(self, label: str, node_kind: str | None = None) -> str:
+        def matches(node: dict) -> bool:
+            if label not in node_labels(node):
+                return False
+            return node_kind is None or node_type(node) == node_kind
+
+        nodes = find_nodes(self.snapshot(), matches)
+        if not nodes:
+            raise FmtkError(f"no snapshot node labeled {label!r}")
+        return nodes[0]["ref"]
+
+    def login(self, email: str, password: str, expect_text: str) -> None:
+        """Fill the login form and submit; wait for ``expect_text``.
+
+        A configured login banner renders as a consent dialog (Cancel /
+        I Accept) over the form — dismiss it first when present.
+        """
+        if self.has_text(expect_text, 2000):
+            return  # already logged in (persisted token after hot restart)
+        self.dismiss_login_banner()
+        fields = find_nodes(self.snapshot(), lambda n: node_type(n) == "textField")
+        if len(fields) < 2:
+            raise FmtkError(f"login form not visible (fields found: {len(fields)})")
+        self.enter_text(fields[0]["ref"], email)
+        self.enter_text(fields[1]["ref"], password)
+        self.tap_label("Log In")
+        self.wait_for_text(expect_text)
+
+    def dismiss_login_banner(self) -> None:
+        if self.has_text("I Accept", 3000):
+            self.tap_label("I Accept")
+
+    def wait_for_login_page(self, timeout_ms: int = 90000) -> None:
+        """The login surface: the form, or the banner dialog covering it."""
+        deadline = time.monotonic() + timeout_ms / 1000
+        while time.monotonic() < deadline:
+            if self.has_text("Log In", 2000) or self.has_text(
+                "Sign in to continue", 2000
+            ):
+                return
+            time.sleep(1)
+        raise HarnessTimeout("login page never appeared")
+
+    def app_errors(self) -> list:
+        data = self.exec("get_app_errors", {"count": 20})
+        errors = data.get("errors", data) if isinstance(data, dict) else data
+        return errors or []
+
+    def hot_restart(self) -> None:
+        """dwds hot restart. Fails with a chrome-devtools error against
+        the proxied debug origin in this setup — prefer
+        ``Harness.restart_app()`` (fresh boot, deterministic)."""
+        self.exec("hot_restart_flutter")
+
+    # --- terminal (canvas: driven via evaluate, per AGENTS.md) -----------
+
+    TERMINAL_LIBRARY = "package:klangk_frontend/terminal/ghostty_terminal.dart"
+
+    WALK_TEMPLATE = """
+() {{
+  GhosttyTerminalState? st;
+  void walk(Element el) {{
+    if (st != null) return;
+    if (el is StatefulElement && el.state is GhosttyTerminalState) {{
+      st = el.state as GhosttyTerminalState;
+      return;
+    }}
+    el.visitChildElements((c) => walk(c));
+  }}
+  walk(WidgetsBinding.instance.rootElement!);
+  if (st == null) return 'NO-TERMINAL-STATE';
+  {body}
+}}()
+"""
+
+    def terminal_eval(self, body: str) -> str:
+        result = self.exec(
+            "evaluate_dart_expression",
+            {
+                "expression": self.WALK_TEMPLATE.format(body=body),
+                "libraryUri": self.TERMINAL_LIBRARY,
+            },
+        )
+        return str(result)
+
+    def terminal_send(self, text: str) -> str:
+        """Type AND execute raw input in the focused terminal."""
+        escaped = (
+            text.replace("\\", "\\\\")
+            .replace("$", "\\$")  # $ interpolates in the Dart literal
+            .replace("'", "\\'")
+            .replace("\n", "\\n")
+        )
+        return self.terminal_eval(f"st!._terminal.sendText('{escaped}')")
+
+    def terminal_buffer(self) -> str:
+        """The visible terminal buffer (plain, unwrapped, trimmed)."""
+        return self.terminal_eval(
+            "var f = st!._terminal.createFormatter("
+            "format: FormatterFormat.plain, unwrap: true, trim: true); "
+            "try { return f.format(); } finally { f.dispose(); }"
+        )
+
+
+def node_labels(node: dict) -> list[str]:
+    """Every human-string field a snapshot node may carry."""
+    keys = ("label", "text", "value", "name", "title", "tooltip", "hint")
+    return [str(node[k]) for k in keys if node.get(k)]
+
+
+def node_type(node: dict) -> str:
+    return str(node.get("type") or node.get("role") or "")
+
+
+def find_nodes(tree, predicate) -> list[dict]:
+    """Depth-first collect of snapshot nodes matching ``predicate``."""
+    found: list[dict] = []
+    walk_nodes(tree, predicate, found)
+    return found
+
+
+def walk_nodes(node, predicate, found: list) -> None:
+    if isinstance(node, dict):
+        if "ref" in node and predicate(node):
+            found.append(node)
+        for child in node.values():
+            walk_nodes(child, predicate, found)
+    elif isinstance(node, list):
+        for child in node:
+            walk_nodes(child, predicate, found)
+
+
+class Harness:
+    """One running fmtk stack: backend + proxy + flutter + client."""
+
+    def __init__(self) -> None:
+        self.backend = Backend()
+        self.proxy = Proxy(self.backend)
+        self.flutter = FlutterRun()
+
+    @property
+    def client(self) -> FmtkClient:
+        if not self.flutter.vm_uri:
+            raise FmtkError("flutter run not launched (call boot() first)")
+        return FmtkClient(self.flutter)
+
+    def restart_app(self) -> None:
+        """Stop and relaunch the debug app (fresh main() -> config
+        re-fetch). The deterministic substitute for dwds hot restart,
+        which fails against the proxied debug origin (chrome devtools
+        error); the incremental debug rebuild keeps it to ~15-30s.
+
+        The app-error monitor is a rolling window that a restart would
+        silently clear — drain it first so errors from the outgoing app
+        instance fail the test instead of being laundered away."""
+        errors = self.client.app_errors()
+        if errors:
+            raise FmtkError(f"app errors before restart_app: {errors}")
+        self.flutter.stop()
+        self.flutter.launch()
+
+    def boot(self, fresh: bool = False) -> None:
+        if fresh:
+            self.wipe()
+        self.backend.ensure()
+        self.proxy.ensure()
+        seed(self.backend.url)
+        self.flutter.launch()
+
+    def wipe(self) -> None:
+        """Stop OUR stack — backend + proxy by config-path-scoped patterns,
+        the flutter run and its Chrome by port-scoped patterns using OUR
+        port overrides — then delete the scratch state. Like ``fmtk-down
+        --wipe`` but safe next to a sibling harness on other ports."""
+        self.flutter.stop()
+        patterns = [
+            self.backend.pgrep_pattern(),
+            self.proxy.pattern,
+            f"run --debug -d chrome.*--web-port {FLUTTER_PORT}",
+            f"[c]hrome.*127.0.0.1:{PROXY_PORT}",
+        ]
+        for pattern in patterns:
+            for pid in pids_matching(pattern):
+                os.kill(pid, signal.SIGTERM)
+        time.sleep(2)
+        for pattern in patterns:
+            for pid in pids_matching(pattern):
+                try:
+                    os.kill(pid, signal.SIGKILL)
+                except ProcessLookupError:
+                    pass
+        shutil.rmtree(STATE_DIR, ignore_errors=True)
+
+    def teardown(self) -> None:
+        """Stop the flutter run; keep backend + proxy for fast re-runs."""
+        self.flutter.stop()

--- a/src/frontend/e2e-tests/fmtk/test_smoke.py
+++ b/src/frontend/e2e-tests/fmtk/test_smoke.py
@@ -1,0 +1,52 @@
+"""Smoke scenario for the fmtk e2e harness (#3232 "done when").
+
+One ordered scenario — the phases share app/server state, so they live in
+a single test:
+
+1. the debug app boots to the login surface (backend + proxy + seed +
+   flutter run all came up through ``Harness.boot``);
+2. a mid-run settings swap lands via SIGHUP (#1587) — a run-unique login
+   banner title changes on the live server, and a fresh app boot renders
+   it in the UI as the banner consent dialog (run-unique so a re-run
+   against the kept backend stays valid);
+3. dismissing the banner and logging in as the fixture owner lands on
+   /workspaces with fmtk-verify under "Owned by Me";
+4. a full server restart (config rewrite + TERM + relaunch) keeps the DB —
+   after re-login the workspace is still there;
+5. zero uncaught app errors across the whole scenario (conftest drain).
+"""
+
+from __future__ import annotations
+
+import uuid
+
+from fmtkharness import ADMIN_EMAIL, FIXTURE_PASSWORD
+
+BANNER_TITLE = f"fmtk e2e swap {uuid.uuid4().hex[:8]}"
+BANNER_BODY = "swapped live over SIGHUP"
+
+
+def test_harness_smoke(harness, app):
+    # --- phase 1: app booted to the login surface -----------------------
+    app.wait_for_login_page()
+
+    # --- phase 2: settings swap + SIGHUP lands in the UI ----------------
+    harness.backend.swap_settings(
+        {"login_banner_title": BANNER_TITLE, "login_banner": BANNER_BODY},
+        apply="sighup",
+    )
+    harness.restart_app()  # fresh main() re-fetches config -> banner renders
+    app.wait_for_login_page()
+    app.wait_for_text(BANNER_TITLE)
+    app.wait_for_text(BANNER_BODY)
+
+    # --- phase 3: login as the fixture owner -> Owned by Me -------------
+    app.login(ADMIN_EMAIL, FIXTURE_PASSWORD, expect_text="fmtk-verify")
+    app.wait_for_text("Owned by Me")
+
+    # --- phase 4: full server restart keeps state -----------------------
+    harness.backend.restart()
+    harness.restart_app()
+    app.wait_for_login_page()
+    app.login(ADMIN_EMAIL, FIXTURE_PASSWORD, expect_text="fmtk-verify")
+    app.wait_for_text("Owned by Me")


### PR DESCRIPTION
Implements #3232 (first subissue of the #3231 fmtk-e2e tracking tree): the programmatic harness every per-feature fmtk suite builds on.

## What's here

- **`src/frontend/e2e-tests/fmtk/fmtkharness.py`** — the library:
  - *Stack boot*: adopt-or-launch the scratch klangkd + origin-splitting caddy (same kept-services reuse model as `fmtk-up`), seed via `fmtk-seed.py`, and run `flutter run --debug -d chrome` with VM-service discovery. Chrome goes headless under CI / no-DISPLAY (`FMTK_CHROME_FLAGS` through the `fmtk-chrome.sh` wrapper).
  - *Config-swap driver*: rewrites the scratch `klangkd.yaml` and applies changes via **SIGHUP** (#1587, in-place reload) or a **full restart**, blocking until `/api/v1/config` reflects the new values — the piece each feature subissue needs for its settings matrices.
  - *FmtkClient*: snapshot/`wait_for` (outer-deadline loop over fmtk's 30s cap), type-aware label→ref lookup, login (dismisses the login-banner consent dialog, fills the form, waits for the landing surface), app-error drain, and terminal `sendText`/buffer helpers via `evaluate_dart_expression` on `GhosttyTerminalState` (per AGENTS.md).
  - *App restart*: `Harness.restart_app()` — dwds hot restart fails with a chrome-devtools error against the proxied debug origin, so a stop+relaunch (fresh `main()` → config re-fetch, incremental rebuild) is the deterministic substitute.
- **`test_smoke.py`** — the #3232 done-when: boot → run-unique login banner swapped over SIGHUP and rendered after a fresh app boot → fixture-owner login lands on `/workspaces` with `fmtk-verify` under "Owned by Me" → full server restart keeps state (re-login works) → zero uncaught app errors (autouse conftest drain).
- **Runner + CI**: `devenv shell -- test-fmtk-e2e` and `.github/workflows/fmtk-e2e-tests.yml` (stock-runner default, nix opt-in via workflow_dispatch, paths-filtered PRs, log artifacts). The shared e2e-suite action now skips its build step when `build-tasks` is empty (no image build needed — the smoke suite compiles from source and starts no containers).
- **Side-by-side harnesses**: `fmtk-chrome.sh` / `fmtk-down.sh` honor `FMTK_PROXY_PORT`/`FMTK_FLUTTER_PORT`, and the harness's `--fresh` wipe is config-path-scoped, so two worktrees' harnesses don't fight over the default ports.
- **Seed fix surfaced by this work**: admin-created users carry `must_change_password` (#3172), which dead-ended every fixture login — `fmtk-seed.py` now clears it for all fixture users on every run.
- AGENTS.md documents the runner; `scripts/tests/test_fmtk_harness.py` pins the new wiring.

## Test evidence

- `test-fmtk-e2e` green twice locally: headed and forced-headless (`FMTK_E2E_HEADLESS=1`), the second run against the kept backend+proxy (idempotent re-run, run-unique banner keeps assertions valid).
- `python -m pytest scripts/tests` — 120 passed (incl. updated contract tests).
- `pre-commit run xenon --all-files`, ruff check/format — clean.
- `test-push` selected areas green.

Closes #3232.
