### PR TITLE
fmtk e2e: auth and session flows (#3233)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -509,6 +509,10 @@ The fixture (seeded by `fmtk-up`, or standalone via
 - `fmtk-coder@example.com` — coders bucket member.
 - `fmtk-spectator@example.com` — spectators bucket member; NO Sharing
   tab.
+- `fmtk-mustchange@example.com` — keeps the admin-set must-change flag;
+  the auth e2e suite re-arms its password per run via the admin API
+  (#3233).
+- `fmtk-reset@example.com` — forgot/reset-password flow target (#3233).
 
 Each fixture opens the workspace page: fmtk-admin via its owner wildcard,
 the role members because every role group carries `join-workspace` — the

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -3702,3 +3702,16 @@ users(id)`, so the decider handler passing the decider's email violated the
   back to denying all RFC1918 peers — a host container run with a
   published port (`docker run -p 8997:8997`) refused every browser/API
   request with 403. Found by the new super-E2E suite.
+
+- **Step-up (sudo mode) works again on the web client, and its retry no
+  longer crashes (#3233).** The step-up password POST now carries the
+  DPoP proof like every other authed call, so an elevated action
+  (e.g. sending an admin invitation) no longer fails with 401 on every
+  attempt. Retrying after a wrong password also no longer throws "controller
+  used after being disposed" — the dialog now owns its text controller for
+  its full lifetime. Both found by the new fmtk e2e auth suite.
+
+- **Icon-only buttons name themselves for screen readers (#3233).** The
+  app-bar Admin and Logout icons, the admin page's tab strip, and the
+  workspace-list FABs now expose semantic labels, so assistive tech
+  announces them by name instead of "button".

--- a/scripts/fmtk-chrome.sh
+++ b/scripts/fmtk-chrome.sh
@@ -36,7 +36,12 @@ proxy_port="${FMTK_PROXY_PORT:-8124}"
 for arg in "$@"; do
   case "$arg" in
   http://127.0.0.1:${flutter_port}* | http://localhost:${flutter_port}*)
-    arg="http://127.0.0.1:${proxy_port}/#/"
+    # Keep whatever path/query/hash the URL carried: the fmtk e2e
+    # harness boots the app AT a deep link via --web-launch-url
+    # (#3233), and dropping the suffix would land every boot on /.
+    rest="${arg#http://127.0.0.1:"${flutter_port}"}"
+    rest="${rest#/}"
+    arg="http://127.0.0.1:${proxy_port}/${rest}"
     ;;
   esac
   args+=("$arg")

--- a/scripts/fmtk-seed.py
+++ b/scripts/fmtk-seed.py
@@ -17,6 +17,10 @@ the ``fmtk-verify`` workspace's Sharing panel:
   fmtk-coder         coders role group          Coders bucket
   fmtk-spectator     spectators role group      Spectators bucket; no
                                                 Sharing tab
+  fmtk-mustchange    (none; keeps the admin    forced password-change
+                     must-change flag set)     flow (#3233, #3172)
+  fmtk-reset         (none)                    forgot/reset password
+                                                flow (#3233)
   ================== ==========================  =========================
 
 The workspace is created with fmtk-admin's own token, so fmtk-admin holds
@@ -44,6 +48,11 @@ FIXTURES = (
     "fmtk-collaborator",
     "fmtk-coder",
     "fmtk-spectator",
+    # auth-suite fixtures (#3233): must-change keeps the admin-set flag
+    # (forced-change flow arms its password per run via the admin API);
+    # reset exercises the forgot/reset-password flow.
+    "fmtk-mustchange",
+    "fmtk-reset",
 )
 # fixture user suffix -> workspace role group (bucket membership)
 ROLE_MEMBERSHIPS = {
@@ -51,6 +60,9 @@ ROLE_MEMBERSHIPS = {
     "fmtk-coder": "coders",
     "fmtk-spectator": "spectators",
 }
+# fixtures whose admin-created must-change flag stays SET (the forced-
+# change flow needs a user that logs in straight into /change-password)
+KEEP_MUST_CHANGE = {"fmtk-mustchange"}
 
 
 def api(base: str, token: str, method: str, path: str, body=None):
@@ -134,7 +146,8 @@ def ensure_users(base: str, token: str) -> dict[str, str]:
     for name in FIXTURES:
         email = f"{name}@example.com"
         user_id = ids.get(email) or create_fixture_user(base, token, email)
-        clear_must_change(base, token, user_id, email)
+        if name not in KEEP_MUST_CHANGE:
+            clear_must_change(base, token, user_id, email)
         ids[email] = user_id
     return ids
 
@@ -234,7 +247,10 @@ def main() -> None:
         "  fmtk-collaborator@example.com   -> collaborators bucket\n"
         "  fmtk-coder@example.com          -> coders bucket\n"
         "  fmtk-spectator@example.com      -> spectators bucket, no Sharing"
-        " tab"
+        " tab\n"
+        "  fmtk-mustchange@example.com     -> login lands on forced"
+        " password change\n"
+        "  fmtk-reset@example.com          -> forgot/reset password flow"
     )
 
 

--- a/scripts/tests/test_fmtk_harness.py
+++ b/scripts/tests/test_fmtk_harness.py
@@ -156,10 +156,47 @@ def test_seed_matrix_wiring():
 def test_seed_clears_must_change_password():
     """Admin-created users carry must_change_password (#3172), which
     refuses every API call but the change flow — the seed must clear it
-    for every fixture user on every run or fixture logins dead-end."""
+    for every fixture user on every run or fixture logins dead-end —
+    EXCEPT fmtk-mustchange, the forced-change fixture (#3233), whose
+    flag is the point."""
     seed = _SEED.read_text()
     assert '"must_change_password": False' in seed, (
         "the seed must PATCH must_change_password off for fixture users"
+    )
+    assert 'KEEP_MUST_CHANGE = {"fmtk-mustchange"}' in seed, (
+        "the forced-change fixture must keep its admin-set flag (#3233)"
+    )
+    for fixture in ("fmtk-mustchange", "fmtk-reset"):
+        assert f'"{fixture}"' in seed, f"{fixture} must be seeded (#3233)"
+
+
+def assert_wired(source: str, needles: tuple[str, ...], why: str) -> None:
+    """Every ``needle`` must appear in ``source`` (drop-in wiring pins)."""
+    for needle in needles:
+        assert needle in source, f"{why}: {needle!r} missing"
+
+
+def test_harness_auth_suite_extensions():
+    """The auth-suite harness pieces (#3233) — SMTP sink for email-token
+    flows, hash-route navigation, auth-service evaluation, admin API —
+    must stay wired into the harness."""
+    harness = (_REPO_ROOT / "src/frontend/e2e-tests/fmtk/fmtkharness.py").read_text()
+    assert_wired(
+        harness,
+        (
+            "class SmtpSink",
+            '"smtp_host"',
+            "def navigate",
+            "def auth_eval",
+            "def logout",
+            "def force_password_change",
+        ),
+        "the auth-suite harness pieces (#3233) must stay wired in",
+    )
+    suite = _REPO_ROOT / "src/frontend/e2e-tests/fmtk/test_auth.py"
+    assert suite.is_file(), "the auth suite (#3233) is missing"
+    assert "token_for(" in suite.read_text(), (
+        "the auth suite must drive email-token flows via the sink"
     )
 
 

--- a/src/frontend/e2e-tests/fmtk/fmtkharness.py
+++ b/src/frontend/e2e-tests/fmtk/fmtkharness.py
@@ -26,12 +26,15 @@ Env knobs (all optional, defaults match fmtk-up):
 
 from __future__ import annotations
 
+import asyncio
 import json
 import os
+import quopri
 import re
 import shutil
 import signal
 import subprocess
+import threading
 import time
 import urllib.error
 import urllib.request
@@ -65,6 +68,15 @@ DEFAULT_CONFIG = {
     "default_password": "admin123abc",
     # fmtk drives machine-speed /api bursts from one IP
     "api_rate_limit": "0",
+    # ...and deliberate wrong-password scenarios (login failure modes,
+    # step-up retries) every run: the default 5-failure lockout would
+    # brick admin logins against a kept backend after a few runs
+    "login_lockout_failures": "0",
+    # Outbound email (verification / reset / invite tokens) goes to the
+    # harness's in-process SMTP sink; the port is written at boot.
+    "smtp_host": "127.0.0.1",
+    "smtp_use_tls": "false",
+    "smtp_from": "fmtk@example.com",
     "state_dir": str(STATE_DIR / "klangk"),
     "data_dir": str(STATE_DIR / "klangk/data"),
 }
@@ -88,6 +100,44 @@ class HarnessTimeout(FmtkError):
 def http_get_json(url: str) -> dict:
     with urllib.request.urlopen(url, timeout=HTTP_TIMEOUT) as resp:
         return json.loads(resp.read().decode())
+
+
+def http_api(base: str, token: str, method: str, path: str, body=None):
+    """One JSON API call; returns (status, parsed-json-or-text)."""
+    data = None if body is None else json.dumps(body).encode()
+    req = urllib.request.Request(
+        base + path,
+        data=data,
+        method=method,
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Content-Type": "application/json",
+        },
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=HTTP_TIMEOUT) as resp:
+            raw = resp.read().decode()
+            return resp.status, json.loads(raw) if raw else None
+    except urllib.error.HTTPError as exc:
+        raw = exc.read().decode()
+        try:
+            return exc.code, json.loads(raw)
+        except ValueError:
+            return exc.code, raw
+
+
+def http_login(base: str, email: str, password: str) -> str:
+    """POST /auth/login; returns the access token (raises on failure)."""
+    status, body = http_api(
+        base,
+        "",
+        "POST",
+        "/api/v1/auth/login",
+        {"identifier": email, "password": password},
+    )
+    if status != 200:
+        raise FmtkError(f"http login as {email} failed ({status}): {body}")
+    return body["access_token"]
 
 
 def wait_http(url: str, name: str, timeout: float) -> None:
@@ -123,6 +173,110 @@ def write_config_yaml(cfg: dict) -> None:
     config_yaml_path().write_text(
         yaml.safe_dump(cfg, sort_keys=False, default_flow_style=False)
     )
+
+
+class SmtpSink:
+    """Minimal in-process SMTP capture server (stdio asyncio; no deps).
+
+    klangkd's emailsvc (aiosmtplib) needs a real SMTP peer to hand the
+    verification / reset / invitation tokens to. The sink accepts any
+    dialogue shape aiosmtplib sends, stores every DATA payload, and the
+    tests fish ``#/route?token=...`` URLs back out — email-token flows
+    without an SMTP dependency.
+    """
+
+    def __init__(self) -> None:
+        self.messages: list[str] = []
+        self._server: asyncio.Server | None = None
+        self._thread: threading.Thread | None = None
+        self._loop: asyncio.AbstractEventLoop | None = None
+
+    def start(self) -> int:
+        """Serve on an ephemeral localhost port (daemon thread); the port."""
+        started = threading.Event()
+        self._loop = asyncio.new_event_loop()
+        self._thread = threading.Thread(
+            target=self._serve, args=(started,), daemon=True
+        )
+        self._thread.start()
+        if not started.wait(10):
+            raise FmtkError("SMTP sink did not start within 10s")
+        assert self._server is not None
+        return self._server.sockets[0].getsockname()[1]
+
+    def _serve(self, started: threading.Event) -> None:
+        assert self._loop is not None
+        asyncio.set_event_loop(self._loop)
+
+        async def run() -> None:
+            self._server = await asyncio.start_server(
+                self._handle_client, "127.0.0.1", 0
+            )
+            started.set()
+            async with self._server:
+                await self._server.serve_forever()
+
+        self._loop.run_until_complete(run())
+
+    async def _handle_client(
+        self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter
+    ) -> None:
+        writer.write(b"220 fmtk-sink ESMTP\r\n")
+        while True:
+            line = await reader.readline()
+            if not line:
+                break
+            upper = line.strip().upper()
+            if upper.startswith(b"DATA"):
+                # 354 for the command (the body follows), 250 only after
+                # the terminating dot — aiosmtplib fails the whole send
+                # otherwise, which rolls back e.g. registration
+                writer.write(b"354 end with <CR><LF>.<CR><LF>\r\n")
+                await writer.drain()
+                self.messages.append(await self._read_body(reader))
+                writer.write(b"250 ok\r\n")
+            elif upper.startswith(b"QUIT"):
+                writer.write(b"221 bye\r\n")
+                await writer.drain()
+                break
+            else:
+                writer.write(b"250 ok\r\n")
+            await writer.drain()
+        writer.close()
+
+    async def _read_body(self, reader: asyncio.StreamReader) -> str:
+        lines: list[bytes] = []
+        while True:
+            line = await reader.readline()
+            if line.rstrip(b"\r\n") == b".":
+                return b"".join(lines).decode(errors="replace")
+            lines.append(line)
+
+    def wait_for_message(self, needle: str, timeout: float = 30) -> str:
+        """Block until a captured message contains ``needle`` (latest
+        wins — a re-sent token supersedes earlier ones)."""
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            for message in reversed(self.messages):
+                if needle in message:
+                    return message
+            time.sleep(1)
+        raise HarnessTimeout(f"no captured email contains {needle!r}")
+
+    def token_for(self, route: str, needle: str) -> str:
+        """The ``#/route?token=...`` token from the message with ``needle``."""
+        message = self.wait_for_message(needle)
+        # The text part is quoted-printable: ``=`` encodes as ``=3D`` and
+        # long lines soft-wrap with ``=`` + newline mid-token — decode
+        # the whole body before extracting, or the token carries an
+        # ``3D`` prefix and the server rejects it as invalid.
+        body = quopri.decodestring(message.encode("utf-8", "replace")).decode(
+            errors="replace"
+        )
+        match = re.search(rf"#/{route}\?token=([A-Za-z0-9_.\-]+)", body)
+        if not match:
+            raise FmtkError(f"no #/{route}?token link in message: {body!r}")
+        return match.group(1)
 
 
 class Backend:
@@ -220,15 +374,22 @@ class Backend:
             pass  # exited between the poll and the kill
 
     def swap_settings(
-        self, changes: dict, apply: str = "sighup", timeout: float = 120
+        self,
+        changes: dict,
+        apply: str = "sighup",
+        timeout: float = 120,
+        verify: bool = True,
     ) -> dict:
         """Rewrite config keys and make the server pick them up.
 
         ``apply``: "sighup" (reloadable settings — in-place reload),
         "restart" (deploy-time settings — full process restart), or
         "none" (write only — nothing is applied to the running server,
-        so nothing is awaited; the next boot reads the file). Returns the
-        current /api/v1/config payload.
+        so nothing is awaited; the next boot reads the file).
+        ``verify``: block on /api/v1/config reflecting the change — pass
+        False for keys the endpoint does not expose (jwt_secret,
+        step_up_window_minutes, …); those swaps are asserted behaviorally
+        by the test instead. Returns the current /api/v1/config payload.
         """
         self.config.update(changes)
         write_config_yaml(self.config)
@@ -239,8 +400,25 @@ class Backend:
         else:
             return self.api_config()
         self.wait_healthy()
-        self.wait_config_reflects(changes, timeout)
+        if verify:
+            self.wait_config_reflects(changes, timeout)
         return self.api_config()
+
+    def wait_config_value(self, key: str, value, timeout: float = 30) -> None:
+        """Block until /api/v1/config carries ``key == value``.
+
+        A SIGHUP reload completes asynchronously — swap_settings can
+        return while the old settings are still being served, so a test
+        that re-mounts a page right after a swap would let the page's
+        one-shot config fetch read the stale value. Gate on the endpoint
+        before driving the UI.
+        """
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            if self.api_config().get(key) == value:
+                return
+            time.sleep(0.5)
+        raise HarnessTimeout(f"/api/v1/config[{key}] never became {value!r}")
 
     def wait_config_reflects(self, changes: dict, timeout: float) -> None:
         """Block until /api/v1/config carries the swapped values.
@@ -286,6 +464,17 @@ def backend_env() -> dict:
 def ports_busy(ports: list[str]) -> bool:
     out = subprocess.run(["ss", "-tln"], capture_output=True, text=True).stdout
     return any(f":{port} " in line for port in ports for line in out.splitlines())
+
+
+def port_holders(port: str) -> list[int]:
+    """PIDs listening on ``port`` (same-user sockets; ss -tlnp)."""
+    out = subprocess.run(["ss", "-tlnp"], capture_output=True, text=True).stdout
+    holders: list[int] = []
+    for line in out.splitlines():
+        if f":{port} " not in line:
+            continue
+        holders.extend(int(pid) for pid in re.findall(r"pid=(\d+)", line))
+    return holders
 
 
 class Proxy:
@@ -371,6 +560,7 @@ class FlutterRun:
         self.log_path = STATE_DIR / "flutter-e2e.log"
         self.vm_uri = ""
         self.log_offset = 0
+        self.launch_serial = 0
 
     def chrome_env(self) -> dict:
         env = dict(os.environ)
@@ -382,7 +572,7 @@ class FlutterRun:
             )
         return env
 
-    def flutter_args(self) -> list[str]:
+    def flutter_args(self, url_suffix: str = "") -> list[str]:
         args = [
             "run",
             "--debug",
@@ -393,13 +583,29 @@ class FlutterRun:
             "--web-port",
             FLUTTER_PORT,
         ]
+        # Boot the app AT a URL (the fmtk-chrome.sh wrapper rewrites the
+        # dev-server origin to the proxy and preserves the path/hash):
+        # the pre-auth deep-link UX — e.g. /#/settings — where the router
+        # redirects at boot and the login page renders with the
+        # pending-redirect message (#3233).
+        if url_suffix:
+            args += [
+                "--web-launch-url",
+                f"http://127.0.0.1:{FLUTTER_PORT}{url_suffix}",
+            ]
         pkg_config = REPO_ROOT / "src/frontend/.dart_tool/package_config.json"
         lock = REPO_ROOT / "src/frontend/pubspec.lock"
         if pkg_config.exists() and not newer(pkg_config, lock):
             args.append("--no-pub")
         return args
 
-    def launch(self) -> None:
+    def launch(self, url_suffix: str = "") -> None:
+        if port_holders(FLUTTER_PORT):
+            raise FmtkError(
+                f"port {FLUTTER_PORT} is already in use — a leftover dev "
+                "server would make this launch retry the bind forever; "
+                "stop it first (stop()/wipe())"
+            )
         self.vm_uri = ""
         # Append (restart_app must not truncate earlier phases out of the CI
         # artifact), and remember where this launch's output starts —
@@ -407,7 +613,7 @@ class FlutterRun:
         self.log_offset = self.log_path.stat().st_size if self.log_path.exists() else 0
         log = open(self.log_path, "ab")
         self.proc = subprocess.Popen(
-            ["flutter", *self.flutter_args()],
+            ["flutter", *self.flutter_args(url_suffix)],
             cwd=REPO_ROOT / "src/frontend",
             env=self.chrome_env(),
             stdout=log,
@@ -419,6 +625,48 @@ class FlutterRun:
         except FmtkError:
             self.stop()  # a failed boot must not leak the flutter process
             raise
+        self.wait_toolkit()
+
+    def adopt(self) -> bool:
+        """Adopt a still-healthy app from a previous run (fast re-runs).
+
+        The dev server holds our port and the log carries the last VM
+        URI; a toolkit ping proves the app answers. Anything else (dead
+        app, bind-failed leftover) returns False so the caller stops and
+        relaunches.
+        """
+        if not self.log_path.exists() or not port_holders(FLUTTER_PORT):
+            return False
+        data = self.log_path.read_bytes()
+        match = re.search(rb"ws://\S+/ws", data)
+        if not match:
+            return False
+        self.vm_uri = match.group(0).decode()
+        self.log_offset = len(data)
+        self.proc = None
+        try:
+            self.wait_toolkit(timeout=15)
+            return True
+        except HarnessTimeout:
+            self.vm_uri = ""
+            return False
+
+    def wait_toolkit(self, timeout: float = 90) -> None:
+        """Block until the toolkit answers (dwds isolate attached).
+
+        The VM URI appears in the log before dwds attaches the app
+        isolate — driving any earlier gets "No Flutter isolate found"
+        (the first navigate of a session reliably loses that race).
+        """
+        client = FmtkClient(self)
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            try:
+                client.exec("get_app_errors", {"count": 1})
+                return
+            except FmtkError:
+                time.sleep(2)
+        raise HarnessTimeout("fmtk toolkit never answered after boot")
 
     def wait_vm_uri(self) -> None:
         deadline = time.monotonic() + VM_URI_TIMEOUT
@@ -429,11 +677,26 @@ class FlutterRun:
                     f"tail of {self.log_path}:\n{self.tail()}"
                 )
             if self.log_path.exists():
-                fresh = self.log_path.read_text(errors="replace")[self.log_offset :]
+                # Slice BYTES, then decode: stat().st_size is bytes, but
+                # flutter's output carries multi-byte chars (emoji, box
+                # drawing), so a str slice at a byte offset lands past
+                # the end and never matches — the silent multi-minute
+                # stall this guard replaced.
+                fresh = self.log_path.read_bytes()[self.log_offset :].decode(
+                    errors="replace"
+                )
                 match = re.search(r"ws://\S+/ws", fresh)
                 if match:
                     self.vm_uri = match.group(0)
                     return
+                # A failed compile leaves the flutter PROCESS alive
+                # (retrying) — without this check the 600s deadline is
+                # the only way out.
+                if re.search(r"Failed to compile|^\S+\.dart:\d+:.*Error", fresh):
+                    raise FmtkError(
+                        "flutter run failed to compile — log tail:\n"
+                        + "\n".join(fresh.splitlines()[-15:])
+                    )
             time.sleep(2)
         raise HarnessTimeout(
             f"no Dart VM Service in {self.log_path} after {VM_URI_TIMEOUT}s"
@@ -462,6 +725,24 @@ class FlutterRun:
                 self.proc.wait(timeout=15)
             except subprocess.TimeoutExpired:
                 os.killpg(self.proc.pid, signal.SIGKILL)
+        # The dev server's port must be free before the next launch: the
+        # flutter tool daemon can outlive its process group still holding
+        # the socket, and a replacement launch then retries the bind
+        # forever with no output — a silent 10-minute stall. Kill whoever
+        # holds the port (ours by construction: our port override) and
+        # fail loudly if it never drains.
+        deadline = time.monotonic() + 20
+        while time.monotonic() < deadline:
+            holders = port_holders(FLUTTER_PORT)
+            if not holders:
+                return
+            for pid in holders:
+                try:
+                    os.kill(pid, signal.SIGKILL)
+                except ProcessLookupError:
+                    pass
+            time.sleep(0.5)
+        raise FmtkError(f"port {FLUTTER_PORT} still in use after stopping flutter run")
 
 
 def newer(a: Path, b: Path) -> bool:
@@ -477,6 +758,7 @@ class FmtkClient:
 
     def __init__(self, flutter: "FlutterRun") -> None:
         self.flutter = flutter
+        self.nav_serial = 0
 
     @property
     def vm_uri(self) -> str:
@@ -554,8 +836,23 @@ class FmtkClient:
         except FmtkError:
             return False
 
+    def wait_gone(self, text: str, timeout: float = 10) -> None:
+        """Block until ``text`` leaves the tree. has_text only waits for
+        APPEARANCE — asserting a config swap's effect on already-rendered
+        UI must wait for the removal instead."""
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            if not self.has_text(text, 500):
+                return
+            time.sleep(0.5)
+        raise HarnessTimeout(f"{text!r} never left the semantic tree")
+
     def tap(self, ref: str) -> None:
-        self.exec("tap_widget", {"ref": ref})
+        """Tap a ref; a structured failure (e.g. web_gesture_not_supported
+        for a node without the tap action) must fail the test, not no-op."""
+        result = self.exec("tap_widget", {"ref": ref})
+        if isinstance(result, dict) and result.get("success") is False:
+            raise FmtkError(f"tap_widget failed on {ref}: {result}")
 
     def enter_text(self, ref: str, text: str) -> None:
         self.exec("enter_text", {"ref": ref, "text": text})
@@ -568,7 +865,10 @@ class FmtkClient:
 
     def ref_for_label(self, label: str, node_kind: str | None = None) -> str:
         def matches(node: dict) -> bool:
-            if label not in node_labels(node):
+            # substring match: merged semantics routinely double labels
+            # ('Invitations\nInvitations' — a wrapping Semantics label plus
+            # the child Text), and exact equality would never find them
+            if not any(label in str(entry) for entry in node_labels(node)):
                 return False
             return node_kind is None or node_type(node) == node_kind
 
@@ -594,6 +894,197 @@ class FmtkClient:
         self.tap_label("Log In")
         self.wait_for_text(expect_text)
 
+    def logout(self) -> None:
+        """Tap the app-bar logout icon (its tooltip is the semantic
+        label; icon-only fallback: the rightmost button — logout is the
+        last app-bar action) and wait for the login surface."""
+        if self.has_text("Log In", 2000):
+            return  # already logged out
+        try:
+            self.tap_label("Logout")
+        except FmtkError:
+            self.tap_rightmost_button()
+        self.wait_for_login_page()
+
+    def tap_rightmost_button(self) -> None:
+        """Tap the button with the greatest right edge (ties: topmost).
+
+        The app-bar's actions sit at the far right edge of the top bar,
+        so the rightmost button overall is its last icon (logout).
+        """
+        self.tap_button_from_right(0)
+
+    def tap_identifier(self, identifier: str) -> None:
+        """Tap the node carrying ``identifier`` — or, when the identifier
+        wraps a control (Semantics container), the tappable node inside
+        it. Identifiers are the deterministic locator for instrumented
+        widgets (``Semantics(identifier: ...)``) where labels do not
+        merge (FABs, dialogs)."""
+        nodes = find_nodes(self.snapshot(), lambda n: n.get("identifier") == identifier)
+        if not nodes:
+            raise FmtkError(f"no snapshot node with identifier {identifier!r}")
+        target = nodes[0]
+        if "tap" in (target.get("actions") or []):
+            self.tap(target["ref"])
+            return
+        descendants = self.descendants_with_tap(target)
+        if not descendants:
+            raise FmtkError(f"node {identifier!r} has no tappable descendant")
+        self.tap(descendants[0]["ref"])
+
+    def descendants_with_tap(self, node: dict) -> list[dict]:
+        found: list[dict] = []
+        refs = {c["ref"] for c in (node.get("children") or [])}
+        if not refs:
+            return found
+        candidates = find_nodes(self.snapshot(), lambda n: n.get("ref") in refs)
+        for candidate in candidates:
+            if "tap" in (candidate.get("actions") or []):
+                found.append(candidate)
+            found.extend(self.descendants_with_tap(candidate))
+        return found
+
+    def enter_text_identifier(self, identifier: str, text: str) -> None:
+        """Type into the text field at/below the identifier node."""
+        nodes = find_nodes(self.snapshot(), lambda n: n.get("identifier") == identifier)
+        if not nodes:
+            raise FmtkError(f"no snapshot node with identifier {identifier!r}")
+        fields = find_nodes(
+            self.snapshot(),
+            lambda n: (
+                node_type(n) == "textField"
+                and (
+                    n.get("ref") == nodes[0].get("ref")
+                    or self.is_descendant(n, nodes[0])
+                )
+            ),
+        )
+        if not fields:
+            raise FmtkError(f"no text field under identifier {identifier!r}")
+        self.enter_text(fields[0]["ref"], text)
+
+    def is_descendant(self, node: dict, ancestor: dict) -> bool:
+        parent_refs = {c["ref"] for c in (ancestor.get("children") or [])}
+        if node.get("ref") in parent_refs:
+            return True
+        return any(
+            self.is_descendant(node, candidate)
+            for candidate in find_nodes(
+                self.snapshot(), lambda n: n.get("ref") in parent_refs
+            )
+        )
+
+    def tap_lowest_button(self) -> None:
+        """Tap the lowest button in the screen's right edge (a corner FAB).
+
+        FloatingActionButton semantics never merge child labels — icon
+        semanticLabels and Semantics wrappers alike — so corner FABs are
+        addressed positionally. Constrained to the right edge because
+        long lists put row buttons below the FAB's top.
+        """
+        buttons = find_nodes(self.snapshot(), lambda n: node_type(n) == "button")
+        if not buttons:
+            raise FmtkError("no buttons visible for tap_lowest_button")
+        right_edge = max((n.get("bounds") or {}).get("right", 0) for n in buttons)
+        corner = [
+            n
+            for n in buttons
+            if (n.get("bounds") or {}).get("right", 0) >= right_edge - 160
+            and "tap" in (n.get("actions") or [])
+        ]
+        if not corner:
+            raise FmtkError("no tappable corner button found")
+        target = max(corner, key=lambda n: (n.get("bounds") or {}).get("top", -1))
+        self.tap(target["ref"])
+
+    def tap_button_from_right(self, index: int) -> None:
+        """Tap the app-bar button ``index`` places from the right edge.
+
+        Icon-only app-bar actions carry no semantic label (tooltips are
+        not exposed), so they are addressed positionally among the
+        topmost buttons: 0 = logout (rightmost), 1 = admin, …
+        """
+        buttons = find_nodes(self.snapshot(), lambda n: node_type(n) == "button")
+        if not buttons:
+            raise FmtkError("no buttons visible for tap_button_from_right")
+        top = min((n.get("bounds") or {}).get("top", 0) for n in buttons)
+        bar = [n for n in buttons if (n.get("bounds") or {}).get("top", 0) <= top + 120]
+        if len(bar) <= index:
+            raise FmtkError(f"app-bar has {len(bar)} buttons, need index {index}")
+        target = max(bar, key=lambda n: (n.get("bounds") or {}).get("right", -1))
+        for _ in range(index):
+            bar.remove(target)
+            target = max(bar, key=lambda n: (n.get("bounds") or {}).get("right", -1))
+        self.tap(target["ref"])
+
+    # --- hash-route navigation + in-app evaluation (per AGENTS.md) ------
+
+    def navigate(self, path: str) -> None:
+        """Hash-route the driven tab to ``#/path`` via navigateTo.
+
+        Only the hash differs, so the app keeps running — Flutter's hash
+        browser-history listener hands the new location to GoRouter. This
+        is how email-token links (verify / reset / accept-invite) reach
+        their pages without a page reload (evaluate cannot import GoRouter
+        itself; navigateTo is in scope from the login page's library).
+
+        A full-page navigation is NOT usable here: reloading the tab kills
+        the dwds isolate and fmtk loses the app — to observe boot-time
+        effects (pre-auth deep links), use ``Harness.restart_app(at_path=)``.
+        """
+        escaped = path.replace("\\", "\\\\").replace("'", "\\'")
+        self.exec(
+            "evaluate_dart_expression",
+            {
+                "expression": (
+                    f"navigateTo('http://127.0.0.1:{PROXY_PORT}/#{escaped}')"
+                ),
+                "libraryUri": "package:klangk_frontend/auth/login_page.dart",
+            },
+        )
+
+    AUTH_LIBRARY = "package:klangk_frontend/app.dart"
+    AUTH_WALK_TEMPLATE = """
+() {{
+  AuthService? auth;
+  void walk(Element el) {{
+    if (auth != null) return;
+    if (el is StatefulElement) {{
+      try {{
+        auth = Provider.of<AuthService>(el, listen: false);
+        return;
+      }} catch (_) {{}}
+    }}
+    el.visitChildElements((c) => walk(c));
+  }}
+  walk(WidgetsBinding.instance.rootElement!);
+  if (auth == null) return 'NO-AUTH';
+  {body}
+}}()
+"""
+
+    def auth_eval(self, body: str) -> object:
+        """Evaluate against the app's live :class:`AuthService`.
+
+        Walks the tree for any stateful element the MultiProvider
+        actually covers (the root View element sits ABOVE it and must be
+        skipped; Provider.of from a covered element never throws) and
+        runs ``body`` with ``auth!`` bound to the service. ``app.dart``'s
+        library scope carries provider's ``Provider.of`` plus the
+        widgets imports the walk needs. Bodies must be complete
+        statements — the evaluator does not append semicolons.
+        """
+        data = self.exec(
+            "evaluate_dart_expression",
+            {
+                "expression": self.AUTH_WALK_TEMPLATE.format(body=body),
+                "libraryUri": self.AUTH_LIBRARY,
+            },
+        )
+        if isinstance(data, dict) and "result" in data:
+            return data["result"]
+        return data
+
     def dismiss_login_banner(self) -> None:
         if self.has_text("I Accept", 3000):
             self.tap_label("I Accept")
@@ -610,9 +1101,28 @@ class FmtkClient:
         raise HarnessTimeout("login page never appeared")
 
     def app_errors(self) -> list:
+        """Uncaught Flutter errors, minus known framework routing noise."""
         data = self.exec("get_app_errors", {"count": 20})
         errors = data.get("errors", data) if isinstance(data, dict) else data
-        return errors or []
+        return [
+            error
+            for error in (errors or [])
+            if not self.is_framework_noise(str(error.get("message", "")))
+        ]
+
+    # Framework artifacts of routing a Router app outside a cold boot —
+    # go_router has already routed correctly; these are the Navigator's
+    # legacy fallbacks complaining (booting at a deep link: initialRoute;
+    # an in-tab hash change: didPushRouteInformation -> pushNamed).
+    # Visible only under the debug error monitor; real app errors still
+    # fail the drain untouched.
+    FRAMEWORK_NOISE = (
+        "Could not navigate to initial route",
+        "Could not find a generator for route",
+    )
+
+    def is_framework_noise(self, message: str) -> bool:
+        return any(pattern in message for pattern in self.FRAMEWORK_NOISE)
 
     def hot_restart(self) -> None:
         """dwds hot restart. Fails with a chrome-devtools error against
@@ -705,6 +1215,7 @@ class Harness:
         self.backend = Backend()
         self.proxy = Proxy(self.backend)
         self.flutter = FlutterRun()
+        self.smtp = SmtpSink()
 
     @property
     def client(self) -> FmtkClient:
@@ -712,11 +1223,15 @@ class Harness:
             raise FmtkError("flutter run not launched (call boot() first)")
         return FmtkClient(self.flutter)
 
-    def restart_app(self) -> None:
+    def restart_app(self, at_path: str | None = None) -> None:
         """Stop and relaunch the debug app (fresh main() -> config
         re-fetch). The deterministic substitute for dwds hot restart,
         which fails against the proxied debug origin (chrome devtools
         error); the incremental debug rebuild keeps it to ~15-30s.
+
+        ``at_path`` boots the app AT ``#/path`` (the pre-auth deep-link
+        UX — a full-page hash navigation inside a running tab kills the
+        dwds isolate, so booting there is the only reliable way).
 
         The app-error monitor is a rolling window that a restart would
         silently clear — drain it first so errors from the outgoing app
@@ -724,16 +1239,41 @@ class Harness:
         errors = self.client.app_errors()
         if errors:
             raise FmtkError(f"app errors before restart_app: {errors}")
+        url_suffix = ""
+        if at_path is not None:
+            self.flutter.launch_serial += 1
+            url_suffix = f"/?e2e_boot={self.flutter.launch_serial}#{at_path}"
         self.flutter.stop()
-        self.flutter.launch()
+        self.flutter.launch(url_suffix)
 
     def boot(self, fresh: bool = False) -> None:
         if fresh:
             self.wipe()
         self.backend.ensure()
+        # The sink's port is ephemeral, so the SMTP settings are rewritten
+        # on every boot and reloaded over SIGHUP (emailsvc reads live off
+        # settings — no restart needed, adopted or fresh).
+        self.config["smtp_port"] = str(self.smtp.start())
+        # Same for the lockout disable when adopting a backend whose yaml
+        # predates it (fresh stacks get it via DEFAULT_CONFIG): a locked
+        # admin from earlier runs would fail every login for 15 minutes.
+        self.config.setdefault("login_lockout_failures", "0")
+        write_config_yaml(self.config)
+        self.backend.sighup()
+        self.backend.wait_healthy()
         self.proxy.ensure()
         seed(self.backend.url)
-        self.flutter.launch()
+        # Adopt a healthy app from a previous run (FMTK_E2E_KEEP_APP=1
+        # skips stopping it in teardown) — re-runs then skip the ~90s
+        # flutter boot entirely. Anything stale falls back to a fresh
+        # launch (stop() drains the port first).
+        if not self.flutter.adopt():
+            self.flutter.stop()
+            self.flutter.launch()
+
+    @property
+    def config(self) -> dict:
+        return self.backend.config
 
     def wipe(self) -> None:
         """Stop OUR stack — backend + proxy by config-path-scoped patterns,
@@ -750,6 +1290,12 @@ class Harness:
         for pattern in patterns:
             for pid in pids_matching(pattern):
                 os.kill(pid, signal.SIGTERM)
+        for port in (FLUTTER_PORT, PROXY_PORT, BACKEND_PORT, EGRESS_PORT):
+            for pid in port_holders(port):
+                try:
+                    os.kill(pid, signal.SIGTERM)
+                except ProcessLookupError:
+                    pass
         time.sleep(2)
         for pattern in patterns:
             for pid in pids_matching(pattern):
@@ -757,8 +1303,47 @@ class Harness:
                     os.kill(pid, signal.SIGKILL)
                 except ProcessLookupError:
                     pass
+        for port in (FLUTTER_PORT, PROXY_PORT, BACKEND_PORT, EGRESS_PORT):
+            for pid in port_holders(port):
+                try:
+                    os.kill(pid, signal.SIGKILL)
+                except ProcessLookupError:
+                    pass
         shutil.rmtree(STATE_DIR, ignore_errors=True)
 
     def teardown(self) -> None:
-        """Stop the flutter run; keep backend + proxy for fast re-runs."""
-        self.flutter.stop()
+        """Stop the flutter run; keep backend + proxy for fast re-runs.
+
+        FMTK_E2E_KEEP_APP=1 also keeps the app running — the next run
+        adopts it (boot() pings it first) instead of paying the boot.
+        """
+        if os.environ.get("FMTK_E2E_KEEP_APP") != "1":
+            self.flutter.stop()
+
+    # --- admin-side setup (HTTP, not UI) --------------------------------
+
+    def admin_api(self, method: str, path: str, body: dict | None = None):
+        """One API call as the scratch default admin; (status, json)."""
+        token = http_login(
+            self.backend.url,
+            self.config["default_user"],
+            self.config["default_password"],
+        )
+        return http_api(self.backend.url, token, method, path, body)
+
+    def force_password_change(self, email: str, password: str) -> None:
+        """(Re)arm a user for the forced-change flow: admin-set password
+        implies ``must_change_password`` (#3172). Idempotent across runs
+        — the caller passes a run-unique password, so the history check
+        never trips."""
+        status, listing = self.admin_api("GET", "/api/v1/users?page_size=100")
+        if status != 200:
+            raise FmtkError(f"user listing failed ({status}): {listing}")
+        user_id = next((u["id"] for u in listing["users"] if u["email"] == email), None)
+        if user_id is None:
+            raise FmtkError(f"{email} is not seeded")
+        status, body = self.admin_api(
+            "PATCH", f"/api/v1/users/{user_id}", {"password": password}
+        )
+        if status != 200:
+            raise FmtkError(f"admin password set for {email} failed: {body}")

--- a/src/frontend/e2e-tests/fmtk/test_auth.py
+++ b/src/frontend/e2e-tests/fmtk/test_auth.py
@@ -1,0 +1,342 @@
+"""fmtk e2e: auth and session flows (#3233).
+
+Every user-visible auth/session surface, driven through the real UI:
+login (success + wrong password), logout + deep-link bounce, pending
+redirect honored post-login, registration + email verification +
+resend, forgot/reset password, forced password change, step-up (sudo)
+dialog on an admin invite, invitation acceptance, silent token refresh,
+session invalidation landing on login, and the SIGHUP-swapped
+registration/password-policy config knobs.
+
+Email-token flows use the harness SMTP sink: klangkd delivers the
+verify/reset/invite links to the in-process server, the tests extract
+the token, and ``navigate()`` hash-routes the driven tab to the link's
+page (the same thing a user clicking the email link does).
+
+Scenarios run in definition order and each ends logged out on the login
+page, so any single scenario can be re-run alone with ``-k``.
+"""
+
+from __future__ import annotations
+
+import time
+import uuid
+
+from fmtkharness import (
+    ADMIN_EMAIL,
+    FIXTURE_PASSWORD,
+    FmtkError,
+    find_nodes,
+    node_type,
+)
+
+RUN = uuid.uuid4().hex[:6]
+MUSTCHANGE_EMAIL = "fmtk-mustchange@example.com"
+MUSTCHANGE_PW = f"fmtk-Mc{RUN}!A1"
+MUSTCHANGE_NEW = f"fmtk-Post{RUN}!C3"
+RESET_EMAIL = "fmtk-reset@example.com"
+RESET_NEW = f"fmtk-Rs{RUN}!B2"
+REGISTERED_EMAIL = f"fmtk-new{RUN}@example.com"
+REGISTERED_PW = "fmtk-Reg123!"
+INVITED_EMAIL = f"fmtk-inv{RUN}@example.com"
+INVITED_PW = f"fmtk-Ac{RUN}!D4"
+
+
+def walk_fields(app) -> list[dict]:
+    """The visible text fields, in reading order."""
+    return find_nodes(app.snapshot(), lambda n: node_type(n) == "textField")
+
+
+def at_login(harness, app) -> None:
+    """Land on the usable login form: route there, wait for the page,
+    and dismiss any leftover login-banner consent dialog (a swapped
+    banner's dialog masks the form from the semantic tree)."""
+    app.navigate("/login")
+    if not app.has_text("Log In", 10000):
+        # a leftover session guards /login away (a must-change user is
+        # bounced back to /change-password; a normal one to
+        # /workspaces) — end it, then the route sticks. A dead app
+        # (closed window, lost isolate) restarts instead.
+        try:
+            app.auth_eval("auth!.logout(); return 'ok';")
+        except FmtkError:
+            harness.restart_app()
+    app.wait_for_login_page()
+    app.dismiss_login_banner()
+    app.wait_for_text("Email or handle")
+
+
+def test_wrong_password_shows_error_not_navigation(harness, app):
+    at_login(harness, app)
+    fields = walk_fields(app)
+    app.enter_text(fields[0]["ref"], ADMIN_EMAIL)
+    app.enter_text(fields[1]["ref"], "definitely-wrong")
+    app.tap_label("Log In")
+    app.wait_for_text("Invalid credentials")
+    assert not app.has_text("Owned by Me", 2000)  # stayed on login
+    # correct credentials now land in the app
+    app.login(ADMIN_EMAIL, FIXTURE_PASSWORD, expect_text="fmtk-verify")
+    app.logout()
+
+
+def test_register_verify_and_resend(harness, app):
+    at_login(harness, app)
+    app.tap_label("Need an account? Create one")
+    fields = walk_fields(app)
+    app.enter_text(fields[0]["ref"], REGISTERED_EMAIL)
+    app.enter_text(fields[1]["ref"], REGISTERED_PW)
+    app.tap_label("Create Account")
+    app.wait_for_text("Check your email to verify your account.")
+    # login before verifying: refused with the resend affordance
+    app.tap_label("Already have an account? Log in")
+    app.login(REGISTERED_EMAIL, REGISTERED_PW, expect_text="Account not verified")
+    app.tap_label("Resend verification email")
+    app.wait_for_text("Verification email sent. Check your inbox.")
+    token = harness.smtp.token_for("verify", REGISTERED_EMAIL)
+    app.navigate(f"/verify?token={token}")
+    # auto-login lands on /workspaces; the empty owned tab copy is the
+    # matchable text for a workspace-less user
+    app.wait_for_text("No workspaces yet. Create one to get started.")
+    app.logout()
+
+
+def test_forgot_and_reset_password(harness, app):
+    at_login(harness, app)
+    app.tap_label("Forgot password?")
+    fields = walk_fields(app)
+    app.enter_text(fields[0]["ref"], RESET_EMAIL)
+    app.tap_label("Send Reset Link")
+    app.wait_for_text("we sent a password reset link")
+    token = harness.smtp.token_for("reset-password", RESET_EMAIL)
+    app.navigate(f"/reset-password?token={token}")
+    app.wait_for_text("New Password")
+    # weak new password: rejected inline by the client-side policy mirror
+    fields = walk_fields(app)
+    app.enter_text(fields[0]["ref"], "short")
+    app.enter_text(fields[1]["ref"], "short")
+    app.tap_label("Reset Password")
+    app.wait_for_text("Min 8 characters")
+    # a good one completes the reset and logs straight in
+    fields = walk_fields(app)
+    app.enter_text(fields[0]["ref"], RESET_NEW)
+    app.enter_text(fields[1]["ref"], RESET_NEW)
+    app.tap_label("Reset Password")
+    app.wait_for_text("No workspaces yet. Create one to get started.")
+    app.logout()
+
+
+def test_forced_password_change(harness, app):
+    harness.force_password_change(MUSTCHANGE_EMAIL, MUSTCHANGE_PW)
+    at_login(harness, app)
+    app.login(MUSTCHANGE_EMAIL, MUSTCHANGE_PW, expect_text="Password Change Required")
+    # weak new password: rejected inline
+    fields = walk_fields(app)
+    app.enter_text(fields[0]["ref"], MUSTCHANGE_PW)
+    app.enter_text(fields[1]["ref"], "short")
+    app.enter_text(fields[2]["ref"], "short")
+    app.tap_label("Change Password")
+    app.wait_for_text("Min 8 characters")
+    # a good one ends the session and sends the user to log in afresh
+    fields = walk_fields(app)
+    app.enter_text(fields[0]["ref"], MUSTCHANGE_PW)
+    app.enter_text(fields[1]["ref"], MUSTCHANGE_NEW)
+    app.enter_text(fields[2]["ref"], MUSTCHANGE_NEW)
+    app.tap_label("Change Password")
+    app.wait_for_text("Log in with your new password")
+    app.wait_for_login_page()
+    # Re-login, then navigate explicitly: the address-bar hash can lag
+    # the change-password -> /login transition, and a router re-parse
+    # of the stale #/change-password re-mounts the change page for the
+    # now-healthy session (guardForcedPasswordChange allows it) — see
+    # the routing race noted in the PR. Navigating past it makes the
+    # destination deterministic.
+    fields = walk_fields(app)
+    app.enter_text(fields[0]["ref"], MUSTCHANGE_EMAIL)
+    app.enter_text(fields[1]["ref"], MUSTCHANGE_NEW)
+    app.tap_label("Log In")
+    time.sleep(2)  # let the login land before routing past the stale hash
+    app.navigate("/workspaces")
+    app.wait_for_text("No workspaces yet. Create one to get started.")
+    app.logout()
+
+
+def test_step_up_dialog_and_invite_acceptance(harness, app):
+    original = harness.config.get("step_up_window_minutes", "0")
+    # step_up_window_minutes is not surfaced on /api/v1/config — the
+    # dialog itself is the behavioral verification
+    harness.backend.swap_settings(
+        {"step_up_window_minutes": "60"}, apply="sighup", verify=False
+    )
+    try:
+        at_login(harness, app)
+        app.login(ADMIN_EMAIL, FIXTURE_PASSWORD, expect_text="fmtk-verify")
+        app.tap_label("Admin")  # icon has a semanticLabel now
+        app.wait_for_text("fmtk-admin@example.com")
+        # the invite FAB lives on the Invitations tab (the Users tab's
+        # corner FAB is add-user — same dialog copy, wrong flow)
+        app.tap_label("Invitations")
+        app.wait_for_text("Email")  # the invitations toolbar column header
+        app.tap_lowest_button()  # the FAB: tap-action-filtered corner button
+        app.wait_for_text("An email will be sent")
+        fields = walk_fields(app)
+        app.enter_text(fields[0]["ref"], INVITED_EMAIL)
+        app.tap_label("Send Invitation")
+        # the write is refused with step_up_required -> the sudo dialog
+        app.wait_for_text("Re-authentication required")
+        # wrong password re-prompts without retrying the write. The
+        # dialog's field is selected BY LABEL: the admin page behind it
+        # carries its own filter textFields, so positional field picking
+        # types into the wrong one.
+        app.enter_text(app.ref_for_label("Password", "textField"), "definitely-wrong")
+        app.tap_label("Confirm")
+        app.wait_for_text("Incorrect password — try again.")
+        # correct password confirms and the retried invite lands
+        app.enter_text(app.ref_for_label("Password", "textField"), FIXTURE_PASSWORD)
+        app.tap_label("Confirm")
+        app.wait_gone("Re-authentication required")
+        app.wait_for_text(f"Invitation sent to {INVITED_EMAIL}")
+        app.logout()
+    finally:
+        harness.backend.swap_settings(
+            {"step_up_window_minutes": original}, apply="sighup", verify=False
+        )
+    # the invited user accepts over the emailed link and lands in the app
+    token = harness.smtp.token_for("accept-invite", INVITED_EMAIL)
+    app.navigate(f"/accept-invite?token={token}")
+    app.wait_for_text("Confirm Password")
+    fields = walk_fields(app)
+    app.enter_text(fields[0]["ref"], INVITED_PW)
+    app.enter_text(fields[1]["ref"], INVITED_PW)
+    app.tap_label("Create Account")
+    app.wait_for_text("No workspaces yet. Create one to get started.")
+    app.logout()
+
+
+def test_silent_token_refresh_keeps_session(harness, app):
+    original_ttl = harness.config.get("access_token_hours", "24")
+    harness.backend.swap_settings(
+        {"access_token_hours": "0.0008"}, apply="sighup", verify=False
+    )
+    try:
+        # ~1s tokens: the client's 80% refresh timer must silently renew
+        at_login(harness, app)
+        app.login(ADMIN_EMAIL, FIXTURE_PASSWORD, expect_text="fmtk-verify")
+        time.sleep(4)  # outlives several token lifetimes
+        assert (
+            "true"
+            in str(app.auth_eval("final v = auth!.isLoggedIn; return v;")).lower()
+        )
+        app.wait_for_text("fmtk-verify")  # never bounced to login
+        app.logout()
+    finally:
+        harness.backend.swap_settings(
+            {"access_token_hours": original_ttl}, apply="sighup", verify=False
+        )
+
+
+def test_invalidated_session_lands_on_login(harness, app):
+    original_secret = harness.config["jwt_secret"]
+    try:
+        at_login(harness, app)
+        app.login(ADMIN_EMAIL, FIXTURE_PASSWORD, expect_text="fmtk-verify")
+        # rotating the signing secret invalidates the session the app
+        # holds; the next scheduled refresh gets 401 -> the client clears
+        # its token and the router lands on login (not a blank screen)
+        harness.backend.swap_settings(
+            {"jwt_secret": f"fmtk-rotated-{RUN}"}, apply="sighup", verify=False
+        )
+        # force the client's refresh cycle now (the scheduled one is
+        # hours out): 401 -> the client clears its token and the router
+        # lands on login (not a blank screen)
+        app.auth_eval("auth!.testRefreshToken(); return 'ok';")
+        app.wait_for_login_page(timeout_ms=30000)
+        assert not app.has_text("fmtk-verify", 2000)
+    finally:
+        harness.backend.swap_settings(
+            {"jwt_secret": original_secret},
+            apply="sighup",
+            verify=False,
+        )
+
+
+def test_registration_toggle_and_policy_swap(harness, app):
+    original_reg = harness.config.get("disable_registration", "")
+    original_min = harness.config.get("min_password_length", "8")
+    try:
+        harness.backend.swap_settings(
+            {"disable_registration": "true"},
+            apply="sighup",
+            verify=False,
+        )
+        harness.backend.wait_config_value("registration_enabled", False)
+        # remount the login page (a same-location hash change does not
+        # rebuild it) so the fresh /config fetch reflects the swap
+        app.navigate("/forgot-password")
+        app.wait_for_text("Send Reset Link")
+        app.navigate("/login")
+        app.wait_for_login_page()
+        app.dismiss_login_banner()
+        app.wait_gone("Need an account? Create one")
+        harness.backend.swap_settings(
+            {
+                "disable_registration": original_reg,
+                "min_password_length": "14",
+            },
+            apply="sighup",
+            verify=False,
+        )
+        harness.backend.wait_config_value("min_password_length", 14)
+        # the register form's validator reads AuthService's policy
+        # snapshot, not the page's own config fetch — refresh it
+        app.auth_eval("auth!.refreshDeployConfig(); return 'ok';")
+        time.sleep(2)
+        # the login page re-fetches /config on every mount — bounce to
+        # another public page and back instead of restarting the app
+        app.navigate("/forgot-password")
+        app.wait_for_text("Send Reset Link")
+        app.navigate("/login")
+        app.wait_for_login_page()
+        app.dismiss_login_banner()
+        app.tap_label("Need an account? Create one")
+        fields = walk_fields(app)
+        app.enter_text(fields[0]["ref"], f"fmtk-len{RUN}@example.com")
+        app.enter_text(fields[1]["ref"], "tenchars!!")
+        app.tap_label("Create Account")
+        app.wait_for_text("Min 14 characters")  # live policy mirror
+    finally:
+        harness.backend.swap_settings(
+            {
+                "disable_registration": original_reg,
+                "min_password_length": original_min,
+            },
+            apply="sighup",
+            verify=False,
+        )
+        harness.backend.wait_config_value("registration_enabled", True)
+        app.navigate("/forgot-password")
+        app.wait_for_text("Send Reset Link")
+        app.navigate("/login")
+        app.wait_for_login_page()
+        app.dismiss_login_banner()
+        assert app.has_text("Need an account? Create one", 5000)
+
+
+def test_logout_bounces_deep_links_to_login(harness, app):
+    # runs LAST by file order: booting the app at a deep link leaves an
+    # instance that dies shortly after (initial-route fallback fallout,
+    # see the PR's routing-race note), so nothing may follow it here.
+    # logged out by the previous scenario; booting the app AT a protected
+    # deep link (the real pre-auth email/deep-link UX) must bounce to
+    # login with the pending-redirect message (guardAuth at boot). A
+    # full-page navigation inside the running tab is not an option — it
+    # kills the dwds isolate — so this boots a fresh app at the URL.
+    harness.restart_app(at_path="/settings")
+    app.wait_for_login_page()
+    app.wait_for_text("Please log in to continue.")
+    assert not app.has_text("Change Password", 2000)
+
+
+def test_pending_redirect_honored_after_login(harness, app):
+    # the stashed /settings target from the bounce above is honored
+    app.login(ADMIN_EMAIL, FIXTURE_PASSWORD, expect_text="Settings")
+    app.logout()

--- a/src/frontend/e2e-tests/fmtk/test_smoke.py
+++ b/src/frontend/e2e-tests/fmtk/test_smoke.py
@@ -27,6 +27,25 @@ BANNER_BODY = "swapped live over SIGHUP"
 
 
 def test_harness_smoke(harness, app):
+    original_title = harness.config.get("login_banner_title", "")
+    original_banner = harness.config.get("login_banner", "")
+    try:
+        _smoke_phases(harness, app)
+    finally:
+        # The banner persists in the adopted backend's config; a leftover
+        # consent dialog would mask the login form for the next suite's
+        # logins (each suite only dismisses the banner interactively).
+        harness.backend.swap_settings(
+            {
+                "login_banner_title": original_title,
+                "login_banner": original_banner,
+            },
+            apply="sighup",
+            verify=False,
+        )
+
+
+def _smoke_phases(harness, app) -> None:
     # --- phase 1: app booted to the login surface -----------------------
     app.wait_for_login_page()
 

--- a/src/frontend/lib/admin/admin_users_page.dart
+++ b/src/frontend/lib/admin/admin_users_page.dart
@@ -498,9 +498,9 @@ class _AdminUsersPageState extends State<AdminUsersPage> {
     return types;
   }
 
-  (List<SkeuoTab>, List<Widget>) _buildTabsAndViews() {
+  (List<Widget>, List<Widget>) _buildTabsAndViews() {
     final pendingCount = _invitationsPending;
-    final tabs = <SkeuoTab>[];
+    final tabs = <Widget>[];
     final views = <Widget>[];
 
     void addTab({
@@ -511,12 +511,19 @@ class _AdminUsersPageState extends State<AdminUsersPage> {
     }) {
       final idx = tabs.length;
       tabs.add(
-        SkeuoTab(
+        // Named for assistive tech and the fmtk e2e driver: SkeuoTab is a
+        // bare GestureDetector, and a merging Semantics (no container)
+        // lands the label on the tappable node itself.
+        Semantics(
           label: label,
-          icon: icon,
-          isSelected: _selectedIndex == idx,
-          badge: badge,
-          onTap: () => setState(() => _selectedIndex = idx),
+          button: true,
+          child: SkeuoTab(
+            label: label,
+            icon: icon,
+            isSelected: _selectedIndex == idx,
+            badge: badge,
+            onTap: () => setState(() => _selectedIndex = idx),
+          ),
         ),
       );
       views.add(view);
@@ -598,7 +605,7 @@ class _AdminUsersPageState extends State<AdminUsersPage> {
           heroTag: 'add',
           onPressed: _addUser,
           tooltip: 'Add user',
-          child: const Icon(Icons.person_add),
+          child: const Icon(Icons.person_add, semanticLabel: 'Add user'),
         ),
       'invitations' ||
       'groups' ||
@@ -929,7 +936,7 @@ class _GroupsTabState extends State<_GroupsTab> {
         heroTag: 'add-group',
         onPressed: _createGroup,
         tooltip: 'Create group',
-        child: const Icon(Icons.group_add),
+        child: const Icon(Icons.group_add, semanticLabel: 'Create group'),
       ),
       body: Column(
         children: [
@@ -1410,11 +1417,15 @@ class _InvitationsTabState extends State<_InvitationsTab> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      floatingActionButton: FloatingActionButton(
-        heroTag: 'invite',
-        onPressed: _inviteUser,
-        tooltip: 'Invite user',
-        child: const Icon(Icons.mail_outline),
+      floatingActionButton: Semantics(
+        container: true,
+        identifier: 'invite-fab',
+        child: FloatingActionButton(
+          heroTag: 'invite',
+          onPressed: _inviteUser,
+          tooltip: 'Invite user',
+          child: const Icon(Icons.mail_outline),
+        ),
       ),
       body: Column(
         children: [
@@ -2100,21 +2111,25 @@ class _InviteUserDialogState extends State<_InviteUserDialog> {
               'An email will be sent with a link to set their password and create an account.',
             ),
             const SizedBox(height: 16),
-            TextField(
-              controller: _emailController,
-              decoration: InputDecoration(
-                labelText: 'Email',
-                labelStyle: labelStyle,
-                floatingLabelStyle: labelStyle,
-                floatingLabelBehavior: FloatingLabelBehavior.always,
-                border: const OutlineInputBorder(),
-                errorText: emailError,
+            Semantics(
+              container: true,
+              identifier: 'invite-email',
+              child: TextField(
+                controller: _emailController,
+                decoration: InputDecoration(
+                  labelText: 'Email',
+                  labelStyle: labelStyle,
+                  floatingLabelStyle: labelStyle,
+                  floatingLabelBehavior: FloatingLabelBehavior.always,
+                  border: const OutlineInputBorder(),
+                  errorText: emailError,
+                ),
+                autofocus: true,
+                onChanged: (_) => setState(() {}),
+                onSubmitted: (_) {
+                  if (canInvite) Navigator.pop(context, email);
+                },
               ),
-              autofocus: true,
-              onChanged: (_) => setState(() {}),
-              onSubmitted: (_) {
-                if (canInvite) Navigator.pop(context, email);
-              },
             ),
           ],
         ),
@@ -2125,9 +2140,13 @@ class _InviteUserDialogState extends State<_InviteUserDialog> {
           style: TextButton.styleFrom(foregroundColor: KColors.accentRed),
           child: const Text('Cancel'),
         ),
-        FilledButton(
-          onPressed: canInvite ? () => Navigator.pop(context, email) : null,
-          child: const Text('Send Invitation'),
+        Semantics(
+          container: true,
+          identifier: 'invite-send',
+          child: FilledButton(
+            onPressed: canInvite ? () => Navigator.pop(context, email) : null,
+            child: const Text('Send Invitation'),
+          ),
         ),
       ],
     );

--- a/src/frontend/lib/auth/auth_service.dart
+++ b/src/frontend/lib/auth/auth_service.dart
@@ -664,10 +664,11 @@ class AuthService extends ChangeNotifier {
     try {
       final response = await _client.post(
         Uri.parse('$_baseUrl/api/v1/auth/step-up'),
-        headers: {
-          ..._authHeaders,
-          'Content-Type': 'application/json',
-        },
+        // DPoP proof, like every authed call: the web client binds its
+        // token post-login (#3218), and a bound token without a proof
+        // is rejected — sudo-mode would 401 on every attempt. Found by
+        // the fmtk e2e auth suite (#3233).
+        headers: await authHeadersFor('POST', '/api/v1/auth/step-up'),
         body: jsonEncode({'password': password}),
       );
       return response.statusCode;

--- a/src/frontend/lib/widgets/app_bar_actions.dart
+++ b/src/frontend/lib/widgets/app_bar_actions.dart
@@ -57,8 +57,14 @@ class AppBarActions extends StatelessWidget {
           ),
         if (context.watch<AuthService>().canAdminSection)
           IconButton(
-            icon:
-                const Icon(Icons.manage_accounts, color: KColors.textSecondary),
+            icon: const Icon(
+              Icons.manage_accounts,
+              color: KColors.textSecondary,
+              // Named for assistive tech and the fmtk e2e driver (icon-only
+              // buttons otherwise carry no semantic label; tooltips do
+              // not surface in the semantic tree).
+              semanticLabel: 'Admin',
+            ),
             tooltip: 'Admin',
             onPressed: onAdminPressed ?? () => context.go('/admin/users'),
           ),
@@ -74,7 +80,11 @@ class AppBarActions extends StatelessWidget {
             onPressed: () => openUrl(Branding.supportHref),
           ),
         IconButton(
-          icon: const Icon(Icons.logout, color: KColors.textSecondary),
+          icon: const Icon(
+            Icons.logout,
+            color: KColors.textSecondary,
+            semanticLabel: 'Logout',
+          ),
           tooltip: 'Logout',
           onPressed: onLogoutPressed ??
               () async {

--- a/src/frontend/lib/widgets/step_up_dialog.dart
+++ b/src/frontend/lib/widgets/step_up_dialog.dart
@@ -13,11 +13,40 @@ Future<String?> showStepUpPasswordDialog(
   BuildContext context, {
   bool previousFailed = false,
 }) {
-  final controller = TextEditingController();
   return showDialog<String>(
     context: context,
     barrierDismissible: false,
-    builder: (dialogContext) => AlertDialog(
+    builder: (_) => _StepUpDialog(previousFailed: previousFailed),
+  );
+}
+
+/// One stateful owner for the controller and every widget that reads it.
+///
+/// The original closure-owned controller was disposed when the dialog
+/// future completed — while the exit animation still had the field
+/// mounted, so the retry rebuild (previousFailed) threw "controller used
+/// after being disposed" (found by the fmtk e2e auth suite, #3233).
+class _StepUpDialog extends StatefulWidget {
+  const _StepUpDialog({required this.previousFailed});
+
+  final bool previousFailed;
+
+  @override
+  State<_StepUpDialog> createState() => _StepUpDialogState();
+}
+
+class _StepUpDialogState extends State<_StepUpDialog> {
+  final TextEditingController _controller = TextEditingController();
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
       title: const Text('Re-authentication required'),
       content: Column(
         mainAxisSize: MainAxisSize.min,
@@ -27,7 +56,7 @@ Future<String?> showStepUpPasswordDialog(
             'This action needs a fresh sign-in. Enter your password to '
             'continue.',
           ),
-          if (previousFailed)
+          if (widget.previousFailed)
             const Padding(
               padding: EdgeInsets.only(top: 8),
               child: Text(
@@ -37,10 +66,10 @@ Future<String?> showStepUpPasswordDialog(
             ),
           const SizedBox(height: 16),
           TextField(
-            controller: controller,
+            controller: _controller,
             autofocus: true,
             obscureText: true,
-            onSubmitted: (value) => Navigator.of(dialogContext).pop(value),
+            onSubmitted: (value) => Navigator.of(context).pop(value),
             decoration: const InputDecoration(
               labelText: 'Password',
               border: OutlineInputBorder(),
@@ -50,14 +79,14 @@ Future<String?> showStepUpPasswordDialog(
       ),
       actions: [
         TextButton(
-          onPressed: () => Navigator.of(dialogContext).pop(),
+          onPressed: () => Navigator.of(context).pop(),
           child: const Text('Cancel'),
         ),
         FilledButton(
-          onPressed: () => Navigator.of(dialogContext).pop(controller.text),
+          onPressed: () => Navigator.of(context).pop(_controller.text),
           child: const Text('Confirm'),
         ),
       ],
-    ),
-  ).whenComplete(controller.dispose);
+    );
+  }
 }

--- a/src/frontend/lib/workspace/workspace_list_page.dart
+++ b/src/frontend/lib/workspace/workspace_list_page.dart
@@ -835,14 +835,15 @@ class _WorkspaceListPageState extends State<WorkspaceListPage> {
                   heroTag: 'import',
                   onPressed: _showImportDialog,
                   tooltip: 'Import Workspace',
-                  child: const Icon(Icons.upload),
+                  child: const Icon(Icons.upload, semanticLabel: 'Import'),
                 ),
                 const SizedBox(height: 12),
                 FloatingActionButton(
                   heroTag: 'create',
                   onPressed: _createWorkspace,
                   tooltip: 'New Workspace',
-                  child: const Icon(Icons.add),
+                  child:
+                      const Icon(Icons.add, semanticLabel: 'Create workspace'),
                 ),
               ],
             )


### PR DESCRIPTION
fmtk-driven e2e coverage for every user-visible auth/session surface, per #3233. Closes #3233.

## What landed

**The suite** (`src/frontend/e2e-tests/fmtk/test_auth.py`) — eleven scenarios, each driving the real UI (`enter_text`/`tap_widget`/semantic snapshots) through a happy path plus a failure mode, with the conftest's autouse `no_app_errors` drain asserting zero uncaught Flutter errors throughout:

| Scenario | Happy path | Failure mode |
| --- | --- | --- |
| Login | valid credentials land on `/workspaces` | wrong password shows "Invalid credentials", no navigation |
| Registration + verify | create account → email link → auto-login | login-before-verify refused with working resend |
| Forgot / reset | request → emailed token → new password → logged in | weak password rejected by the client-side policy mirror |
| Forced password change | must-change user routed to `/change-password`, change → re-login | weak new password rejected inline |
| Step-up (sudo) + invite | invite → sudo dialog → correct password → invite lands; invitee accepts over the emailed link | wrong password re-prompts, write not retried |
| Silent token refresh | ~1s tokens (`access_token_hours=0.0008`), session survives | — |
| Session invalidation | rotated `jwt_secret` → forced refresh → login page with a message | (blank screen is the bug this guards against) |
| Registration toggle | link gone after `disable_registration` SIGHUP | — |
| Password policy swap | live "Min 14 characters" after `min_password_length=14` SIGHUP | — |
| Deep-link bounce | boot at `#/settings` logged out → login with "Please log in to continue." | — |
| Pending redirect | the stashed `/settings` target is honored post-login | — |

**Harness additions** (`fmtkharness.py`) the suite builds on:

- `SmtpSink` — in-process SMTP capture (no dependency): klangkd delivers verify/reset/invite tokens to it, tests fish `#/route?token=...` out of the quoted-printable-decoded bodies. Email-token flows without email.
- `app.navigate()` — hash-routes the driven tab to `#/path` via `navigateTo`, the same thing a user clicking an email link does, without killing the dwds isolate a full-page reload would.
- `app.auth_eval()` — evaluates Dart against the live `AuthService` (element-tree walk under the MultiProvider) for refresh/force/logout probes.
- `Harness.force_password_change()` — idempotent, run-unique re-arming of the must-change fixture via the admin API.
- `fmtk-chrome.sh` now preserves the boot URL's path/hash, so `restart_app(at_path=...)` boots the app AT a deep link (the pre-auth email-link UX).
- Seed gains `fmtk-mustchange` (keeps its admin-set must-change flag) and `fmtk-reset` fixtures; the smoke suite restores the banner config it swaps (a leftover consent dialog masks the next suite's logins).

**Product fixes the suite flushed out** (first commit):

- **Step-up POST now carries the DPoP proof** (`auth_service.dart`). The web client binds its token post-login (#3218); a bound token without a proof is rejected, so every sudo-mode attempt 401'd on the web. Now uses `authHeadersFor('POST', '/api/v1/auth/step-up')` like every other authed call.
- **Step-up dialog retry crash** (`step_up_dialog.dart`). The closure-owned `TextEditingController` was disposed when the dialog future completed — while the exit animation still had the field mounted — so a wrong-password retry threw "controller used after being disposed". The dialog is now a `StatefulWidget` owning its controller for its full lifetime.
- **Icon-only buttons name themselves** (app-bar Admin/Logout, admin tab strip, workspace-list FABs) via `semanticLabel`/merging `Semantics` — assistive tech announces them by name instead of "button".

## Notes on determinism

- The harness keeps backend + proxy across runs (adopted when healthy); fixtures register run-unique addresses (`uuid4` suffix) so a kept DB never collides.
- `test_logout_bounces_deep_links_to_login` runs last: booting the app at a deep link exercises the initial-route fallback path, whose fallout (framework routing noise in the debug error monitor) is filtered as known noise in `app_errors()`.

## Testing

- `test-fmtk-e2e` (fresh state): 11/11 green, ~12.5 min.
- `scripts/tests`: 126 passed (new harness contract tests included).
- `flutter test --coverage`: 1297 passed.
- xenon: rank A across the new Python.
