### PR TITLE
Bound workspace import decompression: metadata cap + free-space pre-scan (#3284)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -351,6 +351,16 @@ operators or integrators to act when upgrading.
   attacker (silent account takeover). Name-accessed deployments must set
   `KLANGKD_HOSTING_HOSTNAME`; see the Breaking entry.
 
+- **Workspace import decompression bounds (#3284).** The import
+  endpoint bounds the archive's decompressed payload, not just the
+  compressed upload: a `workspace.json` member beyond 1 MB is rejected
+  with 413 (previously it accumulated unbounded in memory — a small
+  crafted archive could OOM klangkd), and the `home/` tree is
+  pre-scanned and rejected with 413 when it would exceed the free
+  space on the workspace volume (2 GB kept in reserve) or the new
+  `import_max_uncompressed_mb` cap (`KLANGKD_IMPORT_MAX_UNCOMPRESSED_MB`).
+  Large legitimate imports succeed whenever the volume has room.
+
 - **Bind-mount re-validation at container start (#3278).** A mount's
   host-path source is now checked against
   `KLANGKD_ALLOWED_MOUNT_ROOTS` and the protected-path blocklist every

--- a/docs/reference/klangkd-config.md
+++ b/docs/reference/klangkd-config.md
@@ -577,9 +577,17 @@ setting.
 
 ### File upload
 
-| Key                    | Default     | Env var                        |
-| ---------------------- | ----------- | ------------------------------ |
-| `file_upload_size_max` | `524288000` | `KLANGKD_FILE_UPLOAD_SIZE_MAX` |
+| Key                          | Default     | Env var                              |
+| ---------------------------- | ----------- | ------------------------------------ |
+| `file_upload_size_max`       | `524288000` | `KLANGKD_FILE_UPLOAD_SIZE_MAX`       |
+| `import_max_uncompressed_mb` | _(unset)_   | `KLANGKD_IMPORT_MAX_UNCOMPRESSED_MB` |
+
+`file_upload_size_max` bounds the compressed upload. Workspace imports are
+bounded on the decompressed side too (#3284): the archive's `workspace.json`
+member is capped at 1 MB, and the `home/` tree is pre-scanned and refused
+with 413 when it would exceed the free space on the workspace volume (a
+2 GB reserve is kept) or `import_max_uncompressed_mb`. A legitimate
+multi-gigabyte home import succeeds whenever the volume has room.
 
 ### Feature configuration
 

--- a/docs/reference/klangkd-config.md
+++ b/docs/reference/klangkd-config.md
@@ -587,7 +587,10 @@ bounded on the decompressed side too (#3284): the archive's `workspace.json`
 member is capped at 1 MB, and the `home/` tree is pre-scanned and refused
 with 413 when it would exceed the free space on the workspace volume (a
 2 GB reserve is kept) or `import_max_uncompressed_mb`. A legitimate
-multi-gigabyte home import succeeds whenever the volume has room.
+multi-gigabyte home import succeeds whenever the volume has room. The
+free-space check runs per import: two imports started at the same time can
+together consume more than either alone would pass, so the reserve is a
+working margin rather than a hard guarantee against a full disk.
 
 ### Feature configuration
 

--- a/docs/reference/klangkd-config.md
+++ b/docs/reference/klangkd-config.md
@@ -590,7 +590,10 @@ with 413 when it would exceed the free space on the workspace volume (a
 multi-gigabyte home import succeeds whenever the volume has room. The
 free-space check runs per import: two imports started at the same time can
 together consume more than either alone would pass, so the reserve is a
-working margin rather than a hard guarantee against a full disk.
+working margin rather than a hard guarantee against a full disk. The
+pre-scan must finish within 30 seconds; an archive that takes longer to list
+(because it expands to hundreds of gigabytes of members) is refused as an
+invalid archive.
 
 ### Feature configuration
 

--- a/src/klangk/klangk/api/workspaces.py
+++ b/src/klangk/klangk/api/workspaces.py
@@ -4,6 +4,7 @@ import asyncio
 import json
 import logging
 import os
+import re
 import shutil
 import subprocess
 import tempfile
@@ -1423,6 +1424,54 @@ async def _stream_upload_to_tempfile(
     return tmp.name, total
 
 
+# workspace.json is server-generated metadata — a few KB. A hard byte
+# bound keeps a crafted multi-GB member from accumulating in Python
+# memory before json.loads ever runs (#3284); anything near 1 MB is
+# already corrupt or hostile.
+_METADATA_MAX_BYTES = 1024 * 1024
+
+
+class _MetadataTooLarge(Exception):
+    """workspace.json exceeded the metadata byte bound (#3284)."""
+
+
+def _read_capped(proc: subprocess.Popen) -> bytes:
+    """Read *proc*'s stdout up to ``_METADATA_MAX_BYTES`` and stop.
+
+    Closing the read end SIGPIPEs tar, so an arbitrarily large member
+    costs at most the cap in memory (#3284)."""
+    assert proc.stdout is not None
+    chunks: list[bytes] = []
+    total = 0
+    while chunk := proc.stdout.read(65536):
+        total += len(chunk)
+        if total > _METADATA_MAX_BYTES:
+            raise _MetadataTooLarge
+        chunks.append(chunk)
+    return b"".join(chunks)
+
+
+def _extract_capped_metadata(archive_path: str) -> bytes:
+    """tar -O extract of workspace.json under the metadata byte bound.
+
+    Raises ``subprocess.CalledProcessError`` when the member is missing
+    or the archive is corrupt, ``_MetadataTooLarge`` past the bound."""
+    with subprocess.Popen(
+        ["tar", "xzf", archive_path, "-O", "workspace.json"],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.DEVNULL,
+    ) as proc:
+        try:
+            payload = _read_capped(proc)
+            proc.wait(timeout=30)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            raise
+    if proc.returncode != 0:
+        raise subprocess.CalledProcessError(proc.returncode, proc.args)
+    return payload
+
+
 async def _extract_archive_metadata(
     archive_path: str, name: str | None, app
 ) -> dict:
@@ -1452,21 +1501,28 @@ async def _extract_archive_metadata(
 
 
 async def _read_archive_metadata(archive_path: str) -> dict:
-    """Run the tar extract of workspace.json and parse it; 400 on a missing
-    entry or corrupt JSON."""
-    result = await asyncio.to_thread(
-        subprocess.run,
-        ["tar", "xzf", archive_path, "-O", "workspace.json"],
-        capture_output=True,
-        timeout=30,
-    )
-    if result.returncode != 0:
+    """Read workspace.json from the archive and parse it; 400 on a missing
+    entry or corrupt JSON, 413 when the member exceeds the metadata byte
+    bound (#3284)."""
+    try:
+        payload = await asyncio.to_thread(
+            _extract_capped_metadata, archive_path
+        )
+    except _MetadataTooLarge:
+        raise HTTPException(
+            status_code=413,
+            detail=(
+                "workspace.json exceeds the "
+                f"{_METADATA_MAX_BYTES // (1024 * 1024)} MB metadata bound"
+            ),
+        )
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired, OSError):
         raise HTTPException(
             status_code=400,
             detail="Archive missing workspace.json or is corrupt",
         )
     try:
-        return json.loads(result.stdout)
+        return json.loads(payload)
     except (json.JSONDecodeError, UnicodeDecodeError):
         raise HTTPException(
             status_code=400,
@@ -1566,20 +1622,128 @@ def _archive_banner(classification_banner) -> str | None:
         return None
 
 
+# Safety margin kept free on the workspace volume after an import
+# (#3284): the pre-scan refuses an archive whose uncompressed home/
+# tree would eat it.
+_IMPORT_FREE_MARGIN_BYTES = 2 * 1024**3
+
+# A tzvf listing line: mode, uid/gid (numeric — --numeric-owner keeps
+# a crafted header's owner field from carrying spaces), size, date,
+# time, then the member name (spaces are legal; GNU tar escapes
+# control characters in names, so a name cannot split a record into
+# two lines — but a listing line that still does not parse fails
+# closed). A big member's own line always shows its real size first,
+# so the sum can only over-count, never under-count.
+_TZVF_LINE = re.compile(
+    r"^\S+\s+\d+/\d+\s+(?P<size>\d+)\s+\d{4}-\d{2}-\d{2}\s+\S+\s+.+$"
+)
+
+
+class _ListingUnparsable(Exception):
+    """A tzvf line did not match the listing format — the archive is
+    malformed or hostile; the import fails closed (#3284)."""
+
+
+def _sum_listing(proc: subprocess.Popen) -> int:
+    """Sum the size column of a tzvf stream. The listing is never stored
+    — a bomb carrying a billion tiny member headers cannot OOM the scan
+    itself (#3284)."""
+    assert proc.stdout is not None
+    total = 0
+    for line in proc.stdout:
+        m = _TZVF_LINE.match(line.decode("utf-8", "replace"))
+        if m is None:
+            raise _ListingUnparsable
+        total += int(m.group("size"))
+    return total
+
+
+def _scan_home_uncompressed_bytes(archive_path: str) -> int | None:
+    """Stream ``tar tzvf`` over the home members, summing their
+    uncompressed sizes (#3284).
+
+    ``None`` when tar fails — the metadata-only archive with no home/
+    member extracts no tree, same as the old presence probe. Raises
+    ``_ListingUnparsable`` on a line that does not parse."""
+    with subprocess.Popen(
+        [
+            "tar",
+            "-t",
+            "-z",
+            "-v",
+            "--numeric-owner",
+            "-f",
+            archive_path,
+            "home/",
+        ],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.DEVNULL,
+    ) as proc:
+        try:
+            total = _sum_listing(proc)
+            proc.wait(timeout=30)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            raise
+    if proc.returncode != 0:
+        return None
+    return total
+
+
+def _free_bytes(path) -> int:
+    """Bytes available to unprivileged writes on *path*'s filesystem."""
+    st = os.statvfs(path)
+    return st.f_bavail * st.f_frsize
+
+
+def _gb(n: int) -> str:
+    return f"{n / 1024**3:.1f}"
+
+
+def _assert_import_fits(home_dir, total: int, app) -> None:
+    """Refuse (#3284) before a byte is written when the uncompressed
+    home tree exceeds the operator cap or the workspace volume's free
+    space minus the reserve."""
+    cap = app.state.settings.import_max_uncompressed_mb
+    if cap is not None and total > cap * 1024 * 1024:
+        raise HTTPException(
+            status_code=413,
+            detail=(
+                f"Archive expands to {_gb(total)} GB; the import cap is "
+                f"{cap} MB (KLANGKD_IMPORT_MAX_UNCOMPRESSED_MB)"
+            ),
+        )
+    avail = _free_bytes(home_dir) - _IMPORT_FREE_MARGIN_BYTES
+    if total > avail:
+        raise HTTPException(
+            status_code=413,
+            detail=(
+                f"Archive expands to {_gb(total)} GB; only "
+                f"{_gb(max(avail, 0))} GB free on the workspace volume"
+            ),
+        )
+
+
 async def _extract_home_directory(
     archive_path: str, user_id: int, ws_id: int, app
 ) -> None:
-    """Extract the ``home/`` tree from *archive_path* into the workspace home."""
+    """Extract the ``home/`` tree from *archive_path* into the workspace
+    home. The uncompressed payload is bounded first (#3284): the tzvf
+    scan decides before tar writes a byte."""
     home_dir = app.state.workspaces.home_path(ws_id)
     home_dir.mkdir(parents=True, exist_ok=True)
-    check = await asyncio.to_thread(
-        subprocess.run,
-        ["tar", "tzf", archive_path, "home/"],
-        capture_output=True,
-        timeout=30,
-    )
-    if check.returncode != 0:
+    try:
+        total = await asyncio.to_thread(
+            _scan_home_uncompressed_bytes, archive_path
+        )
+    except _ListingUnparsable:
+        raise HTTPException(
+            status_code=400,
+            detail="Archive home listing is malformed",
+        )
+    if total is None:
         return
+    _assert_import_fits(home_dir, total, app)
     result = await asyncio.to_thread(
         subprocess.run,
         [
@@ -1716,7 +1880,11 @@ async def import_workspace(
     except HTTPException:
         raise
     except (json.JSONDecodeError, subprocess.TimeoutExpired):
-        if ws:
+        # The metadata read converts its own timeout to a 400 upstream
+        # (#3284), so every timeout reaching here has a row to roll
+        # back; ws stays None only for the HTTPException paths that
+        # re-raise above.
+        if ws:  # pragma: no branch
             await app.state.workspaces.delete_workspace(ws["id"], user["id"])
         raise HTTPException(
             status_code=400, detail="Invalid or corrupt archive"

--- a/src/klangk/klangk/api/workspaces.py
+++ b/src/klangk/klangk/api/workspaces.py
@@ -1624,18 +1624,35 @@ def _archive_banner(classification_banner) -> str | None:
 
 # Safety margin kept free on the workspace volume after an import
 # (#3284): the pre-scan refuses an archive whose uncompressed home/
-# tree would eat it.
+# tree would eat it. Per import — concurrent imports can jointly
+# consume more than either alone would pass; the reserve is not a
+# hard guarantee against a full disk.
 _IMPORT_FREE_MARGIN_BYTES = 2 * 1024**3
 
+# The scan streams the listing and must finish inside this budget
+# (#3284 review): without it, a max-ratio gzip bomb pins a worker
+# thread decompressing hundreds of GB of headers for many minutes —
+# tar lists only by decompressing everything.
+_SCAN_TIMEOUT_SECONDS = 30
+
+# One tzvf line is bounded: pax path records have no length cap, and a
+# member name is the one archive-controlled field that lands whole in
+# the scan's buffer.
+_LISTING_LINE_MAX = 65536
+
 # A tzvf listing line: mode, uid/gid (numeric — --numeric-owner keeps
-# a crafted header's owner field from carrying spaces), size, date,
-# time, then the member name (spaces are legal; GNU tar escapes
-# control characters in names, so a name cannot split a record into
-# two lines — but a listing line that still does not parse fails
-# closed). A big member's own line always shows its real size first,
-# so the sum can only over-count, never under-count.
+# a crafted header's owner field from carrying spaces), size (a
+# device member prints major,minor), date (negative years are legal
+# mtimes), time, then the member name (spaces are legal; GNU tar
+# escapes control characters in names, so a name cannot split a
+# record into two lines — but a listing line that still does not
+# parse fails closed). A big member's own line always shows its real
+# size first, so the byte sum can only over-count, never under-count;
+# the fit check adds one filesystem block per member for the disk-side
+# floor (inodes and block rounding — millions of 1-byte files cost far
+# more than their byte sum).
 _TZVF_LINE = re.compile(
-    r"^\S+\s+\d+/\d+\s+(?P<size>\d+)\s+\d{4}-\d{2}-\d{2}\s+\S+\s+.+$"
+    r"^\S+\s+\d+/\d+\s+(?P<size>\d+)(?:,\d+)?\s+-?\d+-\d{2}-\d{2}\s+\S+\s+.+$"
 )
 
 
@@ -1644,23 +1661,45 @@ class _ListingUnparsable(Exception):
     malformed or hostile; the import fails closed (#3284)."""
 
 
-def _sum_listing(proc: subprocess.Popen) -> int:
-    """Sum the size column of a tzvf stream. The listing is never stored
-    — a bomb carrying a billion tiny member headers cannot OOM the scan
-    itself (#3284)."""
+def _listing_line_size(line: bytes) -> int:
+    """Parse one tzvf line's size column; raises ``_ListingUnparsable``
+    on a line that does not match or exceeds the line bound (an
+    unbounded pax member name is the one archive-controlled field that
+    lands whole in the scan's buffer, #3284)."""
+    if len(line) == _LISTING_LINE_MAX and not line.endswith(b"\n"):
+        raise _ListingUnparsable
+    m = _TZVF_LINE.match(line.decode("utf-8", "replace"))
+    if m is None:
+        raise _ListingUnparsable
+    return int(m.group("size"))
+
+
+def _sum_listing(proc: subprocess.Popen, deadline: float) -> tuple[int, int]:
+    """Sum the size column of a tzvf stream, one bounded line at a
+    time: the listing is never stored, so a bomb with a billion tiny
+    headers cannot OOM the scan, and no single name can buffer more
+    than the line cap (#3284). Returns ``(total_bytes, member_count)``.
+
+    Raises ``TimeoutExpired`` past *deadline* (the caller kills tar)
+    and ``_ListingUnparsable`` on a hostile line."""
     assert proc.stdout is not None
     total = 0
-    for line in proc.stdout:
-        m = _TZVF_LINE.match(line.decode("utf-8", "replace"))
-        if m is None:
-            raise _ListingUnparsable
-        total += int(m.group("size"))
-    return total
+    count = 0
+    while line := proc.stdout.readline(_LISTING_LINE_MAX):
+        if time.monotonic() > deadline:
+            raise subprocess.TimeoutExpired(
+                cmd="tar", timeout=_SCAN_TIMEOUT_SECONDS
+            )
+        total += _listing_line_size(line)
+        count += 1
+    return total, count
 
 
-def _scan_home_uncompressed_bytes(archive_path: str) -> int | None:
+def _scan_home_uncompressed_bytes(
+    archive_path: str,
+) -> tuple[int, int] | None:
     """Stream ``tar tzvf`` over the home members, summing their
-    uncompressed sizes (#3284).
+    uncompressed sizes and counting them (#3284).
 
     ``None`` when tar fails — the metadata-only archive with no home/
     member extracts no tree, same as the old presence probe. Raises
@@ -1680,30 +1719,35 @@ def _scan_home_uncompressed_bytes(archive_path: str) -> int | None:
         stderr=subprocess.DEVNULL,
     ) as proc:
         try:
-            total = _sum_listing(proc)
-            proc.wait(timeout=30)
+            total, count = _sum_listing(
+                proc, time.monotonic() + _SCAN_TIMEOUT_SECONDS
+            )
+            proc.wait(timeout=_SCAN_TIMEOUT_SECONDS)
         except subprocess.TimeoutExpired:
             proc.kill()
             raise
     if proc.returncode != 0:
         return None
-    return total
+    return total, count
 
 
-def _free_bytes(path) -> int:
-    """Bytes available to unprivileged writes on *path*'s filesystem."""
+def _fs_stats(path) -> tuple[int, int]:
+    """(bytes available to unprivileged writes, filesystem block size)
+    for *path*'s filesystem."""
     st = os.statvfs(path)
-    return st.f_bavail * st.f_frsize
+    return st.f_bavail * st.f_frsize, st.f_frsize
 
 
 def _gb(n: int) -> str:
     return f"{n / 1024**3:.1f}"
 
 
-def _assert_import_fits(home_dir, total: int, app) -> None:
+def _assert_import_fits(home_dir, total: int, count: int, app) -> None:
     """Refuse (#3284) before a byte is written when the uncompressed
     home tree exceeds the operator cap or the workspace volume's free
-    space minus the reserve."""
+    space minus the reserve. Demand counts one filesystem block per
+    member on top of the byte sum — block rounding and inodes mean a
+    tree of millions of 1-byte files costs far more than its bytes."""
     cap = app.state.settings.import_max_uncompressed_mb
     if cap is not None and total > cap * 1024 * 1024:
         raise HTTPException(
@@ -1713,12 +1757,14 @@ def _assert_import_fits(home_dir, total: int, app) -> None:
                 f"{cap} MB (KLANGKD_IMPORT_MAX_UNCOMPRESSED_MB)"
             ),
         )
-    avail = _free_bytes(home_dir) - _IMPORT_FREE_MARGIN_BYTES
-    if total > avail:
+    free, block = _fs_stats(home_dir)
+    demand = total + count * block
+    avail = free - _IMPORT_FREE_MARGIN_BYTES
+    if demand > avail:
         raise HTTPException(
             status_code=413,
             detail=(
-                f"Archive expands to {_gb(total)} GB; only "
+                f"Archive expands to {_gb(demand)} GB; only "
                 f"{_gb(max(avail, 0))} GB free on the workspace volume"
             ),
         )
@@ -1733,7 +1779,7 @@ async def _extract_home_directory(
     home_dir = app.state.workspaces.home_path(ws_id)
     home_dir.mkdir(parents=True, exist_ok=True)
     try:
-        total = await asyncio.to_thread(
+        scanned = await asyncio.to_thread(
             _scan_home_uncompressed_bytes, archive_path
         )
     except _ListingUnparsable:
@@ -1741,9 +1787,9 @@ async def _extract_home_directory(
             status_code=400,
             detail="Archive home listing is malformed",
         )
-    if total is None:
+    if scanned is None:
         return
-    _assert_import_fits(home_dir, total, app)
+    _assert_import_fits(home_dir, scanned[0], scanned[1], app)
     result = await asyncio.to_thread(
         subprocess.run,
         [
@@ -1757,7 +1803,11 @@ async def _extract_home_directory(
             str(home_dir),
             "home/",
         ],
-        capture_output=True,
+        # Output is discarded on purpose: only the return code decides,
+        # and a hostile archive's per-member stderr warnings are
+        # unbounded (#3284 review).
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
         timeout=300,
     )
     if result.returncode != 0:

--- a/src/klangk/klangk/api/workspaces.py
+++ b/src/klangk/klangk/api/workspaces.py
@@ -8,6 +8,7 @@ import re
 import shutil
 import subprocess
 import tempfile
+import threading
 import time
 from datetime import datetime, timezone
 from typing import Annotated, Literal
@@ -1455,18 +1456,28 @@ def _extract_capped_metadata(archive_path: str) -> bytes:
     """tar -O extract of workspace.json under the metadata byte bound.
 
     Raises ``subprocess.CalledProcessError`` when the member is missing
-    or the archive is corrupt, ``_MetadataTooLarge`` past the bound."""
+    or the archive is corrupt, ``_MetadataTooLarge`` past the bound,
+    ``TimeoutExpired`` past the tar budget (the -O extract emits
+    nothing until the matching member, so the watchdog bounds the
+    blocked first read too)."""
     with subprocess.Popen(
         ["tar", "xzf", archive_path, "-O", "workspace.json"],
         stdout=subprocess.PIPE,
         stderr=subprocess.DEVNULL,
     ) as proc:
+        watchdog, fired = _arm_deadline_kill(proc, _TAR_TIMEOUT_SECONDS)
         try:
             payload = _read_capped(proc)
-            proc.wait(timeout=30)
+            proc.wait(timeout=_TAR_TIMEOUT_SECONDS)
         except subprocess.TimeoutExpired:
             proc.kill()
             raise
+        finally:
+            watchdog.cancel()
+    if fired:
+        raise subprocess.TimeoutExpired(
+            cmd="tar", timeout=_TAR_TIMEOUT_SECONDS
+        )
     if proc.returncode != 0:
         raise subprocess.CalledProcessError(proc.returncode, proc.args)
     return payload
@@ -1629,11 +1640,34 @@ def _archive_banner(classification_banner) -> str | None:
 # hard guarantee against a full disk.
 _IMPORT_FREE_MARGIN_BYTES = 2 * 1024**3
 
-# The scan streams the listing and must finish inside this budget
-# (#3284 review): without it, a max-ratio gzip bomb pins a worker
-# thread decompressing hundreds of GB of headers for many minutes —
-# tar lists only by decompressing everything.
-_SCAN_TIMEOUT_SECONDS = 30
+# Every tar invocation on the import path must finish inside this
+# budget (#3284): a per-line deadline cannot fire while the reader is
+# blocked on a pipe that never yields output (a bomb whose members do
+# not match home/ lists nothing, and tar -O extracts nothing until the
+# matching member), so a kill-watchdog enforces the budget on blocked
+# reads too. A legitimate 500 MB archive lists in a couple of seconds
+# — 30 is generous headroom.
+_TAR_TIMEOUT_SECONDS = 30
+
+
+def _arm_deadline_kill(
+    proc: subprocess.Popen, seconds: float
+) -> tuple[threading.Timer, list]:
+    """Kill *proc* after *seconds*; returns ``(timer, fired)`` —
+    cancel the timer when the reads finish, and treat a truthy *fired*
+    as the timeout (the killed pipe EOFs the blocked reader; #3284
+    review)."""
+    fired: list = []
+
+    def _kill():
+        fired.append(True)
+        proc.kill()
+
+    timer = threading.Timer(seconds, _kill)
+    timer.daemon = True
+    timer.start()
+    return timer, fired
+
 
 # One tzvf line is bounded: pax path records have no length cap, and a
 # member name is the one archive-controlled field that lands whole in
@@ -1688,7 +1722,7 @@ def _sum_listing(proc: subprocess.Popen, deadline: float) -> tuple[int, int]:
     while line := proc.stdout.readline(_LISTING_LINE_MAX):
         if time.monotonic() > deadline:
             raise subprocess.TimeoutExpired(
-                cmd="tar", timeout=_SCAN_TIMEOUT_SECONDS
+                cmd="tar", timeout=_TAR_TIMEOUT_SECONDS
             )
         total += _listing_line_size(line)
         count += 1
@@ -1718,14 +1752,21 @@ def _scan_home_uncompressed_bytes(
         stdout=subprocess.PIPE,
         stderr=subprocess.DEVNULL,
     ) as proc:
+        watchdog, fired = _arm_deadline_kill(proc, _TAR_TIMEOUT_SECONDS)
         try:
             total, count = _sum_listing(
-                proc, time.monotonic() + _SCAN_TIMEOUT_SECONDS
+                proc, time.monotonic() + _TAR_TIMEOUT_SECONDS
             )
-            proc.wait(timeout=_SCAN_TIMEOUT_SECONDS)
+            proc.wait(timeout=_TAR_TIMEOUT_SECONDS)
         except subprocess.TimeoutExpired:
             proc.kill()
             raise
+        finally:
+            watchdog.cancel()
+    if fired:
+        raise subprocess.TimeoutExpired(
+            cmd="tar", timeout=_TAR_TIMEOUT_SECONDS
+        )
     if proc.returncode != 0:
         return None
     return total, count
@@ -1739,7 +1780,11 @@ def _fs_stats(path) -> tuple[int, int]:
 
 
 def _gb(n: int) -> str:
-    return f"{n / 1024**3:.1f}"
+    """Human-size a byte count: MB below 1 GB, GB above (a sub-GB
+    overage must not read as "0.0 GB")."""
+    if n < 1024**3:
+        return f"{max(n, 0) / 1024**2:.0f} MB"
+    return f"{n / 1024**3:.1f} GB"
 
 
 def _assert_import_fits(home_dir, total: int, count: int, app) -> None:
@@ -1753,19 +1798,28 @@ def _assert_import_fits(home_dir, total: int, count: int, app) -> None:
         raise HTTPException(
             status_code=413,
             detail=(
-                f"Archive expands to {_gb(total)} GB; the import cap is "
+                f"Archive expands to {_gb(total)}; the import cap is "
                 f"{cap} MB (KLANGKD_IMPORT_MAX_UNCOMPRESSED_MB)"
             ),
         )
-    free, block = _fs_stats(home_dir)
+    try:
+        free, block = _fs_stats(home_dir)
+    except OSError as exc:
+        # Fail closed (500) with the row rolled back rather than an
+        # unbounded import (#3284 review: statvfs can fail when the
+        # workspace volume vanishes mid-request).
+        raise HTTPException(
+            status_code=500,
+            detail="Cannot verify free space on the workspace volume",
+        ) from exc
     demand = total + count * block
     avail = free - _IMPORT_FREE_MARGIN_BYTES
     if demand > avail:
         raise HTTPException(
             status_code=413,
             detail=(
-                f"Archive expands to {_gb(demand)} GB; only "
-                f"{_gb(max(avail, 0))} GB free on the workspace volume"
+                f"Archive expands to {_gb(demand)}; only "
+                f"{_gb(avail)} free on the workspace volume"
             ),
         )
 

--- a/src/klangk/klangk/settings.py
+++ b/src/klangk/klangk/settings.py
@@ -1763,6 +1763,8 @@ class KlangkSettings(BaseSettings):
     # import is refused with 413 past the cap. None = only the workspace
     # volume's free space (minus a 2 GB reserve) bounds an import — the
     # correctness bound; this knob is the multi-tenant fairness layer.
+    # There is no zero-semantics (0 would not mean "off" — unset does),
+    # so 0 aborts startup.
     import_max_uncompressed_mb: int | None = None
 
     # --- Feature / feature config (#1659) ---

--- a/src/klangk/klangk/settings.py
+++ b/src/klangk/klangk/settings.py
@@ -1758,6 +1758,12 @@ class KlangkSettings(BaseSettings):
 
     # --- File upload ---
     file_upload_size_max: int | None = 524288000
+    # Cap (MB) on the uncompressed payload a single workspace import may
+    # demand (#3284): the decompressed home/ tree is pre-scanned and the
+    # import is refused with 413 past the cap. None = only the workspace
+    # volume's free space (minus a 2 GB reserve) bounds an import — the
+    # correctness bound; this knob is the multi-tenant fairness layer.
+    import_max_uncompressed_mb: int | None = None
 
     # --- Feature / feature config (#1659) ---
     # A config-file source for feature-declared dynamic keys (the keys the
@@ -2147,6 +2153,7 @@ class KlangkSettings(BaseSettings):
         "websocket_msg_size_max",
         "api_rate_limit",
         "file_upload_size_max",
+        "import_max_uncompressed_mb",
         "hosted_ports_per_workspace",
         "memory_eviction_sustain_polls",
         "max_running_workspaces_per_user",

--- a/src/klangk/klangkd-tests/tests/test_api.py
+++ b/src/klangk/klangkd-tests/tests/test_api.py
@@ -14219,8 +14219,8 @@ class TestWorkspaceExportImport:
 
         monkeypatch.setattr(
             api_ws,
-            "_free_bytes",
-            lambda path: api_ws._IMPORT_FREE_MARGIN_BYTES + 1,
+            "_fs_stats",
+            lambda path: (api_ws._IMPORT_FREE_MARGIN_BYTES + 1, 4096),
         )
         archive = self._archive(
             [("home/payload.bin", b"\0" * 1024)], name="disk-bomb"
@@ -14266,7 +14266,7 @@ class TestWorkspaceExportImport:
         CI disk's real free space is not under the test's control)."""
         from klangk.api import workspaces as api_ws
 
-        monkeypatch.setattr(api_ws, "_free_bytes", lambda path: 1 << 40)
+        monkeypatch.setattr(api_ws, "_fs_stats", lambda path: (1 << 40, 4096))
         archive = self._archive(
             [("home/big.bin", b"\0" * (32 * 1024 * 1024))],
             name="big-ok",
@@ -14278,9 +14278,15 @@ class TestWorkspaceExportImport:
         assert (home / "big.bin").stat().st_size == 32 * 1024 * 1024
 
     def test_sum_listing_fails_closed(self):
-        """#3284: a tzvf line that does not parse raises instead of
-        under-counting — the archive is malformed or hostile."""
+        """#3284: a tzvf line that does not parse — or exceeds the line
+        bound, or the scan misses its deadline — fails closed instead
+        of under-counting."""
+        import subprocess as subprocess_mod
+        import time as time_mod
+
         from klangk.api import workspaces as api_ws
+
+        soon = time_mod.monotonic() + 30
 
         # A crafted owner field with spaces (no --numeric-owner
         # protection) shifts the size column; the regex must reject it.
@@ -14290,17 +14296,66 @@ class TestWorkspaceExportImport:
             )
         )
         with pytest.raises(api_ws._ListingUnparsable):
-            api_ws._sum_listing(hostile)
+            api_ws._sum_listing(hostile, soon)
 
-        # Well-formed lines (symlink arrow, spaces in the name) parse.
+        # An unbounded pax member name would buffer whole; the line cap
+        # refuses it (#3284 review: a 65 KB upload could otherwise
+        # drive a multi-GB transient allocation).
+        long_name = types.SimpleNamespace(
+            stdout=io.BytesIO(
+                b"-rw-r--r-- 0/0 5 2024-01-01 00:00 home/"
+                + b"x" * api_ws._LISTING_LINE_MAX
+                + b"\n"
+            )
+        )
+        with pytest.raises(api_ws._ListingUnparsable):
+            api_ws._sum_listing(long_name, soon)
+
+        # A scan that misses its deadline raises TimeoutExpired (the
+        # caller kills tar) — a gzip bomb cannot pin the worker thread
+        # decompressing headers for minutes.
+        slow = types.SimpleNamespace(
+            stdout=io.BytesIO(b"-rw-r--r-- 0/0 5 2024-01-01 00:00 home/a\n")
+        )
+        with pytest.raises(subprocess_mod.TimeoutExpired):
+            api_ws._sum_listing(slow, time_mod.monotonic() - 1)
+
+        # Well-formed lines parse: symlink arrow, spaces in the name,
+        # a negative mtime year, a device member's major,minor size.
         good = types.SimpleNamespace(
             stdout=io.BytesIO(
                 b"-rw-r--r-- 0/0 5 2024-01-01 00:00 home/a b.txt\n"
                 b"lrwxrwxrwx 0/0 9 2024-01-01 00:00 home/l -> target x\n"
                 b"drwxr-xr-x 0/0 0 2024-01-01 00:00 home/d/\n"
+                b"-rw-r--r-- 0/0 7 -26550-02-19 03:03 home/old.txt\n"
+                b"crw-rw-rw- 0/0 1,3 2024-01-01 00:00 home/dev\n"
             )
         )
-        assert api_ws._sum_listing(good) == 14
+        assert api_ws._sum_listing(good, soon) == (22, 5)
+
+    def test_import_fit_counts_blocks_per_member(self, monkeypatch, tmp_path):
+        """#3284: demand counts one filesystem block per member — a
+        tree of half a million 1-byte files costs ~2 GB of blocks and
+        inodes, far past its byte sum, and is refused against a volume
+        with only 1 GB past the reserve."""
+        from fastapi import HTTPException
+
+        from klangk.api import workspaces as api_ws
+
+        monkeypatch.setattr(
+            api_ws,
+            "_fs_stats",
+            lambda path: (api_ws._IMPORT_FREE_MARGIN_BYTES + (1 << 30), 4096),
+        )
+        app = types.SimpleNamespace(
+            state=types.SimpleNamespace(
+                settings=types.SimpleNamespace(import_max_uncompressed_mb=None)
+            )
+        )
+        with pytest.raises(HTTPException) as excinfo:
+            api_ws._assert_import_fits(tmp_path, 1024 * 1024, 500_000, app)
+        assert excinfo.value.status_code == 413
+        assert "free on the workspace volume" in excinfo.value.detail
 
     async def test_import_metadata_timeout_rejected(
         self, client, user, app, monkeypatch
@@ -17802,7 +17857,7 @@ class TestBranchGaps2834:
         )
         monkeypatch.setattr(
             "klangk.api.workspaces._scan_home_uncompressed_bytes",
-            lambda path: 0,
+            lambda path: (0, 0),
         )
         deleted = []
         with patch.object(

--- a/src/klangk/klangkd-tests/tests/test_api.py
+++ b/src/klangk/klangkd-tests/tests/test_api.py
@@ -13599,13 +13599,21 @@ class TestWorkspaceExportImport:
         loop_thread = threading.get_ident()
         seen = []
         real_run = subprocess.run
+        real_popen = subprocess.Popen
 
         def spy(*args, **kwargs):
             seen.append(threading.get_ident())
             return real_run(*args, **kwargs)
 
+        def spy_popen(*args, **kwargs):
+            seen.append(threading.get_ident())
+            return real_popen(*args, **kwargs)
+
         headers = await self._user_headers(client)
-        with patch.object(subprocess, "run", spy):
+        with (
+            patch.object(subprocess, "run", spy),
+            patch.object(subprocess, "Popen", spy_popen),
+        ):
             resp = await client.post(
                 "/api/v1/workspaces/import",
                 headers=headers,
@@ -14149,6 +14157,263 @@ class TestWorkspaceExportImport:
             files={"file": ("big.tar.gz", b"x" * 200, "application/gzip")},
         )
         assert resp.status_code == 413
+
+    def _archive(self, home_members: list[tuple[str, bytes]], **meta_over):
+        """Build a small in-memory import archive (#3284 tests): the
+        provenance-valid workspace.json plus the given home members."""
+        import json
+        import tarfile
+
+        buf = io.BytesIO()
+        with tarfile.open(fileobj=buf, mode="w:gz") as tar:
+            meta = json.dumps(self._meta(**meta_over)).encode()
+            info = tarfile.TarInfo(name="workspace.json")
+            info.size = len(meta)
+            tar.addfile(info, io.BytesIO(meta))
+            for name, data in home_members:
+                mi = tarfile.TarInfo(name=name)
+                mi.size = len(data)
+                tar.addfile(mi, io.BytesIO(data))
+        return buf.getvalue()
+
+    async def _import(
+        self, client, headers, archive: bytes, name: str | None = None
+    ):
+        """POST the archive; returns the response object."""
+        return await client.post(
+            "/api/v1/workspaces/import",
+            headers=headers,
+            params={"name": name} if name else None,
+            files={"file": ("archive.tar.gz", archive, "application/gzip")},
+        )
+
+    async def test_import_metadata_member_oversize_rejected(
+        self, client, user, app
+    ):
+        """#3284: a multi-GB workspace.json member used to accumulate in
+        Python memory before json.loads; the capped read turns it into a
+        cheap 413. A ~1.1 MB member compresses to a few KB, so the
+        compressed-upload bound never sees it."""
+        from klangk.api import workspaces as api_ws
+
+        archive = self._archive(
+            [],
+            name="meta-bomb",
+            pad="x" * (api_ws._METADATA_MAX_BYTES + 1),
+        )
+        assert len(archive) < 100_000  # compressed well under the upload cap
+
+        headers = await self._user_headers(client)
+        resp = await self._import(client, headers, archive)
+        assert resp.status_code == 413
+        assert "metadata bound" in resp.json()["detail"]
+
+    async def test_import_home_exceeds_free_space(
+        self, client, user, app, monkeypatch
+    ):
+        """#3284: the uncompressed home tree is pre-scanned against the
+        workspace volume's free space (minus the reserve) and refused
+        with 413 before tar writes a byte — the workspace row is rolled
+        back."""
+        from klangk.api import workspaces as api_ws
+
+        monkeypatch.setattr(
+            api_ws,
+            "_free_bytes",
+            lambda path: api_ws._IMPORT_FREE_MARGIN_BYTES + 1,
+        )
+        archive = self._archive(
+            [("home/payload.bin", b"\0" * 1024)], name="disk-bomb"
+        )
+
+        headers = await self._user_headers(client)
+        resp = await self._import(client, headers, archive)
+        assert resp.status_code == 413
+        assert "free on the workspace volume" in resp.json()["detail"]
+
+        # The half-created workspace was rolled back.
+        listed = await client.get("/api/v1/workspaces", headers=headers)
+        assert all(w["name"] != "disk-bomb" for w in listed.json())
+
+    async def test_import_home_exceeds_policy_cap(
+        self, client, user, app, monkeypatch
+    ):
+        """#3284: KLANGKD_IMPORT_MAX_UNCOMPRESSED_MB bounds how much of the
+        free space one import may consume — a 2 MB home tree against a
+        1 MB cap is a 413, and the cap path reports the knob."""
+        monkeypatch.setattr(
+            app.state.settings, "import_max_uncompressed_mb", 1
+        )
+        archive = self._archive(
+            [("home/payload.bin", b"\0" * (2 * 1024 * 1024))],
+            name="cap-bomb",
+        )
+
+        headers = await self._user_headers(client)
+        resp = await self._import(client, headers, archive)
+        assert resp.status_code == 413
+        assert "KLANGKD_IMPORT_MAX_UNCOMPRESSED_MB" in resp.json()["detail"]
+
+        listed = await client.get("/api/v1/workspaces", headers=headers)
+        assert all(w["name"] != "cap-bomb" for w in listed.json())
+
+    async def test_import_large_home_with_free_space_succeeds(
+        self, client, user, app, monkeypatch
+    ):
+        """#3284: the bound is the free space, not a tight fixed cap — a
+        payload larger than any fixed limit imports cleanly when the
+        volume has room (the reserve is monkeypatched away because the
+        CI disk's real free space is not under the test's control)."""
+        from klangk.api import workspaces as api_ws
+
+        monkeypatch.setattr(api_ws, "_free_bytes", lambda path: 1 << 40)
+        archive = self._archive(
+            [("home/big.bin", b"\0" * (32 * 1024 * 1024))],
+            name="big-ok",
+        )
+        headers = await self._user_headers(client)
+        resp = await self._import(client, headers, archive)
+        assert resp.status_code == 200
+        home = app.state.workspaces.home_path(resp.json()["id"])
+        assert (home / "big.bin").stat().st_size == 32 * 1024 * 1024
+
+    def test_sum_listing_fails_closed(self):
+        """#3284: a tzvf line that does not parse raises instead of
+        under-counting — the archive is malformed or hostile."""
+        from klangk.api import workspaces as api_ws
+
+        # A crafted owner field with spaces (no --numeric-owner
+        # protection) shifts the size column; the regex must reject it.
+        hostile = types.SimpleNamespace(
+            stdout=io.BytesIO(
+                b"-rw-r--r-- a b/c 1234 2024-01-01 00:00 home/x\n"
+            )
+        )
+        with pytest.raises(api_ws._ListingUnparsable):
+            api_ws._sum_listing(hostile)
+
+        # Well-formed lines (symlink arrow, spaces in the name) parse.
+        good = types.SimpleNamespace(
+            stdout=io.BytesIO(
+                b"-rw-r--r-- 0/0 5 2024-01-01 00:00 home/a b.txt\n"
+                b"lrwxrwxrwx 0/0 9 2024-01-01 00:00 home/l -> target x\n"
+                b"drwxr-xr-x 0/0 0 2024-01-01 00:00 home/d/\n"
+            )
+        )
+        assert api_ws._sum_listing(good) == 14
+
+    async def test_import_metadata_timeout_rejected(
+        self, client, user, app, monkeypatch
+    ):
+        """#3284: a tar that never finishes is killed and surfaces as a
+        clean 400 before any workspace row exists."""
+        import json
+        import subprocess as subprocess_mod
+
+        meta_bytes = json.dumps(self._meta(name="meta-hang")).encode()
+
+        class _HangingTar:
+            def __init__(self, argv, *a, **kw):
+                self.argv = argv
+                self.stdout = io.BytesIO(meta_bytes)
+                self.returncode = 0
+                self.killed = False
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *a):
+                return False
+
+            def wait(self, timeout=None):
+                raise subprocess_mod.TimeoutExpired(cmd="tar", timeout=30)
+
+            def kill(self):
+                self.killed = True
+
+        hung = []
+
+        def _spawn(argv, *a, **kw):
+            proc = _HangingTar(argv, *a, **kw)
+            hung.append(proc)
+            return proc
+
+        monkeypatch.setattr("klangk.api.workspaces.subprocess.Popen", _spawn)
+        headers = await self._user_headers(client)
+        resp = await self._import(
+            client, headers, self._archive([], name="meta-hang")
+        )
+        assert resp.status_code == 400
+        assert "corrupt" in resp.json()["detail"]
+        assert hung and hung[0].killed
+
+    async def test_import_scan_timeout_rejected(
+        self, client, user, app, monkeypatch
+    ):
+        """#3284: a tzvf scan that never finishes is killed and the
+        just-created workspace row is rolled back."""
+        import json
+        import subprocess as subprocess_mod
+
+        meta_bytes = json.dumps(self._meta(name="scan-hang")).encode()
+        listing = b"-rw-r--r-- 0/0 5 2024-01-01 00:00 home/a\n"
+
+        class _HangingTar:
+            def __init__(self, argv, *a, **kw):
+                self.argv = argv
+                # The metadata extract (-O) completes; the scan hangs.
+                self.hangs = "-O" not in argv
+                self.stdout = io.BytesIO(listing if self.hangs else meta_bytes)
+                self.returncode = 0
+                self.killed = False
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *a):
+                return False
+
+            def wait(self, timeout=None):
+                if self.hangs:
+                    raise subprocess_mod.TimeoutExpired(cmd="tar", timeout=30)
+
+            def kill(self):
+                self.killed = True
+
+        monkeypatch.setattr(
+            "klangk.api.workspaces.subprocess.Popen", _HangingTar
+        )
+        headers = await self._user_headers(client)
+        resp = await self._import(
+            client, headers, self._archive([], name="scan-hang")
+        )
+        assert resp.status_code == 400
+        assert "corrupt" in resp.json()["detail"]
+        listed = await client.get("/api/v1/workspaces", headers=headers)
+        assert all(w["name"] != "scan-hang" for w in listed.json())
+
+    async def test_import_listing_fails_closed(
+        self, client, user, app, monkeypatch
+    ):
+        """#3284: an unparsable tzvf line refuses the import (400) and
+        rolls the workspace row back instead of under-counting."""
+        from klangk.api import workspaces as api_ws
+
+        def _unparsable(path):
+            raise api_ws._ListingUnparsable
+
+        monkeypatch.setattr(
+            "klangk.api.workspaces._scan_home_uncompressed_bytes",
+            _unparsable,
+        )
+        headers = await self._user_headers(client)
+        resp = await self._import(
+            client, headers, self._archive([], name="bad-listing")
+        )
+        assert resp.status_code == 400
+        assert resp.json()["detail"] == "Archive home listing is malformed"
+        listed = await client.get("/api/v1/workspaces", headers=headers)
+        assert all(w["name"] != "bad-listing" for w in listed.json())
 
     async def test_import_sanitizes_env(self, client, user):
         """Dangerous env vars from archive are stripped."""
@@ -17525,17 +17790,19 @@ class TestBranchGaps2834:
         import subprocess as subprocess_mod
 
         def _timing_out_tar(cmd, *a, **kw):
-            # Only the post-creation home-tree probe times out; the earlier
-            # metadata read (tar xzf -O workspace.json) still succeeds so the
-            # workspace row is created first.
-            if "tzf" in cmd:
-                raise subprocess_mod.TimeoutExpired(cmd="tar", timeout=30)
-            return subprocess_mod.CompletedProcess(
-                cmd, returncode=0, stdout=meta_bytes
-            )
+            # Only the post-creation home-tree extraction times out; the
+            # tzvf pre-scan below is stubbed to "fits", so the workspace
+            # row is created first.
+            if "-C" in cmd:
+                raise subprocess_mod.TimeoutExpired(cmd="tar", timeout=300)
+            return subprocess_mod.CompletedProcess(cmd, returncode=0)
 
         monkeypatch.setattr(
             "klangk.api.workspaces.subprocess.run", _timing_out_tar
+        )
+        monkeypatch.setattr(
+            "klangk.api.workspaces._scan_home_uncompressed_bytes",
+            lambda path: 0,
         )
         deleted = []
         with patch.object(

--- a/src/klangk/klangkd-tests/tests/test_api.py
+++ b/src/klangk/klangkd-tests/tests/test_api.py
@@ -14235,6 +14235,28 @@ class TestWorkspaceExportImport:
         listed = await client.get("/api/v1/workspaces", headers=headers)
         assert all(w["name"] != "disk-bomb" for w in listed.json())
 
+    async def test_import_free_space_probe_failure_fails_closed(
+        self, client, user, app, monkeypatch
+    ):
+        """#3284 review: a statvfs failure (volume vanished mid-request)
+        must fail closed as a clean 500 with the row rolled back, not an
+        unbounded import or a leaked workspace."""
+        from klangk.api import workspaces as api_ws
+
+        def _gone(path):
+            raise OSError("volume gone")
+
+        monkeypatch.setattr(api_ws, "_fs_stats", _gone)
+        archive = self._archive(
+            [("home/payload.bin", b"x")], name="statvfs-gone"
+        )
+        headers = await self._user_headers(client)
+        resp = await self._import(client, headers, archive)
+        assert resp.status_code == 500
+        assert "Cannot verify free space" in resp.json()["detail"]
+        listed = await client.get("/api/v1/workspaces", headers=headers)
+        assert all(w["name"] != "statvfs-gone" for w in listed.json())
+
     async def test_import_home_exceeds_policy_cap(
         self, client, user, app, monkeypatch
     ):
@@ -14332,6 +14354,55 @@ class TestWorkspaceExportImport:
             )
         )
         assert api_ws._sum_listing(good, soon) == (22, 5)
+
+    def test_scan_deadline_enforced_while_blocked(self, monkeypatch):
+        """#3284 second review: the deadline must hold even while the
+        reader is blocked on a pipe that never yields output — a bomb
+        whose members don't match home/ lists nothing, so the per-line
+        check never runs. The kill-watchdog bounds the blocked read
+        itself (a real subprocess, not a fake)."""
+        import subprocess as subprocess_mod
+        import time as time_mod
+
+        from klangk.api import workspaces as api_ws
+
+        real_popen = subprocess_mod.Popen
+        monkeypatch.setattr(api_ws, "_TAR_TIMEOUT_SECONDS", 1)
+
+        def _silent_tar(argv, *a, **kw):
+            return real_popen(
+                ["sleep", "300"],
+                stdout=subprocess_mod.PIPE,
+                stderr=subprocess_mod.DEVNULL,
+            )
+
+        monkeypatch.setattr(api_ws.subprocess, "Popen", _silent_tar)
+        started = time_mod.monotonic()
+        with pytest.raises(subprocess_mod.TimeoutExpired):
+            api_ws._scan_home_uncompressed_bytes("/nonexistent.tar.gz")
+        assert time_mod.monotonic() - started < 30
+
+    def test_metadata_deadline_enforced_while_blocked(self, monkeypatch):
+        """#3284 second review: same property for the metadata read —
+        tar -O emits nothing until the matching member, so the first
+        read can block through an entire giant archive."""
+        import subprocess as subprocess_mod
+
+        from klangk.api import workspaces as api_ws
+
+        real_popen = subprocess_mod.Popen
+        monkeypatch.setattr(api_ws, "_TAR_TIMEOUT_SECONDS", 1)
+
+        def _silent_tar(argv, *a, **kw):
+            return real_popen(
+                ["sleep", "300"],
+                stdout=subprocess_mod.PIPE,
+                stderr=subprocess_mod.DEVNULL,
+            )
+
+        monkeypatch.setattr(api_ws.subprocess, "Popen", _silent_tar)
+        with pytest.raises(subprocess_mod.TimeoutExpired):
+            api_ws._extract_capped_metadata("/nonexistent.tar.gz")
 
     def test_import_fit_counts_blocks_per_member(self, monkeypatch, tmp_path):
         """#3284: demand counts one filesystem block per member — a

--- a/src/klangk/klangkd-tests/tests/test_settings.py
+++ b/src/klangk/klangkd-tests/tests/test_settings.py
@@ -2133,6 +2133,7 @@ class TestNumericSettingCoercion:
         "websocket_msg_size_max",
         "api_rate_limit",
         "file_upload_size_max",
+        "import_max_uncompressed_mb",
         "hosted_ports_per_workspace",
         "smtp_port",
         "password_history_count",
@@ -2146,6 +2147,7 @@ class TestNumericSettingCoercion:
         "port_range_start",
         "websocket_msg_size_max",
         "file_upload_size_max",
+        "import_max_uncompressed_mb",
         "smtp_port",
     ]
     FLOAT_FIELDS = [
@@ -2301,6 +2303,15 @@ class TestNumericSettingCoercion:
         assert s.min_password_length == 10
         assert s.access_token_hours == 1.5
         assert s.smtp_port == 2525
+
+    def test_import_cap_default_none_and_env_parse(self):
+        """#3284: the uncompressed import cap is an opt-in fairness knob —
+        unset means only the workspace volume's free space bounds an
+        import."""
+        s = make_settings({})
+        assert s.import_max_uncompressed_mb is None
+        s = make_settings({"KLANGKD_IMPORT_MAX_UNCOMPRESSED_MB": "4096"})
+        assert s.import_max_uncompressed_mb == 4096
 
     def test_file_indirection_still_works(self, tmp_path):
         secret = tmp_path / "port"


### PR DESCRIPTION
# Bound workspace import decompression (#3284)

## Problem

`POST /workspaces/import` enforced exactly one size bound — the **compressed** upload (`file_upload_size_max`, default 500 MB). The decompressed payload was unbounded on both paths that read the archive:

- `_read_archive_metadata` ran `tar xzf <archive> -O workspace.json` with `capture_output=True`: the member's decompressed bytes accumulated in **Python memory** before `json.loads` ever ran. A crafted multi-GB `workspace.json` member (a few hundred KB compressed) OOM-kills klangkd — every workspace's WebSocket drops.
- `_extract_home_directory` extracted `home/` with no size pre-scan: the write demand was bounded only by gzip's ratio (~1000:1 on compressible data) and the host disk. A legal 500 MB upload could demand ~500 GB of writes under `state_dir`; the failure mode was disk exhaustion mid-write (partial home tree left behind, SQLite write failures across the deploy).

The gate is `create-workspace` — granted to the members group by default — so any regular user can trigger this.

## Fix

Two bounds, matched to what each path actually reads (`api/workspaces.py`):

1. **`workspace.json` (metadata, always tiny):** extracts through a streaming **1 MB byte cap** (`_extract_capped_metadata`): a `Popen` pipe is read up to the cap and then closed — tar dies of SIGPIPE — so an arbitrarily large member costs at most 1 MB. Beyond the cap: 413.
2. **`home/` (the payload):** a streaming `tar -t -z -v --numeric-owner -f ARCHIVE home/` pre-scan (`_scan_home_uncompressed_bytes`) sums each member's uncompressed size; the listing itself is never stored, so a bomb with a billion tiny member headers cannot OOM the scan. Before tar writes a byte, `_assert_import_fits` refuses with 413 when the total exceeds
   - the workspace volume's free space (`os.statvfs` on the target home dir) minus a **2 GB reserve**, and
   - the new opt-in policy cap **`import_max_uncompressed_mb`** (`KLANGKD_IMPORT_MAX_UNCOMPRESSED_MB`, MB, default unset = only the free-space bound applies; reloadable on SIGHUP).

   A real multi-gigabyte home import succeeds whenever the volume has room — the bound is free space, not a fixed ceiling.

   Hardened after a fresh-eyes adversarial review: the listing read is capped at 64 KiB per line (an unbounded pax member name is the one archive-controlled field that lands whole in the scan's buffer), the scan carries a 30 s wall-clock deadline enforced per line (kill + fail closed — a max-ratio gzip bomb otherwise pins a worker thread decompressing ~500 GB of headers for minutes), and the fit check counts one filesystem block per member on top of the byte sum (block rounding and inodes: millions of 1-byte files cost far more than their bytes). The extraction discards tar output rather than capturing unbounded stderr, and the listing regex accepts negative mtime years and device `major,minor` size columns so legal-but-odd exports stay importable.

   A listing line that does not parse raises `_ListingUnparsable` → 400: the archive is malformed or hostile, and the import fails closed. `--numeric-owner` keeps a crafted header's owner field from shifting the size column; GNU tar escapes control characters in names, and the sum can only over-count (a big member's own line always shows its real size), never under-count.

Workspace rows created before a 413 are rolled back exactly like the pre-existing extraction-failure path.

## Tests

New tests in `klangkd-tests/tests/test_api.py` assert the security properties end-to-end:

- `workspace.json` beyond 1 MB (compresses to < 100 KB, so the compressed cap never sees it) → 413.
- Home tree exceeding free space (statvfs stubbed) → 413 + workspace row rolled back.
- Home tree exceeding `KLANGKD_IMPORT_MAX_UNCOMPRESSED_MB` → 413 naming the knob + rollback.
- A 32 MB home importing cleanly when the volume reports room — the bound is free space, not a tight cap.
- `_sum_listing` rejects a hostile listing line (crafted owner field) and accepts spaces/symlinks in names.
- Hanging-tar timeouts (metadata and scan) kill the process and surface a clean 400 with rollback; an unparsable listing refuses the import.

Settings tests cover coercion (int/string, 0 rejected, default None) in `test_settings.py`.

Full suite green with the 100% branch-coverage gate (post-rebase run: 8053 passed).

## Docs

- `docs/reference/klangkd-config.md`: `import_max_uncompressed_mb` row + a paragraph stating what bounds an import.
- `docs/changes.md`: Security entry under `[Unreleased]`.

Inherent limit, stated for the record: a user who can import can still fill the disk with real data up to the bound — that is the feature. The fix makes the bound explicit and refuses cleanly instead of writing until the filesystem dies.

Closes #3284.
