### PR TITLE
Fix DPoP proofs on subpath deployments (#3287)

### DIFF
--- a/devenv.nix
+++ b/devenv.nix
@@ -628,7 +628,47 @@ in
       fi
     fi
 
-    exec npx playwright test --reporter=list "$@"
+    npx playwright test --reporter=list "$@"
+    _main_status=$?
+
+    # The subpath × web × DPoP suite (#3287): a separate Playwright config
+    # (its own klangkd behind a prefix-stripping outer caddy at /klangk/).
+    # Runs after the main suite; its own config, chromium-only. Project
+    # selection flags (--project=... / --project X, --no-deps) target the
+    # main config's projects and are dropped here so a filtered dispatch
+    # run still exercises the subpath scenario; -g and friends pass
+    # through. --pass-with-no-tests keeps a filter that matches nothing
+    # in the one-test subpath config from failing the whole task.
+    _subpath_status=0
+    if [ -n "''${KLANGKBUILD_TEST_URL:-}" ]; then
+      # External-server mode: the main setup talks to a server we do not
+      # control, while the subpath suite drives its own locally-booted
+      # stack — the spec's API helpers would register on the external
+      # server and the browser would log in against the local one. Skip
+      # the chain, mirroring the main setup's external short-circuit.
+      echo "=== subpath × web × DPoP e2e skipped (KLANGKBUILD_TEST_URL set) ==="
+    else
+      _subpath_args=(--pass-with-no-tests)
+      _skip_next=false
+      for _arg in "$@"; do
+        if [ "$_skip_next" = true ]; then
+          _skip_next=false
+          continue
+        fi
+        case "$_arg" in
+          --project) _skip_next=true ;;
+          --project=*|--no-deps) ;;
+          *) _subpath_args+=("$_arg") ;;
+        esac
+      done
+      echo "=== subpath × web × DPoP e2e (#3287) ==="
+      npx playwright test -c subpath/playwright.subpath.config.ts \
+        --reporter=list "''${_subpath_args[@]}"
+      _subpath_status=$?
+    fi
+
+    [ "$_main_status" -ne 0 ] && exit "$_main_status"
+    exit "$_subpath_status"
   '';
 
   # Bare `playwright` command that always uses the LOCAL binary pinned in

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -2507,6 +2507,19 @@ git-credential` (#1700).** `pig-latin` removed; `word-count` dormant.
 
 ### Fixed
 
+- **Subpath deployments work with DPoP-bound web sessions (#3287).**
+  On a deployment served under a base path (`hosting-base-path` /
+  `X-Forwarded-Prefix`), the web client's DPoP proofs carried the
+  prefix in their `htu` while the server compared against the
+  prefix-stripped path — every authenticated request and both
+  WebSocket connects returned `401 Invalid DPoP proof: uri mismatch`,
+  making the web UI unusable. The client now mints proofs over the
+  backend-visible path, and the server tolerates its own configured or
+  trusted-forwarded base path ahead of the compared path, so
+  already-deployed frontends work without a rebuild. Covered by a new
+  Playwright suite that runs the browser flow behind a
+  prefix-stripping proxy at `/klangk/`.
+
 - **File viewer and WebSocket error messages (#3227).** A transport
   failure while listing a workspace directory or opening a file, and
   socket/parse errors on the workspace WebSocket, no longer show the

--- a/docs/deployment/behind-a-proxy.md
+++ b/docs/deployment/behind-a-proxy.md
@@ -147,6 +147,14 @@ If you serve klangk on a subpath (e.g. `/klangk/`), also set:
 proxy_set_header X-Forwarded-Prefix /klangk;
 ```
 
+The backend accepts DPoP proof `htu` claims spelled either with or without
+this prefix, so a browser session behind the subpath and one at the backend's
+own URL both authenticate. A client that sends a forged `X-Forwarded-Prefix`
+widens only its own request's accepted spellings — every proof is still signed
+by the requester's own bound key, and the stripped path must still match the
+request exactly — so the header cannot make one client's proof verify for
+another.
+
 ### WebSocket upgrade
 
 klangk uses WebSockets at `/ws` for live terminal and container status

