### PR TITLE
Escape LIKE wildcards in user-facing search filters (#3280)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -332,6 +332,14 @@ operators or integrators to act when upgrading.
   allowed roots configured now fails at start — configure the roots
   or remove the mount. See
   [Mount security](features/workspaces.md#mount-security).
+- **`GET /users/search` matches filter text literally (#3280).**
+  `%` and `_` in the `q` parameter are now treated as literal
+  characters (escaped `LIKE` patterns), so a one-character wildcard
+  query can no longer enumerate the full user directory — the
+  type-ahead again requires a real prefix. Every admin list filter
+  (users, groups, invitations, workspace names) and the event-history
+  filters (`workspace` / `actor` / `target` / `event`) match filter
+  text literally the same way.
 
 - **Tokens removed from URLs (#3201).** Session JWTs no longer ride
   URLs anywhere. WebSocket clients (browser and CLI) now authenticate

--- a/docs/reference/api-endpoints.md
+++ b/docs/reference/api-endpoints.md
@@ -236,7 +236,8 @@ Query parameters:
 
 - `page` (default 1), `page_size` (default 10, max 200)
 - `sort` (`name` | `created`), `order` (`asc` | `desc`)
-- `q` — substring filter on name
+- `q` — substring filter on name (matched literally — `%` and `_`
+  are characters, not wildcards)
 - `source` — `manual` (hide the seeded per-workspace role groups) or
   `workspace-role` (show only them); omitted shows all
 
@@ -544,7 +545,9 @@ has acted on it. Query params: `limit` (1–200, default 50),
 is its decider **or** its revoker, while the summary row names the
 revoker for a revoked verdict — the `data` blob carries both),
 `workspace` (exact workspace id or a workspace-name substring), and
-`event` (event-name substring). `workspace_name` and `actor_email`
+`event` (event-name substring). Substring filters match filter text
+literally (`%` and `_` are characters, not wildcards).
+`workspace_name` and `actor_email`
 are resolved for display.
 
 **Auth:** JWT required. User must have the `manage-events`
@@ -602,7 +605,8 @@ the path and byte size in `detail` (the size is omitted where
 meaningless — rename, delete, directory downloads; an export's size
 is a pre-flight estimate). Query params:
 `limit` (1–200, default 50), `offset`, and optional `event`, `actor`
-(matches actor id or email), and `target` (target id) substring filters.
+(matches actor id or email), and `target` (target id) substring filters
+(matched literally — `%` and `_` are characters, not wildcards).
 Each item carries the acting principal (`actor_id` / `actor_email` —
 denormalized so attribution survives the actor's deletion), the target
 (`target_type` / `target_id`), a read-only JSON `detail` blob
@@ -657,7 +661,8 @@ Paged container start/stop history (#2923), newest first, from the
 `/events` resource (the Audit stream is `GET /events/audit`, #3205).
 Renamed from `GET /events` when the resource gained its second stream. Query params: `limit` (1–200,
 default 50), `offset`, and either `workspace` (an exact workspace id or
-a workspace-name substring) or the legacy exact-match `workspace_id` to
+a workspace-name substring, matched literally) or the legacy exact-match
+`workspace_id` to
 narrow to one workspace. Items carry the acting principal
 (`actor_type` user/agent/system + `actor_id`), the `cause`
 (api, idle_timeout, eviction, drain, …), the podman correlation ids
@@ -744,7 +749,9 @@ workspaces or adding group members.
 **Auth:** JWT required. User must have the `search-users` permission on
 `/users` (seeded Allow for Authenticated — distinct from
 `manage-users`, so picker surfaces work for non-admins). Query param:
-`q` (search string, min length 1).
+`q` (search string, min length 1). The needle is a literal prefix
+match on the email or handle — `%` and `_` in `q` are matched as
+characters, not as `LIKE` wildcards.
 
 No request body.
 
@@ -796,7 +803,8 @@ No request body.
 | `page_size` | int    | `10`      | `1`–`200` (clamped)                  |
 | `sort`      | string | `created` | `name` \| `created` (else `created`) |
 | `order`     | string | `desc`    | `asc` \| `desc`                      |
-| `q`         | string | (none)    | substring match, case-insensitive    |
+| `q`         | string | (none)    | substring match, case-insensitive;   |
+|             |        |           | `%` and `_` match literally          |
 
 `q` matches the volume name, the owning workspace's name, or any
 workspace name using the volume.
@@ -846,7 +854,8 @@ both shapes.
 Sorting is whitelisted (`created`→`created_at`, `name`→`name`) with an `id`
 tiebreaker so offset pagination is deterministic. `q` matches anywhere in
 the name (`LIKE '%q%'`), not just a prefix, and is applied before pagination
-so `has_more`/`next_offset` reflect the filtered set.
+so `has_more`/`next_offset` reflect the filtered set. Filter text matches
+literally — `%` and `_` in `q` are characters, not wildcards.
 
 ```json
 [
@@ -905,7 +914,7 @@ No request body.
 
 **Query params (optional, pagination):** same `?limit=` / `?offset=` as
 `GET /api/v1/workspaces`, plus `?sort=name|created`, `?order=asc|desc`, and
-`?q=<substring>` (name substring). Without params returns a bare list, with
+`?q=<substring>` (name substring, matched literally). Without params returns a bare list, with
 params returns the `{ items, has_more, next_offset }` envelope.
 
 Workspace objects use the same shape as

--- a/src/klangk/klangk/model/audit_events.py
+++ b/src/klangk/klangk/model/audit_events.py
@@ -82,6 +82,7 @@ import time
 
 from .audit_hmac import compute_audit_event_hmac
 from .base import Submodel, resolve_prune_now
+from .db import LIKE_ESCAPE, sql_like_escape
 from ..notifier import notify_event
 
 logger = logging.getLogger(__name__)
@@ -117,25 +118,29 @@ def filter_clause(
     """WHERE clause + params narrowing event reads.
 
     All three filters are optional substrings (SQLite ``LIKE`` — ASCII
-    case-insensitive, ``%``/``_`` wildcards not escaped, the same
-    convention as the other admin filters): ``event`` matches the event
-    name, ``actor`` matches the actor id *or* email, ``target``
-    matches the target id. An empty string means no filter.
+    case-insensitive; ``%`` and ``_`` in the filter text match
+    literally, the escaped-pattern convention of every admin filter
+    (#3280)): ``event`` matches the event name, ``actor`` matches the
+    actor id *or* email, ``target`` matches the target id. An empty
+    string means no filter.
     """
     conditions: list[str] = []
     params: list = []
     if event:
-        conditions.append("event LIKE '%' || ? || '%'")
-        params.append(event)
+        conditions.append("event LIKE '%' || ? || '%'" + LIKE_ESCAPE)
+        params.append(sql_like_escape(event))
     if actor:
         conditions.append(
-            "(actor_id LIKE '%' || ? || '%' OR actor_email LIKE"
-            " '%' || ? || '%')"
+            "(actor_id LIKE '%' || ? || '%'"
+            + LIKE_ESCAPE
+            + " OR actor_email LIKE '%' || ? || '%'"
+            + LIKE_ESCAPE
+            + ")"
         )
-        params.extend([actor, actor])
+        params.extend([sql_like_escape(actor), sql_like_escape(actor)])
     if target:
-        conditions.append("target_id LIKE '%' || ? || '%'")
-        params.append(target)
+        conditions.append("target_id LIKE '%' || ? || '%'" + LIKE_ESCAPE)
+        params.append(sql_like_escape(target))
     if not conditions:
         return "", []
     return " WHERE " + " AND ".join(conditions), params

--- a/src/klangk/klangk/model/container_events.py
+++ b/src/klangk/klangk/model/container_events.py
@@ -27,6 +27,7 @@ import time
 
 from .audit_hmac import compute_container_event_hmac
 from .base import Submodel, resolve_prune_now
+from .db import LIKE_ESCAPE, sql_like_escape
 from .users import AGENT_USER_ID
 
 logger = logging.getLogger(__name__)
@@ -99,16 +100,19 @@ def workspace_filter_clause(
     an exact workspace-id match or a workspace whose *name* contains the
     text, so typing either narrows the history. It wins over the legacy
     exact ``workspace_id`` param when both are sent. Name matching is
-    SQLite ``LIKE`` — ASCII case-insensitive, ``%``/``_`` wildcards not
-    escaped (the same convention as the other admin filters). An empty
-    string for either param means no filter, so a degenerate
-    ``?workspace=`` cannot silently narrow the audit history.
+    SQLite ``LIKE`` — ASCII case-insensitive, with ``%`` and ``_`` in
+    the filter text matched literally (the escaped-pattern convention
+    of every admin filter, #3280). An empty string for either param
+    means no filter, so a degenerate ``?workspace=`` cannot silently
+    narrow the audit history.
     """
     if workspace:
         return (
             " WHERE (workspace_id = ? OR workspace_id IN"
-            " (SELECT id FROM workspaces WHERE name LIKE '%' || ? || '%'))",
-            [workspace, workspace],
+            " (SELECT id FROM workspaces WHERE name LIKE '%' || ? || '%'"
+            + LIKE_ESCAPE
+            + "))",
+            [workspace, sql_like_escape(workspace)],
         )
     if workspace_id:
         return " WHERE workspace_id = ?", [workspace_id]

--- a/src/klangk/klangk/model/db.py
+++ b/src/klangk/klangk/model/db.py
@@ -245,3 +245,21 @@ class DB:
         async with self.transaction() as db:
             cursor = await db.execute(query, params)
             return list(await cursor.fetchall())
+
+
+# Appended to every parameterized LIKE in the model layer, pairing
+# with sql_like_escape below (#3280).
+LIKE_ESCAPE = " ESCAPE '\\'"
+
+
+def sql_like_escape(text: str) -> str:
+    """Escape ``%``, ``_`` and ``\\`` so *text* matches literally in a
+    parameterized SQLite ``LIKE`` pattern.
+
+    Every ``LIKE`` whose pattern comes from a request binds an escaped
+    value and carries ``LIKE_ESCAPE``, so ``%`` and ``_`` typed by a
+    caller match literally instead of acting as wildcards (#3280).
+    Literal patterns (fixed suffixes, migration constants) need no
+    escaping.
+    """
+    return text.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")

--- a/src/klangk/klangk/model/invitations.py
+++ b/src/klangk/klangk/model/invitations.py
@@ -11,6 +11,7 @@ import uuid
 from datetime import datetime, timezone
 
 from .base import Submodel
+from .db import LIKE_ESCAPE, sql_like_escape
 
 
 # Whitelisted sort columns for the admin invitations list. Values are the
@@ -114,8 +115,8 @@ class InvitationsModel(Submodel):
             where_clause = ""
             params: list = []
             if q:
-                where_clause = " WHERE i.email LIKE ?"
-                params.append(f"%{q}%")
+                where_clause = " WHERE i.email LIKE ?" + LIKE_ESCAPE
+                params.append(f"%{sql_like_escape(q)}%")
 
             count_cursor = await db.execute(
                 f"SELECT COUNT(*) AS c FROM invitations i{where_clause}",

--- a/src/klangk/klangk/model/merged_events.py
+++ b/src/klangk/klangk/model/merged_events.py
@@ -29,6 +29,7 @@ email where the row's id resolves through the ``users`` table), a
 from dataclasses import dataclass
 
 from .base import Submodel
+from .db import LIKE_ESCAPE, sql_like_escape
 
 # Origin-table discriminators, as shipped in each merged row's
 # ``source`` field.
@@ -78,18 +79,24 @@ _EGRESS_SELECT = (
 
 # A workspace filter narrows workspace-carrying tables by exact id or
 # by a workspace whose *name* contains the text (the ``workspace``
-# convention of the container-events view, #3006).
+# convention of the container-events view, #3006). The name match is
+# an escaped LIKE pattern (#3280).
 _WORKSPACE_ID_OR_NAME = (
     "(workspace_id = ? OR workspace_id IN"
-    " (SELECT id FROM workspaces WHERE name LIKE '%' || ? || '%'))"
+    " (SELECT id FROM workspaces WHERE name LIKE '%' || ? || '%'"
+    + LIKE_ESCAPE
+    + "))"
 )
 
 # An actor substring matches the row's stored actor id directly, or an
 # actor whose email matches through the users table (audit rows carry
-# a denormalized email, so they need no join).
+# a denormalized email, so they need no join). Both LIKEs are escaped
+# patterns (#3280).
 _ACTOR_ID_OR_EMAIL = (
-    "(actor_id LIKE '%' || ? || '%' OR actor_id IN"
-    " (SELECT id FROM users WHERE email LIKE '%' || ? || '%'))"
+    "(actor_id LIKE '%' || ? || '%'" + LIKE_ESCAPE + " OR actor_id IN"
+    " (SELECT id FROM users WHERE email LIKE '%' || ? || '%'"
+    + LIKE_ESCAPE
+    + "))"
 )
 
 
@@ -137,20 +144,27 @@ def audit_branch_clause(filters: MergedEventFilters) -> tuple[str, list]:
     params: list = []
     time_window_conditions(conditions, params, "created_at", filters)
     if filters.event:
-        conditions.append("event LIKE '%' || ? || '%'")
-        params.append(filters.event)
+        conditions.append("event LIKE '%' || ? || '%'" + LIKE_ESCAPE)
+        params.append(sql_like_escape(filters.event))
     if filters.actor:
         conditions.append(
-            "(actor_id LIKE '%' || ? || '%' OR actor_email LIKE"
-            " '%' || ? || '%')"
+            "(actor_id LIKE '%' || ? || '%'"
+            + LIKE_ESCAPE
+            + " OR actor_email LIKE '%' || ? || '%'"
+            + LIKE_ESCAPE
+            + ")"
         )
-        params.extend((filters.actor, filters.actor))
+        params.extend(
+            (sql_like_escape(filters.actor), sql_like_escape(filters.actor))
+        )
     if filters.workspace:
         conditions.append(
             "(target_type = 'workspace' AND (target_id = ? OR target_id IN"
-            " (SELECT id FROM workspaces WHERE name LIKE '%' || ? || '%')))"
+            " (SELECT id FROM workspaces WHERE name LIKE '%' || ? || '%'"
+            + LIKE_ESCAPE
+            + ")))"
         )
-        params.extend((filters.workspace, filters.workspace))
+        params.extend((filters.workspace, sql_like_escape(filters.workspace)))
     return where_clause(conditions), params
 
 
@@ -160,14 +174,16 @@ def container_branch_clause(filters: MergedEventFilters) -> tuple[str, list]:
     params: list = []
     time_window_conditions(conditions, params, "created_at", filters)
     if filters.event:
-        conditions.append("event LIKE '%' || ? || '%'")
-        params.append(filters.event)
+        conditions.append("event LIKE '%' || ? || '%'" + LIKE_ESCAPE)
+        params.append(sql_like_escape(filters.event))
     if filters.actor:
         conditions.append(_ACTOR_ID_OR_EMAIL)
-        params.extend((filters.actor, filters.actor))
+        params.extend(
+            (sql_like_escape(filters.actor), sql_like_escape(filters.actor))
+        )
     if filters.workspace:
         conditions.append(_WORKSPACE_ID_OR_NAME)
-        params.extend((filters.workspace, filters.workspace))
+        params.extend((filters.workspace, sql_like_escape(filters.workspace)))
     return where_clause(conditions), params
 
 
@@ -181,22 +197,30 @@ def egress_branch_clause(filters: MergedEventFilters) -> tuple[str, list]:
     params: list = []
     time_window_conditions(conditions, params, "requested_at", filters)
     if filters.event:
-        conditions.append("('egress.' || decision) LIKE '%' || ? || '%'")
-        params.append(filters.event)
+        conditions.append(
+            "('egress.' || decision) LIKE '%' || ? || '%'" + LIKE_ESCAPE
+        )
+        params.append(sql_like_escape(filters.event))
     if filters.actor:
         conditions.append(
-            "(decided_by LIKE '%' || ? || '%' OR revoked_by LIKE"
-            " '%' || ? || '%' OR decided_by IN"
-            " (SELECT id FROM users WHERE email LIKE '%' || ? || '%')"
+            "(decided_by LIKE '%' || ? || '%'"
+            + LIKE_ESCAPE
+            + " OR revoked_by LIKE '%' || ? || '%'"
+            + LIKE_ESCAPE
+            + " OR decided_by IN"
+            " (SELECT id FROM users WHERE email LIKE '%' || ? || '%'"
+            + LIKE_ESCAPE
+            + ")"
             " OR revoked_by IN"
-            " (SELECT id FROM users WHERE email LIKE '%' || ? || '%'))"
+            " (SELECT id FROM users WHERE email LIKE '%' || ? || '%'"
+            + LIKE_ESCAPE
+            + "))"
         )
-        params.extend(
-            (filters.actor, filters.actor, filters.actor, filters.actor)
-        )
+        actor = sql_like_escape(filters.actor)
+        params.extend((actor, actor, actor, actor))
     if filters.workspace:
         conditions.append(_WORKSPACE_ID_OR_NAME)
-        params.extend((filters.workspace, filters.workspace))
+        params.extend((filters.workspace, sql_like_escape(filters.workspace)))
     return where_clause(conditions), params
 
 

--- a/src/klangk/klangk/model/users.py
+++ b/src/klangk/klangk/model/users.py
@@ -7,6 +7,7 @@ from datetime import datetime, timedelta, timezone
 
 from ..exceptions import ConfigurationError
 from .base import Submodel
+from .db import LIKE_ESCAPE, sql_like_escape
 from .egress_consent import consent_rows_for_actor
 
 
@@ -333,8 +334,8 @@ def _group_filter_clause(q: str | None, source: str | None) -> tuple:
     where_parts: list[str] = []
     params: list = []
     if q:
-        where_parts.append("name LIKE ?")
-        params.append(f"%{q}%")
+        where_parts.append("name LIKE ?" + LIKE_ESCAPE)
+        params.append(f"%{sql_like_escape(q)}%")
     if source is not None:
         where_parts.append("source = ?")
         params.append(source)
@@ -995,8 +996,8 @@ class UsersModel(Submodel):
             where_clause = ""
             params: list = []
             if q:
-                where_clause = " WHERE email LIKE ?"
-                params.append(f"%{q}%")
+                where_clause = " WHERE email LIKE ?" + LIKE_ESCAPE
+                params.append(f"%{sql_like_escape(q)}%")
 
             count_cursor = await db.execute(
                 f"SELECT COUNT(*) AS c FROM users{where_clause}",
@@ -1360,12 +1361,21 @@ class UsersModel(Submodel):
         }
 
     async def search_users(self, query: str, limit: int = 10) -> list[dict]:
-        """Search users by email or handle prefix (#616)."""
+        """Search users by email or handle prefix (#616).
+
+        ``%`` and ``_`` in *query* match literally (#3280): the needle
+        is escaped, so a wildcard query cannot widen the prefix match
+        into a directory dump.
+        """
+        needle = f"{sql_like_escape(query)}%"
         rows = await self.app.state.db.fetchall(
             "SELECT id, email, handle FROM users"
-            " WHERE email LIKE ? OR handle LIKE ?"
-            " ORDER BY email LIMIT ?",
-            (f"{query}%", f"{query}%", limit),
+            " WHERE email LIKE ?"
+            + LIKE_ESCAPE
+            + " OR handle LIKE ?"
+            + LIKE_ESCAPE
+            + " ORDER BY email LIMIT ?",
+            (needle, needle, limit),
         )
         return [
             {

--- a/src/klangk/klangk/model/users.py
+++ b/src/klangk/klangk/model/users.py
@@ -1365,8 +1365,11 @@ class UsersModel(Submodel):
 
         ``%`` and ``_`` in *query* match literally (#3280): the needle
         is escaped, so a wildcard query cannot widen the prefix match
-        into a directory dump.
+        into a directory dump. An empty *query* returns no rows (the
+        route also rejects it, but the model stays safe standalone).
         """
+        if not query:
+            return []
         needle = f"{sql_like_escape(query)}%"
         rows = await self.app.state.db.fetchall(
             "SELECT id, email, handle FROM users"

--- a/src/klangk/klangk/model/workspaces.py
+++ b/src/klangk/klangk/model/workspaces.py
@@ -8,6 +8,7 @@ from datetime import datetime, timezone
 from ..netfilter import parse_allowed_domains
 from .acl import ACTION_ALLOW, PRINCIPAL_GROUP, PRINCIPAL_USER
 from .base import Submodel
+from .db import LIKE_ESCAPE, sql_like_escape
 from .users import (
     AGENT_USER_ID,
     AgentPrincipalError,
@@ -589,8 +590,12 @@ class WorkspacesModel(Submodel):
         role-suffix list is duplicated here. Returns ``[{id, name}]``.
         """
         cursor = await db.execute(
-            "SELECT id, name FROM groups WHERE source = ? AND name LIKE ?",
-            (GROUP_SOURCE_WORKSPACE_ROLE, f"%-{workspace_id}"),
+            "SELECT id, name FROM groups WHERE source = ? AND name LIKE ?"
+            + LIKE_ESCAPE,
+            (
+                GROUP_SOURCE_WORKSPACE_ROLE,
+                f"%-{sql_like_escape(workspace_id)}",
+            ),
         )
         return [
             {"id": row["id"], "name": row["name"]}
@@ -768,8 +773,8 @@ class WorkspacesModel(Submodel):
         where = "WHERE user_id = ?"
         params: list = [user_id]
         if q:
-            where += " AND name LIKE '%' || ? || '%'"
-            params.append(q)
+            where += " AND name LIKE '%' || ? || '%'" + LIKE_ESCAPE
+            params.append(sql_like_escape(q))
         params.extend([limit + 1, offset])
         rows = await self.app.state.db.fetchall(
             "SELECT id, name, container_id, image, service_command,"
@@ -802,7 +807,9 @@ class WorkspacesModel(Submodel):
         a direct user-level ACE or a group-level ACE on
         ``/workspaces/{id}``."""
         order_by = sort_order_clause(sort, order, prefix="w")
-        name_filter = " AND w.name LIKE '%' || ? || '%'" if q else ""
+        name_filter = (
+            (" AND w.name LIKE '%' || ? || '%'" + LIKE_ESCAPE) if q else ""
+        )
         # The group-ids read runs on its own connection (it did before
         # the fetchall conversion too), so it never shared the page
         # read's snapshot.
@@ -838,7 +845,7 @@ class WorkspacesModel(Submodel):
                 user_id,
                 user_id,
                 *group_ids,
-                *([q] if q else []),
+                *([sql_like_escape(q)] if q else []),
                 limit + 1,
                 offset,
             ),

--- a/src/klangk/klangkd-tests/tests/test_api.py
+++ b/src/klangk/klangkd-tests/tests/test_api.py
@@ -7778,6 +7778,31 @@ class TestUserSearch:
         resp = await client.get("/api/v1/users/search?q=", headers=headers)
         assert resp.status_code == 400
 
+    async def test_search_wildcards_are_literal(self, client, app, user):
+        """A lone ``%``/``_``/``\\`` query cannot dump the directory
+        (#3280); a literal-underscore prefix still matches."""
+        headers = await _auth_headers(client)
+        await app.state.model.users.create_user(
+            "qzw7k-unrelated@example.com", "hash"
+        )
+        under = await app.state.model.users.create_user(
+            "_under@example.com", "hash"
+        )
+        for q in ("%", "_", "\\"):
+            resp = await client.get(
+                "/api/v1/users/search", params={"q": q}, headers=headers
+            )
+            assert resp.status_code == 200, q
+            emails = [r["email"] for r in resp.json()]
+            assert "testuser@example.com" not in emails, (q, emails)
+            assert "qzw7k-unrelated@example.com" not in emails, (q, emails)
+        resp = await client.get(
+            "/api/v1/users/search", params={"q": "_"}, headers=headers
+        )
+        emails = [r["email"] for r in resp.json()]
+        assert under["email"] in emails
+        assert "testuser@example.com" not in emails
+
 
 # --- Messages ---
 
@@ -14442,6 +14467,12 @@ class TestInvitations:
         # Two freshly-created pending invitations are reflected in the
         # global pending count (used by the UI badge).
         assert body["pending_count"] >= 2
+        # % matches literally, not as a wildcard (#3280).
+        resp = await client.get(
+            "/api/v1/invitations", params={"q": "%"}, headers=headers
+        )
+        assert resp.status_code == 200
+        assert resp.json()["total"] == 0
 
     async def test_list_invitations_default_page_size_is_10(
         self, client, app, admin_user

--- a/src/klangk/klangkd-tests/tests/test_audit_events.py
+++ b/src/klangk/klangkd-tests/tests/test_audit_events.py
@@ -20,6 +20,7 @@ from test_api import _admin_login, _auth_headers, _mock_pod
 from httpx import ASGITransport, AsyncClient
 from klangk import auth as klangk_auth
 from klangk.model.audit_events import filter_clause, row_to_dict
+from klangk.model.db import LIKE_ESCAPE
 
 # test_api's app fixture, re-bound under a module-local name: pytest
 # registers it here (fixture discovery walks the module namespace) and
@@ -53,7 +54,7 @@ class TestFilterClause:
 
     def test_event_only(self):
         where, params = filter_clause("login", None, None)
-        assert where == " WHERE event LIKE '%' || ? || '%'"
+        assert where == (" WHERE event LIKE '%' || ? || '%'" + LIKE_ESCAPE)
         assert params == ["login"]
 
     def test_actor_only_matches_id_or_email(self):
@@ -63,13 +64,20 @@ class TestFilterClause:
 
     def test_target_only(self):
         where, params = filter_clause(None, None, "ws-1")
-        assert where == " WHERE target_id LIKE '%' || ? || '%'"
+        assert where == (" WHERE target_id LIKE '%' || ? || '%'" + LIKE_ESCAPE)
         assert params == ["ws-1"]
 
     def test_all_three_join_with_and(self):
         where, params = filter_clause("login", "u1", "ws-1")
         assert where.count("AND") == 2
         assert len(params) == 4
+
+    def test_wildcards_are_escaped(self):
+        # #3280: %/_/\ in filter text match literally, and every LIKE
+        # carries the ESCAPE clause.
+        where, params = filter_clause("100%", "a_b", "c\\d")
+        assert params == ["100\\%", "a\\_b", "a\\_b", "c\\\\d"]
+        assert where.count(LIKE_ESCAPE) == 4
 
 
 class TestAuditEventsModel:

--- a/src/klangk/klangkd-tests/tests/test_container_events.py
+++ b/src/klangk/klangkd-tests/tests/test_container_events.py
@@ -32,8 +32,10 @@ from klangk.model.container_events import (
     EVENT_START,
     EVENT_STOP,
     actor_type_for,
+    workspace_filter_clause,
 )
 from klangk.model.users import AGENT_USER_ID
+from klangk.model.db import LIKE_ESCAPE
 from klangk.podman import PodmanError
 
 
@@ -55,6 +57,15 @@ class TestActorClassification:
 
     def test_any_other_id_is_user(self):
         assert actor_type_for("some-user-id") == ACTOR_USER
+
+
+class TestWorkspaceFilterClause:
+    def test_name_needle_is_escaped(self):
+        # #3280: the id stays an exact match; the name needle escapes
+        # % and _ so filter text matches literally.
+        where, params = workspace_filter_clause("a%b_c", None)
+        assert params == ["a%b_c", "a\\%b\\_c"]
+        assert where.count(LIKE_ESCAPE) == 1
 
 
 class TestContainerEventsModel:

--- a/src/klangk/klangkd-tests/tests/test_merged_events.py
+++ b/src/klangk/klangkd-tests/tests/test_merged_events.py
@@ -14,7 +14,13 @@ from test_api import _admin_login, _auth_headers
 from httpx import ASGITransport, AsyncClient
 from klangk.model.egress_consent import DECISION_ALLOWED, DECISION_DENIED
 from klangk.model.container_events import CAUSE_API, EVENT_START, EVENT_STOP
-from klangk.model.merged_events import MergedEventFilters
+from klangk.model.db import LIKE_ESCAPE
+from klangk.model.merged_events import (
+    MergedEventFilters,
+    audit_branch_clause,
+    container_branch_clause,
+    egress_branch_clause,
+)
 
 # test_api's app fixture, re-bound under a module-local name (the
 # test_audit_events.py pattern).
@@ -49,6 +55,23 @@ async def _other_user(app_state, email="other@example.com"):
     return await app_state.state.model.users.create_user(
         email, "not-a-real-hash", verified=True
     )
+
+
+class TestBranchClauses:
+    """Unit pins on the three branch-clause builders."""
+
+    def test_every_like_carries_escape(self):
+        # #3280: dropping one ESCAPE from a compound clause would
+        # silently restore wildcard matching on that axis — pin the
+        # LIKE count to the ESCAPE count for every branch.
+        f = MergedEventFilters(event="e", actor="a", workspace="w")
+        for clause in (
+            audit_branch_clause,
+            container_branch_clause,
+            egress_branch_clause,
+        ):
+            where, _params = clause(f)
+            assert where.count("LIKE") == where.count(LIKE_ESCAPE), clause
 
 
 class TestMergedEventsModel:

--- a/src/klangk/klangkd-tests/tests/test_merged_events.py
+++ b/src/klangk/klangkd-tests/tests/test_merged_events.py
@@ -303,6 +303,16 @@ class TestMergedEventsModel:
         )
         assert denied_rows == []
 
+    async def test_event_filter_wildcards_are_literal(self, app_state, db):
+        # #3280: a lone % must not act as a match-everything wildcard
+        # over the recorded history.
+        merged = app_state.state.model.merged_events
+        await app_state.state.model.audit_events.record(
+            "login.failed", actor_id=None
+        )
+        assert await merged.list_events(MergedEventFilters(event="%")) == []
+        assert await merged.count_events(MergedEventFilters(event="%")) == 0
+
     async def test_pagination_across_the_merge(self, app_state, db, user):
         merged = app_state.state.model.merged_events
         ws = await app_state.state.model.workspaces.create_workspace(

--- a/src/klangk/klangkd-tests/tests/test_model.py
+++ b/src/klangk/klangkd-tests/tests/test_model.py
@@ -2552,6 +2552,14 @@ class TestDB:
         assert str(db.db_path).endswith("klangk.db")
         assert db.engine is None
 
+    def test_sql_like_escape(self):
+        """sql_like_escape neutralizes the LIKE wildcards and the
+        escape char itself (#3280); plain text passes through."""
+        from klangk.model.db import sql_like_escape
+
+        assert sql_like_escape("plain") == "plain"
+        assert sql_like_escape("100%_a\\b") == "100\\%\\_a\\\\b"
+
 
 class TestUsersBackstopBranches:
     """Cover backstop branches not reached by app code (now on the

--- a/src/klangk/klangkd-tests/tests/test_model_users.py
+++ b/src/klangk/klangkd-tests/tests/test_model_users.py
@@ -278,6 +278,7 @@ async def test_search_users_like_wildcards_are_literal(users):
     dump."""
     under = await users.create_user("_under@x.com", "hash")
     plain = await users.create_user("plain@x.com", "hash")
+    assert await users.search_users("") == []
     assert await users.search_users("%") == []
     assert await users.search_users("\\") == []
     found = await users.search_users("_")

--- a/src/klangk/klangkd-tests/tests/test_model_users.py
+++ b/src/klangk/klangkd-tests/tests/test_model_users.py
@@ -272,6 +272,35 @@ async def test_search_users_matches_handle_prefix(users):
     assert any(f["id"] == u["id"] for f in await users.search_users("findme@"))
 
 
+async def test_search_users_like_wildcards_are_literal(users):
+    """``%``/``_``/``\\`` in the needle match literally (#3280) — a
+    lone wildcard cannot widen the prefix match into a directory
+    dump."""
+    under = await users.create_user("_under@x.com", "hash")
+    plain = await users.create_user("plain@x.com", "hash")
+    assert await users.search_users("%") == []
+    assert await users.search_users("\\") == []
+    found = await users.search_users("_")
+    assert any(f["id"] == under["id"] for f in found)
+    assert all(f["id"] != plain["id"] for f in found)
+
+
+async def test_list_users_query_wildcards_are_literal(users):
+    """The admin users-list q filter treats ``%``/``_`` literally."""
+    u = await users.create_user("pct_user@x.com", "hash")
+    await users.create_user("plain@x.com", "hash")
+    assert (await users.list_users(q="%"))["total"] == 0
+    listed = await users.list_users(q="_")
+    assert u["id"] in [item["id"] for item in listed["users"]]
+
+
+async def test_list_groups_query_wildcards_are_literal(users):
+    """The admin groups-list q filter treats ``%``/``_`` literally."""
+    await users.create_group("grp_one")
+    assert (await users.list_groups(q="%"))["total"] == 0
+    assert (await users.list_groups(q="_"))["total"] >= 1
+
+
 async def test_update_email_and_password(users):
     u = await users.create_user("u@x.com", "hash")
     await users.update_email(u["id"], "u2@x.com")

--- a/src/klangk/klangkd-tests/tests/test_model_workspaces.py
+++ b/src/klangk/klangkd-tests/tests/test_model_workspaces.py
@@ -298,6 +298,14 @@ async def test_list_workspaces_with_query(ws, user):
     assert {w["name"] for w in all_items["items"]} == {"alpha", "beta"}
 
 
+async def test_list_workspaces_query_wildcards_are_literal(ws, user):
+    """The q filter treats ``%`` and ``_`` literally (#3280)."""
+    await ws.create_workspace(user["id"], "alpha")
+    await ws.create_workspace(user["id"], "beta")
+    assert (await ws.list_workspaces(user["id"], q="%"))["items"] == []
+    assert (await ws.list_workspaces(user["id"], q="_"))["items"] == []
+
+
 async def test_list_shared_workspaces(ws, app_state, user):
     other = await app_state.state.model.users.create_user("other@x.com", "h")
     ws_row = await ws.create_workspace_with_acl(other["id"], "shared-ws")
@@ -318,6 +326,8 @@ async def test_list_shared_workspaces(ws, app_state, user):
     # q-filter narrows by name.
     filtered = await ws.list_shared_workspaces(user["id"], q="shared")
     assert [w["name"] for w in filtered["items"]] == ["shared-ws"]
+    # % matches literally, not as a wildcard (#3280).
+    assert (await ws.list_shared_workspaces(user["id"], q="%"))["items"] == []
     # Nothing shared with ``other``.
     assert (await ws.list_shared_workspaces(other["id"]))["items"] == []
 


### PR DESCRIPTION
Fixes #3280.

## Summary

`GET /api/v1/users/search` bound the caller's needle straight into a SQLite
`LIKE` pattern (`f"{query}%"`, no escaping), so a one-character query — `q=_`
or `q=%` — matched every account. Any signed-in user (the `search-users`
permission is Allow Authenticated by default) could dump the full email/handle
directory and walk it with narrowing prefixes.

## The fix

- **`model/db.py`** — new shared `sql_like_escape()` (escapes `\`, `%`, `_`)
  plus the matching `LIKE_ESCAPE` (` ESCAPE '\'`) clause constant.
- **`model/users.py`** — `search_users` binds an escaped needle; the admin
  `list_users` and groups-list q filters do the same.
- **`model/invitations.py` / `model/workspaces.py`** — invitations q filter and
  the workspace name filters (owned + shared lists, role-group lookup) use the
  escaped pattern.
- **`model/audit_events.py` / `model/container_events.py` /
  `model/merged_events.py`** — the admin event-history filters previously
  *documented* their wildcard-pass-through behavior; they now match filter text
  literally too, with docstrings updated to the new convention.
- Exact-match axes (`workspace_id = ?`, `target_id = ?`, …) keep binding the
  raw text; only LIKE-bound needles are escaped. Migration files with literal
  LIKE patterns are untouched.

## Tests

- Endpoint regression (`test_api.py::TestUserSearch`): `q=%`, `q=_`, `q=\`
  return nothing, a literal-underscore prefix still matches, and unrelated
  accounts stay invisible.
- Model-level: `search_users` / `list_users` / `list_groups` / workspace and
  shared-workspace q filters treat wildcards literally.
- Unit: `sql_like_escape` itself, `audit_events.filter_clause` (params escaped,
  ESCAPE on every LIKE), `container_events.workspace_filter_clause`.
- Behavioral: a merged-events `event="%"` filter no longer matches everything.
- Full suite green, 100% branch coverage (`-n auto`, CI invocation).
