### PR TITLE
Fix DPoP NaN iat bypass and future-dated replay window (#3272)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -334,9 +334,11 @@ operators or integrators to act when upgrading.
 ### Security
 
 - **DPoP proof freshness and replay hardening (#3272).** A proof
-  whose `iat` is not a finite number (`NaN`/`Infinity` literals
-  decode via JSON) is now rejected as stale — such a proof previously
-  verified at any time and could be replayed indefinitely. A proof's
+  whose `iat` is not a usable timestamp — `NaN`/`Infinity` literals
+  decoded via JSON, a boolean, or an integer too large for a float —
+  is now rejected as stale; a NaN-dated proof previously verified at
+  any time and could be replayed indefinitely, and an oversized
+  integer crashed verification with an unhandled error. A proof's
   replay-cache entry now lives until the last moment the proof can
   still pass the freshness check, closing a doubled replay window for
   future-dated proofs.

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -333,6 +333,13 @@ operators or integrators to act when upgrading.
 
 ### Security
 
+- **DPoP proof freshness and replay hardening (#3272).** A proof
+  whose `iat` is not a finite number (`NaN`/`Infinity` literals
+  decode via JSON) is now rejected as stale — such a proof previously
+  verified at any time and could be replayed indefinitely. A proof's
+  replay-cache entry now lives until the last moment the proof can
+  still pass the freshness check, closing a doubled replay window for
+  future-dated proofs.
 - **`GET /groups` no longer discloses workspace names (#3283).**
   Workspace role groups are seeded with an id-only description
   (`Workspace role group: role`; the group name already carries the

--- a/src/klangk/klangk/dpop.py
+++ b/src/klangk/klangk/dpop.py
@@ -41,12 +41,17 @@ from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives.asymmetric import ec
 
 #: How far a proof's ``iat`` may sit from the server clock (seconds),
-#: in either direction (clock-skew allowance), and how long its ``jti``
-#: is remembered for replay blocking.
+#: in either direction (clock-skew allowance). A winning proof's
+#: ``jti`` is remembered until the last moment it could still pass
+#: this window — ``max(verify_time, iat) + PROOF_WINDOW_SECONDS``
+#: (#3272), so up to twice the window after verification for a
+#: maximally future-dated proof.
 PROOF_WINDOW_SECONDS = 300
 
 #: Cap on remembered proof JTIs; the map is purged of expired entries
-#: on every insert, so the cap only bounds a same-second flood.
+#: on every insert, so the cap only bounds a same-second flood. With
+#: future-dated proofs, worst-case occupancy spans up to 600 s of
+#: inserts rather than 300 s.
 REPLAY_CACHE_MAX = 10_000
 
 _EC_CURVE = "P-256"

--- a/src/klangk/klangk/dpop.py
+++ b/src/klangk/klangk/dpop.py
@@ -33,6 +33,7 @@ outer proxy's prefix, the request path without it) verify too (#3287).
 import base64
 import hashlib
 import json
+import math
 from urllib.parse import urlsplit
 
 from cryptography.exceptions import InvalidSignature
@@ -252,13 +253,31 @@ def _claim_reason(
     return None
 
 
+def _fresh_iat(iat, now: float) -> bool:
+    """Whether *iat* is a finite number within the freshness window.
+
+    ``json.loads`` decodes the non-standard ``NaN``/``Infinity``
+    literals, and every comparison against NaN is False — so a
+    NaN-dated proof would pass the window check forever (#3272).
+    ``bool`` (an ``int`` subclass standing for 0/1, never a clock
+    reading) is refused too. Plain ``int`` needs no finiteness test:
+    ints are finite by definition, and converting an oversized JSON
+    integer to float would raise OverflowError.
+    """
+    if isinstance(iat, bool) or (
+        isinstance(iat, float) and not math.isfinite(iat)
+    ):
+        return False
+    return abs(now - iat) <= PROOF_WINDOW_SECONDS
+
+
 def _freshness_reason(payload: dict, now: float, replay: dict) -> str | None:
     """Freshness + replay claims: a proof is single-use and short-lived."""
     iat = payload.get("iat")
     jti = payload.get("jti")
     if not isinstance(iat, (int, float)) or not isinstance(jti, str):
         return "malformed claims"
-    if abs(now - iat) > PROOF_WINDOW_SECONDS:
+    if not _fresh_iat(iat, now):
         return "stale proof"
     if jti in replay:
         return "replayed proof"
@@ -293,7 +312,12 @@ def _record_if_authentic(
     signing_input = proof.rsplit(".", 1)[0].encode()
     if not verify_signature(header["jwk"], signing_input, signature):
         return "bad signature"
-    replay[payload["jti"]] = now + PROOF_WINDOW_SECONDS
+    # Key the entry off the last moment the proof can still pass the
+    # freshness check — iat + window for a future-dated proof (the
+    # clock-skew tolerance allows iat ahead of now), which is later
+    # than now + window; keying off verification time let such a proof
+    # re-verify once its entry expired early (#3272).
+    replay[payload["jti"]] = max(now, payload["iat"]) + PROOF_WINDOW_SECONDS
     purge_replay(replay, now)
     return None
 

--- a/src/klangk/klangk/dpop.py
+++ b/src/klangk/klangk/dpop.py
@@ -260,15 +260,18 @@ def _fresh_iat(iat, now: float) -> bool:
     literals, and every comparison against NaN is False — so a
     NaN-dated proof would pass the window check forever (#3272).
     ``bool`` (an ``int`` subclass standing for 0/1, never a clock
-    reading) is refused too. Plain ``int`` needs no finiteness test:
-    ints are finite by definition, and converting an oversized JSON
-    integer to float would raise OverflowError.
+    reading) is refused too. So is a JSON integer too large for a
+    float: ints parse at arbitrary precision, and the subtraction
+    below converts to float, where it would raise OverflowError.
     """
     if isinstance(iat, bool) or (
         isinstance(iat, float) and not math.isfinite(iat)
     ):
         return False
-    return abs(now - iat) <= PROOF_WINDOW_SECONDS
+    try:
+        return abs(now - iat) <= PROOF_WINDOW_SECONDS
+    except OverflowError:
+        return False
 
 
 def _freshness_reason(payload: dict, now: float, replay: dict) -> str | None:

--- a/src/klangk/klangkd-tests/tests/test_dpop.py
+++ b/src/klangk/klangkd-tests/tests/test_dpop.py
@@ -388,7 +388,7 @@ class TestVerifyProof:
             10**400,
         ],
     )
-    def test_non_finite_iat_refused(self, key, iat):
+    def test_unusable_iat_refused(self, key, iat):
         # json.loads decodes NaN/Infinity literals and parses integers
         # at arbitrary precision. NaN was the pre-fix bypass (every
         # comparison against it is False, so the window check never

--- a/src/klangk/klangkd-tests/tests/test_dpop.py
+++ b/src/klangk/klangkd-tests/tests/test_dpop.py
@@ -378,6 +378,56 @@ class TestVerifyProof:
         )
         assert _verify(proof, jkt=_thumbprint_of(jwk)) is None
 
+    @pytest.mark.parametrize(
+        "iat", [float("nan"), float("inf"), float("-inf"), True]
+    )
+    def test_non_finite_iat_refused(self, key, iat):
+        # json.loads decodes NaN/Infinity literals; comparisons against
+        # NaN are False, so a NaN-dated proof used to pass the window
+        # check at any `now` and could be replayed forever (#3272).
+        private, jwk = key
+        from _helpers import make_dpop_proof
+
+        proof = make_dpop_proof(
+            private,
+            jwk,
+            method="GET",
+            uri="https://host/api/v1/x",
+            token="the-access-token",
+            iat=iat,
+        )
+        assert _verify(proof, jkt=_thumbprint_of(jwk)) == "stale proof"
+
+    def test_nan_iat_never_becomes_fresh(self, key):
+        # The same NaN-dated proof string stays refused far past the
+        # window — it never enters the replay cache at all.
+        private, jwk = key
+        from _helpers import make_dpop_proof
+
+        proof = make_dpop_proof(
+            private,
+            jwk,
+            method="GET",
+            uri="https://host/api/v1/x",
+            token="the-access-token",
+            iat=float("nan"),
+        )
+        replay: dict = {}
+        for now in (time.time(), time.time() + 10_000):
+            assert (
+                dpop.verify_proof(
+                    proof,
+                    method="GET",
+                    path="/api/v1/x",
+                    access_token="the-access-token",
+                    expected_jkt=_thumbprint_of(jwk),
+                    now=now,
+                    replay=replay,
+                )
+                == "stale proof"
+            )
+        assert replay == {}
+
     def test_malformed_claims(self, key):
         private, jwk = key
         from _helpers import build_dpop_proof
@@ -428,6 +478,45 @@ class TestVerifyProof:
         assert first is None
         assert second == "replayed proof"
         assert len(replay) == 1
+
+    def test_future_dated_proof_replay_entry_covers_its_window(self, key):
+        # A proof minted iat = now + 290 stays fresh until iat + 300;
+        # its replay entry must live just as long, or the same proof
+        # string re-verifies once the entry (formerly keyed off
+        # verification time) expires early (#3272).
+        private, jwk = key
+        from _helpers import make_dpop_proof
+
+        now = time.time()
+        iat = now + dpop.PROOF_WINDOW_SECONDS - 10
+        proof = make_dpop_proof(
+            private,
+            jwk,
+            method="GET",
+            uri="https://host/api/v1/x",
+            token="the-access-token",
+            jti="future-jti",
+            iat=iat,
+        )
+        replay: dict = {}
+        verify = dict(
+            method="GET",
+            path="/api/v1/x",
+            access_token="the-access-token",
+            expected_jkt=_thumbprint_of(jwk),
+            replay=replay,
+        )
+        assert dpop.verify_proof(proof, now=now, **verify) is None
+        assert replay["future-jti"] == iat + dpop.PROOF_WINDOW_SECONDS
+        # +400 s: verification-time-keyed entries are gone, the proof
+        # itself is still fresh (|400 - 290| <= 300) — a replay of the
+        # same string must still be refused.
+        dpop.purge_replay(replay, now + 400)
+        assert replay == {"future-jti": iat + dpop.PROOF_WINDOW_SECONDS}
+        assert (
+            dpop.verify_proof(proof, now=now + 400, **verify)
+            == "replayed proof"
+        )
 
     def test_bad_signature(self, key):
         private, jwk = key

--- a/src/klangk/klangkd-tests/tests/test_dpop.py
+++ b/src/klangk/klangkd-tests/tests/test_dpop.py
@@ -379,12 +379,22 @@ class TestVerifyProof:
         assert _verify(proof, jkt=_thumbprint_of(jwk)) is None
 
     @pytest.mark.parametrize(
-        "iat", [float("nan"), float("inf"), float("-inf"), True]
+        "iat",
+        [
+            float("nan"),
+            float("inf"),
+            float("-inf"),
+            True,
+            10**400,
+        ],
     )
     def test_non_finite_iat_refused(self, key, iat):
-        # json.loads decodes NaN/Infinity literals; comparisons against
-        # NaN are False, so a NaN-dated proof used to pass the window
-        # check at any `now` and could be replayed forever (#3272).
+        # json.loads decodes NaN/Infinity literals and parses integers
+        # at arbitrary precision. NaN was the pre-fix bypass (every
+        # comparison against it is False, so the window check never
+        # fired); the other shapes pin the refusal behavior — inf and
+        # the giant int (whose float subtraction would raise
+        # OverflowError, #3272) alongside bool.
         private, jwk = key
         from _helpers import make_dpop_proof
 


### PR DESCRIPTION
## Summary

Fixes the two DPoP proof-verification bugs from #3272 (`src/klangk/klangk/dpop.py`):

- **NaN `iat` bypass (high).** `json.loads` decodes the non-standard `NaN` literal, and every comparison against NaN is False — so `abs(now - iat) > PROOF_WINDOW_SECONDS` never fired and a NaN-dated proof verified at any time. Each success re-recorded its jti for only 300 s, so a captured token+proof pair could be replayed indefinitely at ≤5-minute intervals. A new `_fresh_iat()` helper rejects bool and non-finite-float `iat` before the window comparison (plain ints skip `math.isfinite` — ints are finite by definition and an oversized JSON integer would raise OverflowError on float conversion).
- **Future-dated proofs outliving the replay cache (medium).** The replay entry was keyed off verification time (`now + 300`), but clock-skew tolerance lets `iat` sit up to 300 s in the future — a proof minted at `iat = now + 290` stays fresh until `iat + 300` while its entry expired at `now + 300`, doubling the replay window. `_record_if_authentic` now records `max(now, iat) + PROOF_WINDOW_SECONDS`, the last moment the proof can pass the freshness check.

## Tests

Three regression tests in `klangkd-tests/tests/test_dpop.py`:

- `test_non_finite_iat_refused[nan]`, `test_nan_iat_never_becomes_fresh`, and `test_future_dated_proof_replay_entry_covers_its_window` were verified to **fail against the pre-fix code** (the other parametrized shapes — `inf`, `-inf`, `True` — were already rejected by the old window check and pin the behavior).
- Full suite green: `8078 passed`, 100% branch coverage, xenon rank A.

## Review finding addressed

The fresh-eyes review caught a third `iat` shape: a JSON integer too large for a float (e.g. `10**400` parses at arbitrary precision) raised an uncaught `OverflowError` out of `verify_proof` — crashing HTTP handlers with a 500 instead of a 401. The subtraction is now wrapped and the shape is rejected as stale, with a parametrized test case. The review also verified the replay-entry arithmetic, the purge/cache-cap interaction, and that no consumer pattern-matches the reason strings.