--- a/src/frontend/e2e-tests/subpath/global-setup.ts
+++ b/src/frontend/e2e-tests/subpath/global-setup.ts
@@ -1,0 +1,259 @@
+import { execSync, spawn } from "child_process";
+import {
+  cpSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  openSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+
+import { ADMIN_PASSWORD, cleanEnv } from "../e2e-env";
+
+// The subpath × web × DPoP stack (#3287): a second klangkd serving the
+// Flutter build with a `/klangk` base href, fronted by an outer caddy
+// that strips the prefix and sends `X-Forwarded-Prefix: /klangk` — the
+// documented nginx pattern from docs/deployment/behind-a-proxy.md, at
+// browser-facing /klangk/.
+//
+// Ports (main suite: backend 18997, egress 18995, port range 19200+):
+// - 18998: outer caddy (the URL the browser uses)
+// - 18999: klangkd browser listener (what the outer caddy forwards to)
+// - 18996: klangkd container egress listener
+// - 23200+: workspace port range (far from the main suite's 19200+)
+// No trailing slash: the setup appends paths to it directly.
+export const SUBPATH_BASE_URL =
+  process.env.KLANGKBUILD_SUBPATH_URL || "http://localhost:18998/klangk";
+export const SUBPATH_PREFIX = "/klangk";
+
+const BACKEND_PORT = "18999";
+const EGRESS_PORT = "18996";
+const OUTER_PORT = "18998";
+
+function subpathWebDir(): string {
+  // A copy of the built frontend with the base href rewritten to the
+  // subpath — the asset-URL shape of a `flutter build web
+  // --base-href=/klangk/` build (the docs' outer-nginx sub_filter does
+  // the same rewrite in flight). Lives under the e2e logs dir, which is
+  // gitignored; rebuilt on every run so it never goes stale.
+  const logsDir = join(__dirname, "..", "logs");
+  mkdirSync(logsDir, { recursive: true });
+  return join(logsDir, "subpath-web");
+}
+
+function prepareSubpathFrontend(): string {
+  const projectRoot = join(__dirname, "..", "..", "..", "..");
+  const built = join(projectRoot, "src", "frontend", "build", "web");
+  const indexHtml = join(built, "index.html");
+  if (!existsSync(indexHtml)) {
+    throw new Error(
+      `Flutter build not found at ${built} — run ` +
+        `'devenv tasks run klangk:flutter-build' first`,
+    );
+  }
+  const target = subpathWebDir();
+  rmSync(target, { recursive: true, force: true });
+  cpSync(built, target, { recursive: true });
+
+  // Rewrite the base tag. Flutter emits `<base href="/" />`; accept
+  // either attribute spacing and fail loudly when the shape drifts.
+  const indexPath = join(target, "index.html");
+  const html = readFileSync(indexPath, "utf8");
+  const rewritten = html.replace(
+    /<base href="\/"\s*\/?>/,
+    `<base href="${SUBPATH_PREFIX}/">`,
+  );
+  if (rewritten === html) {
+    throw new Error(
+      `Could not find '<base href="/">' in ${indexPath} — the build's ` +
+        `base tag shape changed; update the rewrite`,
+    );
+  }
+  writeFileSync(indexPath, rewritten);
+  return target;
+}
+
+function writeOuterCaddyfile(): string {
+  // The outer proxy of the documented subpath pattern: strip the
+  // prefix, tell klangkd about it via X-Forwarded-Prefix (trusted:
+  // klangkd's default trusted-proxy set is loopback, and caddy dials
+  // 127.0.0.1), forward everything else — /api, /ws (upgrades
+  // included), /hosted, documents, assets.
+  const path = join(subpathWebDir(), "..", "subpath-Caddyfile");
+  writeFileSync(
+    path,
+    [
+      "{",
+      "\tauto_https off",
+      "\tadmin off",
+      "}",
+      `http://:${OUTER_PORT} {`,
+      "\tbind 127.0.0.1",
+      `\tredir /klangk /klangk/ 308`,
+      "\thandle_path /klangk/* {",
+      "\t\treverse_proxy 127.0.0.1:" + BACKEND_PORT + " {",
+      `\t\t\theader_up X-Forwarded-Prefix ${SUBPATH_PREFIX}`,
+      "\t\t}",
+      "\t}",
+      "\trespond 404",
+      "}",
+      "",
+    ].join("\n"),
+  );
+  return path;
+}
+
+async function waitHealthy(url: string, label: string): Promise<void> {
+  for (let i = 0; i < 120; i++) {
+    try {
+      const resp = await fetch(url);
+      if (resp.ok) return;
+    } catch {
+      // Not ready yet
+    }
+    await new Promise((r) => setTimeout(r, 1000));
+  }
+  throw new Error(`${label} not reachable at ${url} within 120s`);
+}
+
+function stackHolderPids(port: number): string[] {
+  try {
+    return execSync(`fuser ${port}/tcp 2>/dev/null`, { encoding: "utf8" })
+      .trim()
+      .split(/\s+/)
+      .filter(Boolean)
+      .filter((pid) => {
+        try {
+          const cmdline = readFileSync(`/proc/${pid}/cmdline`, "utf8");
+          return cmdline.includes("klangk.main") || cmdline.includes("caddy");
+        } catch {
+          return false;
+        }
+      });
+  } catch {
+    return [];
+  }
+}
+
+function portHeld(port: number): boolean {
+  try {
+    execSync(`fuser ${port}/tcp 2>/dev/null`, { stdio: "ignore" });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function anyStackPortHeld(): boolean {
+  return [BACKEND_PORT, EGRESS_PORT, OUTER_PORT].some(portHeld);
+}
+
+function signalStackHolders(signal: string): void {
+  for (const port of [BACKEND_PORT, EGRESS_PORT, OUTER_PORT]) {
+    for (const pid of stackHolderPids(port)) {
+      execSync(`kill ${signal} ${pid} 2>/dev/null`, { stdio: "ignore" });
+    }
+  }
+}
+
+async function freeStackPorts(): Promise<void> {
+  // A crashed earlier run can leave this stack's klangkd (or its caddy)
+  // wedged on the ports. Teardown normally reaches klangkd's caddy too
+  // (it carries PDEATHSIG), but a hard-crashed run leaves nothing behind
+  // to kill it. Only holders that ARE this stack — a python running
+  // klangk.main, or a caddy — are killed, so an unrelated process that
+  // happens to hold a port is left alone (the spawn then fails loudly).
+  signalStackHolders("");
+  // A SIGTERM'd klangkd drains workspaces before exiting (seconds, with a
+  // container up), and its caddy follows via PDEATHSIG — wait for the ports
+  // to actually release so the respawn below does not lose the bind race
+  // (or worse, have /health answered by the still-draining old backend).
+  for (let i = 0; i < 40 && anyStackPortHeld(); i++) {
+    await new Promise((r) => setTimeout(r, 250));
+  }
+  // Still draining after 10s — take the stack's processes down hard.
+  signalStackHolders("-9");
+  for (let i = 0; i < 20 && anyStackPortHeld(); i++) {
+    await new Promise((r) => setTimeout(r, 250));
+  }
+}
+
+async function globalSetup() {
+  await freeStackPorts();
+  const projectRoot = join(__dirname, "..", "..", "..", "..");
+  const dataDir = mkdtempSync(join(tmpdir(), "klangk-subpath-e2e-"));
+  const stateDir = mkdtempSync(join(tmpdir(), "klangk-subpath-e2e-state-"));
+  const frontendDir = prepareSubpathFrontend();
+  const caddyfile = writeOuterCaddyfile();
+
+  const logDir = join(__dirname, "..", "logs");
+  const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
+  const backendLog = join(logDir, `subpath-backend-${timestamp}.log`);
+  const outerLog = join(logDir, `subpath-outer-${timestamp}.log`);
+  const backendFd = openSync(backendLog, "w");
+  const outerFd = openSync(outerLog, "w");
+
+  console.log(
+    `Starting subpath stack: klangkd on :${BACKEND_PORT} (frontend ` +
+      `${frontendDir}), outer caddy on :${OUTER_PORT} at ${SUBPATH_PREFIX}/`,
+  );
+
+  const backend = spawn("python3", ["-m", "klangk.main", "--config=none"], {
+    cwd: join(projectRoot, "src", "klangk", "klangkd-tests"),
+    detached: true,
+    stdio: ["ignore", backendFd, backendFd],
+    env: cleanEnv({
+      KLANGKD_PORT: BACKEND_PORT,
+      KLANGKD_EGRESS_PORT: EGRESS_PORT,
+      KLANGKD_DATA_DIR: dataDir,
+      KLANGKD_STATE_DIR: stateDir,
+      KLANGKD_FRONTEND_DIR: frontendDir,
+      KLANGKD_CUSTOMIZE_DIR: join(dataDir, "customize"),
+      KLANGKD_API_RATE_LIMIT: "0",
+      KLANGKD_JWT_SECRET: "e2e-subpath-test-secret",
+      KLANGKD_DEFAULT_USER: "admin@example.com",
+      KLANGKD_DEFAULT_PASSWORD: ADMIN_PASSWORD,
+      KLANGKD_AUTH_MODES: "password",
+      KLANGKD_TEST_MODE: "1",
+      KLANGKD_PORT_RANGE_START: "23200",
+      KLANGKD_LOGIN_BANNER_TITLE: "",
+      KLANGKD_LOGIN_BANNER: "",
+      KLANGKD_OIDC_CONFIG: "",
+      KLANGKD_OIDC_LOGIN_HOOK: "",
+      KLANGKD_DISABLE_REGISTRATION: "",
+      KLANGKD_DISABLE_INVITES: "",
+      LOGFIRE_TOKEN: "",
+    }),
+  });
+  process.env.KLANGKBUILD_SUBPATH_BACKEND_PID = String(backend.pid);
+  process.env.KLANGKBUILD_SUBPATH_BACKEND_LOG = backendLog;
+
+  const outer = spawn(
+    "caddy",
+    ["run", "--config", caddyfile, "--adapter", "caddyfile"],
+    {
+      cwd: logDir,
+      detached: true,
+      stdio: ["ignore", outerFd, outerFd],
+    },
+  );
+  process.env.KLANGKBUILD_SUBPATH_OUTER_PID = String(outer.pid);
+  process.env.KLANGKBUILD_SUBPATH_OUTER_LOG = outerLog;
+
+  await waitHealthy(
+    `http://localhost:${BACKEND_PORT}/health`,
+    "subpath klangkd",
+  );
+  // Health THROUGH the outer proxy proves the prefix strip end to end.
+  await waitHealthy(`${SUBPATH_BASE_URL}/health`, "subpath outer caddy chain");
+
+  console.log(`Subpath stack ready at ${SUBPATH_BASE_URL}/`);
+  console.log(`Backend log: ${backendLog}`);
+  console.log(`Outer log: ${outerLog}`);
+}
+
+export default globalSetup;

--- a/src/frontend/e2e-tests/subpath/global-teardown.ts
+++ b/src/frontend/e2e-tests/subpath/global-teardown.ts
@@ -1,0 +1,43 @@
+import { existsSync } from "fs";
+
+async function killTree(pidEnv: string, label: string): Promise<void> {
+  const pid = Number(process.env[pidEnv]);
+  if (!pid) return;
+  console.log(`Stopping ${label} (PID ${pid})...`);
+  try {
+    process.kill(-pid, "SIGTERM");
+  } catch {
+    return;
+  }
+  for (let i = 0; i < 20; i++) {
+    try {
+      process.kill(pid, 0);
+      await new Promise((r) => setTimeout(r, 500));
+    } catch {
+      return;
+    }
+  }
+  try {
+    process.kill(-pid, "SIGKILL");
+  } catch {
+    // Already dead
+  }
+}
+
+async function globalTeardown() {
+  // Kill the outer proxy first so no new request reaches the backend
+  // while it drains.
+  await killTree("KLANGKBUILD_SUBPATH_OUTER_PID", "subpath outer caddy");
+  await killTree("KLANGKBUILD_SUBPATH_BACKEND_PID", "subpath klangkd");
+
+  const backendLog = process.env.KLANGKBUILD_SUBPATH_BACKEND_LOG;
+  if (backendLog && existsSync(backendLog)) {
+    console.log(`Backend log: ${backendLog}`);
+  }
+  const outerLog = process.env.KLANGKBUILD_SUBPATH_OUTER_LOG;
+  if (outerLog && existsSync(outerLog)) {
+    console.log(`Outer log: ${outerLog}`);
+  }
+}
+
+export default globalTeardown;

--- a/src/frontend/e2e-tests/subpath/playwright.subpath.config.ts
+++ b/src/frontend/e2e-tests/subpath/playwright.subpath.config.ts
@@ -1,0 +1,38 @@
+import { defineConfig } from "@playwright/test";
+
+// The subpath × web × DPoP suite (#3287) — a SEPARATE config from
+// playwright.config.ts: the browser base URL lives under /klangk/, the
+// API helpers talk to the stack's own klangkd (port 18999, direct —
+// browser traffic goes through the outer caddy, test-setup API traffic
+// does not), and globalSetup boots that whole stack (second klangkd
+// serving a /klangk base-href build + prefix-stripping outer caddy).
+// Run via the `test-frontend-e2e` devenv task, which chains this config
+// after the main one, or directly:
+//   npx playwright test -c subpath/playwright.subpath.config.ts
+
+// Set before importing anything that reads it: helpers.ts resolves
+// API_BASE from this at module load, and worker processes inherit the
+// runner's env (config modules load pre-fork).
+process.env.KLANGKBUILD_E2E_PORT = process.env.KLANGKBUILD_E2E_PORT || "18999";
+
+const BASE_URL =
+  process.env.KLANGKBUILD_SUBPATH_URL || "http://localhost:18998/klangk/";
+
+export default defineConfig({
+  testDir: ".",
+  timeout: process.env.CI ? 600_000 : 300_000,
+  retries: process.env.CI ? 1 : 0,
+  workers: 1,
+  fullyParallel: false,
+  globalSetup: "./global-setup.ts",
+  globalTeardown: "./global-teardown.ts",
+  use: {
+    baseURL: BASE_URL,
+    headless: true,
+    screenshot: "only-on-failure",
+    launchOptions: {
+      executablePath: process.env.CHROME_PATH || undefined,
+      args: ["--disable-gpu"],
+    },
+  },
+});

--- a/src/frontend/e2e-tests/subpath/subpath-dpop.spec.ts
+++ b/src/frontend/e2e-tests/subpath/subpath-dpop.spec.ts
@@ -1,0 +1,198 @@
+import { expect, test } from "@playwright/test";
+
+import {
+  TEST_PASSWORD,
+  createWorkspace,
+  loginOnCurrentPage,
+  registerUser,
+  terminalType,
+  waitForFlutter,
+} from "../e2e/helpers";
+
+// Subpath × web × DPoP (#3287): the whole browser flow behind an outer
+// proxy serving the app at /klangk/ with the prefix stripped on forward
+// and X-Forwarded-Prefix set — the documented nginx pattern. DPoP
+// binding is active (the default browser path), so a proof whose htu
+// mishandles the base path fails login's first authenticated call.
+//
+// Covers every gate the fix touches:
+// - the HTTP gate: my-permissions answers 200 (not 401 uri mismatch)
+//   after login+bind;
+// - the refresh gate: NOT exercised here — refresh fires at 80% of a
+//   token lifetime measured in hours, which no e2e flow spans. Its
+//   tolerance is unit-tested (test_auth.py:
+//   test_bound_refresh_tolerates_prefixed_htu) and the client's refresh
+//   minting rides the same authHeadersFor covered below;
+// - the main WS gate: the /klangk/ws connect completes and streams
+//   terminal output (container_ready → terminal_started → echo);
+// - the decider WS gate: the /klangk/ws/consent-decider connect
+//   completes and delivers its egress_rules frame.
+
+// The prefix every browser URL carries in this deployment. Playwright's
+// goto("/") resolves as an ABSOLUTE path (it drops the baseURL's /klangk
+// segment), so this spec always navigates with the prefix spelled out.
+const PREFIX = "/klangk";
+
+/** The path of a DPoP proof's htu claim (the JWT payload's URI).
+ *
+ * The client must mint the htu backend-visible (#3287): the path the
+ * server sees (prefix stripped), never `PREFIX + path`. The server
+ * tolerates the prefixed form for already-deployed clients, so the
+ * behavioral 200s alone cannot catch a minting regression — this
+ * decodes the actual proofs and pins their shape. */
+function htuPathOf(proof: string): string | null {
+  const payload = proof.split(".")[1];
+  if (!payload) return null;
+  const json = Buffer.from(
+    payload.replace(/-/g, "+").replace(/_/g, "/"),
+    "base64",
+  ).toString("utf8");
+  try {
+    const htu = JSON.parse(json).htu;
+    return typeof htu === "string" ? new URL(htu, "http://x").pathname : null;
+  } catch {
+    return null;
+  }
+}
+
+test.describe.serial("subpath deployment × DPoP (#3287)", () => {
+  test("login+bind, authenticated API, and both WS gates pass behind /klangk", async ({
+    page,
+    request,
+  }) => {
+    // Fail-loud guard: no request in the whole flow may 401 with a
+    // DPoP proof complaint.
+    const dpopFailures: string[] = [];
+    page.on("response", async (resp) => {
+      if (resp.status() !== 401) return;
+      const body = await resp.text().catch(() => "");
+      if (body.includes("Invalid DPoP proof")) {
+        dpopFailures.push(`${resp.url()} -> ${body}`);
+      }
+    });
+
+    // Latch both WebSocket gates before any navigation so no frame can
+    // slip past an attached-too-late listener.
+    let resolveTerminal: () => void;
+    let resolveDecider: () => void;
+    const terminalStarted = new Promise<void>((resolve) => {
+      resolveTerminal = resolve;
+    });
+    const deciderRules = new Promise<void>((resolve) => {
+      resolveDecider = resolve;
+    });
+    const wsUrls: string[] = [];
+    const terminalOutput: string[] = [];
+    const httpProofs = new Map<string, string>();
+    page.on("request", (req) => {
+      const proof = req.headers()["dpop"];
+      if (proof) httpProofs.set(req.url(), proof);
+    });
+    page.on("websocket", (ws) => {
+      wsUrls.push(ws.url());
+      ws.on("framereceived", (frame: { payload: string | Buffer }) => {
+        const text = frame.payload.toString();
+        if (text.includes("terminal_started")) resolveTerminal!();
+        if (
+          ws.url().includes("/ws/consent-decider") &&
+          text.includes("egress_rules")
+        ) {
+          resolveDecider!();
+        }
+        if (text.includes('"terminal_output"')) terminalOutput.push(text);
+      });
+    });
+
+    // Setup over the API (direct to the stack's klangkd): a user who
+    // may create workspaces, and one workspace to open.
+    const email = `subpath-dpop-${Date.now()}@test.example.com`;
+    const { headers } = await registerUser(request, email);
+    const { workspaceId, cleanup } = await createWorkspace(
+      request,
+      headers,
+      "subpath-dpop",
+    );
+
+    try {
+      // The document itself must come up under the prefix (assets ride
+      // the rewritten <base href="/klangk/">).
+      await page.goto(`${PREFIX}/`);
+      await waitForFlutter(page);
+
+      // Login + DPoP bind, then the first authenticated call.
+      const permissionsResp = page.waitForResponse(
+        (r) =>
+          r.url().includes("/api/v1/my-permissions") &&
+          r.request().method() === "GET",
+        { timeout: 60_000 },
+      );
+      await loginOnCurrentPage(page, email, TEST_PASSWORD);
+      await expect(page).toHaveTitle(/Workspaces/i, { timeout: 30_000 });
+      expect((await permissionsResp).status()).toBe(200);
+
+      // Open the workspace: container boot, main-WS connect, PTY.
+      await page.goto(`${PREFIX}/#/workspace/${workspaceId}`, {
+        waitUntil: "load",
+      });
+      await waitForFlutter(page);
+      // Dismiss the "Enable accessibility" overlay if it came up (the
+      // in-suite helper is private; same shape as helpers.ts).
+      const a11y = page.locator("button", {
+        hasText: "Enable accessibility",
+      });
+      if (await a11y.isVisible({ timeout: 500 }).catch(() => false)) {
+        await a11y.click();
+        await page.waitForTimeout(300);
+      }
+      await terminalStarted;
+
+      // The main socket connected through the prefixed path.
+      const mainWsUrl = wsUrls.find((u) => /^ws:\/\/[^/]+\/klangk\/ws/.test(u));
+      expect(
+        mainWsUrl,
+        `no /klangk/ws connect among ${JSON.stringify(wsUrls)}`,
+      ).toBeTruthy();
+
+      // The proofs name the backend-visible paths, not the prefixed
+      // ones (#3287): decode the my-permissions proof header and the
+      // main socket's proof query parameter and pin their htu.
+      const permissionsProof = [...httpProofs.entries()].find(([url]) =>
+        url.includes("/klangk/api/v1/my-permissions"),
+      );
+      expect(
+        permissionsProof,
+        "no DPoP header seen on my-permissions",
+      ).toBeTruthy();
+      expect(htuPathOf(permissionsProof![1])).toBe("/api/v1/my-permissions");
+      const wsProof = mainWsUrl
+        ? new URL(mainWsUrl).searchParams.get("dpop")
+        : null;
+      expect(
+        wsProof,
+        "no DPoP proof parameter on the /klangk/ws connect",
+      ).toBeTruthy();
+      expect(htuPathOf(wsProof!)).toBe("/ws");
+
+      // Terminal output is observable: type a marker and read it back
+      // from the PTY stream.
+      await terminalType(page, "echo subpath-dpop-ok");
+      await expect
+        .poll(() => terminalOutput.join("").includes("subpath-dpop-ok"), {
+          timeout: 30_000,
+        })
+        .toBe(true);
+
+      // The decider socket connected through the prefixed path too and
+      // passed its own DPoP gate (rules arrive only after it opens).
+      expect(
+        wsUrls.some((u) => u.includes("/klangk/ws/consent-decider")),
+        `no /klangk/ws/consent-decider connect among ${JSON.stringify(wsUrls)}`,
+      ).toBe(true);
+      await deciderRules;
+
+      expect(dpopFailures).toEqual([]);
+    } finally {
+      await cleanup();
+    }
+  });
+});

--- a/src/frontend/lib/auth/auth_service.dart
+++ b/src/frontend/lib/auth/auth_service.dart
@@ -568,7 +568,7 @@ class AuthService extends ChangeNotifier {
     if (_token == null) return headers;
     final proof = await dpopBackend.createProof(
       method: method,
-      uri: '$_baseUrl$path',
+      uri: backendVisiblePath('$_baseUrl$path'),
       accessToken: _token!,
     );
     if (proof != null) headers['DPoP'] = proof;

--- a/src/frontend/lib/auth/dpop.dart
+++ b/src/frontend/lib/auth/dpop.dart
@@ -7,6 +7,8 @@ library;
 
 export 'dpop_core.dart';
 
+import 'package:klangk_plugin_api/klangk_plugin_api.dart' show baseUrl;
+
 import 'dpop_core.dart';
 import 'dpop_backend_stub.dart'
     if (dart.library.js_interop) 'dpop_backend_web.dart' as impl;
@@ -15,6 +17,28 @@ import 'dpop_backend_stub.dart'
 /// [testDpopBackendOverride]).
 DpopBackend get dpopBackend =>
     testDpopBackendOverride ?? impl.createDpopBackend();
+
+/// The htu a proof must name: the request path as the backend sees it
+/// (#3287).
+///
+/// On a subpath deployment the backend sits behind an outer proxy that
+/// strips the base prefix before forwarding, while the browser — minting
+/// from `<base href>` — carries it. A proof whose htu included the prefix
+/// failed the server's uri comparison, so the htu is minted over the
+/// backend-visible path: the [url]'s path component with [baseUrl]'s
+/// prefix removed. Scheme, host, and query never participate in the
+/// server's comparison, so a bare path is a valid htu (the server also
+/// tolerates the prefixed form, keeping pre-fix clients working).
+String backendVisiblePath(String url) {
+  final path = Uri.tryParse(url)?.path ?? url;
+  if (baseUrl.isEmpty) return path;
+  final base = baseUrl.startsWith('/') ? baseUrl : '/$baseUrl';
+  final trimmed =
+      base.endsWith('/') ? base.substring(0, base.length - 1) : base;
+  if (trimmed.isEmpty) return path;
+  if (path == trimmed) return '';
+  return path.startsWith('$trimmed/') ? path.substring(trimmed.length) : path;
+}
 
 /// Bearer headers for [token], plus a DPoP proof when it is bound
 /// (#3218). For callers that only hold the token string (file viewer,
@@ -32,7 +56,7 @@ Future<Map<String, String>> dpopHeadersFor(
   headers['Authorization'] = 'Bearer $token';
   final proof = await dpopBackend.createProof(
     method: method,
-    uri: url,
+    uri: backendVisiblePath(url),
     accessToken: token,
   );
   if (proof != null) headers['DPoP'] = proof;

--- a/src/frontend/lib/file_viewer/file_viewer_panel.dart
+++ b/src/frontend/lib/file_viewer/file_viewer_panel.dart
@@ -171,21 +171,11 @@ class FileViewerPanelState extends State<FileViewerPanel> {
   }
 
   /// Headers for one authenticated file-API request: the Bearer token
-  /// plus a DPoP proof when that token is bound (#3218).
-  Future<Map<String, String>> _headersFor(String method, String url) async {
-    final headers = <String, String>{
-      if (widget.authToken != null)
-        'Authorization': 'Bearer ${widget.authToken}',
-    };
-    if (widget.authToken == null) return headers;
-    final proof = await dpopBackend.createProof(
-      method: method,
-      uri: url,
-      accessToken: widget.authToken!,
-    );
-    if (proof != null) headers['DPoP'] = proof;
-    return headers;
-  }
+  /// plus a DPoP proof when that token is bound (#3218). Delegates to
+  /// [dpopHeadersFor] so the proof's htu is minted backend-visible
+  /// (#3287) identically to every other minting site.
+  Future<Map<String, String>> _headersFor(String method, String url) =>
+      dpopHeadersFor(method, url, widget.authToken);
 
   Future<void> _loadFiles({bool force = false}) async {
     if (!mounted) return;

--- a/src/frontend/test/dpop_test.dart
+++ b/src/frontend/test/dpop_test.dart
@@ -2,6 +2,8 @@ import 'dart:convert';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:klangk_frontend/auth/dpop.dart';
+import 'package:klangk_plugin_api/klangk_plugin_api.dart'
+    show testBaseUrlOverride;
 
 import 'dpop_test_helpers.dart';
 
@@ -85,6 +87,98 @@ void main() {
       );
       expect(headers['Authorization'], isNotNull);
       expect(headers.containsKey('DPoP'), isFalse);
+    });
+  });
+
+  group('backendVisiblePath (#3287)', () {
+    tearDown(() {
+      testBaseUrlOverride = null;
+    });
+
+    test('root deployment: baseUrl empty, path unchanged', () {
+      testBaseUrlOverride = '';
+      expect(backendVisiblePath('/api/v1/x'), '/api/v1/x');
+      expect(
+        backendVisiblePath('https://h:9/api/v1/x?q=1'),
+        '/api/v1/x',
+      );
+    });
+
+    test('subpath deployment: prefix stripped from htu', () {
+      testBaseUrlOverride = '/klangk';
+      expect(backendVisiblePath('/klangk/api/v1/x'), '/api/v1/x');
+      expect(backendVisiblePath('/klangk/ws'), '/ws');
+      expect(
+        backendVisiblePath('ws://h:443/klangk/api/v1/x?q=1'),
+        '/api/v1/x',
+      );
+    });
+
+    test('subpath with trailing-slash baseUrl strips too', () {
+      testBaseUrlOverride = '/klangk/';
+      expect(backendVisiblePath('/klangk/api/v1/x'), '/api/v1/x');
+    });
+
+    test('multi-segment baseUrl strips whole', () {
+      testBaseUrlOverride = '/tools/klangk';
+      expect(backendVisiblePath('/tools/klangk/ws'), '/ws');
+      expect(
+        backendVisiblePath('https://h/tools/klangk/api/v1/x'),
+        '/api/v1/x',
+      );
+      expect(backendVisiblePath('/tools/other/x'), '/tools/other/x');
+    });
+
+    test('prefix only matches whole segments', () {
+      testBaseUrlOverride = '/klangk';
+      expect(
+          backendVisiblePath('/klangkland/api/v1/x'), '/klangkland/api/v1/x');
+    });
+
+    test('already backend-visible path passes through', () {
+      testBaseUrlOverride = '/klangk';
+      expect(backendVisiblePath('/api/v1/x'), '/api/v1/x');
+    });
+
+    test('bare base path collapses to empty path', () {
+      testBaseUrlOverride = '/klangk';
+      expect(backendVisiblePath('/klangk'), '');
+    });
+
+    test('full-URL baseUrl (test shapes) never matches a path', () {
+      testBaseUrlOverride = 'http://localhost:8997';
+      expect(backendVisiblePath('/api/v1/x'), '/api/v1/x');
+      expect(
+        backendVisiblePath('http://localhost:8997/api/v1/x'),
+        '/api/v1/x',
+      );
+    });
+  });
+
+  group('dpopHeadersFor mints the backend-visible htu (#3287)', () {
+    tearDown(() {
+      testBaseUrlOverride = null;
+      testDpopBackendOverride = null;
+    });
+
+    test('subpath deployment strips the prefix before minting', () async {
+      testBaseUrlOverride = '/klangk';
+      final fake = FakeDpopBackend();
+      testDpopBackendOverride = fake;
+      await dpopHeadersFor('GET', 'ws://h:443/klangk/ws', boundToken());
+      expect(fake.lastUri, '/ws');
+    });
+
+    test('root deployment mints the bare path', () async {
+      testBaseUrlOverride = '';
+      final fake = FakeDpopBackend();
+      testDpopBackendOverride = fake;
+      await dpopHeadersFor(
+        'GET',
+        'https://h/api/v1/my-permissions?q=1',
+        boundToken(),
+      );
+      expect(fake.lastUri, '/api/v1/my-permissions');
     });
   });
 }

--- a/src/frontend/test/dpop_test_helpers.dart
+++ b/src/frontend/test/dpop_test_helpers.dart
@@ -22,12 +22,17 @@ String boundToken({String jkt = 'jkt-1'}) {
 }
 
 /// A programmable [DpopBackend] mirroring the web backend's semantics:
-/// proofs are produced only for bound tokens.
+/// proofs are produced only for bound tokens. Records the last htu it
+/// was asked to mint, so tests can assert the backend-visible path
+/// (#3287).
 class FakeDpopBackend implements DpopBackend {
   FakeDpopBackend({this.hasKey = true, this.proof = 'proof-value'});
 
   final bool hasKey;
   final String proof;
+
+  /// The `uri` of the most recent createProof call (null before any).
+  String? lastUri;
   Map<String, dynamic>? jwk = const {
     'kty': 'EC',
     'crv': 'P-256',
@@ -46,6 +51,8 @@ class FakeDpopBackend implements DpopBackend {
     required String method,
     required String uri,
     required String accessToken,
-  }) async =>
-      hasKey && tokenIsBound(accessToken) ? proof : null;
+  }) async {
+    lastUri = uri;
+    return hasKey && tokenIsBound(accessToken) ? proof : null;
+  }
 }

