### PR TITLE
Stop GET /groups disclosing workspace names (#3283)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -318,6 +318,16 @@ operators or integrators to act when upgrading.
 
 ### Security
 
+- **`GET /groups` no longer discloses workspace names (#3283).**
+  Workspace role groups are seeded with an id-only description
+  (`Workspace role group: role`; the group name already carries the
+  workspace id), and a migration rewrites existing rows — a
+  description no longer embeds the free-form workspace name. The
+  default group listing (no `source` parameter) returns
+  `source='workspace-role'` rows only to callers holding
+  `manage-groups`; other authenticated callers get the manual-only
+  view. Explicit `source=manual` and `source=workspace-role` filters
+  work as before for every authenticated caller.
 - **Bind-mount re-validation at container start (#3278).** A mount's
   host-path source is now checked against
   `KLANGKD_ALLOWED_MOUNT_ROOTS` and the protected-path blocklist every

--- a/docs/reference/api-endpoints.md
+++ b/docs/reference/api-endpoints.md
@@ -239,7 +239,9 @@ Query parameters:
 - `q` — substring filter on name (matched literally — `%` and `_`
   are characters, not wildcards)
 - `source` — `manual` (hide the seeded per-workspace role groups) or
-  `workspace-role` (show only them); omitted shows all
+  `workspace-role` (show only them); omitted shows all rows only to
+  callers holding `manage-groups` — every other authenticated caller
+  gets the manual-only view (#3283)
 
 No request body.
 

--- a/src/frontend/lib/admin/admin_users_page.dart
+++ b/src/frontend/lib/admin/admin_users_page.dart
@@ -271,15 +271,18 @@ class _AdminUsersPageState extends State<AdminUsersPage> {
 
     String summary;
     if (fetchFailed) {
-      summary = 'Delete user "$email"? This will permanently delete all their '
+      summary =
+          'Delete user "$email"? This will permanently delete all their '
           'workspaces and data.';
     } else if (count == 0) {
       summary = 'Delete user "$email"? They own no workspaces.';
     } else if (hasMoreWorkspaces) {
-      summary = 'Delete user "$email"? This will permanently delete '
+      summary =
+          'Delete user "$email"? This will permanently delete '
           '100+ workspaces and all their data:';
     } else {
-      summary = 'Delete user "$email"? This will permanently delete '
+      summary =
+          'Delete user "$email"? This will permanently delete '
           '$count $word and all their data:';
     }
 
@@ -562,11 +565,7 @@ class _AdminUsersPageState extends State<AdminUsersPage> {
       );
     }
     if (_canEvents) {
-      addTab(
-        label: 'Events',
-        icon: Icons.history,
-        view: const EventsTab(),
-      );
+      addTab(label: 'Events', icon: Icons.history, view: const EventsTab());
     }
     // The Volumes tab (#2993): the deployment's instance-managed
     // volume inventory — listing plus delete, no create.
@@ -575,7 +574,9 @@ class _AdminUsersPageState extends State<AdminUsersPage> {
         label: 'Volumes',
         icon: Icons.storage,
         view: _VolumesTab(
-            key: const ValueKey('volumes-tab'), canManage: _canManageVolumes),
+          key: const ValueKey('volumes-tab'),
+          canManage: _canManageVolumes,
+        ),
       );
     }
     // The Access Control browser reads /acl/*, gated on
@@ -602,17 +603,16 @@ class _AdminUsersPageState extends State<AdminUsersPage> {
         : '';
     return switch (currentType) {
       'users' => FloatingActionButton(
-          heroTag: 'add',
-          onPressed: _addUser,
-          tooltip: 'Add user',
-          child: const Icon(Icons.person_add, semanticLabel: 'Add user'),
-        ),
+        heroTag: 'add',
+        onPressed: _addUser,
+        tooltip: 'Add user',
+        child: const Icon(Icons.person_add, semanticLabel: 'Add user'),
+      ),
       'invitations' ||
       'groups' ||
       'server' ||
       'events' ||
-      'volumes' =>
-        null, // FABs inside tabs
+      'volumes' => null, // FABs inside tabs
       _ => null,
     };
   }
@@ -677,8 +677,9 @@ class _GroupsTabState extends State<_GroupsTab> {
 
   // Source filter (#2752): the browser defaults to manual-only — the
   // seeded role-group flood hides where it hurts most — with a chip to
-  // include workspace role groups. Null sends no filter (show all);
-  // the API default stays show-all.
+  // include workspace role groups. Null sends no filter; the API's
+  // no-filter default shows all rows to manage-groups holders (this
+  // page's readers) and manual-only rows to everyone else (#3283).
   bool _showWorkspaceRoles = false;
   String? get _groupsSource => _showWorkspaceRoles ? null : 'manual';
 
@@ -1037,13 +1038,14 @@ class _ManageMembersDialogState extends State<_ManageMembersDialog> {
     );
     if (!mounted || resp.statusCode != 200) return;
     final memberIds = _members.map((m) => m['id']).toSet();
-    final found = List<Map<String, dynamic>>.from(
-      (jsonDecode(resp.body) as List).cast<Map<String, dynamic>>(),
-    )
-        .where((u) => !memberIds.contains(u['id']))
-        // The agent can never be a group member (the backend rejects
-        // making it an ACL principal), so don't offer it (#2892).
-        .where((u) => !isSystemAgent(u));
+    final found =
+        List<Map<String, dynamic>>.from(
+              (jsonDecode(resp.body) as List).cast<Map<String, dynamic>>(),
+            )
+            .where((u) => !memberIds.contains(u['id']))
+            // The agent can never be a group member (the backend rejects
+            // making it an ACL principal), so don't offer it (#2892).
+            .where((u) => !isSystemAgent(u));
     setState(() => _results = found.toList());
   }
 
@@ -1220,7 +1222,8 @@ class _InvitationsTabState extends State<_InvitationsTab> {
     try {
       final auth = context.read<AuthService>();
       final q = _invitationsQuery.trim();
-      final query = 'page=$_invitationsPage'
+      final query =
+          'page=$_invitationsPage'
           '&page_size=$_invitationsPageSize'
           '&sort=${Uri.encodeQueryComponent(_invitationsSort)}'
           '&order=${Uri.encodeQueryComponent(_invitationsOrder)}'
@@ -1231,8 +1234,8 @@ class _InvitationsTabState extends State<_InvitationsTab> {
         if (mounted) {
           final pendingCount = (data['pending_count'] as num).toInt();
           setState(() {
-            _invitations =
-                (data['invitations'] as List).cast<Map<String, dynamic>>();
+            _invitations = (data['invitations'] as List)
+                .cast<Map<String, dynamic>>();
             _invitationsTotal = (data['total'] as num).toInt();
           });
           widget.onPendingCountChanged?.call(pendingCount);
@@ -1373,8 +1376,8 @@ class _InvitationsTabState extends State<_InvitationsTab> {
               backgroundColor: isPending
                   ? KColors.accentAmber
                   : status == 'accepted'
-                      ? KColors.accentGreen
-                      : KColors.textMuted,
+                  ? KColors.accentGreen
+                  : KColors.textMuted,
               child: Text(
                 initial,
                 style: const TextStyle(
@@ -1553,9 +1556,7 @@ class _VolumesTabState extends State<_VolumesTab> {
       };
       final q = _query.trim();
       if (q.isNotEmpty) query['q'] = q;
-      final resp = await auth.authGet(
-        '/api/v1/volumes?${_encodeQuery(query)}',
-      );
+      final resp = await auth.authGet('/api/v1/volumes?${_encodeQuery(query)}');
       if (!mounted) return;
       if (resp.statusCode == 200) {
         final data = jsonDecode(resp.body) as Map<String, dynamic>;
@@ -1620,9 +1621,8 @@ class _VolumesTabState extends State<_VolumesTab> {
       } catch (_) {
         detail = 'Error ${resp.statusCode}';
       }
-      ScaffoldMessenger.of(
-        context,
-      ).showSnackBar(SnackBar(content: Text(detail)));
+      ScaffoldMessenger.of(context)
+          .showSnackBar(SnackBar(content: Text(detail)));
     }
   }
 
@@ -1637,8 +1637,9 @@ class _VolumesTabState extends State<_VolumesTab> {
         final volume = _volumes[i];
         final name = volume['name'] as String? ?? '';
         final createdRaw = volume['created'] as String? ?? '';
-        final created =
-            createdRaw.length >= 10 ? createdRaw.substring(0, 10) : createdRaw;
+        final created = createdRaw.length >= 10
+            ? createdRaw.substring(0, 10)
+            : createdRaw;
         // The owning workspace (#3153 — volumes are workspace-owned):
         // its name when the row still exists, else the label's id.
         final wsName = volume['workspace'] as String? ?? '';
@@ -1766,9 +1767,11 @@ class _AddUserDialogState extends State<_AddUserDialog> {
     final email = _emailController.text.trim();
     // Flag a malformed address as soon as it's typed, mirroring how the
     // password fields surface policy errors (blank stays quiet).
-    final emailError =
-        email.isEmpty || isValidEmail(email) ? null : 'Enter a valid email';
-    final canAdd = email.isNotEmpty &&
+    final emailError = email.isEmpty || isValidEmail(email)
+        ? null
+        : 'Enter a valid email';
+    final canAdd =
+        email.isNotEmpty &&
         emailError == null &&
         (_sendVerificationEmail || passwordValid);
     return AlertDialog(
@@ -1835,8 +1838,9 @@ class _AddUserDialogState extends State<_AddUserDialog> {
                   floatingLabelStyle: labelStyle,
                   floatingLabelBehavior: FloatingLabelBehavior.always,
                   border: const OutlineInputBorder(),
-                  errorText:
-                      passwordsMismatch ? 'Passwords do not match' : null,
+                  errorText: passwordsMismatch
+                      ? 'Passwords do not match'
+                      : null,
                   suffixIcon: KObscureToggle(
                     obscured: _obscureConfirm,
                     onToggle: () =>
@@ -1949,8 +1953,9 @@ class _EditUserDialogState extends State<_EditUserDialog> {
         !settingPassword || (policyError == null && password == confirm);
     final email = _emailController.text.trim();
     // Same as the add dialog: only flag a malformed address once typed.
-    final emailError =
-        email.isEmpty || isValidEmail(email) ? null : 'Enter a valid email';
+    final emailError = email.isEmpty || isValidEmail(email)
+        ? null
+        : 'Enter a valid email';
     final canSave = email.isNotEmpty && emailError == null && passwordValid;
     return AlertDialog(
       title: Text('Edit User', style: TextStyle(color: KColors.textPrimary)),
@@ -2016,8 +2021,9 @@ class _EditUserDialogState extends State<_EditUserDialog> {
                   floatingLabelStyle: labelStyle,
                   floatingLabelBehavior: FloatingLabelBehavior.always,
                   border: const OutlineInputBorder(),
-                  errorText:
-                      passwordsMismatch ? 'Passwords do not match' : null,
+                  errorText: passwordsMismatch
+                      ? 'Passwords do not match'
+                      : null,
                   suffixIcon: KObscureToggle(
                     obscured: _obscureConfirm,
                     onToggle: () =>
@@ -2097,8 +2103,9 @@ class _InviteUserDialogState extends State<_InviteUserDialog> {
       fontWeight: FontWeight.bold,
     );
     final email = _emailController.text.trim();
-    final emailError =
-        email.isEmpty || isValidEmail(email) ? null : 'Enter a valid email';
+    final emailError = email.isEmpty || isValidEmail(email)
+        ? null
+        : 'Enter a valid email';
     final canInvite = emailError == null && email.isNotEmpty;
     return AlertDialog(
       title: Text('Invite User', style: TextStyle(color: KColors.textPrimary)),
@@ -2178,8 +2185,9 @@ class _UserAvatar extends StatelessWidget {
         children: [
           CircleAvatar(
             radius: 20,
-            backgroundColor:
-                isAgent ? KColors.accentAmber : KColors.colorForString(email),
+            backgroundColor: isAgent
+                ? KColors.accentAmber
+                : KColors.colorForString(email),
             child: isAgent
                 ? const Icon(Icons.smart_toy, color: Colors.white, size: 20)
                 : Text(
@@ -2260,15 +2268,13 @@ class _AclBrowserTabState extends State<_AclBrowserTab> {
   /// status derives from admins-group membership.
   static const _resourceHints = {
     '/': 'view — held by every authenticated user via the seed',
-    '/workspaces':
-        'create-workspace — workspace creation; per-workspace permissions live on each /workspaces/{id}',
+    '/workspaces': 'create-workspace — workspace creation; per-workspace permissions live on each /workspaces/{id}',
     '/users': 'manage-users; search-users — the member-picker type-ahead',
     '/groups': 'manage-groups (listing stays authenticated for pickers)',
     '/invitations': 'manage-invitations',
     '/server': 'manage-server-schedule',
     '/events': 'manage-events (read-only audit)',
-    '/volumes':
-        'view-volumes — the Volumes tab listing; manage-volumes — create/delete',
+    '/volumes': 'view-volumes — the Volumes tab listing; manage-volumes — create/delete',
     '/images': 'view-images — the image/capability listing',
     '/acl': 'manage-acls — root-equivalent, administrators only',
   };
@@ -2457,8 +2463,9 @@ class _AdminListToolbar extends StatelessWidget {
     return ActionChip(
       label: Text(active ? '$label $arrow' : label),
       onPressed: () => onChangeSort(sortKey),
-      backgroundColor:
-          active ? KColors.accentBlue.withValues(alpha: 0.2) : null,
+      backgroundColor: active
+          ? KColors.accentBlue.withValues(alpha: 0.2)
+          : null,
     );
   }
 

--- a/src/klangk/klangk/api/admin.py
+++ b/src/klangk/klangk/api/admin.py
@@ -27,6 +27,7 @@ from ..model import (
     ACTION_ALLOW,
     AgentPrincipalError,
     GROUP_SOURCES,
+    GROUP_SOURCE_MANUAL,
     PRINCIPAL_SYSTEM,
     SYSTEM_AUTHENTICATED,
 )
@@ -805,6 +806,26 @@ async def update_group_fields(app, group_id: str, req) -> dict:
     return {"status": "updated"}
 
 
+async def default_groups_source(app, user: dict) -> str | None:
+    """The ``source`` filter the default group listing runs under
+    (#3283).
+
+    A caller holding ``manage-groups`` keeps the show-all default —
+    the admin Groups tab's role-group chip reads it. Every other
+    authenticated caller gets ``manual``: the seeded workspace-role
+    rows stay behind the permission their management lives behind,
+    so workspace ids (in the role-group names) are not pageable by
+    any signed-in user. An explicit ``source=…`` query parameter is
+    unaffected — it is honored as given.
+    """
+    principals = await app.state.acl.get_principals(user["id"])
+    if await app.state.acl.check_permission(
+        "/groups", principals, "manage-groups"
+    ):
+        return None
+    return GROUP_SOURCE_MANUAL
+
+
 @router.get("/groups")
 async def list_groups(
     page: int = 1,
@@ -823,15 +844,20 @@ async def list_groups(
 
     Returns the paged envelope ``{groups, page, page_size, total}``
     (#2750). ``source=manual`` hides the seeded per-workspace role
-    groups; ``source=workspace-role`` shows only them; the default
-    shows all. Writes (create/edit/delete, members) on this tree are
-    gated ``manage-groups``.
+    groups; ``source=workspace-role`` shows only them. The default
+    (no ``source``) shows all rows only for callers holding
+    ``manage-groups``; everyone else gets the manual-only view
+    (#3283) — the role-group rows carry workspace ids and have no
+    cross-user reader. Writes (create/edit/delete, members) on this
+    tree are gated ``manage-groups``.
     """
     if source is not None and source not in GROUP_SOURCES:
         raise HTTPException(
             status_code=422,
             detail="source must be one of: manual, workspace-role",
         )
+    if source is None:
+        source = await default_groups_source(app, user)
     return await app.state.model.users.list_groups(
         page=page,
         page_size=page_size,

--- a/src/klangk/klangk/api/admin.py
+++ b/src/klangk/klangk/api/admin.py
@@ -848,8 +848,10 @@ async def list_groups(
     Returns the paged envelope ``{groups, page, page_size, total}``
     (#2750). ``source=manual`` hides the seeded per-workspace role
     groups; ``source=workspace-role`` shows only them (served to any
-    authenticated caller — the descriptions carry the role only,
-    never a workspace name, #3283). The default (no ``source``)
+    authenticated caller — the seeded descriptions carry the role
+    only, never a workspace name, #3283; a description a
+    manage-groups holder writes into a role group after seeding is
+    served as written to those readers). The default (no ``source``)
     shows all rows only for callers holding ``manage-groups``;
     everyone else gets the manual-only view. Writes
     (create/edit/delete, members) on this tree are gated

--- a/src/klangk/klangk/api/admin.py
+++ b/src/klangk/klangk/api/admin.py
@@ -812,11 +812,14 @@ async def default_groups_source(app, user: dict) -> str | None:
 
     A caller holding ``manage-groups`` keeps the show-all default —
     the admin Groups tab's role-group chip reads it. Every other
-    authenticated caller gets ``manual``: the seeded workspace-role
-    rows stay behind the permission their management lives behind,
-    so workspace ids (in the role-group names) are not pageable by
-    any signed-in user. An explicit ``source=…`` query parameter is
-    unaffected — it is honored as given.
+    authenticated caller gets ``manual``: on the default listing the
+    seeded workspace-role rows (whose names carry workspace ids) are
+    visible only through the permission their management lives
+    behind. An explicit ``source=workspace-role`` query parameter
+    still serves those rows to any authenticated caller — their
+    descriptions carry the role only, never the workspace name; a
+    description a manage-groups holder writes into a role group
+    after seeding is served as written to those readers.
     """
     principals = await app.state.acl.get_principals(user["id"])
     if await app.state.acl.check_permission(
@@ -844,12 +847,13 @@ async def list_groups(
 
     Returns the paged envelope ``{groups, page, page_size, total}``
     (#2750). ``source=manual`` hides the seeded per-workspace role
-    groups; ``source=workspace-role`` shows only them. The default
-    (no ``source``) shows all rows only for callers holding
-    ``manage-groups``; everyone else gets the manual-only view
-    (#3283) — the role-group rows carry workspace ids and have no
-    cross-user reader. Writes (create/edit/delete, members) on this
-    tree are gated ``manage-groups``.
+    groups; ``source=workspace-role`` shows only them (served to any
+    authenticated caller — the descriptions carry the role only,
+    never a workspace name, #3283). The default (no ``source``)
+    shows all rows only for callers holding ``manage-groups``;
+    everyone else gets the manual-only view. Writes
+    (create/edit/delete, members) on this tree are gated
+    ``manage-groups``.
     """
     if source is not None and source not in GROUP_SOURCES:
         raise HTTPException(

--- a/src/klangk/klangk/model/migrations/__init__.py
+++ b/src/klangk/klangk/model/migrations/__init__.py
@@ -86,6 +86,7 @@ from klangk.model.migrations import m0035_user_sessions_step_up
 from klangk.model.migrations import m0036_audit_forward_state
 from klangk.model.migrations import m0037_audit_forward_cursors
 from klangk.model.migrations import m0038_audit_events_method_referer
+from klangk.model.migrations import m0039_role_group_descriptions
 from klangk.model.migrations.base import Migration
 
 __all__ = ["MIGRATIONS", "Migration", "run_migrations"]
@@ -132,6 +133,7 @@ MIGRATIONS: list[Migration] = [
     m0036_audit_forward_state.migration,
     m0037_audit_forward_cursors.migration,
     m0038_audit_events_method_referer.migration,
+    m0039_role_group_descriptions.migration,
 ]
 
 

--- a/src/klangk/klangk/model/migrations/m0039_role_group_descriptions.py
+++ b/src/klangk/klangk/model/migrations/m0039_role_group_descriptions.py
@@ -1,0 +1,49 @@
+"""Migration 0039: id-only workspace-role-group descriptions (#3283).
+
+The workspace seed wrote each role group's description as
+``Workspace role group: <role> of workspace <name>`` — the free-form,
+user-chosen workspace name. ``GET /groups`` is an authenticated listing
+(#2944), so any signed-in user could page the group list and read every
+workspace's name on the deploy, data the workspaces endpoints expose
+per-user only.
+
+This migration rewrites the seeded-template descriptions of rows
+carrying ``source = 'workspace-role'`` to the id-only form
+``Workspace role group: <role>`` (the group name already carries the
+workspace id). Descriptions that no longer match the template — an
+admin who edited one after seeding — are left untouched: only the
+machine-written rows are rewritten. The seed itself now writes the
+id-only wording, so this migration exists solely for existing rows.
+"""
+
+import re
+
+from klangk.model.migrations.base import Migration
+
+# The pre-#3283 seed template: "Workspace role group: <role> of
+# workspace <name>" — the name is the leaked half.
+_SEEDED_TEMPLATE = re.compile(
+    r"^Workspace role group: "
+    r"(owners|coders|collaborators|spectators)"
+    r" of workspace "
+)
+
+
+async def apply(db) -> None:
+    cursor = await db.execute(
+        "SELECT id, description FROM groups WHERE source = 'workspace-role'"
+    )
+    rows = await cursor.fetchall()
+    for group_id, description in rows:
+        if description is None:
+            continue
+        match = _SEEDED_TEMPLATE.match(description)
+        if match is None:
+            continue  # human-edited description — leave it alone
+        await db.execute(
+            "UPDATE groups SET description = ? WHERE id = ?",
+            (f"Workspace role group: {match.group(1)}", group_id),
+        )
+
+
+migration = Migration(39, "0039_role_group_descriptions", apply)

--- a/src/klangk/klangk/model/workspaces.py
+++ b/src/klangk/klangk/model/workspaces.py
@@ -641,8 +641,12 @@ class WorkspacesModel(Submodel):
                 (
                     group_id,
                     group_name,
-                    f"Workspace role group: {suffix} of workspace"
-                    f" {ws['name']}",
+                    # Id-only wording: the group name already carries
+                    # the workspace id, and the free-form workspace
+                    # name must not land in a description any
+                    # authenticated reader can page through
+                    # (GET /groups, #3283).
+                    f"Workspace role group: {suffix}",
                     GROUP_SOURCE_WORKSPACE_ROLE,
                 ),
             )

--- a/src/klangk/klangkd-tests/tests/test_api.py
+++ b/src/klangk/klangkd-tests/tests/test_api.py
@@ -7642,6 +7642,64 @@ class TestUserGroupEndpoints:
         assert paged.status_code == 200
         assert len(paged.json()["groups"]) == 1
 
+    async def test_default_listing_hides_role_groups_from_plain_users(
+        self, client, user, app_state
+    ):
+        """#3283: the default (no ``source``) listing shows the seeded
+        workspace-role rows only to manage-groups holders. A plain
+        authenticated caller gets the manual-only view — another
+        user's workspace id (in role-group names) and workspace name
+        are not pageable through /groups."""
+        headers = await _auth_headers(client)
+        await app_state.state.model.workspaces.create_workspace_with_acl(
+            user["id"], "merger-dossier-384ac4"
+        )
+        resp = await client.get(
+            "/api/v1/groups?page_size=200", headers=headers
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert all(g["source"] == "manual" for g in body["groups"])
+        assert "merger-dossier-384ac4" not in str(body)
+
+    async def test_role_group_descriptions_carry_no_workspace_name(
+        self, client, user, app_state
+    ):
+        """#3283: role-group rows reachable via an explicit
+        ``source=workspace-role`` describe the role only — the
+        free-form workspace name never lands in a description any
+        authenticated reader can page through."""
+        headers = await _auth_headers(client)
+        await app_state.state.model.workspaces.create_workspace_with_acl(
+            user["id"], "therapy-notes-dev"
+        )
+        resp = await client.get(
+            "/api/v1/groups?source=workspace-role&page_size=200",
+            headers=headers,
+        )
+        assert resp.status_code == 200
+        assert resp.json()["total"] >= 4
+        for group in resp.json()["groups"]:
+            assert group["description"].startswith("Workspace role group: ")
+            assert "therapy-notes-dev" not in group["description"]
+
+    async def test_admin_default_listing_keeps_role_groups(
+        self, client, admin_user, user, app_state
+    ):
+        """#3283: a manage-groups holder keeps the show-all default —
+        the admin Groups tab's role-group chip reads it."""
+        await app_state.state.model.workspaces.create_workspace_with_acl(
+            user["id"], "admin-view-ws"
+        )
+        headers = await self._admin_login(client)
+        resp = await client.get(
+            "/api/v1/groups?page_size=200", headers=headers
+        )
+        assert resp.status_code == 200
+        assert any(
+            g["source"] == "workspace-role" for g in resp.json()["groups"]
+        )
+
     async def test_admin_list_groups_source_filter(
         self, client, admin_user, app_state
     ):

--- a/src/klangk/klangkd-tests/tests/test_api.py
+++ b/src/klangk/klangkd-tests/tests/test_api.py
@@ -7650,10 +7650,18 @@ class TestUserGroupEndpoints:
         authenticated caller gets the manual-only view — another
         user's workspace id (in role-group names) and workspace name
         are not pageable through /groups."""
-        headers = await _auth_headers(client)
-        await app_state.state.model.workspaces.create_workspace_with_acl(
-            user["id"], "merger-dossier-384ac4"
+        # A second user owns the probe workspace — the cross-user
+        # threat the issue describes. Created via the model: the
+        # workspace-creation endpoint is not under test here.
+        other = await app_state.state.model.users.create_user(
+            "leak-owner@example.com",
+            auth_mod.hash_password("ownerpass"),
+            verified=True,
         )
+        await app_state.state.model.workspaces.create_workspace_with_acl(
+            other["id"], "merger-dossier-384ac4"
+        )
+        headers = await _auth_headers(client)
         resp = await client.get(
             "/api/v1/groups?page_size=200", headers=headers
         )

--- a/src/klangk/klangkd-tests/tests/test_migrations.py
+++ b/src/klangk/klangkd-tests/tests/test_migrations.py
@@ -99,6 +99,7 @@ class TestRunner:
             (36, "0036_audit_forward_state"),
             (37, "0037_audit_forward_cursors"),
             (38, "0038_audit_events_method_referer"),
+            (39, "0039_role_group_descriptions"),
         ]
         async with aiosqlite.connect(str(app_state.state.db.db_path)) as db:
             assert await _recorded(db) == expected
@@ -207,6 +208,7 @@ class TestRunner:
                 (36, "0036_audit_forward_state"),
                 (37, "0037_audit_forward_cursors"),
                 (38, "0038_audit_events_method_referer"),
+                (39, "0039_role_group_descriptions"),
             ]
 
     async def test_m0008_agent_identity_and_human_collision(
@@ -3623,5 +3625,119 @@ class TestM0038AuditEventsMethodReferer:
                 "SELECT event, method, referer FROM audit_events"
             )
             assert await cursor.fetchone() == ("login", None, None)
+        finally:
+            await db.__aexit__(None, None, None)
+
+
+class TestM0039RoleGroupDescriptions:
+    """m0039: workspace-role-group descriptions lose the embedded
+    workspace name (#3283) — the /groups listing is readable by any
+    authenticated user, and the free-form name must not be pageable
+    through it. Rows whose description an admin edited after seeding
+    (no longer matching the seed template) keep their wording."""
+
+    async def _db(self, tmp_path):
+        db = aiosqlite.connect(str(tmp_path / "m0039.db"))
+        await db.__aenter__()
+        await db.execute(
+            "CREATE TABLE groups ("
+            " id TEXT PRIMARY KEY, name TEXT UNIQUE NOT NULL,"
+            " description TEXT, source TEXT NOT NULL DEFAULT 'manual',"
+            " created_at TEXT NOT NULL DEFAULT (datetime('now')))"
+        )
+        return db
+
+    async def _descriptions(self, db) -> dict[str, str | None]:
+        cursor = await db.execute("SELECT name, description FROM groups")
+        return {row[0]: row[1] for row in await cursor.fetchall()}
+
+    async def test_rewrites_seeded_template_rows(self, tmp_path):
+        db = await self._db(tmp_path)
+        try:
+            from klangk.model.migrations import m0039_role_group_descriptions
+
+            await db.executemany(
+                "INSERT INTO groups (id, name, description, source)"
+                " VALUES (?, ?, ?, 'workspace-role')",
+                [
+                    (
+                        "g1",
+                        "owners-11111111-2222-3333-4444-555555555555",
+                        "Workspace role group: owners of workspace"
+                        " acme-merger-dossier",
+                    ),
+                    (
+                        "g2",
+                        "spectators-11111111-2222-3333-4444-555555555555",
+                        "Workspace role group: spectators of workspace"
+                        " acme-merger-dossier",
+                    ),
+                ],
+            )
+            await m0039_role_group_descriptions.migration.apply(db)
+            rows = await self._descriptions(db)
+            assert rows["owners-11111111-2222-3333-4444-555555555555"] == (
+                "Workspace role group: owners"
+            )
+            assert rows["spectators-11111111-2222-3333-4444-555555555555"] == (
+                "Workspace role group: spectators"
+            )
+        finally:
+            await db.__aexit__(None, None, None)
+
+    async def test_leaves_edited_and_manual_rows_alone(self, tmp_path):
+        db = await self._db(tmp_path)
+        try:
+            from klangk.model.migrations import m0039_role_group_descriptions
+
+            await db.executemany(
+                "INSERT INTO groups (id, name, description, source)"
+                " VALUES (?, ?, ?, ?)",
+                [
+                    # Admin-edited role-group description: not the
+                    # seeded wording anymore.
+                    (
+                        "g1",
+                        "coders-11111111-2222-3333-4444-555555555555",
+                        "editing team (renamed)",
+                        "workspace-role",
+                    ),
+                    # Seeded shape on a manual group: out of scope.
+                    (
+                        "g2",
+                        "human-group",
+                        "Workspace role group: owners of workspace x",
+                        "manual",
+                    ),
+                    # NULL description on a role group.
+                    (
+                        "g3",
+                        "spectators-11111111-2222-3333-4444-555555555556",
+                        None,
+                        "workspace-role",
+                    ),
+                ],
+            )
+            await m0039_role_group_descriptions.migration.apply(db)
+            rows = await self._descriptions(db)
+            assert rows["coders-11111111-2222-3333-4444-555555555555"] == (
+                "editing team (renamed)"
+            )
+            assert rows["human-group"] == (
+                "Workspace role group: owners of workspace x"
+            )
+            assert (
+                rows["spectators-11111111-2222-3333-4444-555555555556"] is None
+            )
+        finally:
+            await db.__aexit__(None, None, None)
+
+    async def test_empty_table_is_a_noop(self, tmp_path):
+        db = await self._db(tmp_path)
+        try:
+            from klangk.model.migrations import m0039_role_group_descriptions
+
+            await m0039_role_group_descriptions.migration.apply(db)
+            assert await self._descriptions(db) == {}
         finally:
             await db.__aexit__(None, None, None)

--- a/src/klangk/klangkd-tests/tests/test_model_workspaces.py
+++ b/src/klangk/klangkd-tests/tests/test_model_workspaces.py
@@ -921,8 +921,9 @@ async def test_settings_in_auto_start_listing(ws, user):
 
 
 async def test_role_groups_carry_workspace_role_source(ws, app_state, user):
-    """#2750: seeded role groups are marked ``workspace-role`` and their
-    descriptions carry the normalized purpose."""
+    """#2750: seeded role groups are marked ``workspace-role``; the
+    description carries the normalized purpose with no workspace name
+    (#3283 — the listing is readable by any authenticated user)."""
     from klangk.model.users import GROUP_SOURCE_WORKSPACE_ROLE
 
     ws_row = await ws.create_workspace_with_acl(user["id"], "marked-ws")
@@ -932,9 +933,7 @@ async def test_role_groups_carry_workspace_role_source(ws, app_state, user):
         )
         assert group is not None
         assert group["source"] == GROUP_SOURCE_WORKSPACE_ROLE
-        assert group["description"] == (
-            f"Workspace role group: {suffix} of workspace marked-ws"
-        )
+        assert group["description"] == f"Workspace role group: {suffix}"
 
 
 async def test_delete_workspace_tears_down_unknown_suffix_role_group(


### PR DESCRIPTION
## Summary

`GET /api/v1/groups` disclosed every workspace's free-form name to any
authenticated user: role groups were seeded with
`Workspace role group: <role> of workspace <name>` and the default listing
(no `source`) returned all rows with descriptions (#3283).

- **Seed** (`WorkspacesModel.seed_workspace_acl`): role-group descriptions
  are now id-only — `Workspace role group: <role>`; the group name already
  carries the workspace id.
- **Migration `m0039`**: rewrites existing seeded-template descriptions of
  `source='workspace-role'` rows to the id-only wording. Rows whose
  description an admin edited after seeding (no longer matching the
  template) keep their wording.
- **Listing gate** (`GET /groups`): the default (no `source` parameter)
  view returns `workspace-role` rows only to callers holding
  `manage-groups` on `/groups`; every other authenticated caller gets the
  manual-only view. Explicit `source=manual` / `source=workspace-role`
  filters are unchanged for every authenticated caller (rows now carry no
  workspace names).

The admin Groups tab (manage-groups-gated, defaults to `source=manual`,
role-group chip sends no source) and the ACL-editor picker
(`source=manual`) are unaffected. The `q` LIKE-escape half of the issue
had already landed with #3280.

Fixes #3283
