### PR TITLE
fmtk e2e: workspace list, create/import, start/stop/restart, delete (#3234)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -3715,3 +3715,20 @@ users(id)`, so the decider handler passing the decider's email violated the
   app-bar Admin and Logout icons, the admin page's tab strip, and the
   workspace-list FABs now expose semantic labels, so assistive tech
   announces them by name instead of "button".
+
+- **Self-registered and invited users can create workspaces again
+  (#3234).** Both the self-registration and the admin-invite paths insert
+  their user rows without the `members`-group join that admin-created
+  users get, so such users held no `create-workspace` grant (the stock
+  self-service posture) and saw no create button. Both paths now join
+  `members` on creation, like every other user-creation route.
+
+- **Workspace-page dialogs no longer trip "setState() called during
+  build" (#3234).** A WebSocket event (container started or stopped,
+  workspace list changed) could arrive while a dialog route was
+  mid-build on the web client, marking the `WsClient` provider scope
+  mid-frame — a debug assertion, and in release mode a silently dropped
+  UI update for that event. `WsClient` now defers its listener
+  notification past the frame whenever one is in its build/layout/paint
+  phase; every other phase still notifies immediately. Found by the new
+  fmtk workspace-lifecycle suite.

--- a/scripts/tests/test_fmtk_harness.py
+++ b/scripts/tests/test_fmtk_harness.py
@@ -200,6 +200,43 @@ def test_harness_auth_suite_extensions():
     )
 
 
+def test_workspace_suite_extensions():
+    """The workspace-suite harness pieces (#3234) — exact-label tile
+    taps, label/identifier waits, scroll-to-reveal, binary downloads —
+    must stay wired into the harness, and the suite must drive the
+    instrumented identifiers."""
+    harness = (_REPO_ROOT / "src/frontend/e2e-tests/fmtk/fmtkharness.py").read_text()
+    assert_wired(
+        harness,
+        (
+            "def tap_labeled_exact",
+            "def wait_for_label",
+            "def wait_for_identifier",
+            "def wait_identifier_gone",
+            "def scroll_until_label",
+            "def http_download",
+            "def find_label_nodes",
+            "def parent_map",
+        ),
+        "the workspace-suite locators (#3234) must stay wired in",
+    )
+    suite = _REPO_ROOT / "src/frontend/e2e-tests/fmtk/test_workspaces.py"
+    assert suite.is_file(), "the workspace suite (#3234) is missing"
+    assert_wired(
+        suite.read_text(),
+        (
+            "create-workspace-fab",
+            "import-workspace-fab",
+            "testPickFileBytesOverride",
+            "per_handle_home",
+            "container-stopped-overlay",
+            "workspace-delete-confirm",
+            "file-browser-path",
+        ),
+        "the workspace suite (#3234) must drive the instrumented UI",
+    )
+
+
 def test_agents_documents_the_harness():
     agents = _AGENTS.read_text()
     assert "fmtk-up" in agents, "AGENTS.md must point at the fmtk-up harness"

--- a/scripts/tests/test_fmtk_harness.py
+++ b/scripts/tests/test_fmtk_harness.py
@@ -210,6 +210,7 @@ def test_workspace_suite_extensions():
         harness,
         (
             "def tap_labeled_exact",
+            "def tap_button_exact",
             "def wait_for_label",
             "def wait_for_identifier",
             "def wait_identifier_gone",
@@ -225,12 +226,12 @@ def test_workspace_suite_extensions():
     assert_wired(
         suite.read_text(),
         (
-            "create-workspace-fab",
-            "import-workspace-fab",
+            'tap_label("Create workspace")',
+            'tap_label("Import")',
+            "tap_button_exact",
             "testPickFileBytesOverride",
             "per_handle_home",
             "container-stopped-overlay",
-            "workspace-delete-confirm",
             "file-browser-path",
         ),
         "the workspace suite (#3234) must drive the instrumented UI",

--- a/src/frontend/e2e-tests/fmtk/conftest.py
+++ b/src/frontend/e2e-tests/fmtk/conftest.py
@@ -19,17 +19,41 @@ under CI or without DISPLAY). Run via the ``test-fmtk-e2e`` devenv script.
 from __future__ import annotations
 
 import os
+import signal
 
 import pytest
 
 from fmtkharness import Harness
 
 
+def _install_teardown_handlers(harness: Harness) -> dict:
+    """An aborted run (SIGTERM / Ctrl-C at the process level) must still
+    close the browser: the session teardown never runs when the process
+    dies on a signal, so re-raise after tearing down."""
+
+    def handler(signum, frame):
+        harness.teardown()
+        signal.signal(signum, signal.SIG_DFL)
+        os.kill(os.getpid(), signum)
+
+    saved = {}
+    for sig in (signal.SIGINT, signal.SIGTERM):
+        saved[sig] = signal.signal(sig, handler)
+    return saved
+
+
+def _restore_handlers(saved: dict) -> None:
+    for sig, previous in saved.items():
+        signal.signal(sig, previous)
+
+
 @pytest.fixture(scope="session")
 def harness() -> Harness:
     instance = Harness()
     instance.boot(fresh=os.environ.get("FMTK_E2E_FRESH") == "1")
+    saved = _install_teardown_handlers(instance)
     yield instance
+    _restore_handlers(saved)
     instance.teardown()
 
 

--- a/src/frontend/e2e-tests/fmtk/fmtkharness.py
+++ b/src/frontend/e2e-tests/fmtk/fmtkharness.py
@@ -718,6 +718,34 @@ class FlutterRun:
             self.log_path.read_text(errors="replace").splitlines()[-lines:]
         )
 