--- a/src/klangk/klangk/api/auth.py
+++ b/src/klangk/klangk/api/auth.py
@@ -798,12 +798,17 @@ async def refresh_token(request: Request):
     # The pair feeds binding enforcement (#3194); the method/referer
     # feed the session-limit eviction row a refresh can mint (#3255).
     source_ip, user_agent, method, referer = request_metadata(request)
+    client = request.client
+    base_path = request.app.state.util.hosting_base_path_for(
+        request.headers, client.host if client else None
+    )
     return await request.app.state.auth.refresh_token(
         token,
         (source_ip, user_agent),
         proof=request.headers.get("dpop"),
         method=method,
         referer=referer,
+        base_path=base_path,
     )
 
 

--- a/src/klangk/klangk/auth.py
+++ b/src/klangk/klangk/auth.py
@@ -2342,14 +2342,23 @@ class Auth:
             )
 
     def check_dpop(
-        self, proof, method: str, path: str, access_token: str, payload: dict
+        self,
+        proof,
+        method: str,
+        path: str,
+        access_token: str,
+        payload: dict,
+        base_path: str = "",
     ) -> str | None:
         """Verify a DPoP proof for *payload*; None = OK / not bound.
 
         Unbound tokens (no ``cnf.jkt``) verify trivially — CLI/TUI and
         every pre-#3218 client keeps working untouched; the web client
         binds its tokens at login, so a browser session always carries
-        the claim.
+        the claim. *base_path* is the live hosting base path of the
+        request (#3287): a proof whose ``htu`` path carries it ahead of
+        *path* verifies too — the subpath-deployment form an outer
+        proxy strips before forwarding.
         """
         jkt = self.token_binding(payload)
         if jkt is None:
