### PR TITLE
fmtk e2e: wait for the page before grabbing its fields (#3264)

### DIFF
--- a/src/frontend/e2e-tests/fmtk/fmtkharness.py
+++ b/src/frontend/e2e-tests/fmtk/fmtkharness.py
@@ -1387,6 +1387,17 @@ def find_nodes(tree, predicate) -> list[dict]:
     return found
 
 
+def wait_for_fields(app, marker: str) -> list[dict]:
+    """Wait for the page marker, then return its text fields in reading
+    order (#3264): a snapshot taken between a navigation tap and the route
+    swap returns the *old* page's fields, and text typed into them dies
+    with that page when the new one mounts — the caller must hand us a
+    marker that only the target page shows (a submit button's label is a
+    reliable one)."""
+    app.wait_for_text(marker)
+    return find_nodes(app.snapshot(), lambda n: node_type(n) == "textField")
+
+
 def walk_nodes(node, predicate, found: list) -> None:
     if isinstance(node, dict):
         if "ref" in node and predicate(node):

--- a/src/frontend/e2e-tests/fmtk/test_auth.py
+++ b/src/frontend/e2e-tests/fmtk/test_auth.py
@@ -28,6 +28,7 @@ from fmtkharness import (
     FmtkError,
     find_nodes,
     node_type,
+    wait_for_fields,
 )
 
 RUN = uuid.uuid4().hex[:6]
@@ -82,7 +83,7 @@ def test_wrong_password_shows_error_not_navigation(harness, app):
 def test_register_verify_and_resend(harness, app):
     at_login(harness, app)
     app.tap_label("Need an account? Create one")
-    fields = walk_fields(app)
+    fields = wait_for_fields(app, "Create Account")
     app.enter_text(fields[0]["ref"], REGISTERED_EMAIL)
     app.enter_text(fields[1]["ref"], REGISTERED_PW)
     app.tap_label("Create Account")
@@ -103,7 +104,7 @@ def test_register_verify_and_resend(harness, app):
 def test_forgot_and_reset_password(harness, app):
     at_login(harness, app)
     app.tap_label("Forgot password?")
-    fields = walk_fields(app)
+    fields = wait_for_fields(app, "Send Reset Link")
     app.enter_text(fields[0]["ref"], RESET_EMAIL)
     app.tap_label("Send Reset Link")
     app.wait_for_text("we sent a password reset link")
@@ -298,7 +299,7 @@ def test_registration_toggle_and_policy_swap(harness, app):
         app.wait_for_login_page()
         app.dismiss_login_banner()
         app.tap_label("Need an account? Create one")
-        fields = walk_fields(app)
+        fields = wait_for_fields(app, "Create Account")
         app.enter_text(fields[0]["ref"], f"fmtk-len{RUN}@example.com")
         app.enter_text(fields[1]["ref"], "tenchars!!")
         app.tap_label("Create Account")

--- a/src/frontend/e2e-tests/fmtk/test_terminals.py
+++ b/src/frontend/e2e-tests/fmtk/test_terminals.py
@@ -48,10 +48,9 @@ from fmtkharness import (
     FIXTURE_PASSWORD,
     FmtkError,
     find_label_nodes,
-    find_nodes,
     http_api,
     http_login,
-    node_type,
+    wait_for_fields,
 )
 
 RUN = uuid.uuid4().hex[:6]
@@ -65,11 +64,6 @@ SPECTATOR_EMAIL = "fmtk-spectator@example.com"
 
 
 # --- shared driving helpers (suite-local; harness keeps primitives) ----
-
-
-def walk_fields(app) -> list[dict]:
-    """The visible text fields, in reading order."""
-    return find_nodes(app.snapshot(), lambda n: node_type(n) == "textField")
 
 
 def at_login(harness, app) -> None:
@@ -89,7 +83,7 @@ def at_login(harness, app) -> None:
 def register_user(harness, app, email: str, password: str) -> None:
     """Register + email-verify; the auto-login lands on the empty list."""
     app.tap_label("Need an account? Create one")
-    fields = walk_fields(app)
+    fields = wait_for_fields(app, "Create Account")
     app.enter_text(fields[0]["ref"], email)
     app.enter_text(fields[1]["ref"], password)
     app.tap_label("Create Account")

--- a/src/frontend/e2e-tests/fmtk/test_workspaces.py
+++ b/src/frontend/e2e-tests/fmtk/test_workspaces.py
@@ -37,11 +37,10 @@ from fmtkharness import (
     ADMIN_EMAIL,
     FIXTURE_PASSWORD,
     FmtkError,
-    find_nodes,
     http_api,
     http_login,
     node_labels,
-    node_type,
+    wait_for_fields,
 )
 
 RUN = uuid.uuid4().hex[:6]
@@ -59,11 +58,6 @@ SWAP_IMAGE = "localhost/klangk-workspace:2026.09.05-7422a6cfd"
 
 
 # --- shared driving helpers (suite-local; harness keeps primitives) ----
-
-
-def walk_fields(app) -> list[dict]:
-    """The visible text fields, in reading order."""
-    return find_nodes(app.snapshot(), lambda n: node_type(n) == "textField")
 
 
 def at_login(harness, app) -> None:
@@ -88,7 +82,7 @@ def register_fresh_user(harness, app) -> None:
     """Register + email-verify the run-unique user; the auto-login lands
     on the empty owned list (the issue's Done-when starting point)."""
     app.tap_label("Need an account? Create one")
-    fields = walk_fields(app)
+    fields = wait_for_fields(app, "Create Account")
     app.enter_text(fields[0]["ref"], FRESH_EMAIL)
     app.enter_text(fields[1]["ref"], FRESH_PW)
     app.tap_label("Create Account")


### PR DESCRIPTION
Fixes the fmtk e2e flake from #3264. Closes #3264.

## The race

`test_forgot_and_reset_password` walked fields immediately after `tap_label("Forgot password?")` with no wait. When the snapshot landed between the tap and the route swap, `fields[0]` was the **login page's** email field; the typed address died with that field when `/forgot-password` mounted, the submit sent an empty form, the validator showed "Required", no POST went out, and `wait_for_text("we sent a password reset link")` timed out for the full 30 s. The backend path answers in milliseconds — the flake was entirely in the test/harness interaction, as the issue diagnosed.

## The fix

- New harness helper **`wait_for_fields(app, marker)`**: waits for a marker only the target page shows (a submit button's label is a reliable one), then returns the page's text fields. The stale-field grab is now impossible to repeat by construction.
- All five tap-then-immediately-walk sites use it:
  - `test_auth.py` — forgot-password (the flake itself), register-verify, and the policy-swap register scenario (the issue named the first two; the third had the same shape);
  - `test_workspaces.py` `register_fresh_user` and `test_terminals.py` `register_user` — the identical latent race, fixed before it flakes the same way.
- The now-duplicated local `walk_fields` defs in the workspaces/terminals suites are gone (the shared helper replaces them); `test_auth.py` keeps its own for the already-waited grabs (reset/invite forms that follow an explicit `wait_for_text`).

## Testing

- The affected suite green locally through the real harness (headed, kept stack): `test_auth.py` **10/10 in 6:51** — including `test_forgot_and_reset_password` and both register scenarios.
- `scripts/tests`: 128 passed (contract suite unaffected).