+    def stop_chrome(self) -> None:
+        """Close the Chrome window(s) this run opened — even when the
+        app beneath is wedged. Matched on the proxy-origin URL the
+        fmtk-chrome.sh wrapper rewrites into Chrome's command line,
+        plus the run's remote-debugging port; TERM, grace, KILL."""
+        patterns = [f"[c]hrome.*127.0.0.1:{PROXY_PORT}"]
+        cdp = self.cdp_port()
+        if cdp:
+            patterns.append(f"[c]hrome.*remote-debugging-port={cdp}")
+        pids = {pid for pattern in patterns for pid in pids_matching(pattern)}
+        for pid in pids:
+            try:
+                os.kill(pid, signal.SIGTERM)
+            except ProcessLookupError:
+                pass
+        deadline = time.monotonic() + 5
+        while time.monotonic() < deadline and pids:
+            live = {pid for pattern in patterns for pid in pids_matching(pattern)}
+            pids &= live
+            if not pids:
+                return
+            time.sleep(0.5)
+        for pid in pids:
+            try:
+                os.kill(pid, signal.SIGKILL)
+            except ProcessLookupError:
+                pass
+
     def cdp_port(self) -> str:
         out = subprocess.run(
             ["pgrep", "-af", "chrome"], capture_output=True, text=True
@@ -728,6 +756,10 @@ class FlutterRun:
         return ""
 
     def stop(self) -> None:
+        # Close the browser window FIRST: a wedged app (dead isolate,
+        # hung boot) can keep flutter run from tearing its Chrome down,
+        # and a leftover window outlives every failure mode below.
+        self.stop_chrome()
         if self.proc and self.proc.poll() is None:
             os.killpg(self.proc.pid, signal.SIGTERM)
             try:
@@ -1050,6 +1082,23 @@ class FmtkClient:
             node = parents.get(id(node))
         raise FmtkError(f"no tappable node above label {label!r}")
 
+    def tap_button_exact(self, label: str) -> None:
+        """Tap the button whose labels carry ``label`` as a whole line.
+
+        Button semantics absorb Semantics-wrapper identifiers (only
+        text fields keep them), and substring matching collides with
+        siblings ('Restart' vs 'Restart now', 'Shut Down' vs 'Shut Down
+        Container') — exact-line matching is the deterministic form.
+        """
+        hits = [
+            node
+            for node in find_nodes(self.snapshot(), lambda n: node_type(n) == "button")
+            if label_has_line(node, label)
+        ]
+        if not hits:
+            raise FmtkError(f"no button labeled {label!r}")
+        self.tap(hits[0]["ref"])
+
     def wait_for_label(self, text: str, timeout: float = 30) -> dict:
         """Block until some node's label fields carry ``text``.
 
@@ -1092,12 +1141,17 @@ class FmtkClient:
         raise HarnessTimeout(f"identifier {identifier!r} never left the tree")
 
     def scroll_until_label(self, text: str, timeout: float = 60) -> None:
-        """Scroll down until ``text`` is labeled anywhere in the tree —
-        long forms (the settings panel's Danger Zone) keep their target
-        below the fold."""
+        """Scroll down until ``text`` is labeled by a node IN the
+        viewport — the snapshot lists off-screen nodes too, so a bare
+        label match can leave the target untappable."""
         deadline = time.monotonic() + timeout
         while time.monotonic() < deadline:
-            if find_label_nodes(self.snapshot(), text):
+            visible = [
+                node
+                for node in find_label_nodes(self.snapshot(), text)
+                if node.get("visibleInViewport")
+            ]
+            if visible:
                 return
             self.exec("scroll", {"direction": "down", "distance": 600})
             time.sleep(0.5)
@@ -1253,14 +1307,16 @@ class FmtkClient:
         return str(result)
 
     def terminal_send(self, text: str) -> str:
-        """Type AND execute raw input in the focused terminal."""
+        """Type AND execute raw input in the focused terminal. The body
+        is a bare statement — the trailing semicolon is required (the
+        evaluator does not append one)."""
         escaped = (
             text.replace("\\", "\\\\")
             .replace("$", "\\$")  # $ interpolates in the Dart literal
             .replace("'", "\\'")
             .replace("\n", "\\n")
         )
-        return self.terminal_eval(f"st!._terminal.sendText('{escaped}')")
+        return self.terminal_eval(f"st!._terminal.sendText('{escaped}');")
 
     def terminal_buffer(self) -> str:
         """The visible terminal buffer (plain, unwrapped, trimmed)."""
@@ -1275,6 +1331,15 @@ def node_labels(node: dict) -> list[str]:
     """Every human-string field a snapshot node may carry."""
     keys = ("label", "text", "value", "name", "title", "tooltip", "hint")
     return [str(node[k]) for k in keys if node.get(k)]
+
+
+def label_has_line(node: dict, text: str) -> bool:
+    """The node's labels carry ``text`` as a whole line (merged
+    semantics join labels with newlines — line equality stays exact)."""
+    for entry in node_labels(node):
+        if any(line == text for line in entry.split("\n")):
+            return True
+    return False
 
 
 def find_label_nodes(tree, text: str, exact: bool = False) -> list[dict]:

--- a/src/frontend/e2e-tests/fmtk/fmtkharness.py
+++ b/src/frontend/e2e-tests/fmtk/fmtkharness.py
@@ -126,6 +126,15 @@ def http_api(base: str, token: str, method: str, path: str, body=None):
             return exc.code, raw
 
 
+def http_download(base: str, token: str, path: str) -> bytes:
+    """Raw-bytes authenticated GET (exports are tar.gz streams, not JSON)."""
+    req = urllib.request.Request(
+        base + path, headers={"Authorization": f"Bearer {token}"}
+    )
+    with urllib.request.urlopen(req, timeout=HTTP_TIMEOUT) as resp:
+        return resp.read()
+
+
 def http_login(base: str, email: str, password: str) -> str:
     """POST /auth/login; returns the access token (raises on failure)."""
     status, body = http_api(
@@ -1017,6 +1026,83 @@ class FmtkClient:
             target = max(bar, key=lambda n: (n.get("bounds") or {}).get("right", -1))
         self.tap(target["ref"])
 
+    # --- label / identifier locators (#3234) -----------------------------
+
+    def tap_labeled_exact(self, label: str) -> None:
+        """Tap the nearest tappable node at or above the node whose label
+        carries ``label`` as a whole line.
+
+        A list tile's title text is not itself tappable (the tap lives on
+        the tile semantics above it), and substring matching would hit
+        the tile's own ``Delete <name>`` trailing button — so the label
+        match is line-exact and the climb starts at the labeled node.
+        Tabs, segments and tiles all resolve through this.
+        """
+        tree = self.snapshot()
+        hits = find_label_nodes(tree, label, exact=True)
+        if not hits:
+            raise FmtkError(f"no snapshot node labeled {label!r}")
+        parents = parent_map(tree)
+        node: dict | None = hits[0]
+        while node is not None:
+            if "tap" in (node.get("actions") or []):
+                return self.tap(node["ref"])
+            node = parents.get(id(node))
+        raise FmtkError(f"no tappable node above label {label!r}")
+
+    def wait_for_label(self, text: str, timeout: float = 30) -> dict:
+        """Block until some node's label fields carry ``text``.
+
+        Semantic labels (icon ``semanticLabel``s, ``Semantics(label:)``
+        wrappers) are not text-kind nodes, so ``wait_for``'s text
+        predicate cannot see them — e.g. the list tile's
+        ``Workspace status:`` state.
+        """
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            hits = find_label_nodes(self.snapshot(), text)
+            if hits:
+                return hits[0]
+            time.sleep(1)
+        raise HarnessTimeout(f"no node label carries {text!r}")
+
+    def identifier_node(self, identifier: str) -> dict | None:
+        hits = find_nodes(self.snapshot(), lambda n: n.get("identifier") == identifier)
+        return hits[0] if hits else None
+
+    def wait_for_identifier(self, identifier: str, timeout: float = 30) -> dict:
+        """Block until the instrumented node (``Semantics(identifier:)``)
+        is in the tree."""
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            node = self.identifier_node(identifier)
+            if node:
+                return node
+            time.sleep(1)
+        raise HarnessTimeout(f"no node with identifier {identifier!r}")
+
+    def wait_identifier_gone(self, identifier: str, timeout: float = 60) -> None:
+        """Block until the instrumented node leaves the tree (an overlay
+        the server cleared, a dialog that closed)."""
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            if self.identifier_node(identifier) is None:
+                return
+            time.sleep(1)
+        raise HarnessTimeout(f"identifier {identifier!r} never left the tree")
+
+    def scroll_until_label(self, text: str, timeout: float = 60) -> None:
+        """Scroll down until ``text`` is labeled anywhere in the tree —
+        long forms (the settings panel's Danger Zone) keep their target
+        below the fold."""
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            if find_label_nodes(self.snapshot(), text):
+                return
+            self.exec("scroll", {"direction": "down", "distance": 600})
+            time.sleep(0.5)
+        raise HarnessTimeout(f"{text!r} never appeared while scrolling")
+
     # --- hash-route navigation + in-app evaluation (per AGENTS.md) ------
 
     def navigate(self, path: str) -> None:
@@ -1159,6 +1245,11 @@ class FmtkClient:
                 "libraryUri": self.TERMINAL_LIBRARY,
             },
         )
+        # the evaluate envelope wraps the value in {'result': ...} — the
+        # same unwrap auth_eval applies, or every buffer read comes back
+        # as a dict repr
+        if isinstance(result, dict) and "result" in result:
+            return str(result["result"])
         return str(result)
 
     def terminal_send(self, text: str) -> str:
@@ -1184,6 +1275,40 @@ def node_labels(node: dict) -> list[str]:
     """Every human-string field a snapshot node may carry."""
     keys = ("label", "text", "value", "name", "title", "tooltip", "hint")
     return [str(node[k]) for k in keys if node.get(k)]
+
+
+def find_label_nodes(tree, text: str, exact: bool = False) -> list[dict]:
+    """Nodes whose label fields carry ``text`` — as a whole line
+    (``exact``) or as a substring of any line. Merged semantics join
+    labels with newlines, so line-wise matching keeps exact hits exact."""
+
+    def matches(node: dict) -> bool:
+        for entry in node_labels(node):
+            for line in entry.split("\n"):
+                if line == text if exact else text in line:
+                    return True
+        return False
+
+    return find_nodes(tree, matches)
+
+
+def parent_map(tree) -> dict:
+    """``id(node) -> parent node`` over the snapshot tree — the climb
+    from a labeled node to its tappable ancestor needs parent links the
+    nodes themselves do not carry."""
+    parents: dict = {}
+
+    def link(node, parent) -> None:
+        if isinstance(node, dict):
+            parents[id(node)] = parent
+            for child in node.get("children") or []:
+                link(child, node)
+        elif isinstance(node, list):
+            for child in node:
+                link(child, parent)
+
+    link(tree, None)
+    return parents
 
 
 def node_type(node: dict) -> str:

--- a/src/frontend/e2e-tests/fmtk/test_workspaces.py
+++ b/src/frontend/e2e-tests/fmtk/test_workspaces.py
@@ -101,8 +101,10 @@ def register_fresh_user(harness, app) -> None:
 def create_workspace(app, name: str, idle: str | None = None) -> None:
     """Create via the create FAB + dialog (``idle`` fills the Idle
     Timeout field); the dialog closing and the name listing are the
-    assertions."""
-    app.tap_identifier("create-workspace-fab")
+    assertions. The FAB is tapped by its surfaced icon label — FAB
+    semantics swallow Semantics-wrapper identifiers, and the label
+    ('Create workspace') is unique among buttons on the page."""
+    app.tap_label("Create workspace")
     app.wait_for_text("New Workspace")
     app.enter_text_identifier("create-workspace-name", name)
     if idle is not None:
@@ -136,7 +138,7 @@ def terminal_marker(app, marker: str, timeout: float = 150) -> None:
             return
         if "NO-TERMINAL-STATE" in buffer:
             app.tap_labeled_exact("Terminal")
-        app.terminal_send(f"echo {marker}")
+        app.terminal_send(f"echo {marker}\n")
         time.sleep(3)
     raise AssertionError(f"terminal never echoed {marker!r}")
 
@@ -150,12 +152,13 @@ def own_workspace_id(harness, email: str, password: str, name: str) -> int:
 
 def delete_from_list(app, name: str) -> None:
     """Delete via the tile's trailing button + confirm dialog; the name
-    leaving the list is the assertion."""
+    leaving the list is the assertion. Buttons are addressed by exact
+    label — wrapper identifiers do not survive on buttons."""
     app.navigate("/workspaces")
     app.wait_for_text(name)
     app.tap_label(f"Delete {name}")
-    app.wait_for_identifier("workspace-delete-confirm")
-    app.tap_identifier("workspace-delete-confirm")
+    app.wait_for_text("This will delete the workspace")
+    app.tap_button_exact("Delete")
     app.wait_gone(name)
 
 
@@ -209,19 +212,34 @@ def test_open_workspace_terminal_works(harness, app):
     app.wait_for_label("Workspace status: running")
 
 
+def open_settings_pane(app) -> None:
+    """Switch to the Settings tab and wait for its first section. A
+    tab tap can race a concurrent WS-driven rebuild (container events
+    land while the workspace page is settling) — re-tap until the pane
+    actually mounts (selecting an already-selected tab is a no-op)."""
+    deadline = time.monotonic() + 45
+    while time.monotonic() < deadline:
+        app.tap_labeled_exact("Settings")
+        try:
+            app.wait_for_label("General", 5)
+            return
+        except FmtkError:
+            continue
+    raise FmtkError("Settings pane never mounted")
+
+
 def test_stop_and_restart_from_overlay(harness, app):
     open_workspace(app, LIFE_WS)
     # stop: Settings -> Danger Zone -> Shut Down Container -> confirm
-    app.tap_labeled_exact("Settings")
-    app.wait_for_label("General")
+    open_settings_pane(app)
     app.scroll_until_label("Shut Down Container")
-    app.tap_identifier("shutdown-container")
-    app.wait_for_identifier("shutdown-confirm")
-    app.tap_identifier("shutdown-confirm")
+    app.tap_button_exact("Shut Down Container")
+    app.wait_for_text("end all terminal sessions")
+    app.tap_button_exact("Shut Down")
     app.wait_for_identifier("container-stopped-overlay", 60)
     # start again from the overlay: spinner, then container_ready clears
     # it and the workspace is usable again (the stop -> start cycle)
-    app.tap_identifier("container-restart-button")
+    app.tap_button_exact("Restart")
     app.wait_identifier_gone("container-stopped-overlay", 120)
     terminal_marker(app, f"RST{RUN}")
     app.navigate("/workspaces")
@@ -230,8 +248,7 @@ def test_stop_and_restart_from_overlay(harness, app):
 
 def test_settings_edit_restarts_via_notice(harness, app):
     open_workspace(app, LIFE_WS)
-    app.tap_labeled_exact("Settings")
-    app.wait_for_label("General")
+    open_settings_pane(app)
     app.scroll_until_label("Idle Timeout (s)")
     app.enter_text_identifier("settings-idle-timeout", "0")
     app.scroll_until_label("Save")
@@ -267,9 +284,11 @@ def test_import_from_archive(harness, app):
             ),
         },
     )
-    app.tap_identifier("import-workspace-fab")
+    app.tap_label("Import")  # the import FAB (label-unique on the page)
     app.wait_for_text("Import Workspace")
-    app.tap_identifier("import-select-file")
+    # button semantics absorb wrapper identifiers (only text fields keep
+    # them) — address the picker and the submit by their exact labels
+    app.tap_button_exact("Select .tar.gz file")
     app.wait_for_text("workspace.tar.gz")  # the picked file rendered
     app.enter_text_identifier("import-workspace-name", IMP_WS)
     app.tap_label("Import")
@@ -282,9 +301,13 @@ def test_import_from_archive(harness, app):
 
 
 def test_per_user_home_roots_file_browser(harness, app):
-    original = harness.config.get("per_handle_home", False)
-    harness.backend.swap_settings({"per_handle_home": True}, apply="sighup")
-    harness.backend.wait_config_value("per_handle_home_available", True)
+    # Always restore the stock shared-home posture (False) rather than a
+    # captured original: earlier failed runs can leave a polluted yaml,
+    # and "restoring" to that would carry the pollution forward forever.
+    harness.backend.swap_settings(
+        {"per_handle_home": True}, apply="sighup", verify=False
+    )
+    harness.backend.wait_config_value("default_per_handle_home", True)
     try:
         at_login(harness, app)
         login_fresh(app)
@@ -304,8 +327,24 @@ def test_per_user_home_roots_file_browser(harness, app):
         delete_from_list(app, HOME_WS)
         app.logout()
     finally:
-        harness.backend.swap_settings({"per_handle_home": original}, apply="sighup")
-        harness.backend.wait_config_value("per_handle_home_available", False)
+        harness.backend.swap_settings(
+            {"per_handle_home": False}, apply="sighup", verify=False
+        )
+        harness.backend.wait_config_value("default_per_handle_home", False)
+
+
+def wait_default_image(harness, image: str, timeout: float = 30) -> None:
+    """Block until /api/v1/images carries ``image`` as the default — a
+    SIGHUP reload completes asynchronously and /config does not expose
+    image_name, so the picker endpoint is the gate."""
+    token = http_login(harness.backend.url, ADMIN_EMAIL, FIXTURE_PASSWORD)
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        status, images = http_api(harness.backend.url, token, "GET", "/api/v1/images")
+        if status == 200 and images.get("default") == image:
+            return
+        time.sleep(1)
+    raise AssertionError(f"default image never became {image!r}")
 
 
 def test_swapped_default_image_picked_up(harness, app):
@@ -314,13 +353,10 @@ def test_swapped_default_image_picked_up(harness, app):
         {"image_name": SWAP_IMAGE}, apply="sighup", verify=False
     )
     try:
-        # /config does not expose image_name — the picker endpoint does
-        token = http_login(harness.backend.url, ADMIN_EMAIL, FIXTURE_PASSWORD)
-        status, images = http_api(harness.backend.url, token, "GET", "/api/v1/images")
-        assert status == 200 and images["default"] == SWAP_IMAGE, images
+        wait_default_image(harness, SWAP_IMAGE)
         at_login(harness, app)
         app.login(ADMIN_EMAIL, FIXTURE_PASSWORD, expect_text="fmtk-verify")
-        app.tap_identifier("create-workspace-fab")
+        app.tap_label("Create workspace")
         app.wait_for_text("New Workspace")
         # the dialog preselects the swapped default; a workspace created
         # from this form resolves to it at start

--- a/src/frontend/e2e-tests/fmtk/test_workspaces.py
+++ b/src/frontend/e2e-tests/fmtk/test_workspaces.py
@@ -1,0 +1,384 @@
+"""fmtk e2e: workspace list, create/import, start/stop/restart, delete
+(#3234).
+
+Every user-visible workspace-lifecycle surface, driven through the real
+UI: the list page's Owned/Shared sections, creation (dialog + FAB) and
+the container reaching ``running``, import from an archive over the
+import dialog's file hook, stop / start / restart transitions (settings
+Danger Zone + the stopped overlay + the pending-restart notice) with the
+list status label tracking the real container state throughout, delete
+disappearing for the owner and for shared members, the per-user-home
+file-browser rooting (the per-handle-home ceiling swapped on over
+SIGHUP), the swapped default image picked up by the create dialog, and
+the idle auto-stop reaper stopping a workspace in-test.
+
+Tests run in definition order and share one ordered chain: 2-6 drive
+one run-unique workspace through create → open → terminal → stop →
+restart → settings-restart → delete as the run-registered user; the
+later scenarios are self-contained logins. Re-run the whole file (a
+``-k`` selection breaks the chain — workspace names and users are
+run-unique).
+
+The fixture workspace ``fmtk-verify`` is never mutated or deleted; every
+scratch workspace is run-unique and cleaned up by the scenario that
+created it.
+"""
+
+from __future__ import annotations
+
+import base64
+import io
+import json
+import tarfile
+import time
+import uuid
+
+from fmtkharness import (
+    ADMIN_EMAIL,
+    FIXTURE_PASSWORD,
+    FmtkError,
+    find_nodes,
+    http_api,
+    http_login,
+    node_labels,
+    node_type,
+)
+
+RUN = uuid.uuid4().hex[:6]
+FRESH_EMAIL = f"fmtk-ws{RUN}@example.com"
+FRESH_PW = f"fmtk-Ws{RUN}!E5"
+LIFE_WS = f"fmtk-life-{RUN}"
+IDLE_WS = f"fmtk-idle-{RUN}"
+HOME_WS = f"fmtk-home-{RUN}"
+IMP_WS = f"fmtk-imp-{RUN}"
+DEL_WS = f"fmtk-del-{RUN}"
+COLLAB_EMAIL = "fmtk-collaborator@example.com"
+# A second real tag of the workspace image: swapping the default must
+# point somewhere startable, not just anywhere.
+SWAP_IMAGE = "localhost/klangk-workspace:2026.09.05-7422a6cfd"
+
+
+# --- shared driving helpers (suite-local; harness keeps primitives) ----
+
+
+def walk_fields(app) -> list[dict]:
+    """The visible text fields, in reading order."""
+    return find_nodes(app.snapshot(), lambda n: node_type(n) == "textField")
+
+
+def at_login(harness, app) -> None:
+    """Land on the usable login form (dead sessions are ended, a dead
+    app restarted), then dismiss any leftover login-banner dialog."""
+    app.navigate("/login")
+    if not app.has_text("Log In", 10000):
+        try:
+            app.auth_eval("auth!.logout(); return 'ok';")
+        except FmtkError:
+            harness.restart_app()
+    app.wait_for_login_page()
+    app.dismiss_login_banner()
+    app.wait_for_text("Email or handle")
+
+
+def login_fresh(app) -> None:
+    app.login(FRESH_EMAIL, FRESH_PW, expect_text="No workspaces yet")
+
+
+def register_fresh_user(harness, app) -> None:
+    """Register + email-verify the run-unique user; the auto-login lands
+    on the empty owned list (the issue's Done-when starting point)."""
+    app.tap_label("Need an account? Create one")
+    fields = walk_fields(app)
+    app.enter_text(fields[0]["ref"], FRESH_EMAIL)
+    app.enter_text(fields[1]["ref"], FRESH_PW)
+    app.tap_label("Create Account")
+    app.wait_for_text("Check your email to verify your account.")
+    token = harness.smtp.token_for("verify", FRESH_EMAIL)
+    app.navigate(f"/verify?token={token}")
+    app.wait_for_text("No workspaces yet. Create one to get started.")
+
+
+def create_workspace(app, name: str, idle: str | None = None) -> None:
+    """Create via the create FAB + dialog (``idle`` fills the Idle
+    Timeout field); the dialog closing and the name listing are the
+    assertions."""
+    app.tap_identifier("create-workspace-fab")
+    app.wait_for_text("New Workspace")
+    app.enter_text_identifier("create-workspace-name", name)
+    if idle is not None:
+        app.enter_text_identifier("create-workspace-idle-timeout", idle)
+    app.tap_label("Create")
+    app.wait_gone("New Workspace")
+    app.wait_for_text(name)
+
+
+def open_workspace(app, name: str) -> None:
+    """Tap the tile; the workspace page's Terminal tab (absent from the
+    list page) is the mount signal."""
+    app.navigate("/workspaces")
+    app.wait_for_text(name)
+    app.tap_labeled_exact(name)
+    app.wait_for_text("Terminal", 60000)
+
+
+def terminal_marker(app, marker: str, timeout: float = 150) -> None:
+    """Prove the workspace is usable: execute an echo and find it in the
+    buffer. sendText's return proves nothing (AGENTS.md) — only the
+    buffer read does. Self-healing across the states a lifecycle test
+    leaves the pane in: an unmounted terminal (another tab was active,
+    or the pane was replaced) remounts via the Terminal tab, and a
+    stop/restart still in flight simply retries until container_ready.
+    """
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        buffer = app.terminal_buffer()
+        if marker in buffer:
+            return
+        if "NO-TERMINAL-STATE" in buffer:
+            app.tap_labeled_exact("Terminal")
+        app.terminal_send(f"echo {marker}")
+        time.sleep(3)
+    raise AssertionError(f"terminal never echoed {marker!r}")
+
+
+def own_workspace_id(harness, email: str, password: str, name: str) -> int:
+    token = http_login(harness.backend.url, email, password)
+    status, mine = http_api(harness.backend.url, token, "GET", "/api/v1/workspaces")
+    assert status == 200, mine
+    return next(w["id"] for w in mine if w["name"] == name)
+
+
+def delete_from_list(app, name: str) -> None:
+    """Delete via the tile's trailing button + confirm dialog; the name
+    leaving the list is the assertion."""
+    app.navigate("/workspaces")
+    app.wait_for_text(name)
+    app.tap_label(f"Delete {name}")
+    app.wait_for_identifier("workspace-delete-confirm")
+    app.tap_identifier("workspace-delete-confirm")
+    app.wait_gone(name)
+
+
+def import_archive_bytes(harness) -> bytes:
+    """A minimal valid import archive: workspace.json carrying THIS
+    instance's id (provenance is checked) — the home/ tree is optional
+    and omitted."""
+    instance_id = harness.backend.config["data_dir"].rstrip("/") + "/instance-id"
+    with open(instance_id) as fh:
+        local_id = fh.read().strip()
+    meta = json.dumps({"name": "archived", "instance_id": local_id}).encode()
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w:gz") as tar:
+        entry = tarfile.TarInfo("workspace.json")
+        entry.size = len(meta)
+        tar.addfile(entry, io.BytesIO(meta))
+    return buf.getvalue()
+
+
+# --- scenarios ---------------------------------------------------------
+
+
+def test_list_sections_owner_and_shared(harness, app):
+    # the fixture owner sees fmtk-verify under "Owned by Me"
+    at_login(harness, app)
+    app.login(ADMIN_EMAIL, FIXTURE_PASSWORD, expect_text="fmtk-verify")
+    app.wait_for_text("Owned by Me")
+    app.wait_for_text("Shared with Me")
+    app.logout()
+    # a role member sees it under "Shared with Me" after tapping the tab
+    app.login(COLLAB_EMAIL, FIXTURE_PASSWORD, expect_text="No workspaces yet")
+    app.tap_labeled_exact("Shared with Me")
+    app.wait_for_text("fmtk-verify")
+    app.wait_for_text("fmtk-admin@example.com")  # shared tiles show the owner
+    app.logout()
+
+
+def test_fresh_user_registers_and_creates_workspace(harness, app):
+    at_login(harness, app)
+    register_fresh_user(harness, app)
+    create_workspace(app, LIFE_WS)
+    # a fresh workspace's container has never started
+    app.wait_for_label("Workspace status: stopped")
+
+
+def test_open_workspace_terminal_works(harness, app):
+    open_workspace(app, LIFE_WS)
+    terminal_marker(app, f"OPEN{RUN}")
+    # the tile tracks the real container state once it runs
+    app.navigate("/workspaces")
+    app.wait_for_label("Workspace status: running")
+
+
+def test_stop_and_restart_from_overlay(harness, app):
+    open_workspace(app, LIFE_WS)
+    # stop: Settings -> Danger Zone -> Shut Down Container -> confirm
+    app.tap_labeled_exact("Settings")
+    app.wait_for_label("General")
+    app.scroll_until_label("Shut Down Container")
+    app.tap_identifier("shutdown-container")
+    app.wait_for_identifier("shutdown-confirm")
+    app.tap_identifier("shutdown-confirm")
+    app.wait_for_identifier("container-stopped-overlay", 60)
+    # start again from the overlay: spinner, then container_ready clears
+    # it and the workspace is usable again (the stop -> start cycle)
+    app.tap_identifier("container-restart-button")
+    app.wait_identifier_gone("container-stopped-overlay", 120)
+    terminal_marker(app, f"RST{RUN}")
+    app.navigate("/workspaces")
+    app.wait_for_label("Workspace status: running")
+
+
+def test_settings_edit_restarts_via_notice(harness, app):
+    open_workspace(app, LIFE_WS)
+    app.tap_labeled_exact("Settings")
+    app.wait_for_label("General")
+    app.scroll_until_label("Idle Timeout (s)")
+    app.enter_text_identifier("settings-idle-timeout", "0")
+    app.scroll_until_label("Save")
+    app.tap_label("Save")
+    # a create-time edit arms the pending-restart notice with its action
+    app.wait_for_text("Restart the workspace to apply")
+    app.tap_label("Restart now")
+    # the running container restarts (no overlay between states here) —
+    # the terminal coming back is the proof
+    terminal_marker(app, f"SVR{RUN}")
+
+
+def test_delete_workspace(harness, app):
+    delete_from_list(app, LIFE_WS)
+    app.logout()
+
+
+def test_import_from_archive(harness, app):
+    at_login(harness, app)
+    app.login(ADMIN_EMAIL, FIXTURE_PASSWORD, expect_text="fmtk-verify")
+    archive = base64.b64encode(import_archive_bytes(harness)).decode()
+    # hand the archive to the dialog's visible-for-testing picker hook —
+    # the browser's native file chooser cannot be driven from the harness
+    app.exec(
+        "evaluate_dart_expression",
+        {
+            "expression": (
+                "testPickFileBytesOverride = ({String accept = '*'}) "
+                f"async => base64Decode('{archive}');"
+            ),
+            "libraryUri": (
+                "package:klangk_frontend/workspace/import_workspace_dialog.dart"
+            ),
+        },
+    )
+    app.tap_identifier("import-workspace-fab")
+    app.wait_for_text("Import Workspace")
+    app.tap_identifier("import-select-file")
+    app.wait_for_text("workspace.tar.gz")  # the picked file rendered
+    app.enter_text_identifier("import-workspace-name", IMP_WS)
+    app.tap_label("Import")
+    app.wait_gone("Import Workspace")
+    app.wait_for_text(IMP_WS)
+    # the imported workspace opens like any other
+    open_workspace(app, IMP_WS)
+    delete_from_list(app, IMP_WS)
+    app.logout()
+
+
+def test_per_user_home_roots_file_browser(harness, app):
+    original = harness.config.get("per_handle_home", False)
+    harness.backend.swap_settings({"per_handle_home": True}, apply="sighup")
+    harness.backend.wait_config_value("per_handle_home_available", True)
+    try:
+        at_login(harness, app)
+        login_fresh(app)
+        # the create flow re-fetches deploy config (#2994): the per-handle
+        # checkbox now defaults on, so an untouched form opts the new
+        # workspace in
+        create_workspace(app, HOME_WS)
+        open_workspace(app, HOME_WS)
+        app.tap_labeled_exact("Files")
+        node = app.wait_for_identifier("file-browser-path")
+        label = " ".join(node_labels(node))
+        # rooted at the member's per-handle home, not the shared
+        # /home/klangk (the per-user-home Playwright spec's assertion,
+        # driven through the UI this time)
+        assert "/home/" in label, label
+        assert "/home/klangk" not in label, label
+        delete_from_list(app, HOME_WS)
+        app.logout()
+    finally:
+        harness.backend.swap_settings({"per_handle_home": original}, apply="sighup")
+        harness.backend.wait_config_value("per_handle_home_available", False)
+
+
+def test_swapped_default_image_picked_up(harness, app):
+    original = harness.config.get("image_name", "klangk-workspace")
+    harness.backend.swap_settings(
+        {"image_name": SWAP_IMAGE}, apply="sighup", verify=False
+    )
+    try:
+        # /config does not expose image_name — the picker endpoint does
+        token = http_login(harness.backend.url, ADMIN_EMAIL, FIXTURE_PASSWORD)
+        status, images = http_api(harness.backend.url, token, "GET", "/api/v1/images")
+        assert status == 200 and images["default"] == SWAP_IMAGE, images
+        at_login(harness, app)
+        app.login(ADMIN_EMAIL, FIXTURE_PASSWORD, expect_text="fmtk-verify")
+        app.tap_identifier("create-workspace-fab")
+        app.wait_for_text("New Workspace")
+        # the dialog preselects the swapped default; a workspace created
+        # from this form resolves to it at start
+        app.wait_for_text(SWAP_IMAGE)
+        app.tap_label("Cancel")
+        app.wait_gone("New Workspace")
+        app.logout()
+    finally:
+        harness.backend.swap_settings(
+            {"image_name": original}, apply="sighup", verify=False
+        )
+
+
+def test_idle_auto_stop(harness, app):
+    at_login(harness, app)
+    login_fresh(app)
+    # 15s idle timeout; the reaper sweeps at half the smallest active
+    # timeout, so the stop lands within ~25s of the last input
+    create_workspace(app, IDLE_WS, idle="15")
+    open_workspace(app, IDLE_WS)
+    terminal_marker(app, f"IDL{RUN}")
+    # no further input: the overlay carries the idle reason, and the
+    # list status label tracks the stop
+    app.wait_for_identifier("container-stopped-overlay", 90)
+    app.wait_for_text("idle timeout")
+    app.navigate("/workspaces")
+    app.wait_for_label("Workspace status: stopped")
+    delete_from_list(app, IDLE_WS)
+    app.logout()
+
+
+def test_delete_disappears_for_shared_member(harness, app):
+    at_login(harness, app)
+    login_fresh(app)
+    create_workspace(app, DEL_WS)
+    # share with the fixture collaborator over the owner API (the
+    # Sharing UI is #3238's surface)
+    token = http_login(harness.backend.url, FRESH_EMAIL, FRESH_PW)
+    ws_id = own_workspace_id(harness, FRESH_EMAIL, FRESH_PW, DEL_WS)
+    status, body = http_api(
+        harness.backend.url,
+        token,
+        "POST",
+        f"/api/v1/workspaces/{ws_id}/members",
+        {"email": COLLAB_EMAIL},
+    )
+    assert status == 200, body
+    # the member sees it under Shared with Me
+    app.logout()
+    app.login(COLLAB_EMAIL, FIXTURE_PASSWORD, expect_text="No workspaces yet")
+    app.tap_labeled_exact("Shared with Me")
+    app.wait_for_text(DEL_WS)
+    app.logout()
+    # the owner deletes; it leaves the member's shared list too
+    app.login(FRESH_EMAIL, FRESH_PW, expect_text=DEL_WS)
+    delete_from_list(app, DEL_WS)
+    app.logout()
+    app.login(COLLAB_EMAIL, FIXTURE_PASSWORD, expect_text="No workspaces yet")
+    app.tap_labeled_exact("Shared with Me")
+    app.wait_gone(DEL_WS)
+    app.logout()

--- a/src/frontend/lib/file_viewer/file_viewer_panel.dart
+++ b/src/frontend/lib/file_viewer/file_viewer_panel.dart
@@ -1,10 +1,14 @@
 import 'dart:convert';
 import 'dart:typed_data';
+
 import 'package:flutter/material.dart';
 import 'package:http/http.dart' as http;
+
 import '../auth/dpop.dart';
 import '../ws/ws_client.dart';
+
 import 'package:klangk_plugin_api/klangk_plugin_api.dart';
+
 import '../utils/web_helpers_stub.dart'
     if (dart.library.js_interop) '../utils/web_helpers_web.dart';
 import 'file_upload.dart';
@@ -168,10 +172,7 @@ class FileViewerPanelState extends State<FileViewerPanel> {
 
   /// Headers for one authenticated file-API request: the Bearer token
   /// plus a DPoP proof when that token is bound (#3218).
-  Future<Map<String, String>> _headersFor(
-    String method,
-    String url,
-  ) async {
+  Future<Map<String, String>> _headersFor(String method, String url) async {
     final headers = <String, String>{
       if (widget.authToken != null)
         'Authorization': 'Bearer ${widget.authToken}',
@@ -434,9 +435,7 @@ class FileViewerPanelState extends State<FileViewerPanel> {
     } catch (e) {
       debugPrint('Delete error: $e');
       if (mounted) {
-        ScaffoldMessenger.of(
-          context,
-        ).showSnackBar(
+        ScaffoldMessenger.of(context).showSnackBar(
           const SnackBar(content: Text('Could not delete. Please try again.')),
         );
       }
@@ -492,9 +491,8 @@ class FileViewerPanelState extends State<FileViewerPanel> {
         // listing was cached). Drop the stale entry and inform the user.
         _invalidateCurrent();
         _loadFiles(force: true);
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text('"$name" no longer exists')),
-        );
+        ScaffoldMessenger.of(context)
+            .showSnackBar(SnackBar(content: Text('"$name" no longer exists')));
       } else {
         if (mounted) {
           final body = jsonDecode(response.body);
@@ -510,9 +508,7 @@ class FileViewerPanelState extends State<FileViewerPanel> {
     } catch (e) {
       debugPrint('Rename error: $e');
       if (mounted) {
-        ScaffoldMessenger.of(
-          context,
-        ).showSnackBar(
+        ScaffoldMessenger.of(context).showSnackBar(
           const SnackBar(content: Text('Could not rename. Please try again.')),
         );
       }
@@ -534,9 +530,9 @@ class FileViewerPanelState extends State<FileViewerPanel> {
         _invalidateCurrent();
         _loadFiles(force: true);
         if (mounted) {
-          ScaffoldMessenger.of(context).showSnackBar(
-            SnackBar(content: Text('"$name" no longer exists')),
-          );
+          ScaffoldMessenger.of(
+            context,
+          ).showSnackBar(SnackBar(content: Text('"$name" no longer exists')));
         }
         return;
       }
@@ -553,9 +549,7 @@ class FileViewerPanelState extends State<FileViewerPanel> {
     } catch (e) {
       debugPrint('Download error: $e');
       if (mounted) {
-        ScaffoldMessenger.of(
-          context,
-        ).showSnackBar(
+        ScaffoldMessenger.of(context).showSnackBar(
           const SnackBar(
             content: Text('Could not download. Please try again.'),
           ),
@@ -701,13 +695,33 @@ class FileViewerPanelState extends State<FileViewerPanel> {
         children: [
           InkWell(
             onTap: () => _navigateTo(widget.userHome ?? '/'),
-            child: const Icon(Icons.home, size: 16),
+            child: const Icon(
+              Icons.home,
+              size: 16,
+              // Named for assistive tech and the fmtk e2e driver.
+              semanticLabel: 'Go to home directory',
+            ),
           ),
           const SizedBox(width: 4),
-          Expanded(child: _buildBreadcrumbs()),
+          Expanded(
+            // The breadcrumbs are a RichText (invisible to semantic
+            // snapshots); carry the current path as a labeled node for
+            // assistive tech and the fmtk e2e driver — the per-user-home
+            // assertion reads it (#3234).
+            child: Semantics(
+              container: true,
+              identifier: 'file-browser-path',
+              label: 'Current directory: $_currentPath',
+              child: _buildBreadcrumbs(),
+            ),
+          ),
           if (_currentPath != '/')
             IconButton(
-              icon: const Icon(Icons.arrow_upward, size: 28),
+              icon: const Icon(
+                Icons.arrow_upward,
+                size: 28,
+                semanticLabel: 'Up one directory',
+              ),
               onPressed: () {
                 final lastSlash = _currentPath.lastIndexOf('/');
                 final parent =
@@ -718,7 +732,11 @@ class FileViewerPanelState extends State<FileViewerPanel> {
               tooltip: 'Up',
             ),
           IconButton(
-            icon: const Icon(Icons.refresh, size: 28),
+            icon: const Icon(
+              Icons.refresh,
+              size: 28,
+              semanticLabel: 'Refresh file list',
+            ),
             onPressed: () => _loadFiles(force: true),
             iconSize: 28,
           ),
@@ -762,10 +780,7 @@ class FileViewerPanelState extends State<FileViewerPanel> {
       },
       child: ListTile(
         dense: true,
-        leading: Icon(
-          isDir ? Icons.folder : Icons.insert_drive_file,
-          size: 18,
-        ),
+        leading: Icon(isDir ? Icons.folder : Icons.insert_drive_file, size: 18),
         title: Text(name, style: const TextStyle(fontSize: 13)),
         subtitle: isDir
             ? null
@@ -815,9 +830,7 @@ class FileViewerPanelState extends State<FileViewerPanel> {
           child: Text(
             'Cannot list this directory:\n$_listError',
             textAlign: TextAlign.center,
-            style: TextStyle(
-              color: Theme.of(context).colorScheme.error,
-            ),
+            style: TextStyle(color: Theme.of(context).colorScheme.error),
           ),
         ),
       );

--- a/src/frontend/lib/workspace/create_workspace_dialog.dart
+++ b/src/frontend/lib/workspace/create_workspace_dialog.dart
@@ -1,6 +1,8 @@
 import 'dart:convert';
+
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+
 import '../auth/auth_service.dart';
 import '../theme/colors.dart';
 import 'marking_banner.dart' show classificationBannerMaxLength;
@@ -351,38 +353,48 @@ class _CreateWorkspaceDialogState extends State<CreateWorkspaceDialog> {
                       icon: Icons.tune,
                       title: 'General',
                       children: [
-                        TextField(
-                          controller: _nameController,
-                          decoration: InputDecoration(
-                            labelText: 'Name',
-                            labelStyle: _labelStyle,
-                            floatingLabelStyle: _labelStyle,
-                            floatingLabelBehavior: FloatingLabelBehavior.always,
-                            border: const OutlineInputBorder(),
+                        Semantics(
+                          container: true,
+                          identifier: 'create-workspace-name',
+                          child: TextField(
+                            controller: _nameController,
+                            decoration: InputDecoration(
+                              labelText: 'Name',
+                              labelStyle: _labelStyle,
+                              floatingLabelStyle: _labelStyle,
+                              floatingLabelBehavior:
+                                  FloatingLabelBehavior.always,
+                              border: const OutlineInputBorder(),
+                            ),
+                            autofocus: true,
+                            onSubmitted: (_) => _submit(),
                           ),
-                          autofocus: true,
-                          onSubmitted: (_) => _submit(),
                         ),
                         const SizedBox(height: 16),
-                        DropdownButtonFormField<String>(
-                          initialValue: _selectedImage,
-                          decoration: InputDecoration(
-                            labelText: 'Container Image',
-                            labelStyle: _labelStyle,
-                            floatingLabelStyle: _labelStyle,
-                            floatingLabelBehavior: FloatingLabelBehavior.always,
-                            border: const OutlineInputBorder(),
-                          ),
-                          items: widget.allowedImages
-                              .map(
-                                (img) => DropdownMenuItem(
-                                  value: img,
-                                  child: Text(img),
-                                ),
-                              )
-                              .toList(),
-                          onChanged: (v) => setState(
-                            () => _selectedImage = v ?? widget.defaultImage,
+                        Semantics(
+                          container: true,
+                          identifier: 'create-workspace-image',
+                          child: DropdownButtonFormField<String>(
+                            initialValue: _selectedImage,
+                            decoration: InputDecoration(
+                              labelText: 'Container Image',
+                              labelStyle: _labelStyle,
+                              floatingLabelStyle: _labelStyle,
+                              floatingLabelBehavior:
+                                  FloatingLabelBehavior.always,
+                              border: const OutlineInputBorder(),
+                            ),
+                            items: widget.allowedImages
+                                .map(
+                                  (img) => DropdownMenuItem(
+                                    value: img,
+                                    child: Text(img),
+                                  ),
+                                )
+                                .toList(),
+                            onChanged: (v) => setState(
+                              () => _selectedImage = v ?? widget.defaultImage,
+                            ),
                           ),
                         ),
                         if (widget.allowAutostart) ...[
@@ -392,16 +404,21 @@ class _CreateWorkspaceDialogState extends State<CreateWorkspaceDialog> {
                           // opaque background surface.
                           Material(
                             type: MaterialType.transparency,
-                            child: CheckboxListTile(
-                              value: _autoStart,
-                              onChanged: (v) =>
-                                  setState(() => _autoStart = v ?? false),
-                              title: const Text('Auto start'),
-                              subtitle: const Text(
-                                'Start this workspace when the server starts',
+                            child: Semantics(
+                              container: true,
+                              identifier: 'create-workspace-autostart',
+                              child: CheckboxListTile(
+                                value: _autoStart,
+                                onChanged: (v) =>
+                                    setState(() => _autoStart = v ?? false),
+                                title: const Text('Auto start'),
+                                subtitle: const Text(
+                                  'Start this workspace when the server starts',
+                                ),
+                                controlAffinity:
+                                    ListTileControlAffinity.leading,
+                                contentPadding: EdgeInsets.zero,
                               ),
-                              controlAffinity: ListTileControlAffinity.leading,
-                              contentPadding: EdgeInsets.zero,
                             ),
                           ),
                         ],
@@ -472,9 +489,8 @@ class _CreateWorkspaceDialogState extends State<CreateWorkspaceDialog> {
                               child: Text('allow (default-permit)'),
                             ),
                           ],
-                          onChanged: (v) => setState(
-                            () => _egressMode = v ?? 'interactive',
-                          ),
+                          onChanged: (v) =>
+                              setState(() => _egressMode = v ?? 'interactive'),
                         ),
                         const SizedBox(height: 16),
                         ..._buildAllowedDomainsEditor(),
@@ -491,18 +507,22 @@ class _CreateWorkspaceDialogState extends State<CreateWorkspaceDialog> {
                         Row(
                           children: [
                             Expanded(
-                              child: TextField(
-                                controller: _idleTimeoutController,
-                                decoration: InputDecoration(
-                                  labelText: 'Idle Timeout (s)',
-                                  labelStyle: _labelStyle,
-                                  floatingLabelStyle: _labelStyle,
-                                  floatingLabelBehavior:
-                                      FloatingLabelBehavior.always,
-                                  border: const OutlineInputBorder(),
-                                  hintText: '0 = never',
+                              child: Semantics(
+                                container: true,
+                                identifier: 'create-workspace-idle-timeout',
+                                child: TextField(
+                                  controller: _idleTimeoutController,
+                                  decoration: InputDecoration(
+                                    labelText: 'Idle Timeout (s)',
+                                    labelStyle: _labelStyle,
+                                    floatingLabelStyle: _labelStyle,
+                                    floatingLabelBehavior:
+                                        FloatingLabelBehavior.always,
+                                    border: const OutlineInputBorder(),
+                                    hintText: '0 = never',
+                                  ),
+                                  keyboardType: TextInputType.number,
                                 ),
-                                keyboardType: TextInputType.number,
                               ),
                             ),
                             const SizedBox(width: 12),
@@ -644,9 +664,8 @@ class _CreateWorkspaceDialogState extends State<CreateWorkspaceDialog> {
                             type: MaterialType.transparency,
                             child: CheckboxListTile(
                               value: _perHandleHome,
-                              onChanged: (v) => setState(
-                                () => _perHandleHome = v ?? true,
-                              ),
+                              onChanged: (v) =>
+                                  setState(() => _perHandleHome = v ?? true),
                               title: const Text('Per-handle home'),
                               subtitle: const Text(
                                 'Each member gets a private /home/<handle>; '
@@ -715,7 +734,11 @@ class _CreateWorkspaceDialogState extends State<CreateWorkspaceDialog> {
                     ),
                   ),
                   IconButton(
-                    icon: const Icon(Icons.copy, size: 16),
+                    icon: const Icon(
+                      Icons.copy,
+                      size: 16,
+                      semanticLabel: 'Copy mount',
+                    ),
                     tooltip: 'Copy',
                     onPressed: () =>
                         Clipboard.setData(ClipboardData(text: e.value)),
@@ -724,7 +747,11 @@ class _CreateWorkspaceDialogState extends State<CreateWorkspaceDialog> {
                   ),
                   const SizedBox(width: 4),
                   IconButton(
-                    icon: const Icon(Icons.close, size: 18),
+                    icon: const Icon(
+                      Icons.close,
+                      size: 18,
+                      semanticLabel: 'Remove mount',
+                    ),
                     onPressed: () => setState(() => _mounts.removeAt(e.key)),
                     padding: EdgeInsets.zero,
                     constraints: const BoxConstraints(),
@@ -758,7 +785,10 @@ class _CreateWorkspaceDialogState extends State<CreateWorkspaceDialog> {
             ),
           ),
           const SizedBox(width: 8),
-          IconButton(icon: const Icon(Icons.add), onPressed: _tryAddMount),
+          IconButton(
+            icon: const Icon(Icons.add, semanticLabel: 'Add mount'),
+            onPressed: _tryAddMount,
+          ),
         ],
       ),
     ];
@@ -778,7 +808,11 @@ class _CreateWorkspaceDialogState extends State<CreateWorkspaceDialog> {
                     ),
                   ),
                   IconButton(
-                    icon: const Icon(Icons.copy, size: 16),
+                    icon: const Icon(
+                      Icons.copy,
+                      size: 16,
+                      semanticLabel: 'Copy environment variable',
+                    ),
                     tooltip: 'Copy',
                     onPressed: () => Clipboard.setData(
                       ClipboardData(text: '${e.value.key}=${e.value.value}'),
@@ -788,7 +822,11 @@ class _CreateWorkspaceDialogState extends State<CreateWorkspaceDialog> {
                   ),
                   const SizedBox(width: 4),
                   IconButton(
-                    icon: const Icon(Icons.close, size: 18),
+                    icon: const Icon(
+                      Icons.close,
+                      size: 18,
+                      semanticLabel: 'Remove environment variable',
+                    ),
                     onPressed: () =>
                         setState(() => _envVars.remove(e.value.key)),
                     padding: EdgeInsets.zero,
@@ -823,7 +861,13 @@ class _CreateWorkspaceDialogState extends State<CreateWorkspaceDialog> {
             ),
           ),
           const SizedBox(width: 8),
-          IconButton(icon: const Icon(Icons.add), onPressed: _tryAddEnv),
+          IconButton(
+            icon: const Icon(
+              Icons.add,
+              semanticLabel: 'Add environment variable',
+            ),
+            onPressed: _tryAddEnv,
+          ),
         ],
       ),
     ];
@@ -850,7 +894,11 @@ class _CreateWorkspaceDialogState extends State<CreateWorkspaceDialog> {
                     ),
                   ),
                   IconButton(
-                    icon: const Icon(Icons.copy, size: 16),
+                    icon: const Icon(
+                      Icons.copy,
+                      size: 16,
+                      semanticLabel: 'Copy allowed domain',
+                    ),
                     tooltip: 'Copy',
                     onPressed: () =>
                         Clipboard.setData(ClipboardData(text: e.value)),
@@ -859,7 +907,11 @@ class _CreateWorkspaceDialogState extends State<CreateWorkspaceDialog> {
                   ),
                   const SizedBox(width: 4),
                   IconButton(
-                    icon: const Icon(Icons.close, size: 18),
+                    icon: const Icon(
+                      Icons.close,
+                      size: 18,
+                      semanticLabel: 'Remove allowed domain',
+                    ),
                     onPressed: () =>
                         setState(() => _allowedDomains.removeAt(e.key)),
                     padding: EdgeInsets.zero,
@@ -895,7 +947,9 @@ class _CreateWorkspaceDialogState extends State<CreateWorkspaceDialog> {
           ),
           const SizedBox(width: 8),
           IconButton(
-              icon: const Icon(Icons.add), onPressed: _tryAddAllowedDomain),
+            icon: const Icon(Icons.add, semanticLabel: 'Add allowed domain'),
+            onPressed: _tryAddAllowedDomain,
+          ),
         ],
       ),
       if (_allowedDomains.isNotEmpty && !widget.netfilterEnabled) ...[
@@ -946,7 +1000,11 @@ class _CreateWorkspaceDialogState extends State<CreateWorkspaceDialog> {
                     ),
                   ),
                   IconButton(
-                    icon: const Icon(Icons.close, size: 18),
+                    icon: const Icon(
+                      Icons.close,
+                      size: 18,
+                      semanticLabel: 'Remove rejected domain',
+                    ),
                     onPressed: () =>
                         setState(() => _rejectedDomains.removeAt(e.key)),
                     padding: EdgeInsets.zero,
@@ -982,7 +1040,7 @@ class _CreateWorkspaceDialogState extends State<CreateWorkspaceDialog> {
           ),
           const SizedBox(width: 8),
           IconButton(
-            icon: const Icon(Icons.add),
+            icon: const Icon(Icons.add, semanticLabel: 'Add rejected domain'),
             onPressed: _tryAddRejectedDomain,
           ),
         ],

--- a/src/frontend/lib/workspace/import_workspace_dialog.dart
+++ b/src/frontend/lib/workspace/import_workspace_dialog.dart
@@ -1,8 +1,12 @@
 import 'dart:convert';
+
 import 'package:flutter/material.dart';
 import 'package:http/http.dart' as http;
+
 import '../auth/auth_service.dart';
+
 import 'package:klangk_plugin_api/klangk_plugin_api.dart';
+
 import '../utils/web_helpers_stub.dart'
     if (dart.library.js_interop) '../utils/web_helpers_web.dart';
 
@@ -110,16 +114,18 @@ class _ImportWorkspaceDialogState extends State<ImportWorkspaceDialog> {
             if (_errorMessage != null) ...[
               Text(
                 _errorMessage!,
-                style: TextStyle(
-                  color: Theme.of(context).colorScheme.error,
-                ),
+                style: TextStyle(color: Theme.of(context).colorScheme.error),
               ),
               const SizedBox(height: 12),
             ],
-            OutlinedButton.icon(
-              onPressed: _importing ? null : _pickFile,
-              icon: const Icon(Icons.file_open, size: 18),
-              label: Text(_fileName ?? 'Select .tar.gz file'),
+            Semantics(
+              container: true,
+              identifier: 'import-select-file',
+              child: OutlinedButton.icon(
+                onPressed: _importing ? null : _pickFile,
+                icon: const Icon(Icons.file_open, size: 18),
+                label: Text(_fileName ?? 'Select .tar.gz file'),
+              ),
             ),
             if (_selectedBytes != null) ...[
               const SizedBox(height: 4),
@@ -132,12 +138,16 @@ class _ImportWorkspaceDialogState extends State<ImportWorkspaceDialog> {
               ),
             ],
             const SizedBox(height: 16),
-            TextField(
-              controller: _nameController,
-              decoration: const InputDecoration(
-                labelText: 'Workspace Name (optional)',
-                hintText: 'Uses name from archive if empty',
-                border: OutlineInputBorder(),
+            Semantics(
+              container: true,
+              identifier: 'import-workspace-name',
+              child: TextField(
+                controller: _nameController,
+                decoration: const InputDecoration(
+                  labelText: 'Workspace Name (optional)',
+                  hintText: 'Uses name from archive if empty',
+                  border: OutlineInputBorder(),
+                ),
               ),
             ),
           ],

--- a/src/frontend/lib/workspace/workspace_list_page.dart
+++ b/src/frontend/lib/workspace/workspace_list_page.dart
@@ -872,31 +872,25 @@ class _WorkspaceListPageState extends State<WorkspaceListPage> {
           ? Column(
               mainAxisSize: MainAxisSize.min,
               children: [
-                // Identified for the fmtk e2e driver — FAB semantics
-                // never merge child labels, so labels alone cannot
-                // address them (the invite-fab pattern, #3233).
-                Semantics(
-                  container: true,
-                  identifier: 'import-workspace-fab',
-                  child: FloatingActionButton.small(
-                    heroTag: 'import',
-                    onPressed: _showImportDialog,
-                    tooltip: 'Import Workspace',
-                    child: const Icon(Icons.upload, semanticLabel: 'Import'),
-                  ),
+                // The icon semanticLabels surface as the FAB buttons'
+                // labels ('Import' / 'Create workspace') — enough for the
+                // fmtk driver. FloatingActionButton semantics never merge
+                // Semantics wrappers (identifiers do not survive), so
+                // wrapping adds nothing.
+                FloatingActionButton.small(
+                  heroTag: 'import',
+                  onPressed: _showImportDialog,
+                  tooltip: 'Import Workspace',
+                  child: const Icon(Icons.upload, semanticLabel: 'Import'),
                 ),
                 const SizedBox(height: 12),
-                Semantics(
-                  container: true,
-                  identifier: 'create-workspace-fab',
-                  child: FloatingActionButton(
-                    heroTag: 'create',
-                    onPressed: _createWorkspace,
-                    tooltip: 'New Workspace',
-                    child: const Icon(
-                      Icons.add,
-                      semanticLabel: 'Create workspace',
-                    ),
+                FloatingActionButton(
+                  heroTag: 'create',
+                  onPressed: _createWorkspace,
+                  tooltip: 'New Workspace',
+                  child: const Icon(
+                    Icons.add,
+                    semanticLabel: 'Create workspace',
                   ),
                 ),
               ],

--- a/src/frontend/lib/workspace/workspace_list_page.dart
+++ b/src/frontend/lib/workspace/workspace_list_page.dart
@@ -1,9 +1,13 @@
 import 'dart:async';
 import 'dart:convert';
+
 import 'package:flutter/material.dart';
+
 import '../theme/colors.dart';
+
 import 'package:go_router/go_router.dart';
 import 'package:provider/provider.dart';
+
 import '../auth/auth_service.dart';
 import '../ws/ws_client.dart';
 import '../utils/page_title.dart';
@@ -125,10 +129,12 @@ String? _validateCidrDomainSpec(String spec) {
   // `00`/`010` are not (octal-ambiguity guard). Octet is inlined 4x so
   // the whole regex is one raw string; `\.` is a literal dot, `$` the
   // end anchor.
-  final ipRe = RegExp(r'^(0|[1-9][0-9]?|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\.'
-      r'(0|[1-9][0-9]?|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\.'
-      r'(0|[1-9][0-9]?|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\.'
-      r'(0|[1-9][0-9]?|1[0-9][0-9]|2[0-4][0-9]|25[0-5])$');
+  final ipRe = RegExp(
+    r'^(0|[1-9][0-9]?|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\.'
+    r'(0|[1-9][0-9]?|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\.'
+    r'(0|[1-9][0-9]?|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\.'
+    r'(0|[1-9][0-9]?|1[0-9][0-9]|2[0-4][0-9]|25[0-5])$',
+  );
   if (!ipRe.hasMatch(ip)) {
     return 'Expected IPv4 CIDR (e.g. 10.0.0.0/8)';
   }
@@ -497,13 +503,17 @@ class _WorkspaceListPageState extends State<WorkspaceListPage> {
             style: TextButton.styleFrom(foregroundColor: KColors.accentRed),
             child: const Text('Cancel'),
           ),
-          FilledButton(
-            onPressed: () => Navigator.pop(context, true),
-            style: FilledButton.styleFrom(
-              backgroundColor: KColors.accentRed,
-              foregroundColor: Colors.white,
+          Semantics(
+            container: true,
+            identifier: 'workspace-delete-confirm',
+            child: FilledButton(
+              onPressed: () => Navigator.pop(context, true),
+              style: FilledButton.styleFrom(
+                backgroundColor: KColors.accentRed,
+                foregroundColor: Colors.white,
+              ),
+              child: const Text('Delete'),
             ),
-            child: const Text('Delete'),
           ),
         ],
       ),
@@ -607,19 +617,27 @@ class _WorkspaceListPageState extends State<WorkspaceListPage> {
           _sortChip(section, 'Created', 'created'),
           const SizedBox(width: 12),
           Expanded(
-            child: TextField(
-              controller: section.searchController,
-              decoration: const InputDecoration(
-                isDense: true,
-                hintText: 'Filter by name...',
-                prefixIcon: Icon(Icons.search, size: 18),
-                border: OutlineInputBorder(),
-                contentPadding: EdgeInsets.symmetric(
-                  horizontal: 8,
-                  vertical: 0,
+            // Identified for the fmtk e2e driver (one id per section —
+            // both tabs' controls can be alive at once).
+            child: Semantics(
+              container: true,
+              identifier: section.isShared
+                  ? 'workspace-filter-shared'
+                  : 'workspace-filter-owned',
+              child: TextField(
+                controller: section.searchController,
+                decoration: const InputDecoration(
+                  isDense: true,
+                  hintText: 'Filter by name...',
+                  prefixIcon: Icon(Icons.search, size: 18),
+                  border: OutlineInputBorder(),
+                  contentPadding: EdgeInsets.symmetric(
+                    horizontal: 8,
+                    vertical: 0,
+                  ),
                 ),
+                onChanged: (v) => _onQueryChanged(section, v),
               ),
-              onChanged: (v) => _onQueryChanged(section, v),
             ),
           ),
         ],
@@ -637,110 +655,112 @@ class _WorkspaceListPageState extends State<WorkspaceListPage> {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          ...section.workspaces.asMap().entries.map(
-                (e) => Material(
-                  color: e.key.isEven
-                      ? Colors.white.withValues(alpha: 0.03)
-                      : Colors.transparent,
-                  child: ListTile(
-                    leading: Icon(
-                      Icons.terminal,
-                      size: 20,
-                      // The icon signals container/health state: green
-                      // when healthy (or running with no health check),
-                      // amber when running but the health check failed,
-                      // grey when stopped.
-                      color: () {
-                        final running = (e.value['running'] as bool? ?? false);
-                        if (!running) return KColors.textSecondary;
-                        final health = e.value['health'] as String?;
-                        if (health == 'unhealthy') {
-                          return Colors.orange;
-                        }
-                        return KColors.accentGreen;
-                      }(),
-                    ),
-                    title: Text(e.value['name'] as String),
-                    subtitle: section.isShared
-                        ? Text(
-                            '${e.value['owner_email']} · ${_formatCreatedAt(e.value['created_at'] as String?)}',
-                          )
-                        : Builder(
-                            builder: (context) {
-                              final wsMembers =
-                                  _workspaceMembers[e.value['id'] as String] ??
-                                      [];
-                              return Row(
-                                children: [
-                                  Text(
-                                    _formatCreatedAt(
-                                      e.value['created_at'] as String?,
-                                    ),
+          ...section.workspaces.asMap().entries.map((e) {
+            final status = _statusVisual(e.value);
+            return Material(
+              color: e.key.isEven
+                  ? Colors.white.withValues(alpha: 0.03)
+                  : Colors.transparent,
+              child: ListTile(
+                leading: Icon(
+                  Icons.terminal,
+                  size: 20,
+                  // The icon signals container/health state by color
+                  // (see _statusVisual); the semanticLabel carries the
+                  // same state as text for assistive tech and the fmtk
+                  // e2e driver — color alone is invisible to semantic
+                  // snapshots.
+                  color: status.color,
+                  semanticLabel: status.label,
+                ),
+                title: Text(e.value['name'] as String),
+                subtitle: section.isShared
+                    ? Text(
+                        '${e.value['owner_email']} · ${_formatCreatedAt(e.value['created_at'] as String?)}',
+                      )
+                    : Builder(
+                        builder: (context) {
+                          final wsMembers =
+                              _workspaceMembers[e.value['id'] as String] ?? [];
+                          return Row(
+                            children: [
+                              Text(
+                                _formatCreatedAt(
+                                  e.value['created_at'] as String?,
+                                ),
+                              ),
+                              if (_hasUnenforcedEgress(e.value)) ...[
+                                const SizedBox(width: 8),
+                                Tooltip(
+                                  message: 'Allowed-domains set but '
+                                      'egress filtering is not '
+                                      'enforced (netfilter disabled '
+                                      'on server)',
+                                  child: Icon(
+                                    Icons.warning_amber,
+                                    size: 16,
+                                    color: Colors.orange,
+                                    // Named for assistive tech and the
+                                    // fmtk e2e driver (tooltips are not
+                                    // exposed to semantic snapshots).
+                                    semanticLabel:
+                                        'Egress filtering not enforced',
                                   ),
-                                  if (_hasUnenforcedEgress(e.value)) ...[
-                                    const SizedBox(width: 8),
-                                    Tooltip(
-                                      message: 'Allowed-domains set but '
-                                          'egress filtering is not '
-                                          'enforced (netfilter disabled '
-                                          'on server)',
-                                      child: Icon(
-                                        Icons.warning_amber,
-                                        size: 16,
-                                        color: Colors.orange,
-                                      ),
-                                    ),
-                                  ],
-                                  if (wsMembers.isNotEmpty) ...[
-                                    const SizedBox(width: 8),
-                                    ...wsMembers.map((m) {
-                                      final email = m['email'] as String;
-                                      final letter = email.isNotEmpty
-                                          ? email[0].toUpperCase()
-                                          : '?';
-                                      return Padding(
-                                        padding:
-                                            const EdgeInsets.only(right: 2),
-                                        child: Tooltip(
-                                          message: email,
-                                          child: CircleAvatar(
-                                            radius: 10,
-                                            backgroundColor:
-                                                KColors.colorForString(
-                                              email,
-                                            ),
-                                            child: Text(
-                                              letter,
-                                              style: const TextStyle(
-                                                fontSize: 10,
-                                                color: Colors.white,
-                                                fontWeight: FontWeight.bold,
-                                              ),
-                                            ),
+                                ),
+                              ],
+                              if (wsMembers.isNotEmpty) ...[
+                                const SizedBox(width: 8),
+                                ...wsMembers.map((m) {
+                                  final email = m['email'] as String;
+                                  final letter = email.isNotEmpty
+                                      ? email[0].toUpperCase()
+                                      : '?';
+                                  return Padding(
+                                    padding: const EdgeInsets.only(right: 2),
+                                    child: Tooltip(
+                                      message: email,
+                                      child: CircleAvatar(
+                                        radius: 10,
+                                        backgroundColor: KColors.colorForString(
+                                          email,
+                                        ),
+                                        child: Text(
+                                          letter,
+                                          style: const TextStyle(
+                                            fontSize: 10,
+                                            color: Colors.white,
+                                            fontWeight: FontWeight.bold,
                                           ),
                                         ),
-                                      );
-                                    }),
-                                  ],
-                                ],
-                              );
-                            },
-                          ),
-                    trailing: section.isShared
-                        ? null
-                        : IconButton(
-                            icon: const Icon(Icons.delete_outline),
-                            tooltip: 'Delete workspace',
-                            onPressed: () =>
-                                _deleteWorkspace(e.value['id'] as String),
-                          ),
-                    onTap: () =>
-                        // coverage:ignore-start
-                        context.go('/workspace/${e.value['id']}'),
-                    // coverage:ignore-end
-                  ),
-                ),
+                                      ),
+                                    ),
+                                  );
+                                }),
+                              ],
+                            ],
+                          );
+                        },
+                      ),
+                trailing: section.isShared
+                    ? null
+                    : IconButton(
+                        icon: Icon(
+                          Icons.delete_outline,
+                          // Named per workspace for assistive tech
+                          // and the fmtk e2e driver.
+                          semanticLabel: 'Delete ${e.value['name']}',
+                        ),
+                        tooltip: 'Delete workspace',
+                        onPressed: () =>
+                            _deleteWorkspace(e.value['id'] as String),
+                      ),
+                onTap: () =>
+                    // coverage:ignore-start
+                    context.go('/workspace/${e.value['id']}'),
+                // coverage:ignore-end
               ),
+            );
+          }),
           _loadMoreButton(
             section.isShared
                 ? 'Load more shared workspaces'
@@ -764,6 +784,26 @@ class _WorkspaceListPageState extends State<WorkspaceListPage> {
     final rejected = ws['rejected_domains'] as List?;
     return (allowed != null && allowed.isNotEmpty) ||
         (rejected != null && rejected.isNotEmpty);
+  }
+
+  /// Color + semantic label for a list tile's status icon: green when
+  /// healthy (or running with no health check), amber when running but the
+  /// health check failed, grey when stopped. The label mirrors the color
+  /// for assistive tech and the fmtk e2e driver (#3234) — semantic
+  /// snapshots cannot see color.
+  ({Color color, String label}) _statusVisual(Map<String, dynamic> ws) {
+    final running = ws['running'] as bool? ?? false;
+    if (!running) {
+      return (color: KColors.textSecondary, label: 'Workspace status: stopped');
+    }
+    final health = ws['health'] as String?;
+    if (health == 'unhealthy') {
+      return (
+        color: Colors.orange,
+        label: 'Workspace status: running, unhealthy',
+      );
+    }
+    return (color: KColors.accentGreen, label: 'Workspace status: running');
   }
 
   Widget _buildTabBody(_Section section) {
@@ -825,9 +865,10 @@ class _WorkspaceListPageState extends State<WorkspaceListPage> {
         title: const AppBarTitle(title: 'Workspaces'),
         actions: const [AppBarActions()],
       ),
-      floatingActionButton: context
-              .watch<AuthService>()
-              .hasPermission('/workspaces', 'create-workspace')
+      floatingActionButton: context.watch<AuthService>().hasPermission(
+                '/workspaces',
+                'create-workspace',
+              )
           ? Column(
               mainAxisSize: MainAxisSize.min,
               children: [
@@ -842,8 +883,10 @@ class _WorkspaceListPageState extends State<WorkspaceListPage> {
                   heroTag: 'create',
                   onPressed: _createWorkspace,
                   tooltip: 'New Workspace',
-                  child:
-                      const Icon(Icons.add, semanticLabel: 'Create workspace'),
+                  child: const Icon(
+                    Icons.add,
+                    semanticLabel: 'Create workspace',
+                  ),
                 ),
               ],
             )

--- a/src/frontend/lib/workspace/workspace_list_page.dart
+++ b/src/frontend/lib/workspace/workspace_list_page.dart
@@ -872,20 +872,31 @@ class _WorkspaceListPageState extends State<WorkspaceListPage> {
           ? Column(
               mainAxisSize: MainAxisSize.min,
               children: [
-                FloatingActionButton.small(
-                  heroTag: 'import',
-                  onPressed: _showImportDialog,
-                  tooltip: 'Import Workspace',
-                  child: const Icon(Icons.upload, semanticLabel: 'Import'),
+                // Identified for the fmtk e2e driver — FAB semantics
+                // never merge child labels, so labels alone cannot
+                // address them (the invite-fab pattern, #3233).
+                Semantics(
+                  container: true,
+                  identifier: 'import-workspace-fab',
+                  child: FloatingActionButton.small(
+                    heroTag: 'import',
+                    onPressed: _showImportDialog,
+                    tooltip: 'Import Workspace',
+                    child: const Icon(Icons.upload, semanticLabel: 'Import'),
+                  ),
                 ),
                 const SizedBox(height: 12),
-                FloatingActionButton(
-                  heroTag: 'create',
-                  onPressed: _createWorkspace,
-                  tooltip: 'New Workspace',
-                  child: const Icon(
-                    Icons.add,
-                    semanticLabel: 'Create workspace',
+                Semantics(
+                  container: true,
+                  identifier: 'create-workspace-fab',
+                  child: FloatingActionButton(
+                    heroTag: 'create',
+                    onPressed: _createWorkspace,
+                    tooltip: 'New Workspace',
+                    child: const Icon(
+                      Icons.add,
+                      semanticLabel: 'Create workspace',
+                    ),
                   ),
                 ),
               ],

--- a/src/frontend/lib/workspace/workspace_overlays.dart
+++ b/src/frontend/lib/workspace/workspace_overlays.dart
@@ -85,44 +85,57 @@ Widget buildContainerStoppedOverlay({
     color: Colors.black54,
     child: Center(
       child: restarting
-          ? const Column(
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                CircularProgressIndicator(color: Colors.white),
-                SizedBox(height: 12),
-                Text(
-                  'Restarting...',
-                  style: TextStyle(color: Colors.white),
-                ),
-              ],
+          // Identified for assistive tech and the fmtk e2e driver — the
+          // 'Restart' button label collides (substring-wise) with the
+          // settings panel's 'Restart now', which stays mounted in the
+          // stack under this overlay.
+          ? Semantics(
+              container: true,
+              identifier: 'container-restarting',
+              child: const Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  CircularProgressIndicator(color: Colors.white),
+                  SizedBox(height: 12),
+                  Text('Restarting...', style: TextStyle(color: Colors.white)),
+                ],
+              ),
             )
-          : Column(
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                Text(
-                  stopReason,
-                  style: const TextStyle(color: Colors.white, fontSize: 16),
-                ),
-                const SizedBox(height: 16),
-                if (canRestart)
-                  ElevatedButton.icon(
-                    onPressed: onRestart,
-                    icon: const Icon(Icons.refresh, size: 18),
-                    label: const Text('Restart'),
-                    style: ElevatedButton.styleFrom(
-                      backgroundColor: KColors.accentGreen,
-                      foregroundColor: Colors.white,
+          : Semantics(
+              container: true,
+              identifier: 'container-stopped-overlay',
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Text(
+                    stopReason,
+                    style: const TextStyle(color: Colors.white, fontSize: 16),
+                  ),
+                  const SizedBox(height: 16),
+                  if (canRestart)
+                    Semantics(
+                      container: true,
+                      identifier: 'container-restart-button',
+                      child: ElevatedButton.icon(
+                        onPressed: onRestart,
+                        icon: const Icon(Icons.refresh, size: 18),
+                        label: const Text('Restart'),
+                        style: ElevatedButton.styleFrom(
+                          backgroundColor: KColors.accentGreen,
+                          foregroundColor: Colors.white,
+                        ),
+                      ),
+                    ),
+                  const SizedBox(height: 12),
+                  TextButton(
+                    onPressed: onBack,
+                    child: const Text(
+                      'Back to workspaces',
+                      style: TextStyle(color: Colors.white54),
                     ),
                   ),
-                const SizedBox(height: 12),
-                TextButton(
-                  onPressed: onBack,
-                  child: const Text(
-                    'Back to workspaces',
-                    style: TextStyle(color: Colors.white54),
-                  ),
-                ),
-              ],
+                ],
+              ),
             ),
     ),
   );
@@ -136,10 +149,7 @@ Widget buildContainerStoppedOverlay({
 /// action: the refusal is permanent from this client, so retrying can never
 /// succeed; the only sensible action is leaving the page. [detail] (the
 /// server's refusal message) renders under the explanation for diagnosis.
-Widget buildAccessRevokedView({
-  String? detail,
-  required VoidCallback onBack,
-}) {
+Widget buildAccessRevokedView({String? detail, required VoidCallback onBack}) {
   return Scaffold(
     appBar: AppBar(title: const Text('Workspace')),
     body: Center(
@@ -190,63 +200,68 @@ Widget buildDisconnectedOverlay({
   return Container(
     color: Colors.black54,
     child: Center(
-      child: reconnecting
-          ? Column(
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                const CircularProgressIndicator(color: Colors.white),
-                const SizedBox(height: 12),
-                Text(
-                  'Reconnecting (attempt $reconnectAttempt)...',
-                  style: const TextStyle(color: Colors.white),
-                ),
-                const SizedBox(height: 16),
-                ElevatedButton.icon(
-                  onPressed: onReconnect,
-                  icon: const Icon(Icons.refresh, size: 18),
-                  label: const Text('Reconnect now'),
-                  style: ElevatedButton.styleFrom(
-                    backgroundColor: KColors.accentGreen,
-                    foregroundColor: Colors.white,
+      // Identified for assistive tech and the fmtk e2e driver.
+      child: Semantics(
+        container: true,
+        identifier: 'disconnected-overlay',
+        child: reconnecting
+            ? Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  const CircularProgressIndicator(color: Colors.white),
+                  const SizedBox(height: 12),
+                  Text(
+                    'Reconnecting (attempt $reconnectAttempt)...',
+                    style: const TextStyle(color: Colors.white),
                   ),
-                ),
-                const SizedBox(height: 12),
-                TextButton(
-                  onPressed: onBack,
-                  child: const Text(
-                    'Back to workspaces',
-                    style: TextStyle(color: Colors.white54),
+                  const SizedBox(height: 16),
+                  ElevatedButton.icon(
+                    onPressed: onReconnect,
+                    icon: const Icon(Icons.refresh, size: 18),
+                    label: const Text('Reconnect now'),
+                    style: ElevatedButton.styleFrom(
+                      backgroundColor: KColors.accentGreen,
+                      foregroundColor: Colors.white,
+                    ),
                   ),
-                ),
-              ],
-            )
-          : Column(
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                const Text(
-                  'Connection lost',
-                  style: TextStyle(color: Colors.white, fontSize: 16),
-                ),
-                const SizedBox(height: 16),
-                ElevatedButton.icon(
-                  onPressed: onReconnect,
-                  icon: const Icon(Icons.refresh, size: 18),
-                  label: const Text('Reconnect'),
-                  style: ElevatedButton.styleFrom(
-                    backgroundColor: KColors.accentGreen,
-                    foregroundColor: Colors.white,
+                  const SizedBox(height: 12),
+                  TextButton(
+                    onPressed: onBack,
+                    child: const Text(
+                      'Back to workspaces',
+                      style: TextStyle(color: Colors.white54),
+                    ),
                   ),
-                ),
-                const SizedBox(height: 12),
-                TextButton(
-                  onPressed: onBack,
-                  child: const Text(
-                    'Back to workspaces',
-                    style: TextStyle(color: Colors.white54),
+                ],
+              )
+            : Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  const Text(
+                    'Connection lost',
+                    style: TextStyle(color: Colors.white, fontSize: 16),
                   ),
-                ),
-              ],
-            ),
+                  const SizedBox(height: 16),
+                  ElevatedButton.icon(
+                    onPressed: onReconnect,
+                    icon: const Icon(Icons.refresh, size: 18),
+                    label: const Text('Reconnect'),
+                    style: ElevatedButton.styleFrom(
+                      backgroundColor: KColors.accentGreen,
+                      foregroundColor: Colors.white,
+                    ),
+                  ),
+                  const SizedBox(height: 12),
+                  TextButton(
+                    onPressed: onBack,
+                    child: const Text(
+                      'Back to workspaces',
+                      style: TextStyle(color: Colors.white54),
+                    ),
+                  ),
+                ],
+              ),
+      ),
     ),
   );
 }

--- a/src/frontend/lib/workspace/workspace_settings_panel.dart
+++ b/src/frontend/lib/workspace/workspace_settings_panel.dart
@@ -1,9 +1,11 @@
 import 'dart:async';
 import 'dart:convert';
+
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:http/http.dart' as http;
 import 'package:provider/provider.dart';
+
 import '../auth/auth_service.dart';
 import '../theme/colors.dart';
 import '../utils/system_agent.dart';
@@ -211,12 +213,14 @@ class WorkspaceSettingsPanelState extends State<WorkspaceSettingsPanel> {
       sudoAvailable: _sudoAvailable,
       perHandleHomeAvailable: _perHandleHomeAvailable,
       canExport: widget.canExport,
-      allowAutostart:
-          context.select<AuthService, bool>((a) => a.allowAutostart),
+      allowAutostart: context.select<AuthService, bool>(
+        (a) => a.allowAutostart,
+      ),
       saveMessage: _saveMessage,
       pendingRestart: _pendingRestart,
-      netfilterEnabled:
-          context.select<AuthService, bool>((a) => a.netfilterEnabled),
+      netfilterEnabled: context.select<AuthService, bool>(
+        (a) => a.netfilterEnabled,
+      ),
       onSave: _saveSettings,
       canRestart: widget.canRestart,
       onRestart: _restartNow,
@@ -297,7 +301,9 @@ bool _hasCreateTimeFieldChanged(
   }
   // rejected_domains — set comparison (#2386)
   if (!_domainListsEqual(
-      prev['rejected_domains'], fields['rejected_domains'])) {
+    prev['rejected_domains'],
+    fields['rejected_domains'],
+  )) {
     return true;
   }
   // egress_mode — the network sidecar is set up at container create
@@ -651,8 +657,9 @@ class _SettingsFormState extends State<_SettingsForm> {
     // instead of 422-ing the whole panel PUT and blocking every other
     // field from saving.
     if (name.isEmpty) {
-      setState(() =>
-          _nameError = 'Workspace name cannot be empty or only whitespace');
+      setState(
+        () => _nameError = 'Workspace name cannot be empty or only whitespace',
+      );
       return;
     }
     setState(() {
@@ -1045,9 +1052,7 @@ class _SettingsFormState extends State<_SettingsForm> {
               child: Text('allow (default-permit)'),
             ),
           ],
-          onChanged: (v) => setState(
-            () => _egressMode = v ?? 'interactive',
-          ),
+          onChanged: (v) => setState(() => _egressMode = v ?? 'interactive'),
         ),
         const SizedBox(height: 16),
         _buildAllowedDomainsEditor(labelStyle),
@@ -1066,16 +1071,20 @@ class _SettingsFormState extends State<_SettingsForm> {
         Row(
           children: [
             Expanded(
-              child: TextField(
-                controller: _idleTimeoutCtrl,
-                decoration: InputDecoration(
-                  labelText: 'Idle Timeout (s)',
-                  labelStyle: labelStyle,
-                  floatingLabelBehavior: FloatingLabelBehavior.always,
-                  border: const OutlineInputBorder(),
-                  hintText: '0 = never',
+              child: Semantics(
+                container: true,
+                identifier: 'settings-idle-timeout',
+                child: TextField(
+                  controller: _idleTimeoutCtrl,
+                  decoration: InputDecoration(
+                    labelText: 'Idle Timeout (s)',
+                    labelStyle: labelStyle,
+                    floatingLabelBehavior: FloatingLabelBehavior.always,
+                    border: const OutlineInputBorder(),
+                    hintText: '0 = never',
+                  ),
+                  keyboardType: TextInputType.number,
                 ),
-                keyboardType: TextInputType.number,
               ),
             ),
             const SizedBox(width: 12),
@@ -1292,10 +1301,7 @@ class _SettingsFormState extends State<_SettingsForm> {
           'Restricts outbound network to these hosts (host or host:port). '
           'Requires netfilter to be enabled on the server; empty '
           'means unrestricted.',
-          style: TextStyle(
-            color: KColors.textSecondary,
-            fontSize: 12,
-          ),
+          style: TextStyle(color: KColors.textSecondary, fontSize: 12),
         ),
         if (_allowedDomains.isNotEmpty && !widget.netfilterEnabled) ...[
           const SizedBox(height: 8),
@@ -1335,10 +1341,7 @@ class _SettingsFormState extends State<_SettingsForm> {
         Text(
           'Hosts blocked unconditionally (never resolved, no consent asked). '
           'CIDR ranges are not supported.',
-          style: TextStyle(
-            color: KColors.textSecondary,
-            fontSize: 12,
-          ),
+          style: TextStyle(color: KColors.textSecondary, fontSize: 12),
         ),
         if (_rejectedDomains.isNotEmpty && !widget.netfilterEnabled) ...[
           const SizedBox(height: 8),
@@ -1585,10 +1588,7 @@ class _SettingsFormState extends State<_SettingsForm> {
                           ),
                           onTap: () {
                             Navigator.of(ctx).pop();
-                            _confirmTransfer(
-                              context,
-                              r['email'] as String,
-                            );
+                            _confirmTransfer(context, r['email'] as String);
                           },
                         ),
                       )
@@ -1666,17 +1666,21 @@ class _SettingsFormState extends State<_SettingsForm> {
       titleColor: Colors.red,
       children: [
         const SizedBox(height: 12),
-        OutlinedButton.icon(
-          onPressed: () => _confirmShutdown(context),
-          icon: const Icon(
-            Icons.power_settings_new,
-            size: 18,
-            color: Colors.red,
-          ),
-          label: const Text('Shut Down Container'),
-          style: OutlinedButton.styleFrom(
-            foregroundColor: Colors.red,
-            side: const BorderSide(color: Colors.red),
+        Semantics(
+          container: true,
+          identifier: 'shutdown-container',
+          child: OutlinedButton.icon(
+            onPressed: () => _confirmShutdown(context),
+            icon: const Icon(
+              Icons.power_settings_new,
+              size: 18,
+              color: Colors.red,
+            ),
+            label: const Text('Shut Down Container'),
+            style: OutlinedButton.styleFrom(
+              foregroundColor: Colors.red,
+              side: const BorderSide(color: Colors.red),
+            ),
           ),
         ),
       ],
@@ -1714,9 +1718,8 @@ class _SettingsFormState extends State<_SettingsForm> {
     } catch (_) {
       // coverage:ignore-start
       if (mounted) {
-        ScaffoldMessenger.of(
-          context,
-        ).showSnackBar(const SnackBar(content: Text('Export failed')));
+        ScaffoldMessenger.of(context)
+            .showSnackBar(const SnackBar(content: Text('Export failed')));
       }
     } finally {
       // coverage:ignore-end
@@ -1738,13 +1741,17 @@ class _SettingsFormState extends State<_SettingsForm> {
             onPressed: () => Navigator.of(ctx).pop(),
             child: const Text('Cancel'),
           ),
-          FilledButton(
-            onPressed: () {
-              Navigator.of(ctx).pop();
-              _shutdownContainer();
-            },
-            style: FilledButton.styleFrom(backgroundColor: Colors.red),
-            child: const Text('Shut Down'),
+          Semantics(
+            container: true,
+            identifier: 'shutdown-confirm',
+            child: FilledButton(
+              onPressed: () {
+                Navigator.of(ctx).pop();
+                _shutdownContainer();
+              },
+              style: FilledButton.styleFrom(backgroundColor: Colors.red),
+              child: const Text('Shut Down'),
+            ),
           ),
         ],
       ),

--- a/src/frontend/lib/ws/ws_client.dart
+++ b/src/frontend/lib/ws/ws_client.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:math';
 import 'package:flutter/foundation.dart';
+import 'package:flutter/scheduler.dart';
 import 'package:http/http.dart' as http;
 import 'package:web_socket_channel/web_socket_channel.dart';
 import 'package:klangk_plugin_api/klangk_plugin_api.dart' show baseUrl;
@@ -164,8 +165,54 @@ class WsClient extends ChangeNotifier {
   void connectForTest(WebSocketChannel channel) {
     _channel = channel;
     _connected = true;
-    notifyListeners();
+    _notify();
     _listenToChannel();
+  }
+
+  /// Notify listeners, deferred past the current frame when one is
+  /// mid-build. WS messages arrive as DOM events, and the web engine
+  /// splits a frame across tasks — a message landing between them
+  /// fires this from a handler while a route is building, and the
+  /// resulting mid-frame mark trips "setState() called during build"
+  /// (the debug error monitor surfaces it; the release-mode equivalent
+  /// silently drops the UI update). No binding (plain unit tests) or
+  /// an idle scheduler notifies immediately — ordinary event-driven
+  /// updates keep their timing.
+  /// The scheduler binding, or null when none is initialized (plain
+  /// unit tests construct WsClient with no binding; the uninitialized
+  /// getter throws under asserts — that case notifies synchronously).
+  SchedulerBinding? _scheduler() {
+    try {
+      return SchedulerBinding.instance;
+    } catch (_) {
+      return null;
+    }
+  }
+
+  /// Notify listeners, deferred past the frame only while one is in
+  /// the persistent-callbacks phase (build/layout/paint — where a
+  /// mark is illegal). WS messages arrive as DOM events, and the web
+  /// engine splits a frame across tasks — a message landing inside the
+  /// draw-frame task fires this from a handler mid-build, tripping
+  /// "setState() called during build" (the debug error monitor
+  /// surfaces it; the release-mode equivalent silently drops the UI
+  /// update). Every other phase (idle, animations, frame microtasks)
+  /// allows marking, so those notify immediately and keep their timing.
+  /// Set in dispose(): a deferred _notify (post-frame) must not fire
+  /// on a disposed notifier — the client can be torn down between the
+  /// mid-frame notify attempt and the frame's end.
+  bool _disposed = false;
+
+  void _notify() {
+    final binding = _scheduler();
+    if (binding == null ||
+        binding.schedulerPhase != SchedulerPhase.persistentCallbacks) {
+      notifyListeners();
+      return;
+    }
+    binding.addPostFrameCallback((_) {
+      if (!_disposed) notifyListeners();
+    });
   }
 
   final _errorController = StreamController<WsError>.broadcast();
@@ -407,7 +454,7 @@ class WsClient extends ChangeNotifier {
     _removeBeforeUnload = onBeforeUnload(() {
       _channel?.sink.close(1000, 'page unload'); // coverage:ignore-line
     });
-    notifyListeners();
+    _notify();
     _listenToChannel();
   }
 
@@ -443,7 +490,7 @@ class WsClient extends ChangeNotifier {
               .toList()
           : <Map<String, dynamic>>[];
       _serverScheduleController.add(_serverSchedules!);
-      notifyListeners();
+      _notify();
     },
     'server_schedule_fired': (json) {
       final action = json['action'] as String? ?? 'action';
@@ -485,7 +532,7 @@ class WsClient extends ChangeNotifier {
     if (_hostNotice == notice) return;
     _hostNotice = notice;
     if (notice != null) _hostNoticeController.add(notice);
-    notifyListeners();
+    _notify();
   }
 
   void _listenToChannel() {
@@ -545,7 +592,7 @@ class WsClient extends ChangeNotifier {
           _reconnecting = false;
           _reconnectAttempt = 0;
         }
-        notifyListeners();
+        _notify();
         if (authFailure) {
           _errorController.add(
             const WsError(message: 'Session expired, please log in again'),
@@ -579,7 +626,7 @@ class WsClient extends ChangeNotifier {
           _reconnecting = false;
           _reconnectAttempt = 0;
         }
-        notifyListeners();
+        _notify();
         if (authFailure) {
           _auth?.logout();
         } else {
@@ -605,25 +652,25 @@ class WsClient extends ChangeNotifier {
     // the equality guard).
     _hostNotice = null;
     _startHeartbeat();
-    notifyListeners();
+    _notify();
   }
 
   void _onTerminalWindows(Map<String, dynamic> json) {
     debugPrint('[WsClient] terminal_windows received: ${DateTime.now()}');
     final windows = json['windows'] as List? ?? [];
     terminalWindows = List<Map<String, dynamic>>.from(windows);
-    notifyListeners();
+    _notify();
   }
 
   void _onSharedTerminals(Map<String, dynamic> json) {
     final terminals = json['terminals'] as List? ?? [];
     sharedTerminals = List<Map<String, dynamic>>.from(terminals);
-    notifyListeners();
+    _notify();
   }
 
   void _onSharedTerminalDeleted(Map<String, dynamic> json) {
     _sharedTerminalDeletedController.add(json);
-    notifyListeners();
+    _notify();
   }
 
   void disconnect() {
@@ -640,7 +687,7 @@ class WsClient extends ChangeNotifier {
     _currentWorkspaceId = null;
     _containerReady = false; // see [containerReady] (#3000)
     _serverSchedules = null;
-    notifyListeners();
+    _notify();
   }
 
   void _send(Map<String, dynamic> msg) {
@@ -675,7 +722,7 @@ class WsClient extends ChangeNotifier {
     _containerReady = false; // see [#containerReady] (#3000)
     _send({'cmd': 'workspace_disconnect'});
     _currentWorkspaceId = null;
-    notifyListeners();
+    _notify();
   }
 
   void sendUiReady() {
@@ -795,12 +842,12 @@ class WsClient extends ChangeNotifier {
     if (_reconnectAttempt > 25) {
       _autoReconnect = false;
       _reconnecting = false;
-      notifyListeners();
+      _notify();
       return;
     }
 
     _reconnecting = true;
-    notifyListeners();
+    _notify();
     // coverage:ignore-start
     final delay = testBackoffOverride != null
         ? testBackoffOverride!(_reconnectAttempt)
@@ -854,7 +901,9 @@ class WsClient extends ChangeNotifier {
   }
 
   @override
+  @override
   void dispose() {
+    _disposed = true;
     _cancelReconnect();
     disconnect();
     _errorController.close();

--- a/src/klangk/klangk/model/users.py
+++ b/src/klangk/klangk/model/users.py
@@ -533,6 +533,13 @@ class UsersModel(Submodel):
         Runs on the **caller's** transaction so it composes with a follow-up
         verification-email send (see the module-level docstring). Returns
         the generated handle.
+
+        #2569 parity with ``create_user``: the new user joins the
+        ``members`` group on the same transaction — the self-service
+        ``create-workspace`` grant is the members group's (#3137), and
+        both callers (self-registration and the admin invite) used to
+        skip the join ``create_user`` does, leaving such users unable
+        to create workspaces.
         """
         handle = await self.generate_handle(db, email)
         await db.execute(
@@ -540,6 +547,13 @@ class UsersModel(Submodel):
             " VALUES (?, ?, ?, 0, ?)",
             (user_id, email, password_hash, handle),
         )
+        members_gid = getattr(self.app.state, "members_group_id", None)
+        if members_gid:
+            await db.execute(
+                "INSERT OR IGNORE INTO user_groups (user_id, group_id,"
+                " source) VALUES (?, ?, 'manual')",
+                (user_id, members_gid),
+            )
         return handle
 
     async def get_user_handle(self, user_id: str) -> str | None:

--- a/src/klangk/klangkd-tests/tests/test_model_users.py
+++ b/src/klangk/klangkd-tests/tests/test_model_users.py
@@ -98,7 +98,21 @@ async def test_link_oidc_and_external_id_and_verify(users):
     assert await users.verify_user("missing", "d@x.com") is False
 
 
+async def _arm_members_group(users) -> str:
+    """Create + arm the members group on the ``users`` fixture's app
+    state (the plain ``app_state`` fixture does not seed it — only
+    ``admin_group`` does). Returns the group id."""
+    group = await users.get_group_by_name("members")
+    if group is None:
+        group = await users.create_group(
+            "members", description="All regular users"
+        )
+    users.app.state.members_group_id = group["id"]
+    return group["id"]
+
+
 async def test_insert_unverified_user(users):
+    members_gid = await _arm_members_group(users)
     async with users.app.state.db.transaction() as db:
         handle = await users.insert_unverified_user(
             db, "uid-uv", "uv@x.com", "hash"
@@ -107,6 +121,27 @@ async def test_insert_unverified_user(users):
     fetched = await users.get_user_by_email("uv@x.com")
     assert fetched["id"] == "uid-uv"
     assert fetched["verified"] is False
+    # #2569 parity with create_user: the registrant joins the members
+    # group on the caller's transaction — the self-service
+    # create-workspace grant (#3137) depends on it.
+    member_ids = [m["id"] for m in await users.get_group_members(members_gid)]
+    assert "uid-uv" in member_ids
+
+
+async def test_insert_unverified_user_without_members_group(users):
+    """A boot that has not seeded members_group_id (pre-#2569 database
+    rebooting) still inserts the user — the join is skipped, not fatal."""
+    await _arm_members_group(users)
+    users.app.state.members_group_id = None
+    async with users.app.state.db.transaction() as db:
+        await users.insert_unverified_user(db, "uid-uv2", "uv2@x.com", "hash")
+    fetched = await users.get_user_by_email("uv2@x.com")
+    assert fetched["id"] == "uid-uv2"
+    members = await users.get_group_by_name("members")
+    member_ids = [
+        m["id"] for m in await users.get_group_members(members["id"])
+    ]
+    assert "uid-uv2" not in member_ids
 
 
 async def test_create_group_and_lookup(users):


### PR DESCRIPTION
fmtk-driven e2e coverage for the workspaces list page and workspace lifecycle, per #3234. Closes #3234.

## Product fixes the suite flushed out

- **Self-registered and invited users can create workspaces again.** `insert_unverified_user` (both the self-registration and admin-invite routes) inserted the user row without the `members`-group join that `create_user` performs — so those users held no `create-workspace` grant (the stock #3137 self-service posture) and the list page rendered no create button. The join now happens on the caller's transaction, mirroring `create_user`.
- **Workspace-page dialogs no longer trip `setState() called during build`.** A WebSocket event (container start/stop, workspaces-changed) landing inside the web engine's draw-frame task marked the `WsClient` provider scope mid-build — a debug assertion, and in release mode a silently dropped UI update for that event. `WsClient` now defers its listener notification past the frame only while it is in the persistent-callbacks phase; every other phase keeps immediate timing.

## The suite

`src/frontend/e2e-tests/fmtk/test_workspaces.py` — eleven ordered scenarios, each driving the real UI:

| Scenario | What it proves |
| --- | --- |
| List sections | `fmtk-admin` sees `fmtk-verify` under **Owned by Me**; `fmtk-collaborator` sees it under **Shared with Me** after tapping the tab (shared tiles carry the owner email) |
| Register + create | A run-registered user lands on "No workspaces yet", creates via the FAB + dialog, and the workspace lists with `Workspace status: stopped` |
| Open + terminal | Opening the tile starts the container (workspace_connect auto-start); the terminal executes an echo found in the buffer, and the tile label flips to `running` |
| Stop → start cycle | Settings → Danger Zone → **Shut Down Container** raises the stopped overlay; **Restart** (overlay) brings it back and the terminal responds again |
| Settings restart | An Idle Timeout edit + Save arms the pending-restart notice; **Restart now** restarts the running container and the terminal comes back |
| Delete | The tile's per-workspace delete button + confirm removes it from the list |
| Import | A provenance-carrying archive (synthetic `workspace.json` with the instance id — the browser's native file chooser can't be driven) goes through the import dialog's `testPickFileBytesOverride` hook; the imported workspace lists and opens |
| Per-user home | With the `per_handle_home` ceiling swapped on over SIGHUP (restored to the stock posture in `finally`), a workspace created by the untouched form roots the file browser at `/home/<handle>` — the per-user-home Playwright spec's assertion, driven through the UI |
| Default image swap | `image_name` swapped over SIGHUP (verified via `/api/v1/images`): the create dialog preselects the swapped default — the create flow re-fetches deploy config (#2994), no re-login |
| Idle auto-stop | A 15s-idle workspace is stopped by the reaper: the overlay carries the reason (`Container stopped (idle timeout)`) and the tile label tracks `stopped` |
| Shared delete | A member-shared scratch workspace disappears from the owner's list *and* the member's Shared list after the owner deletes it |

**Harness additions** (`fmtkharness.py`): `tap_labeled_exact` (nearest tappable node above a line-exact label — tiles, tabs, segments), `tap_button_exact` (button semantics absorb wrapper identifiers; substring matching collides with `Restart`/`Restart now`), `wait_for_label`/`wait_for_identifier`/`wait_identifier_gone` (semantic labels and instrumented nodes are not text-kind), viewport-aware `scroll_until_label`, `find_label_nodes`+`parent_map`+`label_has_line`, raw-bytes `http_download`, the `terminal_eval` result unwrap, and terminal sends carrying their newline (execution, not just echoed input). `conftest` installs SIGINT/SIGTERM teardown handlers and `FlutterRun.stop()` closes the run's Chrome windows — an aborted run no longer strands a browser.

**Instrumentation** (first commit): every element the suite locates was named/identified ahead of the test work — the list tile's status icon carries its color-only state as text (`Workspace status: running/stopped/unhealthy`), per-workspace delete buttons are named, the overlays/dialogs/fields get deterministic identifiers, and the file-browser breadcrumb exposes the current path as a labeled node.

## Notes on determinism

- Tests 2-6 form one ordered chain (create → … → delete of one run-unique workspace as the run-registered user); the later scenarios are self-contained logins. Re-run the whole file — `-k` selections break the chain.
- The fixture workspace is never mutated or deleted; every scratch workspace is run-unique and deleted by the scenario that created it.
- The terminal-usability probe is self-healing across tab switches and in-flight restarts (remounts the pane, retries until `container_ready`), and the settings-pane switch re-taps until the pane mounts (a concurrent WS-driven rebuild can race the first tap).

## Testing

- `test_workspaces.py` via the kept-stack harness (headed, adopted backend + app): **11/11 green** (~7.5 min).
- `scripts/tests`: 127 passed (contract test pins the new locators + suite wiring).
- `flutter test`: 1297 passed (WsClient deferral included).
- Backend suite: 7815 passed (`klangkd-tests` + `klangkc-tests`, `-n auto`), incl. the two new `insert_unverified_user` membership tests.
- xenon: rank A across the graded trees.