@@ -2362,13 +2371,22 @@ class Auth:
             expected_jkt=jkt,
             now=time.time(),
             replay=self.dpop_replay,
+            base_path=base_path,
         )
 
     def enforce_dpop(
-        self, proof, method: str, path: str, access_token: str, payload: dict
+        self,
+        proof,
+        method: str,
+        path: str,
+        access_token: str,
+        payload: dict,
+        base_path: str = "",
     ) -> None:
         """Raise 401 unless a bound token presents a valid DPoP proof."""
-        reason = self.check_dpop(proof, method, path, access_token, payload)
+        reason = self.check_dpop(
+            proof, method, path, access_token, payload, base_path
+        )
         if reason is not None:
             raise HTTPException(
                 status_code=401, detail=f"Invalid DPoP proof: {reason}"
@@ -2500,6 +2518,7 @@ class Auth:
         proof: str | None = None,
         method: str | None = None,
         referer: str | None = None,
+        base_path: str = "",
     ) -> TokenResponse:
         """Exchange a valid access token for a new one.
 
@@ -2514,7 +2533,9 @@ class Auth:
         is revoked and refused here too — the refresh seam is the one
         place a headless stolen-token client must eventually surface.
         A DPoP-bound token (#3218) must prove possession to rotate,
-        and the replacement keeps the binding.
+        and the replacement keeps the binding. *base_path* is the
+        presenting request's live hosting base path (#3287), tolerated
+        ahead of the refresh path in the proof's ``htu``.
         """
         try:
             payload = self.decode_token(token)
