### PR TITLE
Terminal close/rename target by window id (#3288)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -2520,6 +2520,15 @@ git-credential` (#1700).** `pig-latin` removed; `word-count` dormant.
   Playwright suite that runs the browser flow behind a
   prefix-stripping proxy at `/klangk/`.
 
+- **Terminal close/rename target by window id (#3288).** The web UI
+  and the CLI now send the stable tmux window id (`window_id`) when
+  closing or renaming a terminal tab, and the server's rename handler
+  accepts `window_id` the same way close already did. A stale list can
+  no longer close or rename the wrong window when another member's
+  action shifts window indexes between sync and click. Index-only
+  frames keep working (compat with older clients), and a frame with
+  neither field is refused instead of acting on window 0.
+
 - **File viewer and WebSocket error messages (#3227).** A transport
   failure while listing a workspace directory or opening a file, and
   socket/parse errors on the workspace WebSocket, no longer show the

--- a/src/frontend/e2e-tests/e2e/docs-screenshots.spec.ts
+++ b/src/frontend/e2e-tests/e2e/docs-screenshots.spec.ts
@@ -235,7 +235,7 @@ test.describe("documentation screenshots", () => {
       // --- Rename the terminal ---
       ownerWs.send({
         cmd: "terminal_rename_window",
-        index: firstWindow.index as number,
+        window_id: firstWindow.id as string,
         name: "build",
       });
       await ownerWs.recvUntil((m) => m.type === "terminal_windows");

--- a/src/frontend/e2e-tests/e2e/shared-terminals.spec.ts
+++ b/src/frontend/e2e-tests/e2e/shared-terminals.spec.ts
@@ -1147,10 +1147,10 @@ test.describe("shared terminal visibility", () => {
         )[0].window_name as string;
         expect(originalName).toBe(firstWindow.name as string);
 
-        // Admin renames the terminal
+        // Admin renames the terminal — by stable id (#3288)
         adminWs.send({
           cmd: "terminal_rename_window",
-          index: firstWindow.index as number,
+          window_id: firstWindow.id as string,
           name: "my-build",
         });
 

--- a/src/frontend/e2e-tests/e2e/terminal-tabs.spec.ts
+++ b/src/frontend/e2e-tests/e2e/terminal-tabs.spec.ts
@@ -296,10 +296,11 @@ test.describe("terminal tabs", () => {
         )!;
         expect(tempWindow).toBeDefined();
 
-        // Close it
+        // Close it — by stable id, the wire shape every current client
+        // sends (#3288)
         client.send({
           cmd: "terminal_close_window",
-          index: tempWindow.index,
+          window_id: tempWindow.id,
         });
         // The close handler broadcasts a refreshed terminal_windows list,
         // but a stale pre-close frame can arrive first — poll the
@@ -330,12 +331,12 @@ test.describe("terminal tabs", () => {
       const client = await connectToWorkspace(token, workspaceId);
       try {
         const windows = await startTerminalAndGetWindows(client);
-        const firstIndex = windows[0].index;
+        const firstId = windows[0].id;
 
-        // Rename window 0
+        // Rename the first window by its stable id (#3288)
         client.send({
           cmd: "terminal_rename_window",
-          index: firstIndex,
+          window_id: firstId,
           name: "main-shell",
         });
         const msg = await client.recvUntil(
@@ -365,13 +366,18 @@ test.describe("terminal tabs", () => {
 
         // Create a second window named "build"
         client.send({ cmd: "terminal_new_window", name: "build" });
-        await client.recvUntil((m) => m.type === "terminal_windows");
+        const created = await client.recvUntil(
+          (m) => m.type === "terminal_windows",
+        );
 
-        // Renaming window 0 to "build" is permitted — names are
+        // Renaming the first window to "build" is permitted — names are
         // display-only and window identity is the @N id (#2192).
+        const firstId = (created.windows as WindowInfo[]).find(
+          (w) => w.index === 0,
+        )!.id;
         client.send({
           cmd: "terminal_rename_window",
-          index: 0,
+          window_id: firstId,
           name: "build",
         });
         const msg = await client.recvUntil(

--- a/src/frontend/e2e-tests/e2e/terminal-tabs.spec.ts
+++ b/src/frontend/e2e-tests/e2e/terminal-tabs.spec.ts
@@ -339,10 +339,12 @@ test.describe("terminal tabs", () => {
           window_id: firstId,
           name: "main-shell",
         });
-        const msg = await client.recvUntil(
-          (m) => m.type === "terminal_windows",
+        // A stale pre-rename frame can arrive first — poll the
+        // authoritative list until the rename really landed (#3057).
+        const renamed = await waitForWindows(
+          client,
+          (ws) => ws[0].name === "main-shell",
         );
-        const renamed = msg.windows as WindowInfo[];
         expect(renamed[0].name).toBe("main-shell");
       } finally {
         client.close();
@@ -380,12 +382,14 @@ test.describe("terminal tabs", () => {
           window_id: firstId,
           name: "build",
         });
-        const msg = await client.recvUntil(
-          (m) => m.type === "terminal_windows",
-        );
-        const named = (msg.windows as WindowInfo[]).filter(
-          (w) => w.name === "build",
-        );
+        // Poll the authoritative list — a stale pre-rename frame could
+        // arrive first and would lack the second "build" (#3057).
+        const named = (
+          await waitForWindows(
+            client,
+            (ws) => ws.filter((w) => w.name === "build").length === 2,
+          )
+        ).filter((w) => w.name === "build");
         expect(named.length).toBe(2);
         expect(named[0].id).not.toBe(named[1].id);
       } finally {

--- a/src/frontend/e2e-tests/fmtk/test_terminals.py
+++ b/src/frontend/e2e-tests/fmtk/test_terminals.py
@@ -293,7 +293,7 @@ def test_own_terminal_tabs(harness, app):
     # from a right-click the driver cannot perform)
     first = wait_terminal_windows(app, 1)[0]
     app.terminal_eval(
-        f"st!.widget.wsClient.sendTerminalRenameWindow({first['index']}, 'main');"
+        f"st!.widget.wsClient.sendTerminalRenameWindow('{first['id']}', 'main');"
     )
     deadline = time.monotonic() + 15
     while time.monotonic() < deadline:

--- a/src/frontend/lib/workspace/terminal_tabs_view.dart
+++ b/src/frontend/lib/workspace/terminal_tabs_view.dart
@@ -139,12 +139,12 @@ class TerminalTabsView extends StatelessWidget {
                             ),
                             onClose: windows.length > 1
                                 ? () => wsClient.sendTerminalCloseWindow(
-                                      w['index'] as int,
+                                      w['id'] as String? ?? '',
                                     )
                                 : null,
                             onRename: (newName) =>
                                 wsClient.sendTerminalRenameWindow(
-                              w['index'] as int,
+                              w['id'] as String? ?? '',
                               newName,
                             ),
                             onToggleShare: _toggleShareHandler(w),

--- a/src/frontend/lib/ws/ws_client.dart
+++ b/src/frontend/lib/ws/ws_client.dart
@@ -772,12 +772,16 @@ class WsClient extends ChangeNotifier {
     _send({'cmd': 'terminal_select_window', 'window_id': windowId});
   }
 
-  void sendTerminalCloseWindow(int index) {
-    _send({'cmd': 'terminal_close_window', 'index': index});
+  void sendTerminalCloseWindow(String windowId) {
+    _send({'cmd': 'terminal_close_window', 'window_id': windowId});
   }
 
-  void sendTerminalRenameWindow(int index, String name) {
-    _send({'cmd': 'terminal_rename_window', 'index': index, 'name': name});
+  void sendTerminalRenameWindow(String windowId, String name) {
+    _send({
+      'cmd': 'terminal_rename_window',
+      'window_id': windowId,
+      'name': name,
+    });
   }
 
   void sendTerminalListWindows() {

--- a/src/frontend/test/terminal_tabs_view_test.dart
+++ b/src/frontend/test/terminal_tabs_view_test.dart
@@ -51,12 +51,12 @@ class _MockWsClient extends WsClient {
   void sendTerminalStop() => sentCommands.add('terminal_stop');
 
   @override
-  void sendTerminalCloseWindow(int index) =>
-      sentCommands.add('close_window:$index');
+  void sendTerminalCloseWindow(String windowId) =>
+      sentCommands.add('close_window:$windowId');
 
   @override
-  void sendTerminalRenameWindow(int index, String name) =>
-      sentCommands.add('rename_window:$index:$name');
+  void sendTerminalRenameWindow(String windowId, String name) =>
+      sentCommands.add('rename_window:$windowId:$name');
 
   @override
   void sendTerminalNewWindow({String? name}) => sentCommands.add('new_window');
@@ -513,7 +513,7 @@ void main() {
       await tester.tap(find.text('OK'));
       await tester.pumpAndSettle();
 
-      expect(client.sentCommands, contains('rename_window:0:zsh'));
+      expect(client.sentCommands, contains('rename_window:w1:zsh'));
     });
 
     testWidgets('context menu rename cancel does not rename', (tester) async {
@@ -793,7 +793,8 @@ void main() {
 
       // Find close icons and tap the first one
       await tester.tap(find.byIcon(Icons.close).first);
-      expect(client.sentCommands, contains('close_window:0'));
+      // Close addresses the window by its stable id, not the index (#3288).
+      expect(client.sentCommands, contains('close_window:w1'));
     });
 
     testWidgets('long handle and window name are truncated in shared tab',
@@ -942,7 +943,7 @@ void main() {
       await tester.testTextInput.receiveAction(TextInputAction.done);
       await tester.pumpAndSettle();
 
-      expect(client.sentCommands, contains('rename_window:0:fish'));
+      expect(client.sentCommands, contains('rename_window:w1:fish'));
     });
 
     testWidgets('hover exit on + button resets state', (tester) async {

--- a/src/frontend/test/ws_client_test.dart
+++ b/src/frontend/test/ws_client_test.dart
@@ -408,8 +408,8 @@ void main() {
       client.sendTerminalNewWindow();
       client.sendTerminalNewWindow(name: 'build');
       client.sendTerminalSelectWindow('@1');
-      client.sendTerminalCloseWindow(1);
-      client.sendTerminalRenameWindow(0, 'test');
+      client.sendTerminalCloseWindow('@1');
+      client.sendTerminalRenameWindow('@0', 'test');
       client.sendTerminalListWindows();
       client.sendShareWindow('@0');
       client.sendUnshareWindow('@0');
@@ -1386,8 +1386,8 @@ void main() {
       client.sendTerminalResize(120, 40);
       client.sendTerminalNewWindow(name: 'build');
       client.sendTerminalSelectWindow('@2');
-      client.sendTerminalCloseWindow(1);
-      client.sendTerminalRenameWindow(0, 'main');
+      client.sendTerminalCloseWindow('@3');
+      client.sendTerminalRenameWindow('@0', 'main');
       client.sendTerminalListWindows();
       client.sendShareWindow('@0');
       client.sendUnshareWindow('@0');
@@ -1408,10 +1408,13 @@ void main() {
       expect(msgs[3], {'cmd': 'terminal_resize', 'cols': 120, 'rows': 40});
       expect(msgs[4], {'cmd': 'terminal_new_window', 'name': 'build'});
       expect(msgs[5], {'cmd': 'terminal_select_window', 'window_id': '@2'});
-      expect(msgs[6], {'cmd': 'terminal_close_window', 'index': 1});
+      // Close and rename address windows by their stable @N id — never a
+      // positional index, which a concurrent window mutation can shift
+      // between sync and click (#3288).
+      expect(msgs[6], {'cmd': 'terminal_close_window', 'window_id': '@3'});
       expect(msgs[7], {
         'cmd': 'terminal_rename_window',
-        'index': 0,
+        'window_id': '@0',
         'name': 'main',
       });
       expect(msgs[8], {'cmd': 'terminal_list_windows'});

--- a/src/klangk/klangk/cli/client.py
+++ b/src/klangk/klangk/cli/client.py
@@ -908,10 +908,10 @@ class KlangkClient:
         )
 
     async def rename_terminal(
-        self, name: str, index: int, new_name: str
+        self, name: str, window_id: str, new_name: str
     ) -> list[dict]:
-        """Rename terminal window at *index* in workspace *name*; return list."""
-        return await self.terminals(name, rename=(index, new_name))
+        """Rename terminal window *window_id* in workspace *name*; return list."""
+        return await self.terminals(name, rename=(window_id, new_name))
 
     async def _maybe_close_window(
         self, conn, windows: list[dict], close_window_id
@@ -947,12 +947,12 @@ class KlangkClient:
     ) -> list[dict]:
         """Rename the requested window; the refreshed window list."""
         if rename is not None and windows:
-            idx, new_name = rename
+            window_id, new_name = rename
             await conn.send(
                 json.dumps(
                     {
                         "cmd": "terminal_rename_window",
-                        "index": idx,
+                        "window_id": window_id,
                         "name": new_name,
                     }
                 )
@@ -967,7 +967,7 @@ class KlangkClient:
         close_window_id: str | None = None,
         create_window: bool = False,
         window_name: str | None = None,
-        rename: tuple[int, str] | None = None,
+        rename: tuple[str, str] | None = None,
     ) -> list[dict]:
         try:
             ws = self.resolve_workspace(name)

--- a/src/klangk/klangk/cli/client.py
+++ b/src/klangk/klangk/cli/client.py
@@ -942,21 +942,32 @@ class KlangkClient:
             return await self._recv_windows(conn)
         return windows
 
+    @staticmethod
+    def _window_index(windows: list[dict], window_id: str):
+        """The current index of *window_id* in *windows*, or None."""
+        return next(
+            (w.get("index") for w in windows if w.get("id") == window_id),
+            None,
+        )
+
     async def _maybe_rename_window(
         self, conn, windows: list[dict], rename
     ) -> list[dict]:
         """Rename the requested window; the refreshed window list."""
         if rename is not None and windows:
             window_id, new_name = rename
-            await conn.send(
-                json.dumps(
-                    {
-                        "cmd": "terminal_rename_window",
-                        "window_id": window_id,
-                        "name": new_name,
-                    }
-                )
-            )
+            # Send the stable id and the row's current index: current
+            # servers prefer the id, pre-#3288 servers ignore it and
+            # would otherwise default the missing index to window 0.
+            index = self._window_index(windows, window_id)
+            cmd = {
+                "cmd": "terminal_rename_window",
+                "window_id": window_id,
+                "name": new_name,
+            }
+            if index is not None:
+                cmd["index"] = index
+            await conn.send(json.dumps(cmd))
             return await self._recv_windows(conn)
         return windows
 

--- a/src/klangk/klangk/cli/tui/screens/workspace_detail.py
+++ b/src/klangk/klangk/cli/tui/screens/workspace_detail.py
@@ -1184,10 +1184,16 @@ class WorkspaceDetailScreen(StatusScreen):
         child = lv.highlighted_child
         if child is None or not child.name:
             return
-        # The rename controller targets the window by INDEX (tmux
-        # rename-window -t session:INDEX), not the @N id used by select /
-        # delete. The list row key *is* the index (#1965).
-        index = int(child.name)
+        # Target the window by its stable @N id, not the row index —
+        # a stale list could otherwise rename the wrong window (#3288).
+        # The resolution matches delete_terminal's (#1965).
+        window_id = self._window_id_for(child.name)
+        if window_id is None:
+            self.msg(
+                "Terminal no longer exists — refreshing list.", error=True
+            )
+            self.run_worker(self._load_terminals, exit_on_error=False)
+            return
         current = self._terminal_label_for(child.name)
 
         def _on_rename(new_name: str | None) -> None:
@@ -1196,7 +1202,7 @@ class WorkspaceDetailScreen(StatusScreen):
             if not new_name or new_name == current:
                 return
             self.run_worker(
-                self._do_rename_terminal(index, new_name),
+                self._do_rename_terminal(window_id, new_name),
                 exit_on_error=False,
             )
 
@@ -1210,16 +1216,16 @@ class WorkspaceDetailScreen(StatusScreen):
             _on_rename,
         )
 
-    async def _do_rename_terminal(self, index: int, new_name: str) -> None:
+    async def _do_rename_terminal(self, window_id: str, new_name: str) -> None:
         try:
             windows = await self.app.tui_state.rename_terminal(
-                self._name, index, new_name
+                self._name, window_id, new_name
             )
         except Exception as exc:
             self.app.notify(
                 f"Rename failed: {exc}", severity="error", timeout=8
             )
-            # Stale index — refresh so the row self-heals (#1965).
+            # Stale target — refresh so the row self-heals (#1965).
             await self._load_terminals()
             return
         if not windows:

--- a/src/klangk/klangk/cli/tui/state.py
+++ b/src/klangk/klangk/cli/tui/state.py
@@ -483,9 +483,9 @@ class TuiState:
         return await self.client().create_terminal(name, window_name)
 
     async def rename_terminal(
-        self, name: str, index: int, new_name: str
+        self, name: str, window_id: str, new_name: str
     ) -> list[dict]:
-        return await self.client().rename_terminal(name, index, new_name)
+        return await self.client().rename_terminal(name, window_id, new_name)
 
     # --- auth mode (probed live via /config) ---
 

--- a/src/klangk/klangk/terminal.py
+++ b/src/klangk/klangk/terminal.py
@@ -954,10 +954,13 @@ class Terminal:
         self,
         container_id: str,
         session_name: str,
-        index: int,
+        target: int | str,
         name: str,
     ) -> None:
         """Rename a tmux window.
+
+        *target* can be a window index (int), window name (str), or
+        window id (``@N`` string — preferred, globally unique).
 
         Raises ``ValueError`` if *name* contains unsafe characters.
         Window names are display-only, so duplicate names are permitted —
@@ -971,7 +974,7 @@ class Terminal:
             [
                 "rename-window",
                 "-t",
-                _window_target(session_name, index),
+                _window_target(session_name, target),
                 name,
             ],
         )

--- a/src/klangk/klangk/wshandler/controllers.py
+++ b/src/klangk/klangk/wshandler/controllers.py
@@ -1401,13 +1401,17 @@ class TerminalController:
     def _window_target(msg: dict) -> int | str | None:
         """Prefer @N window_id (stable); fall back to index for compat.
 
-        None when the frame carries neither field — callers refuse
-        rather than act on a defaulted window 0 (#3288).
+        None when the frame carries neither usable field — callers refuse
+        rather than act on a defaulted window 0 (#3288). An empty-string
+        index is unusable too: ``sess:`` would match a window named "".
         """
         window_id = msg.get("window_id")
         if window_id:
             return window_id
-        return msg.get("index")
+        index = msg.get("index")
+        if index is None or index == "":
+            return None
+        return index
 
     async def forward_output(self, session: TerminalSession) -> None:
         """Forward terminal output to the frontend via WebSocket."""

--- a/src/klangk/klangk/wshandler/controllers.py
+++ b/src/klangk/klangk/wshandler/controllers.py
@@ -1190,7 +1190,10 @@ class TerminalController:
         # affects this client, not other connections to the same workspace.
         session_name = self._grouped_session_name()
         # Prefer @N window_id (stable); fall back to index for compat.
-        target: int | str = self._window_target(msg)
+        target: int | str | None = self._window_target(msg)
+        if target is None:
+            send_error(self._conn.sock, "window_id or index required")
+            return
         try:
             await self._conn.app.state.terminal.select_window(
                 self._conn.container_id,
@@ -1212,7 +1215,10 @@ class TerminalController:
 
         session_name = self.tmux_session_name()
         # Prefer @N window_id (stable); fall back to index for compat (#1965).
-        target: int | str = self._window_target(msg)
+        target: int | str | None = self._window_target(msg)
+        if target is None:
+            send_error(self._conn.sock, "window_id or index required")
+            return
         try:
             terminal = self._conn.app.state.terminal
             windows = await terminal.list_windows(
@@ -1241,7 +1247,12 @@ class TerminalController:
             return
 
         session_name = self.tmux_session_name()
-        index = msg.get("index", 0)
+        # Prefer @N window_id (stable); fall back to index for
+        # compat — the same resolution close_window uses (#3288).
+        target: int | str | None = self._window_target(msg)
+        if target is None:
+            send_error(self._conn.sock, "window_id or index required")
+            return
         name = msg.get("name", "")
         if not name:
             send_error(self._conn.sock, "Name required")
@@ -1250,7 +1261,7 @@ class TerminalController:
             await self._conn.app.state.terminal.rename_window(
                 self._conn.container_id,
                 session_name,
-                index,
+                target,
                 name,
             )
             windows = await self._conn.app.state.terminal.list_windows(
@@ -1387,9 +1398,16 @@ class TerminalController:
         return self.tmux_session_name()
 
     @staticmethod
-    def _window_target(msg: dict) -> int | str:
-        """Prefer @N window_id (stable); fall back to index for compat."""
-        return msg.get("window_id") or msg.get("index", 0)
+    def _window_target(msg: dict) -> int | str | None:
+        """Prefer @N window_id (stable); fall back to index for compat.
+
+        None when the frame carries neither field — callers refuse
+        rather than act on a defaulted window 0 (#3288).
+        """
+        window_id = msg.get("window_id")
+        if window_id:
+            return window_id
+        return msg.get("index")
 
     async def forward_output(self, session: TerminalSession) -> None:
         """Forward terminal output to the frontend via WebSocket."""

--- a/src/klangk/klangkc-tests/tests/test_cli.py
+++ b/src/klangk/klangkc-tests/tests/test_cli.py
@@ -2267,8 +2267,60 @@ class TestKlangkClient:
             s for s in sent if s.get("cmd") == "terminal_rename_window"
         ]
         assert len(rename_cmds) == 1
+        # Current servers prefer the stable id; the index rides along so
+        # a pre-#3288 server (index-only) still targets the right window
+        # instead of defaulting to window 0.
         assert rename_cmds[0]["window_id"] == "@1"
+        assert rename_cmds[0]["index"] == 1
         assert rename_cmds[0]["name"] == "ci"
+
+    def test_rename_terminal_stale_id_omits_index(self):
+        """A window id absent from the synced list sends no index — an
+        old server must refuse rather than default to window 0."""
+        client = KlangkClient("http://test:8995", "token")
+        ws = Workspace(id="ws" + "0" * 60, name="alpha", created_at="x")
+        client.resolve_workspace = MagicMock(return_value=ws)
+        messages = [
+            json.dumps({"type": "container_ready"}),
+            json.dumps(
+                {"type": "event", "event": {"name": "container_ready"}}
+            ),
+            json.dumps(
+                {
+                    "type": "terminal_windows",
+                    "windows": [
+                        {"index": 0, "name": "main", "id": "@0"},
+                        {"index": 1, "name": "build", "id": "@1"},
+                    ],
+                }
+            ),
+            json.dumps(
+                {
+                    "type": "terminal_windows",
+                    "windows": [
+                        {"index": 0, "name": "main", "id": "@0"},
+                        {"index": 1, "name": "build", "id": "@1"},
+                    ],
+                }
+            ),
+        ]
+        mock_ws = AsyncMock()
+        mock_ws.recv = AsyncMock(side_effect=messages)
+        mock_ws.send = AsyncMock()
+        mock_ws.__aenter__ = AsyncMock(return_value=mock_ws)
+        mock_ws.__aexit__ = AsyncMock(return_value=False)
+        with patch(
+            "klangk.cli.transport.websockets.connect",
+            return_value=mock_ws,
+        ):
+            asyncio.run(client.rename_terminal("alpha", "@9", "ci"))
+        sent = [json.loads(c.args[0]) for c in mock_ws.send.call_args_list]
+        rename_cmds = [
+            s for s in sent if s.get("cmd") == "terminal_rename_window"
+        ]
+        assert len(rename_cmds) == 1
+        assert rename_cmds[0]["window_id"] == "@9"
+        assert "index" not in rename_cmds[0]
 
     def test_list_workspaces_parses_response(self):
         client = KlangkClient("http://test:8995", "valid-token")

--- a/src/klangk/klangkc-tests/tests/test_cli.py
+++ b/src/klangk/klangkc-tests/tests/test_cli.py
@@ -2258,16 +2258,16 @@ class TestKlangkClient:
             "klangk.cli.transport.websockets.connect",
             return_value=mock_ws,
         ):
-            windows = asyncio.run(client.rename_terminal("alpha", 1, "ci"))
+            windows = asyncio.run(client.rename_terminal("alpha", "@1", "ci"))
         assert len(windows) == 2
         assert windows[1]["name"] == "ci"
-        # Verify terminal_rename_window was sent with index + name
+        # Verify terminal_rename_window was sent with the stable id + name
         sent = [json.loads(c.args[0]) for c in mock_ws.send.call_args_list]
         rename_cmds = [
             s for s in sent if s.get("cmd") == "terminal_rename_window"
         ]
         assert len(rename_cmds) == 1
-        assert rename_cmds[0]["index"] == 1
+        assert rename_cmds[0]["window_id"] == "@1"
         assert rename_cmds[0]["name"] == "ci"
 
     def test_list_workspaces_parses_response(self):

--- a/src/klangk/klangkc-tests/tests/test_tui.py
+++ b/src/klangk/klangkc-tests/tests/test_tui.py
@@ -1042,8 +1042,8 @@ async def test_rename_terminal_delegates(monkeypatch, redirect_xdg):
 
     renamed = {}
 
-    async def fake_rename(name, index, new_name):
-        renamed.update(name=name, index=index, new=new_name)
+    async def fake_rename(name, window_id, new_name):
+        renamed.update(name=name, window_id=window_id, new=new_name)
         return [
             {"index": 0, "name": "main"},
             {"index": 1, "name": new_name},
@@ -1055,8 +1055,8 @@ async def test_rename_terminal_delegates(monkeypatch, redirect_xdg):
     fake_client.rename_terminal = fake_rename
     t = TuiState("https://x.example")
     monkeypatch.setattr(t, "client", lambda: fake_client)
-    result = await t.rename_terminal("ws1", 1, "ci")
-    assert renamed == {"name": "ws1", "index": 1, "new": "ci"}
+    result = await t.rename_terminal("ws1", "@1", "ci")
+    assert renamed == {"name": "ws1", "window_id": "@1", "new": "ci"}
     assert len(result) == 2
 
 
@@ -8820,8 +8820,8 @@ async def test_detail_rename_terminal(monkeypatch):
 
     renamed = {}
 
-    async def _rename(name, index, new_name):
-        renamed.update(name=name, index=index, new=new_name)
+    async def _rename(name, window_id, new_name):
+        renamed.update(name=name, window_id=window_id, new=new_name)
         return [
             {"index": 0, "name": "main", "id": "@0"},
             {"index": 1, "name": new_name, "id": "@1"},
@@ -8852,7 +8852,7 @@ async def test_detail_rename_terminal(monkeypatch):
         app.screen.on_button_pressed(FakeBtnPress("ok"))
         for _ in range(4):
             await pilot.pause()
-        assert renamed == {"name": "alpha", "index": 1, "new": "ci"}
+        assert renamed == {"name": "alpha", "window_id": "@1", "new": "ci"}
         assert any("Renamed terminal to 'ci'" in m for m in notified)
 
 
@@ -8876,6 +8876,49 @@ async def test_detail_rename_terminal_no_selection(monkeypatch):
         await app.workers.wait_for_complete()
         await pilot.pause()
         # No InputScreen pushed — still on the detail screen.
+        assert app.screen is d
+
+
+async def test_detail_rename_terminal_stale_row_refuses(monkeypatch):
+    """A row whose window has no resolvable id refuses to rename and
+    refreshes the list, rather than risking the wrong window (#3288)."""
+
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr_main, "listen_for_status", noop)
+    a = _wsobj("alpha")
+    calls = {"rename": 0, "list": 0}
+
+    async def _terms_no_id(*a, **k):
+        calls["list"] += 1
+        return [
+            {"index": 0, "name": "main", "id": "@0"},
+            {"index": 1, "name": "build"},  # no id — contract violation
+        ]
+
+    async def _rename(name, window_id, new_name):
+        calls["rename"] += 1
+        return []
+
+    st = _ws(list_terminals=_terms_no_id, rename_terminal=_rename)
+    st.find_workspace = lambda n: a
+    app = KlangkApp(st)
+    async with app.run_test() as pilot:
+        app.push_screen(WorkspaceDetailScreen("alpha"))
+        await pilot.pause()
+        await app.screen._load_terminals()
+        await pilot.pause()
+        d = app.screen
+        d.query_one("#term_list").index = 1
+        before = calls["list"]
+        d.action_rename_terminal()
+        for _ in range(4):
+            await pilot.pause()
+        # No rename sent, no InputScreen pushed, and the list refreshed.
+        assert calls["rename"] == 0
+        assert calls["list"] > before
+        assert "no longer exists" in str(d.query_one("#detail_msg").render())
         assert app.screen is d
 
 
@@ -8915,7 +8958,7 @@ async def test_detail_rename_terminal_failure(monkeypatch):
     async def noop(*a, **k):
         return None
 
-    async def _rename(name, index, new_name):
+    async def _rename(name, window_id, new_name):
         raise RuntimeError("boom")
 
     monkeypatch.setattr(scr_main, "listen_for_status", noop)
@@ -8947,7 +8990,7 @@ async def test_detail_rename_terminal_empty_result(monkeypatch):
     async def noop(*a, **k):
         return None
 
-    async def _rename(name, index, new_name):
+    async def _rename(name, window_id, new_name):
         return []
 
     monkeypatch.setattr(scr_main, "listen_for_status", noop)

--- a/src/klangk/klangkd-tests/tests/test_terminal.py
+++ b/src/klangk/klangkd-tests/tests/test_terminal.py
@@ -1115,6 +1115,21 @@ class TestRenameWindow:
             ["rename-window", "-t", "sess:0", "build"],
         )
 
+    async def test_renames_window_by_id(self):
+        # A @N window id stays session-qualified (grouped-session safety,
+        # #1883) — the same resolution select_window uses (#3288).
+        with patch.object(
+            _terminal,
+            "tmux_command",
+            return_value="",
+        ) as mock_cmd:
+            await _terminal.rename_window("cid", "sess", "@3", "build")
+        mock_cmd.assert_called_once_with(
+            "cid",
+            "sess",
+            ["rename-window", "-t", "sess:@3", "build"],
+        )
+
     async def test_rejects_shell_injection(self):
         with pytest.raises(ValueError, match="only contain"):
             await _terminal.rename_window("cid", "sess", 0, "';rm -rf /;'")

--- a/src/klangk/klangkd-tests/tests/test_wshandler.py
+++ b/src/klangk/klangkd-tests/tests/test_wshandler.py
@@ -7900,6 +7900,7 @@ class TestTerminalWindowHandlers:
                 {"index": "", "name": "build"}
             )
         mock_ren.assert_not_called()
+        assert sock.send_json.call_count == 2
         sent = sock.send_json.call_args[0][0]
         assert sent["type"] == "error"
         assert "window_id or index" in sent["message"]

--- a/src/klangk/klangkd-tests/tests/test_wshandler.py
+++ b/src/klangk/klangkd-tests/tests/test_wshandler.py
@@ -7894,6 +7894,11 @@ class TestTerminalWindowHandlers:
         conn._user_home = "/home/alice"
         with patch.object(_mock_term, "rename_window") as mock_ren:
             await conn.handle_terminal_rename_window({"name": "build"})
+            # An empty-string index is not a usable target either —
+            # ``sess:`` would match a window named "" (#3288).
+            await conn.handle_terminal_rename_window(
+                {"index": "", "name": "build"}
+            )
         mock_ren.assert_not_called()
         sent = sock.send_json.call_args[0][0]
         assert sent["type"] == "error"

--- a/src/klangk/klangkd-tests/tests/test_wshandler.py
+++ b/src/klangk/klangkd-tests/tests/test_wshandler.py
@@ -7638,6 +7638,20 @@ class TestTerminalWindowHandlers:
         sent = sock.send_json.call_args[0][0]
         assert sent["type"] == "error"
 
+    async def test_select_window_missing_target_refused(self):
+        """A select frame with neither window_id nor index is refused,
+        not defaulted to window 0 (#3288)."""
+        sock = _mock_sock()
+        conn = _base_conn(ws=sock, perms=("code-in-isolation",))
+        conn.container_id = "cid"
+        conn._user_home = "/home/alice"
+        with patch.object(_mock_term, "select_window") as mock_sel:
+            await conn.handle_terminal_select_window({})
+        mock_sel.assert_not_called()
+        sent = sock.send_json.call_args[0][0]
+        assert sent["type"] == "error"
+        assert "window_id or index" in sent["message"]
+
     async def test_close_window(self):
         sock = _mock_sock()
         conn = _base_conn(ws=sock, perms=("code-in-isolation",))
@@ -7784,6 +7798,23 @@ class TestTerminalWindowHandlers:
             )
             assert _mock_term.close_window.call_args[0][2] == "@1"
 
+    async def test_close_window_missing_target_refused(self):
+        """A close frame with neither window_id nor index is refused,
+        not defaulted to window 0 (#3288)."""
+        sock = _mock_sock()
+        conn = _base_conn(ws=sock, perms=("code-in-isolation",))
+        conn.container_id = "cid"
+        conn._user_home = "/home/alice"
+        with (
+            patch.object(_mock_term, "list_windows"),
+            patch.object(_mock_term, "close_window"),
+        ):
+            await conn.handle_terminal_close_window({})
+        _mock_term.close_window.assert_not_called()
+        sent = sock.send_json.call_args[0][0]
+        assert sent["type"] == "error"
+        assert "window_id or index" in sent["message"]
+
     async def test_rename_window(self):
         sock = _mock_sock()
         conn = _base_conn(ws=sock, perms=("code-in-isolation",))
@@ -7805,8 +7836,68 @@ class TestTerminalWindowHandlers:
             await conn.handle_terminal_rename_window(
                 {"index": 0, "name": "build"}
             )
+            # Index-only frames keep working — the compat fallback (#3288).
+            assert _mock_term.rename_window.call_args[0][2] == 0
         sent = sock.send_json.call_args[0][0]
         assert sent["type"] == "terminal_windows"
+
+    async def test_rename_window_by_id(self):
+        sock = _mock_sock()
+        conn = _base_conn(ws=sock, perms=("code-in-isolation",))
+        conn.container_id = "cid"
+        conn._user_home = "/home/alice"
+        with (
+            patch.object(_mock_term, "rename_window"),
+            patch.object(
+                _mock_term,
+                "list_windows",
+                return_value=[
+                    {"id": "@1", "index": 1, "name": "build", "active": True}
+                ],
+            ),
+        ):
+            await conn.handle_terminal_rename_window(
+                {"window_id": "@1", "name": "build"}
+            )
+            # Targeted the window by its stable id, not an index (#3288).
+            assert _mock_term.rename_window.call_args[0][2] == "@1"
+        sent = sock.send_json.call_args[0][0]
+        assert sent["type"] == "terminal_windows"
+
+    async def test_rename_window_prefers_window_id(self):
+        sock = _mock_sock()
+        conn = _base_conn(ws=sock, perms=("code-in-isolation",))
+        conn.container_id = "cid"
+        conn._user_home = "/home/alice"
+        with (
+            patch.object(_mock_term, "rename_window"),
+            patch.object(
+                _mock_term,
+                "list_windows",
+                return_value=[
+                    {"id": "@1", "index": 1, "name": "build", "active": True}
+                ],
+            ),
+        ):
+            # Both present → window_id wins over index (#3288).
+            await conn.handle_terminal_rename_window(
+                {"window_id": "@1", "index": 0, "name": "build"}
+            )
+            assert _mock_term.rename_window.call_args[0][2] == "@1"
+
+    async def test_rename_window_missing_target_refused(self):
+        """A rename frame with neither window_id nor index is refused,
+        not defaulted to window 0 (#3288)."""
+        sock = _mock_sock()
+        conn = _base_conn(ws=sock, perms=("code-in-isolation",))
+        conn.container_id = "cid"
+        conn._user_home = "/home/alice"
+        with patch.object(_mock_term, "rename_window") as mock_ren:
+            await conn.handle_terminal_rename_window({"name": "build"})
+        mock_ren.assert_not_called()
+        sent = sock.send_json.call_args[0][0]
+        assert sent["type"] == "error"
+        assert "window_id or index" in sent["message"]
 
     async def test_rename_window_no_name(self):
         sock = _mock_sock()
@@ -8648,6 +8739,17 @@ class TestTerminalController:
         ctrl, sock, _ = self._controller()
         await ctrl.rename_window({"index": 0, "name": ""})
         assert sock.send_json.call_args[0][0]["type"] == "error"
+
+    async def test_rename_window_missing_target_sends_error(self):
+        """Neither window_id nor index → error, not a rename of window 0
+        (#3288)."""
+        ctrl, sock, _ = self._controller()
+        with patch.object(_mock_term, "rename_window") as mock_ren:
+            await ctrl.rename_window({"name": "build"})
+        mock_ren.assert_not_called()
+        msg = sock.send_json.call_args[0][0]
+        assert msg["type"] == "error"
+        assert "window_id or index" in msg["message"]
 
     async def test_list_windows_no_container(self):
         ctrl, sock, _ = self._controller(container_id=None)


### PR DESCRIPTION
## Summary

Window identity was settled as the stable tmux `@N` id in #2192, and
`close_window` already had an id path (#1965) — but the two **destructive**
operations never finished the migration:

- The web client sent **index only** for close/rename
  (`sendTerminalCloseWindow(int index)`), never the `window_id` sitting in the
  same window dict — so the server's stable-id path for close was dead code in
  practice.
- The server's `rename_window` read only `msg["index"]` and **defaulted to 0**
  when the field was missing.

Any concurrent window mutation (another member's shared-terminal op, the same
user's second tab, the agent's service-cmd window churning via
`sync_service_windows`) shifts indexes between the client's last
`terminal_windows` sync and the click — a stale index then `kill-window`s or
mislabels the **wrong** window. This is the index variant of the failure mode
#2192 documented when it moved identity off names.

Fixes #3288.

## Changes

- **Web client** (`ws_client.dart`): `sendTerminalCloseWindow` /
  `sendTerminalRenameWindow` take the window id and send `window_id`;
  `terminal_tabs_view.dart` passes `w['id']` (already present) instead of
  `w['index']`. A widget test pins the wire shape (close/rename frames carry
  `window_id`).
- **CLI/TUI**: `rename_terminal` now takes the window id and sends `window_id`;
  `action_rename_terminal` resolves the highlighted row to its stable `@N` id
  via `_window_id_for` — the same resolution delete uses (#1965) — and refuses
  (notify + refresh) when the row no longer resolves.
- **Server** (`wshandler/controllers.py`): `rename_window` resolves its target
  through the shared `_window_target(msg)` helper close already uses — id
  preferred, index kept as a compat fallback for old clients. `_window_target`
  now returns `None` when a frame carries neither field, and select / close /
  rename all **refuse** such frames instead of defaulting to window 0.
- **Service** (`terminal.py`): `rename_window` accepts `target: int | str` like
  select/close; an `@N` id stays session-qualified (`sess:@3`) for
  grouped-session safety (#1883), matching `select_window`'s behavior.

## Testing

- `test_wshandler.py`: rename by id, rename prefers id over index, refusal
  (neither field → error, no tmux call) for select/close/rename, index-only
  compat fallback.
- `test_terminal.py`: rename with an `@N` target produces `sess:@3`.
- `test_cli.py` / `test_tui.py`: rename sends `window_id`; the TUI stale-row
  refusal path.
- Flutter: `ws_client_test.dart` wire-shape pin; `terminal_tabs_view_test.dart`
  close/rename address the tab's id.
- Full suites green at 100% branch coverage: Python (`-n auto`, 8025 passed)
  and Flutter (`flutter test --coverage`).
