### PR TITLE
Await the consent-decider WS handshake before reporting connected (#3289)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -2528,6 +2528,16 @@ git-credential` (#1700).** `pig-latin` removed; `word-count` dormant.
   paths — in a 400 body. It is now a 500 "Internal server error"
   with the underlying error logged server-side.
 
+- **Consent decider connection state (#3289).** The web consent-decider
+  client now reports "connected" only after the WebSocket handshake
+  completes. A handshake the server refuses (missing `egress-consent`
+  permission, static egress mode, expired session) previously looked like
+  an endless connect/disconnect cycle with no reason; the consent banner
+  now shows "The server refused this decider connection" and the rules
+  panel header shows "refused", and a verdict clicked before the
+  handshake completes shows the disconnected flash instead of being
+  written to a connection that never opened.
+
 - **Files API error responses (#3150).** The workspace files routes
   (list/read/delete/rename/upload/download) no longer echo raw
   exception text — podman stderr, container paths, library messages —

--- a/src/frontend/lib/workspace/consent_banner.dart
+++ b/src/frontend/lib/workspace/consent_banner.dart
@@ -47,8 +47,9 @@ const Map<String, String> _durationLabels = {
 
 /// A banner over the workspace body showing held egress requests + actions.
 ///
-/// Renders nothing when there are no pending requests (and the service isn't
-/// in an auth-failed state), so a static-mode or idle workspace sees no UI.
+/// Renders nothing when there are no pending requests (and the service
+/// isn't in an auth-failed or handshake-refused state), so a static-mode or
+/// idle workspace sees no UI.
 class ConsentBanner extends StatefulWidget {
   const ConsentBanner({super.key, required this.service});
 
@@ -94,6 +95,21 @@ class _ConsentBannerState extends State<ConsentBanner> {
           dense: true,
           leading: Icon(Icons.lock_outline, size: 20),
           title: Text('Consent session expired — please log in again'),
+        ),
+      );
+    }
+    // #3289: a handshake the server refused (missing egress-consent
+    // permission, static egress mode, expired session) is a distinct state
+    // from a drop — the banner surfaces the refusal instead of flapping
+    // "reconnecting…", since held requests can neither be seen nor decided
+    // here and auto-deny on their hold timeout.
+    if (service.refused) {
+      return const _BannerSurface(
+        child: ListTile(
+          dense: true,
+          leading: Icon(Icons.link_off, size: 20),
+          title: Text('The server refused this decider connection'),
+          subtitle: Text('Held connections are auto-denied'),
         ),
       );
     }

--- a/src/frontend/lib/workspace/consent_decider_service.dart
+++ b/src/frontend/lib/workspace/consent_decider_service.dart
@@ -452,6 +452,17 @@ class ConsentDeciderService extends ChangeNotifier {
   bool _authFailed = false;
   bool get authFailed => _authFailed;
 
+  /// Whether the last connect attempt failed at the WebSocket handshake
+  /// itself (#3289) — the server refused the upgrade (authz gate, static
+  /// egress mode, expired session) or the endpoint was unreachable. A
+  /// pre-accept refusal is answered with a bare HTTP 403, so no WS close
+  /// frame reaches the client and [_onClosed]'s close-code classification
+  /// can never see it; this flag is the surfaced state instead of the
+  /// connected/disconnected flap. The reconnect loop keeps retrying, and
+  /// the next successful handshake clears it.
+  bool _refused = false;
+  bool get refused => _refused;
+
   /// Transient status flash (server `error` frame / verdict send failure /
   /// verdict attempted while disconnected), shown by the banner until
   /// [_flashUntil]. Mirrors the TUI's status-line flash (cli/tui/consent.py
@@ -567,6 +578,48 @@ class ConsentDeciderService extends ChangeNotifier {
       ch = WebSocketChannel.connect(Uri.parse(url), protocols: protocols);
       // coverage:ignore-end
     }
+    // #3289: connected state flips only after the handshake resolves
+    // (mirrors WsClient._connectWs). A pre-accept refusal arrives as a bare
+    // HTTP 403 — `ready` throws, no close frame — and was previously
+    // invisible: the service reported itself live, reset the backoff, and
+    // wrote verdicts to a channel that never opened.
+    try {
+      await ch.ready;
+    } catch (e) {
+      debugPrint('[ConsentDecider] handshake failed: $e');
+      // #3289 review: dispose() may have completed while we were parked on
+      // the handshake's await -- stay silent (no notify on a disposed
+      // notifier, no reconnect scheduling for a dead service).
+      if (_stopped) return;
+      // A failed handshake normally carries no close code (the server's
+      // pre-accept refusals never become a close frame), but classify
+      // defensively in case the platform surfaces one — mirrors WsClient.
+      // A prior attempt's refused flag must not survive into the auth
+      // state (the banner/header would split on which condition won).
+      if (_isAuthCloseCode(ch.closeCode)) {
+        _authFailed = true;
+        _refused = false;
+        notifyListeners();
+        return; // stop reconnecting; the app surfaces re-login
+      }
+      // Refused/unreachable handshake: a distinct state from a
+      // post-connect drop, so the UI can say the connection was refused
+      // instead of flapping "reconnecting". connect()'s catch schedules
+      // the normal backoff reconnect; the next handshake that completes
+      // clears this.
+      _refused = true;
+      notifyListeners();
+      rethrow;
+    }
+    // #3289 review: the same dispose-during-await race on the success side
+    // -- never adopt the channel into a disposed service. Its ping timer
+    // and stream subscription would outlive dispose(), keeping a phantom
+    // decider registered server-side; close the orphaned channel instead.
+    if (_stopped) {
+      ch.sink.close(1000, 'dispose');
+      return;
+    }
+    _refused = false;
     _channel = ch;
     // The server's snapshot (sent immediately on connect) is authoritative
     // for currently-held requests, so rows that resolved while we were
@@ -683,8 +736,7 @@ class ConsentDeciderService extends ChangeNotifier {
       return; // a stale callback from a prior socket
     _stopPing();
     _connected = false;
-    final code = ch.closeCode;
-    if (code == 4001 || code == 4002 || code == 4004) {
+    if (_isAuthCloseCode(ch.closeCode)) {
       _authFailed = true;
       notifyListeners();
       return; // stop reconnecting; the app surfaces re-login
@@ -1022,3 +1074,10 @@ class ConsentDeciderService extends ChangeNotifier {
 }
 
 DateTime _wallClock() => DateTime.now();
+
+/// Whether a WS close code is an auth failure (invalid/expired token, or the
+/// must-change-password gate, #3172) — the caller stops reconnecting and the
+/// app surfaces re-login. Duplicated from `WsClient.isAuthCloseCode` per the
+/// client isolation boundary this service shares with the TUI.
+bool _isAuthCloseCode(int? code) =>
+    code == 4001 || code == 4002 || code == 4004;

--- a/src/frontend/lib/workspace/consent_rules_panel.dart
+++ b/src/frontend/lib/workspace/consent_rules_panel.dart
@@ -243,7 +243,18 @@ class _Header extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final conn = service.connected ? 'connected' : 'reconnecting';
+    // #3289: a refused handshake is its own state — the server declined the
+    // connect (authz/static-mode gate), which "reconnecting" would misreport.
+    // authFailed takes precedence over refused, mirroring the banner: the
+    // re-login path is terminal, and a live-socket 4001 close (session
+    // eviction) must not read as an endless "reconnecting".
+    final conn = service.authFailed
+        ? 'session expired'
+        : service.refused
+            ? 'refused'
+            : service.connected
+                ? 'connected'
+                : 'reconnecting';
     final held = service.pending.length;
     return Container(
       padding: const EdgeInsets.fromLTRB(16, 8, 16, 8),

--- a/src/frontend/test/consent_banner_test.dart
+++ b/src/frontend/test/consent_banner_test.dart
@@ -44,6 +44,16 @@ class _FakeSink extends Fake implements WebSocketSink {
   Future close([int? code, String? reason]) async {}
 }
 
+/// A channel whose handshake never opens (#3289): `ready` fails the way a
+/// pre-accept HTTP 403 refusal does.
+class _RefusedChannel extends Fake implements WebSocketChannel {
+  @override
+  int? get closeCode => null;
+
+  @override
+  Future<void> get ready => Future.error(WebSocketChannelException('refused'));
+}
+
 ConsentDeciderService _serviceWithChannel(_FakeChannel channel) {
   ConsentDeciderService.testChannelFactory = (_, __) => channel;
   return ConsentDeciderService(
@@ -408,6 +418,29 @@ void main() {
     await tester.pump(); // flush onDone -> notifyListeners -> rebuild
     await tester.pump();
     expect(find.text('reconnecting…'), findsOneWidget);
+    svc.dispose();
+  });
+
+  testWidgets('surfaces a refused handshake instead of the flap (#3289)', (
+    tester,
+  ) async {
+    ConsentDeciderService.testChannelFactory = (_, __) => _RefusedChannel();
+    final svc = ConsentDeciderService(
+      workspaceId: 'ws',
+      token: 't',
+      reconnectDelays: const [Duration(minutes: 5)],
+      clock: () =>
+          DateTime.fromMillisecondsSinceEpoch(2000 * 1000, isUtc: true),
+    );
+    await svc.connect(); // handshake refused — never connected
+    await tester.pumpWidget(_wrap(ConsentBanner(service: svc)));
+    await tester.pumpAndSettle();
+    // The banner renders the refusal (even with nothing pending) rather
+    // than claiming the decider is live or endlessly "reconnecting…".
+    expect(find.text('The server refused this decider connection'),
+        findsOneWidget);
+    expect(find.textContaining('Pending egress consent'), findsNothing);
+    expect(find.text('reconnecting…'), findsNothing);
     svc.dispose();
   });
 }

--- a/src/frontend/test/consent_decider_service_test.dart
+++ b/src/frontend/test/consent_decider_service_test.dart
@@ -72,6 +72,54 @@ class _ThrowingSink extends Fake implements WebSocketSink {
   Future close([int? code, String? reason]) async {}
 }
 
+/// A channel whose handshake never opens (#3289): `ready` fails the way a
+/// pre-accept HTTP 403 refusal does — an exception, no close frame (a close
+/// code can be injected for the defensive auth classification).
+class _RefusedChannel extends Fake implements WebSocketChannel {
+  _RefusedChannel({this.closeCode});
+
+  @override
+  final int? closeCode;
+
+  @override
+  Future<void> get ready => Future.error(WebSocketChannelException('refused'));
+}
+
+/// A channel whose handshake resolves only when the test drives it
+/// (#3289 review): lets a test dispose the service while connect() is
+/// parked on `ready` — the navigate-away-mid-handshake race.
+class _GatedChannel extends Fake implements WebSocketChannel {
+  final _ready = Completer<void>();
+  final closes = <(int?, String?)>[];
+
+  @override
+  Stream<dynamic> get stream => const Stream.empty();
+
+  @override
+  WebSocketSink get sink => _GatedSink(closes);
+
+  @override
+  int? get closeCode => null;
+
+  @override
+  Future<void> get ready => _ready.future;
+
+  void acceptHandshake() => _ready.complete();
+  void refuseHandshake() =>
+      _ready.completeError(WebSocketChannelException('refused'));
+}
+
+class _GatedSink extends Fake implements WebSocketSink {
+  _GatedSink(this.closes);
+  final List<(int?, String?)> closes;
+
+  @override
+  void add(dynamic data) {}
+
+  @override
+  Future close([int? code, String? reason]) async => closes.add((code, reason));
+}
+
 Map<String, dynamic> _request({
   String id = 'r1',
   String host = 'example.com',
@@ -762,6 +810,152 @@ void main() {
       expect(svc.flashMessage, contains('verdict send failed'));
       svc.dispose();
     });
+
+    test(
+      'a refused handshake never reports connected and surfaces refused (#3289)',
+      () async {
+        final refused = _RefusedChannel();
+        ConsentDeciderService.testChannelFactory = (_, __) => refused;
+        final svc = ConsentDeciderService(
+          workspaceId: 'ws',
+          token: 't',
+          // Long delay so the scheduled reconnect Timer never fires.
+          reconnectDelays: const [Duration(minutes: 5)],
+        );
+        await svc.connect();
+        // The handshake failed: the service must NOT claim connected (the
+        // old code flipped it before awaiting ready), and the refusal is a
+        // distinct state from both an auth failure and a plain drop.
+        expect(svc.connected, isFalse);
+        expect(svc.refused, isTrue);
+        expect(svc.authFailed, isFalse);
+        // The reconnect path stayed intact: a later successful handshake
+        // connects and clears the refused flag.
+        final good = _FakeChannel();
+        ConsentDeciderService.testChannelFactory = (_, __) => good;
+        await svc.connect();
+        expect(svc.connected, isTrue);
+        expect(svc.refused, isFalse);
+        svc.dispose();
+      },
+    );
+
+    test(
+      'a verdict during the refused window flashes disconnected (#3289)',
+      () async {
+        ConsentDeciderService.testChannelFactory = (_, __) => _RefusedChannel();
+        final svc = ConsentDeciderService(
+          workspaceId: 'ws',
+          token: 't',
+          reconnectDelays: const [Duration(minutes: 5)],
+        );
+        await svc.connect(); // refused — never connected
+        svc.sendVerdict('r1', 'allowed', 'once');
+        // Pre-ready verdicts hit the same disconnected flash as post-drop
+        // ones instead of being written to a channel that never opened.
+        expect(svc.flashMessage, contains('disconnected'));
+        svc.dispose();
+      },
+    );
+
+    test(
+      'a handshake failure carrying an auth close code classifies as auth',
+      () async {
+        // Some platforms surface a close code alongside the ready failure;
+        // the defensive classification (mirroring WsClient) must take the
+        // auth path: authFailed, no refused flag, no reconnect loop.
+        ConsentDeciderService.testChannelFactory =
+            (_, __) => _RefusedChannel(closeCode: 4001);
+        final svc = ConsentDeciderService(
+          workspaceId: 'ws',
+          token: 't',
+          reconnectDelays: const [Duration(minutes: 5)],
+        );
+        await svc.connect();
+        expect(svc.authFailed, isTrue);
+        expect(svc.refused, isFalse);
+        expect(svc.connected, isFalse);
+        svc.dispose();
+      },
+    );
+
+    test(
+      'the auth classification clears a prior refused flag (#3289 review)',
+      () async {
+        // refused first (no close code), then a ready failure carrying an
+        // auth close code: authFailed wins and refused must not linger —
+        // the banner/header must not split on which condition won.
+        ConsentDeciderService.testChannelFactory = (_, __) => _RefusedChannel();
+        final svc = ConsentDeciderService(
+          workspaceId: 'ws',
+          token: 't',
+          reconnectDelays: const [Duration(minutes: 5)],
+        );
+        await svc.connect();
+        expect(svc.refused, isTrue);
+        ConsentDeciderService.testChannelFactory =
+            (_, __) => _RefusedChannel(closeCode: 4001);
+        await svc.connect();
+        expect(svc.authFailed, isTrue);
+        expect(svc.refused, isFalse);
+        svc.dispose();
+      },
+    );
+
+    test(
+      'a refused handshake keeps the reconnect loop retrying (#3289)',
+      () async {
+        var opens = 0;
+        ConsentDeciderService.testChannelFactory = (_, __) {
+          opens += 1;
+          return _RefusedChannel();
+        };
+        final svc = ConsentDeciderService(
+          workspaceId: 'ws',
+          token: 't',
+          reconnectDelays: const [Duration(milliseconds: 10)],
+        );
+        await svc.connect();
+        expect(opens, 1);
+        // connect()'s catch must have scheduled the reconnect (the rethrow
+        // path): the backoff timer fires and re-attempts the still-refused
+        // handshake instead of going dormant after one refusal.
+        await Future<void>.delayed(const Duration(milliseconds: 100));
+        expect(opens, greaterThan(1));
+        svc.dispose();
+      },
+    );
+
+    test(
+      'a handshake resolving after dispose adopts no channel (#3289)',
+      () async {
+        final ch = _GatedChannel();
+        ConsentDeciderService.testChannelFactory = (_, __) => ch;
+        final svc = ConsentDeciderService(workspaceId: 'ws', token: 't');
+        final connecting = svc.connect(); // parked on ch.ready
+        svc.dispose(); // navigate away mid-handshake
+        ch.acceptHandshake(); // ready succeeds — into a disposed service
+        await connecting;
+        // The channel was closed, never adopted: no connected claim, no ping
+        // timer, no stream sub, and no notify on the disposed notifier.
+        expect(svc.connected, isFalse);
+        expect(ch.closes, [(1000, 'dispose')]);
+      },
+    );
+
+    test(
+      'a handshake failing after dispose stays silent (#3289)',
+      () async {
+        final ch = _GatedChannel();
+        ConsentDeciderService.testChannelFactory = (_, __) => ch;
+        final svc = ConsentDeciderService(workspaceId: 'ws', token: 't');
+        final connecting = svc.connect();
+        svc.dispose();
+        ch.refuseHandshake();
+        await connecting; // no throw, no post-dispose notify
+        expect(svc.refused, isFalse);
+      },
+    );
 
     test(
       'auth-fail close (4001) sets authFailed and stops reconnecting',

--- a/src/frontend/test/consent_rules_panel_test.dart
+++ b/src/frontend/test/consent_rules_panel_test.dart
@@ -44,6 +44,16 @@ class _FakeSink extends Fake implements WebSocketSink {
   Future close([int? code, String? reason]) async {}
 }
 
+/// A channel whose handshake never opens (#3289): `ready` fails the way a
+/// pre-accept HTTP 403 refusal does.
+class _RefusedChannel extends Fake implements WebSocketChannel {
+  @override
+  int? get closeCode => null;
+
+  @override
+  Future<void> get ready => Future.error(WebSocketChannelException('refused'));
+}
+
 Map<String, dynamic> _ruleJson({
   String id = 'v1',
   String host = 'a.io',
@@ -666,6 +676,47 @@ void main() {
       await tester.pump();
       await tester.pump(); // flush onDone -> notifyListeners -> rebuild
       expect(find.textContaining('reconnecting'), findsOneWidget);
+      svc.dispose();
+    });
+
+    testWidgets('header shows refused when the handshake is refused (#3289)',
+        (tester) async {
+      ConsentDeciderService.testChannelFactory = (_, __) => _RefusedChannel();
+      final svc = ConsentDeciderService(
+        workspaceId: 'ws',
+        token: 't',
+        // Long delay so the reconnect Timer never fires during the test
+        // (dispose cancels it regardless).
+        reconnectDelays: const [Duration(minutes: 5)],
+      );
+      svc.connect();
+      await tester.pumpWidget(_wrap(ConsentRulesPanel(service: svc)));
+      await tester.pump();
+      await tester.pump(); // flush the refused notify -> rebuild
+      expect(find.textContaining('refused'), findsOneWidget);
+      expect(find.textContaining('reconnecting'), findsNothing);
+      svc.dispose();
+    });
+
+    testWidgets(
+        'header shows session expired when a live socket auth-closes '
+        '(#3289 review)', (tester) async {
+      final ch = _FakeChannel();
+      ConsentDeciderService.testChannelFactory = (_, __) => ch;
+      final svc = ConsentDeciderService(
+        workspaceId: 'ws',
+        token: 't',
+        reconnectDelays: const [Duration(minutes: 5)],
+      );
+      svc.connect();
+      await tester.pumpWidget(_wrap(ConsentRulesPanel(service: svc)));
+      ch.serverSend(_rulesFrame(allowList: ['a.io']));
+      await tester.pump();
+      ch.serverClose(4001); // live-socket auth close -> authFailed, no retry
+      await tester.pump();
+      await tester.pump(); // flush onDone -> notifyListeners -> rebuild
+      expect(find.textContaining('session expired'), findsOneWidget);
+      expect(find.textContaining('reconnecting'), findsNothing);
       svc.dispose();
     });
 


### PR DESCRIPTION
Fixes #3289.

## What changed

`ConsentDeciderService._openChannel` flipped `_connected`, reset the backoff
counter, and cleared `_authFailed` immediately after
`WebSocketChannel.connect(...)` — before the handshake resolved. A verdict
clicked in that window was written to a channel that might never open (the
server's hold timer then auto-denies), and a pre-accept refusal — answered by
uvicorn as a bare HTTP 403 with no WS close frame — was indistinguishable from
a network drop, so the service reconnected forever flipping
connected→disconnected with no surfaced reason.

The fix mirrors the sibling client (`WsClient._connectWs`):

- **`consent_decider_service.dart`** — `_openChannel` holds the channel in a
  local, `await ch.ready` in a try, and only after success assigns `_channel`,
  flips `_connected`, resets backoff, starts the ping, notifies, and
  subscribes. On a `ready` failure it classifies defensively by close code
  (auth codes 4001/4002/4004 → `_authFailed`, stop reconnecting), otherwise
  sets a new `refused` flag and rethrows so `connect()`'s existing catch
  schedules the normal backoff reconnect. The next successful handshake clears
  the flag. `_onClosed`'s inline code check was extracted to
  `_isAuthCloseCode` (duplicated from `WsClient.isAuthCloseCode` on purpose —
  this service shares the CLI isolation boundary and must not import the ws
  client).
- **`consent_banner.dart`** — while `refused`, the banner renders "The server
  refused this decider connection" (even with nothing pending) instead of
  flapping "reconnecting…".
- **`consent_rules_panel.dart`** — the header shows `refused` as its own state
  between `connected` and `reconnecting`.
- `sendVerdict`'s existing disconnected flash now also covers the pre-ready
  window (a verdict attempted during the handshake flashes instead of being
  written to a channel that never opened).
- Because `await ready` widens the dispose-during-connect window to the full
  handshake RTT, `_openChannel` re-checks `_stopped` after the await on both
  sides: a channel that resolves (or fails) after `dispose()` is closed and
  dropped rather than adopted — no leaked ping timer, no phantom decider
  registration server-side, no notify on a disposed notifier.

Note: a failed handshake is also what an unreachable endpoint produces; in a
genuine network outage the main `WsClient` over the same origin is down too
and its overlay owns that state, so the refusal copy on the decider banner is
only shown when the main connection is otherwise healthy.

## Tests

- `consent_decider_service_test.dart` — refused handshake never reports
  connected and surfaces `refused`; a later successful handshake clears it;
  a verdict during the refused window flashes disconnected; a ready failure
  carrying an auth close code classifies as auth; the reconnect loop keeps
  retrying after a refusal; a handshake resolving or failing after `dispose`
  adopts no channel and stays silent.
- `consent_banner_test.dart` — the banner renders the refusal notice.
- `consent_rules_panel_test.dart` — the header shows `refused`.
- Full frontend suite passes (`flutter test --coverage`), 100% line coverage
  on all three touched lib files; `flutter analyze` clean.

## Changelog

`docs/changes.md` `[Unreleased]` → Fixed entry added.