@@ -2536,7 +2557,12 @@ class Auth:
                 return cached
 
             self.enforce_dpop(
-                proof, "POST", "/api/v1/auth/refresh", token, payload
+                proof,
+                "POST",
+                "/api/v1/auth/refresh",
+                token,
+                payload,
+                base_path,
             )
 
             user = await self._require_active_user(user_id)
@@ -2686,6 +2712,17 @@ class Auth:
 # ---------------------------------------------------------------------------
 
 
+def _dpop_base_path(request: Request) -> str:
+    """The hosting base path this request's DPoP comparison tolerates
+    (#3287): the pinned ``KLANGKD_HOSTING_BASE_PATH``, else the trusted
+    ``X-Forwarded-Prefix``, else ``""``. A request fake without a client
+    reads as an unknown peer (forwarded headers then untrusted)."""
+    client = getattr(request, "client", None)
+    return request.app.state.util.hosting_base_path_for(
+        request.headers, client.host if client else None
+    )
+
+
 async def _authenticated_user(request: Request, credentials) -> dict:
     """The user for valid, unrevoked credentials; raises 401 for every
     failure mode (missing claims, a revoked token, an unknown user,
@@ -2697,6 +2734,7 @@ async def _authenticated_user(request: Request, credentials) -> dict:
         request.url.path,
         credentials.credentials,
         payload,
+        base_path=_dpop_base_path(request),
     )
     request.app.state.auth.enforce_bind_deadline(payload)
     user_id = payload.get("sub")
@@ -2734,6 +2772,7 @@ async def _optional_user(request: Request, credentials) -> dict | None:
         request.url.path,
         credentials.credentials,
         payload,
+        base_path=_dpop_base_path(request),
     )
     request.app.state.auth.enforce_bind_deadline(payload)
     user_id = payload.get("sub")

--- a/src/klangk/klangk/dpop.py
+++ b/src/klangk/klangk/dpop.py
@@ -24,7 +24,10 @@ is replay-blocked for the freshness window, and its ``ath`` claim binds
 it to the exact access token it accompanies. The ``htu`` check compares
 the URI's *path* (query and scheme/host are ignored) so deployments
 behind the Caddy reverse proxy — where the app may see a different
-scheme or port than the browser used — do not reject honest proofs.
+scheme or port than the browser used — do not reject honest proofs; the
+live hosting base path is additionally stripped from the htu path before
+the comparison, so a subpath deployment's proofs (``htu`` carrying the
+outer proxy's prefix, the request path without it) verify too (#3287).
 """
 
 import base64
@@ -194,11 +197,55 @@ def _htu_path(htu) -> str | None:
         return None
 
 
-def _claim_reason(payload: dict, method: str, path: str, token: str):
+def strip_hosting_prefix(path: str | None, base_path: str) -> str | None:
+    """*path* with one leading *base_path* segment removed (#3287).
+
+    A subpath deployment's browser mints proof ``htu`` paths that still
+    carry the outer proxy's prefix (the client builds them from ``<base
+    href>``), while the backend compares against the prefix-stripped path
+    it sees. Stripping the live hosting base path — the same prefix
+    :meth:`klangk.util.Util.derive_hosting_info` re-attaches when building
+    external URLs — from the proof's htu path before the comparison makes
+    both forms verify. Only a whole-segment match is removed: ``/klangk``
+    never strips from ``/klangkland/api``. ``None`` passes through (a bad
+    htu must stay bad), and an empty or slash-only base path is a no-op
+    (a root deployment needs no tolerance).
+
+    The tolerance cannot turn a proof for one request into a proof for
+    another: the stripped htu must still equal the request path exactly,
+    and only the presenter of an already-bound key can mint a proof at
+    all — a forged ``X-Forwarded-Prefix`` merely widens its *own*
+    request's accepted htu spelling, never anyone else's.
+    """
+    if path is None:
+        return path
+    base = "/" + base_path.strip("/")
+    if len(base) == 1:
+        return path
+    if path == base:
+        return ""
+    if path.startswith(base + "/"):
+        return path[len(base) :]
+    return path
+
+
+def _uri_reason(payload: dict, path: str, base_path: str) -> str | None:
+    """None when the htu names *path* — bare or behind *base_path*."""
+    htu = _htu_path(payload.get("htu"))
+    if htu == path:
+        return None
+    if strip_hosting_prefix(htu, base_path) == path:
+        return None
+    return "uri mismatch"
+
+
+def _claim_reason(
+    payload: dict, method: str, path: str, token: str, base_path: str = ""
+):
     """Binding claims: the proof names this request and this token."""
     if payload.get("htm") != method:
         return "method mismatch"
-    if _htu_path(payload.get("htu")) != path:
+    if _uri_reason(payload, path, base_path) is not None:
         return "uri mismatch"
     if payload.get("ath") != access_token_hash(token):
         return "token hash mismatch"
@@ -260,11 +307,15 @@ def verify_proof(
     expected_jkt: str,
     now: float,
     replay: dict,
+    base_path: str = "",
 ) -> str | None:
     """Verify a DPoP proof; None on success, a reason string on failure.
 
     *replay* is the caller-owned JTI→expiry map (the live server keeps
     one on ``app.state.auth``); a winning proof's JTI is recorded in it.
+    *base_path* is the live hosting base path of the request (#3287): a
+    proof whose ``htu`` path carries it ahead of *path* verifies too —
+    the subpath-deployment form an outer proxy strips before forwarding.
     """
     if not isinstance(proof, str):
         return "missing proof"
@@ -274,7 +325,7 @@ def verify_proof(
     header, payload, signature = decoded
     for reason in (
         _header_reason(header, expected_jkt),
-        _claim_reason(payload, method, path, access_token),
+        _claim_reason(payload, method, path, access_token, base_path),
         _freshness_reason(payload, now, replay),
     ):
         if reason is not None:

--- a/src/klangk/klangk/util.py
+++ b/src/klangk/klangk/util.py
@@ -806,6 +806,21 @@ class Util:
             return hostname
         return f"{hostname}:{port}"
 
+    def hosting_base_path_for(
+        self, headers=None, client_host: str | None = None
+    ) -> str:
+        """The live hosting base path of this request (#3287).
+
+        The pinned ``KLANGKD_HOSTING_BASE_PATH``, else the trusted
+        ``X-Forwarded-Prefix``, else ``""`` — the same prefix
+        :meth:`derive_hosting_info` re-attaches when building external
+        URLs. The DPoP gates pass it to proof verification so a proof
+        whose ``htu`` path still carries the prefix (minted by a browser
+        from ``<base href>``) verifies against the prefix-stripped path
+        the backend sees.
+        """
+        return self.derive_hosting_info(headers, client_host)[2] or ""
+
     def cors_origins(self) -> list[str]:
         """Build the CORS allowed-origins list.
 

--- a/src/klangk/klangk/wshandler/decider.py
+++ b/src/klangk/klangk/wshandler/decider.py
@@ -57,7 +57,7 @@ from fastapi import WebSocket, WebSocketDisconnect
 from jose import ExpiredSignatureError, JWTError
 
 from .safe_websocket import SafeWebSocket, SlowClientError
-from .dispatch import ws_workstation
+from .dispatch import ws_hosting_base_path, ws_workstation
 from .support import ws_bearer_token, ws_echo_subprotocol
 from ..model.egress_consent import (
     DECISION_ALLOWED,
@@ -283,13 +283,15 @@ async def _decider_dpop_gate(
     websocket: WebSocket, app, token, payload
 ) -> bool:
     """DPoP proof gate for the decider handshake (#3218) — mirrors the
-    main socket's ``_dpop_gate`` (one-shot ``dpop`` query parameter)."""
+    main socket's ``_dpop_gate`` (one-shot ``dpop`` query parameter),
+    including the hosting-base-path tolerance (#3287)."""
     reason = app.state.auth.check_dpop(
         websocket.query_params.get("dpop"),
         "GET",
         websocket.url.path,
         token,
         payload,
+        base_path=ws_hosting_base_path(websocket, app),
     )
     if reason is None:
         return True

--- a/src/klangk/klangk/wshandler/dispatch.py
+++ b/src/klangk/klangk/wshandler/dispatch.py
@@ -120,6 +120,19 @@ async def _decode_socket_token(websocket: WebSocket, a, token: str):
         return None
 
 
+def ws_hosting_base_path(websocket, app) -> str:
+    """The hosting base path this connect's DPoP comparison tolerates
+    (#3287): the pinned ``KLANGKD_HOSTING_BASE_PATH``, else the trusted
+    ``X-Forwarded-Prefix`` — resolved from the handshake headers and the
+    connection peer, same resolver as the HTTP gates. Shared with the
+    consent-decider gate."""
+    client = getattr(websocket, "client", None)
+    return app.state.util.hosting_base_path_for(
+        getattr(websocket, "headers", None),
+        client.host if client else None,
+    )
+
+
 async def _dpop_gate(
     websocket: WebSocket, app, token: str, payload: dict
 ) -> bool:
@@ -129,7 +142,9 @@ async def _dpop_gate(
     the same compact proof the HTTP ``DPoP`` header carries (its jti
     is single-use and its ath binds it to this exact token, so its
     presence in the URL leaks nothing reusable). Unbound tokens
-    (CLI/TUI, pre-#3218 clients) pass untouched.
+    (CLI/TUI, pre-#3218 clients) pass untouched. A proof whose htu
+    path carries the live hosting base path verifies too — the
+    subpath-deployment form (#3287).
     """
     reason = app.state.auth.check_dpop(
         websocket.query_params.get("dpop"),
@@ -137,6 +152,7 @@ async def _dpop_gate(
         websocket.url.path,
         token,
         payload,
+        base_path=ws_hosting_base_path(websocket, app),
     )
     if reason is None:
         return True

--- a/src/klangk/klangkd-tests/tests/test_auth.py
+++ b/src/klangk/klangkd-tests/tests/test_auth.py
@@ -35,11 +35,17 @@ def _req(auth=None):
     ``model``/``db`` the dep callables reach (#1572). The HTTP surface
     the DPoP gate reads (#3218) — headers, method, url.path — is
     faked with no DPoP header; tokens minted by these tests are
-    unbound, so the gate no-ops.
+    unbound, so the gate no-ops. A real ``util`` is wired when the
+    fake lacks one — the gate's base-path resolution reads it
+    (#3287) even for unbound tokens.
     """
     if auth is None:
         auth = _auth()
     auth.app.state.auth = auth
+    if not hasattr(auth.app.state, "util"):
+        from klangk.util import Util
+
+        auth.app.state.util = Util(auth.app)
     return _types.SimpleNamespace(
         app=auth.app,
         headers={},
@@ -3709,6 +3715,23 @@ class TestDpopRefresh:
         result = await a.refresh_token(token)
         assert result.access_token != token
 
+    async def test_bound_refresh_tolerates_prefixed_htu(self, user):
+        """#3287: the refresh gate strips the live base path from the
+        proof's htu, like the HTTP deps and both WS gates."""
+        a = _auth()
+        private, jwk = make_binding_key()
+        jkt = dpop.jwk_thumbprint(jwk)
+        token = a.create_token(user["id"], user["email"], jkt=jkt)
+        proof = make_dpop_proof(
+            private,
+            jwk,
+            method="POST",
+            uri="https://h/klangk/api/v1/auth/refresh",
+            token=token,
+        )
+        result = await a.refresh_token(token, proof=proof, base_path="/klangk")
+        assert a.decode_token(result.access_token)["cnf"]["jkt"] == jkt
+
 
 class TestDpopEnforcement:
     """The FastAPI deps enforce proofs for bound tokens (#3218)."""
@@ -3790,6 +3813,76 @@ class TestDpopEnforcement:
     async def test_lenient_logout_dep_ignores_proofs(self, user):
         a, _, _, creds = self._bound_credentials(user)
         result = await auth.get_current_user_lenient(_dpop_req(a), creds)
+        assert result["id"] == user["id"]
+
+    async def test_prefixed_htu_accepted_behind_trusted_prefix(self, user):
+        """#3287: a subpath deployment's browser mints the htu with the
+        base path; a trusted X-Forwarded-Prefix lets the gate strip it."""
+        a, private, jwk, creds = self._bound_credentials(user)
+        proof = make_dpop_proof(
+            private,
+            jwk,
+            method="GET",
+            uri="https://h/klangk/api/v1/x",
+            token=creds.credentials,
+        )
+        req = _dpop_req(
+            a,
+            headers={
+                "dpop": proof,
+                "x-forwarded-prefix": "/klangk",
+                "x-forwarded-for": "203.0.113.9",
+                "x-real-ip": "203.0.113.9",
+            },
+        )
+        req.client = _types.SimpleNamespace(host="127.0.0.1")
+        result = await auth.get_current_user(req, creds)
+        assert result["id"] == user["id"]
+
+    async def test_prefixed_htu_rejected_from_untrusted_peer(self, user):
+        """The same forwarded headers from a peer outside the trust set
+        must not loosen the comparison (#3287)."""
+        a, private, jwk, creds = self._bound_credentials(user)
+        proof = make_dpop_proof(
+            private,
+            jwk,
+            method="GET",
+            uri="https://h/klangk/api/v1/x",
+            token=creds.credentials,
+        )
+        req = _dpop_req(
+            a,
+            headers={
+                "dpop": proof,
+                "x-forwarded-prefix": "/klangk",
+            },
+        )
+        req.client = _types.SimpleNamespace(host="203.0.113.9")
+        with pytest.raises(HTTPException) as exc_info:
+            await auth.get_current_user(req, creds)
+        assert exc_info.value.status_code == 401
+        assert "uri mismatch" in exc_info.value.detail
+
+    async def test_prefixed_htu_accepted_with_pinned_base_path(self, user):
+        """#3287: a pinned KLANGKD_HOSTING_BASE_PATH applies with no
+        forwarded headers at all (the env pin wins over headers)."""
+        pinned = _auth({"KLANGKD_HOSTING_BASE_PATH": "/klangk"})
+        private, jwk = make_binding_key()
+        creds = HTTPAuthorizationCredentials(
+            scheme="Bearer",
+            credentials=pinned.create_token(
+                user["id"], user["email"], jkt=dpop.jwk_thumbprint(jwk)
+            ),
+        )
+        proof = make_dpop_proof(
+            private,
+            jwk,
+            method="GET",
+            uri="https://h/klangk/api/v1/x",
+            token=creds.credentials,
+        )
+        req = _dpop_req(pinned, headers={"dpop": proof})
+        result = await auth.get_current_user(req, creds)
         assert result["id"] == user["id"]
 
 

--- a/src/klangk/klangkd-tests/tests/test_consent_deciders.py
+++ b/src/klangk/klangkd-tests/tests/test_consent_deciders.py
@@ -1312,3 +1312,37 @@ class TestConsentDeciderDpopGate:
         # The proof arrived via the dpop query parameter.
         check = app.state.auth.check_dpop
         assert check.call_args.args[0] == "a-proof"
+
+    async def test_gate_passes_trusted_hosting_base_path(self):
+        """#3287: the decider gate resolves the handshake's live hosting
+        base path and forwards it to proof verification."""
+        from klangk.wshandler.decider import _decider_authenticate
+
+        app = _ws_app({"id": "u1", "email": "a@x"})
+        ws = _FakeWS(
+            {"token": "tok", "dpop": "a-proof"},
+            [],
+            headers={"x-forwarded-prefix": "/klangk"},
+        )
+        ws.client = types.SimpleNamespace(host="127.0.0.1")
+        result = await _decider_authenticate(ws, app, lambda label: None)
+        assert result is not None
+        check = app.state.auth.check_dpop
+        assert check.call_args.kwargs.get("base_path") == "/klangk"
+
+    async def test_gate_passes_empty_base_path_without_trust(self):
+        """An untrusted peer (or no forwarded prefix) resolves an empty
+        base path — the comparison stays exact (#3287)."""
+        from klangk.wshandler.decider import _decider_authenticate
+
+        app = _ws_app({"id": "u1", "email": "a@x"})
+        ws = _FakeWS(
+            {"token": "tok", "dpop": "a-proof"},
+            [],
+            headers={"x-forwarded-prefix": "/klangk"},
+        )
+        ws.client = types.SimpleNamespace(host="203.0.113.9")
+        result = await _decider_authenticate(ws, app, lambda label: None)
+        assert result is not None
+        check = app.state.auth.check_dpop
+        assert check.call_args.kwargs.get("base_path") == ""

--- a/src/klangk/klangkd-tests/tests/test_dpop.py
+++ b/src/klangk/klangkd-tests/tests/test_dpop.py
@@ -40,6 +40,7 @@ def _verify(
     path="/api/v1/x",
     jkt="expected",
     token="the-access-token",
+    base_path="",
 ):
     return dpop.verify_proof(
         proof,
@@ -49,6 +50,7 @@ def _verify(
         expected_jkt=jkt,
         now=time.time(),
         replay={},
+        base_path=base_path,
     )
 
 
@@ -474,3 +476,124 @@ class TestCanonicalJson:
             "kty": jwk["kty"],
         }
         assert dpop.jwk_thumbprint(reordered) == dpop.jwk_thumbprint(jwk)
+
+
+class TestStripHostingPrefix:
+    """strip_hosting_prefix: the subpath tolerance (#3287)."""
+
+    def test_strips_leading_base_path(self):
+        assert (
+            dpop.strip_hosting_prefix("/klangk/api/v1/x", "/klangk")
+            == "/api/v1/x"
+        )
+
+    def test_strips_multi_segment_base_path(self):
+        assert (
+            dpop.strip_hosting_prefix("/tools/klangk/ws", "/tools/klangk")
+            == "/ws"
+        )
+
+    def test_strips_trailing_slash_base_path(self):
+        assert (
+            dpop.strip_hosting_prefix("/klangk/api/v1/x", "/klangk/")
+            == "/api/v1/x"
+        )
+
+    def test_strips_unpinned_slash_base_path(self):
+        assert (
+            dpop.strip_hosting_prefix("/klangk/api/v1/x", "klangk")
+            == "/api/v1/x"
+        )
+
+    def test_bare_base_path_collapses_to_empty(self):
+        assert dpop.strip_hosting_prefix("/klangk", "/klangk") == ""
+
+    def test_only_whole_segments_strip(self):
+        assert (
+            dpop.strip_hosting_prefix("/klangkland/api/v1/x", "/klangk")
+            == "/klangkland/api/v1/x"
+        )
+
+    def test_unprefixed_path_untouched(self):
+        assert dpop.strip_hosting_prefix("/api/v1/x", "/klangk") == "/api/v1/x"
+
+    def test_empty_or_root_base_path_is_a_no_op(self):
+        assert dpop.strip_hosting_prefix("/api/v1/x", "") == "/api/v1/x"
+        assert dpop.strip_hosting_prefix("/api/v1/x", "/") == "/api/v1/x"
+        assert dpop.strip_hosting_prefix("/api/v1/x", "//") == "/api/v1/x"
+
+    def test_none_passes_through(self):
+        assert dpop.strip_hosting_prefix(None, "/klangk") is None
+
+
+class TestBasePathTolerance:
+    """verify_proof accepts a prefixed htu when base_path is live (#3287)."""
+
+    def test_prefixed_htu_accepted_with_base_path(self, key):
+        private, jwk = key
+        from _helpers import make_dpop_proof
+
+        proof = make_dpop_proof(
+            private,
+            jwk,
+            method="GET",
+            uri="https://h/klangk/api/v1/x",
+            token="the-access-token",
+        )
+        assert (
+            _verify(proof, jkt=_thumbprint_of(jwk), base_path="/klangk")
+            is None
+        )
+
+    def test_prefixed_htu_rejected_without_base_path(self, key):
+        private, jwk = key
+        from _helpers import make_dpop_proof
+
+        proof = make_dpop_proof(
+            private,
+            jwk,
+            method="GET",
+            uri="https://h/klangk/api/v1/x",
+            token="the-access-token",
+        )
+        assert _verify(proof, jkt=_thumbprint_of(jwk)) == "uri mismatch"
+
+    def test_wrong_prefix_still_mismatches(self, key):
+        private, jwk = key
+        from _helpers import make_dpop_proof
+
+        proof = make_dpop_proof(
+            private,
+            jwk,
+            method="GET",
+            uri="https://h/other/api/v1/x",
+            token="the-access-token",
+        )
+        assert (
+            _verify(proof, jkt=_thumbprint_of(jwk), base_path="/klangk")
+            == "uri mismatch"
+        )
+
+    def test_prefixed_htu_for_a_different_path_mismatches(self, key):
+        private, jwk = key
+        from _helpers import make_dpop_proof
+
+        proof = make_dpop_proof(
+            private,
+            jwk,
+            method="GET",
+            uri="https://h/klangk/other",
+            token="the-access-token",
+        )
+        assert (
+            _verify(proof, jkt=_thumbprint_of(jwk), base_path="/klangk")
+            == "uri mismatch"
+        )
+
+    def test_bare_htu_still_accepted_with_base_path(self, key):
+        private, jwk = key
+        proof = _proof_ok(private, jwk)
+        assert (
+            _verify(proof, jkt=_thumbprint_of(jwk), base_path="/klangk")
+            is None
+        )

--- a/src/klangk/klangkd-tests/tests/test_wshandler.py
+++ b/src/klangk/klangkd-tests/tests/test_wshandler.py
@@ -13015,3 +13015,36 @@ class TestWsDpopGate:
         ws.close.assert_awaited_once_with(
             code=4001, reason="Invalid DPoP proof"
         )
+
+    async def test_prefixed_htu_accepted_behind_trusted_prefix(self, user):
+        """#3287: a subpath deployment's browser mints the htu with the
+        base path; a trusted X-Forwarded-Prefix on the handshake lets
+        the gate strip it."""
+        from _helpers import make_dpop_proof
+
+        a, private, jwk, token, ws = self._bound_socket(user)
+        ws.headers["x-forwarded-prefix"] = "/klangk"
+        ws.client = types.SimpleNamespace(host="127.0.0.1")
+        ws.query_params["dpop"] = make_dpop_proof(
+            private, jwk, method="GET", uri="wss://h/klangk/ws", token=token
+        )
+        result = await ws_authenticate(ws, _make_app_state())
+        assert result is not None
+        ws.close.assert_not_awaited()
+
+    async def test_prefixed_htu_rejected_from_untrusted_peer(self, user):
+        """The same forwarded header from a peer outside the trust set
+        must not loosen the comparison (#3287)."""
+        from _helpers import make_dpop_proof
+
+        a, private, jwk, token, ws = self._bound_socket(user)
+        ws.headers["x-forwarded-prefix"] = "/klangk"
+        ws.client = types.SimpleNamespace(host="203.0.113.9")
+        ws.query_params["dpop"] = make_dpop_proof(
+            private, jwk, method="GET", uri="wss://h/klangk/ws", token=token
+        )
+        result = await ws_authenticate(ws, _make_app_state())
+        assert result is None
+        ws.close.assert_awaited_once_with(
+            code=4001, reason="Invalid DPoP proof"
+        )


### PR DESCRIPTION
## Summary

On a subpath deployment (`hosting-base-path: "/klangk"` / trusted
`X-Forwarded-Prefix`, the documented shape in
[behind-a-proxy.md](https://github.com/mcdonc/klangk/blob/main/docs/deployment/behind-a-proxy.md)),
the web client minted every DPoP proof `htu` from `<base href>` — carrying the
base path — while the server compared against the backend-visible path (prefix
stripped by the outer proxy). Every authenticated request and both WebSocket
connects returned `401 Invalid DPoP proof: uri mismatch`, so since #3218
(browser sessions always bind) the web UI was unusable on any subpath
deployment. CLI/TUI sessions (unbound tokens) were unaffected.

## The fix — both sides

**Client** (correct minting): a new `backendVisiblePath()` in
`lib/auth/dpop.dart` reduces a URL to its path with the `baseUrl` prefix
stripped, and every minting site uses it — `dpopHeadersFor` (which also covers
the WS clients, uploads, workspace file API, consent-decider service, import
dialog), `AuthService.authHeadersFor`, and the file viewer's header helper
(which now delegates to `dpopHeadersFor` instead of hand-rolling the same
headers).

**Server** (repairs already-deployed frontends without a rebuild):
`verify_proof` accepts a `base_path` and strips one leading whole-segment
match from the proof's `htu` path before the uri comparison
(`dpop.strip_hosting_prefix`). The gates resolve the live base path — the
pinned `KLANGKD_HOSTING_BASE_PATH`, else the trusted `X-Forwarded-Prefix`,
else `""` (same trust gate `derive_hosting_info` uses; an untrusted peer's
forwarded prefix does not loosen anything) — and pass it in:

- the HTTP deps (`_authenticated_user`, `_optional_user`) via
  `auth._dpop_base_path`,
- the refresh gate (`api/auth.py` → `Auth.refresh_token(base_path=…)`),
- both WS gates (`wshandler/dispatch.py::_dpop_gate` and
  `wshandler/decider.py::_decider_dpop_gate`) via the shared
  `ws_hosting_base_path`.

Only a whole-segment match strips: `/klangk` never strips from
`/klangkland/api`, and a proof whose stripped path still differs from the
request path keeps failing with `uri mismatch`.

## E2E coverage (the gap that let this ship)

Every test environment ran at the origin root, so subpath × web × DPoP had no
coverage. New `src/frontend/e2e-tests/subpath/` adds a second Playwright
config whose global setup boots the documented proxy topology at browser speed:

- a second klangkd (ports 18999/18996, own state) serving a copy of the
  Flutter build with `<base href="/klangk/">` (the rewrite the docs' nginx
  `sub_filter` does in flight),
- an outer caddy on 18998 that strips the prefix (`handle_path /klangk/*`) and
  sets `X-Forwarded-Prefix: /klangk` — the exact nginx pattern.

The spec drives the full browser flow behind `/klangk/` with DPoP binding
active (the default path): login **and** bind succeed, `my-permissions`
returns 200, the main WS at `/klangk/ws` connects and streams observable
terminal output (`terminal_started` + an echoed marker), and the
consent-decider WS at `/klangk/ws/consent-decider` connects and delivers its
`egress_rules` frame. It also decodes the actual DPoP proofs (JWT payload) and
pins their `htu` as backend-visible — the server tolerance would otherwise
mask a client minting regression, so the decode makes any minting-site
regression fail the suite on its own. A global guard fails the test on any
`401 Invalid DPoP proof` anywhere in the flow.

The suite is chained into the `test-frontend-e2e` devenv task (runs after the
main suite; project-selection flags are filtered out of the subpath
invocation), so the merge-gating frontend e2e workflow exercises it.

## Verification

- Full backend suite CI-style: 8020 passed, 100% branch coverage maintained;
  new unit tests for `strip_hosting_prefix`, the `base_path`-tolerant
  `verify_proof`, and each gate (trusted prefix accepted, untrusted peer
  rejected, pinned env accepted, refresh and both WS gates).
- Full Flutter suite: 1329 passed; new unit tests for `backendVisiblePath`
  shapes and the minted htu.
- Subpath e2e passes (35s); a deliberate client-regression revert (htu minted
  with the prefix) fails it exactly: `Expected: "/ws", Received: "/klangk/ws"`.
- Xenon gate passes (new helpers at rank A).

Fixes #3287.
