### PR TITLE
Require terminal window names to start alphanumeric (#3279)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -2560,9 +2560,10 @@ git-credential` (#1700).** `pig-latin` removed; `word-count` dormant.
   Renaming a terminal tab to a name with a leading hyphen (e.g. `-dev`)
   failed as a server-side tmux error: the name is passed positionally to
   `rename-window`, which tmux parses as a flag. The name validator now
-  rejects a leading hyphen, dot, underscore, or space at the source —
-  same rule as volume names (#3018) — so the rename is refused as
-  invalid input instead of erroring in the tmux call.
+  rejects a leading hyphen, dot, underscore, or space (same start rule as
+  volume names, #3018), and the create/rename handlers send the
+  validator's message to the client, so the rename is refused as invalid
+  input with wording that states the rule.
 
 - **Subpath deployments work with DPoP-bound web sessions (#3287).**
   On a deployment served under a base path (`hosting-base-path` /

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -2558,11 +2558,11 @@ git-credential` (#1700).** `pig-latin` removed; `word-count` dormant.
 
 - **Terminal window names must start with a letter or digit (#3279).**
   Renaming a terminal tab to a name with a leading hyphen (e.g. `-dev`)
-  failed with a tmux `unknown flag` error: the name is passed positionally
-  to `rename-window`, which tmux parses as a flag. The name validator now
+  failed as a server-side tmux error: the name is passed positionally to
+  `rename-window`, which tmux parses as a flag. The name validator now
   rejects a leading hyphen, dot, underscore, or space at the source —
-  same rule as volume names (#3018) — so the rename is refused with a
-  clear message instead of erroring server-side.
+  same rule as volume names (#3018) — so the rename is refused as
+  invalid input instead of erroring in the tmux call.
 
 - **Subpath deployments work with DPoP-bound web sessions (#3287).**
   On a deployment served under a base path (`hosting-base-path` /

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -2556,6 +2556,14 @@ git-credential` (#1700).** `pig-latin` removed; `word-count` dormant.
 
 ### Fixed
 
+- **Terminal window names must start with a letter or digit (#3279).**
+  Renaming a terminal tab to a name with a leading hyphen (e.g. `-dev`)
+  failed with a tmux `unknown flag` error: the name is passed positionally
+  to `rename-window`, which tmux parses as a flag. The name validator now
+  rejects a leading hyphen, dot, underscore, or space at the source —
+  same rule as volume names (#3018) — so the rename is refused with a
+  clear message instead of erroring server-side.
+
 - **Subpath deployments work with DPoP-bound web sessions (#3287).**
   On a deployment served under a base path (`hosting-base-path` /
   `X-Forwarded-Prefix`), the web client's DPoP proofs carried the

--- a/src/klangk/klangk/terminal.py
+++ b/src/klangk/klangk/terminal.py
@@ -34,7 +34,12 @@ _WRITE_TIMEOUT = 30.0  # seconds before a stuck PTY write stops the session
 _READ_CHUNK = 65536
 CONTAINER_USER = "klangk"
 
-_SAFE_WINDOW_NAME = re.compile(r"^[A-Za-z0-9 _.\-]+$")
+# First character must be alphanumeric (mirrors VOLUME_NAME_PATTERN,
+# #3018): tmux has no "--" separator for command arguments, so a
+# leading hyphen in a name passed positionally to ``rename-window`` is
+# parsed as a flag (``unknown flag -dev``). Window names are display-only
+# (#2192), so no other start rule is needed.
+_SAFE_WINDOW_NAME = re.compile(r"^[A-Za-z0-9][A-Za-z0-9 _.\-]*$")
 _MAX_WINDOW_NAME_LEN = 64
 
 
@@ -51,8 +56,9 @@ def validate_window_name(name: str) -> None:
         )
     if not _SAFE_WINDOW_NAME.match(name):
         raise ValueError(
-            "Window name may only contain letters, digits,"
-            " spaces, hyphens, underscores, and dots"
+            "Window name must start with a letter or digit and may only"
+            " contain letters, digits, spaces, hyphens, underscores, and"
+            " dots"
         )
 
 

--- a/src/klangk/klangk/terminal.py
+++ b/src/klangk/klangk/terminal.py
@@ -38,8 +38,10 @@ CONTAINER_USER = "klangk"
 # #3018): tmux has no "--" separator for command arguments, so a
 # leading hyphen in a name passed positionally to ``rename-window`` is
 # parsed as a flag (``unknown flag -dev``). Window names are display-only
-# (#2192), so no other start rule is needed.
-_SAFE_WINDOW_NAME = re.compile(r"^[A-Za-z0-9][A-Za-z0-9 _.\-]*$")
+# (#2192), so no other start rule is needed. Anchored with \Z (not
+# Python re's `$`, which also matches before a trailing newline) to
+# mirror the pydantic-core strict-$ semantics of VOLUME_NAME_PATTERN.
+_SAFE_WINDOW_NAME = re.compile(r"^[A-Za-z0-9][A-Za-z0-9 _.\-]*\Z")
 _MAX_WINDOW_NAME_LEN = 64
 
 

--- a/src/klangk/klangk/wshandler/controllers.py
+++ b/src/klangk/klangk/wshandler/controllers.py
@@ -1157,6 +1157,21 @@ class TerminalController:
             self._conn.user["id"], ws_id, windows
         )
 
+    def _send_window_error(self, e: Exception, action: str) -> None:
+        """Send the right error frame for a failed window operation.
+
+        A ``ValueError`` is the name validator refusing the input — send
+        its wording so the client sees the rule (#3279). Anything else is
+        an infrastructure failure: log the traceback and send the
+        generic text (*action* is "create", "rename", or "close").
+        """
+        if isinstance(e, ValueError):
+            logger.info("Window name rejected: %s", e)
+            send_error(self._conn.sock, str(e))
+        else:
+            logger.exception("Failed to %s window: %s", action, e)
+            send_error(self._conn.sock, f"Failed to {action} window")
+
     async def new_window(self, msg: dict) -> None:
         t0 = time.monotonic()
         if not await self._own_windows_allowed():
@@ -1178,8 +1193,7 @@ class TerminalController:
             self.notify_user_terminal_windows(windows)
             self._notify_terminals_changed(windows)
         except Exception as e:
-            logger.exception("Failed to create window: %s", e)
-            send_error(self._conn.sock, "Failed to create window")
+            self._send_window_error(e, "create")
 
     async def select_window(self, msg: dict) -> None:
         t0 = time.monotonic()
@@ -1239,8 +1253,7 @@ class TerminalController:
             self.notify_user_terminal_windows(windows)
             self._notify_terminals_changed(windows)
         except Exception as e:
-            logger.exception("Failed to close window: %s", e)
-            send_error(self._conn.sock, "Failed to close window")
+            self._send_window_error(e, "close")
 
     async def rename_window(self, msg: dict) -> None:
         if not await self._own_windows_allowed():
@@ -1272,8 +1285,7 @@ class TerminalController:
             self.notify_user_terminal_windows(windows)
             self._notify_terminals_changed(windows)
         except Exception as e:
-            logger.exception("Failed to rename window: %s", e)
-            send_error(self._conn.sock, "Failed to rename window")
+            self._send_window_error(e, "rename")
 
     async def list_windows(self) -> None:
         if not await self._own_windows_allowed():

--- a/src/klangk/klangkd-tests/tests/test_terminal.py
+++ b/src/klangk/klangkd-tests/tests/test_terminal.py
@@ -937,6 +937,15 @@ class TestValidateWindowName:
             with pytest.raises(ValueError, match="only contain"):
                 validate_window_name(name)
 
+    def test_rejects_leading_non_alphanumeric(self):
+        # #3279: a leading hyphen reaches tmux's rename-window positionally
+        # and parses as a flag; same class as #3018. Also covers dot,
+        # underscore, and space, which tmux would accept as names but which
+        # the volume-name rule (#3018) rejects for consistency.
+        for name in ["-dev", "--flags", "-", ".dev", "_dev", " dev"]:
+            with pytest.raises(ValueError, match="must start with a letter"):
+                validate_window_name(name)
+
 
 class TestNewWindow:
     async def test_creates_window_auto_name(self):

--- a/src/klangk/klangkd-tests/tests/test_terminal.py
+++ b/src/klangk/klangkd-tests/tests/test_terminal.py
@@ -946,6 +946,12 @@ class TestValidateWindowName:
             with pytest.raises(ValueError, match="must start with a letter"):
                 validate_window_name(name)
 
+    def test_rejects_trailing_newline(self):
+        # Python re's `$` also matches before a trailing newline; \Z does
+        # not (mirrors the strict-$ semantics of #3018's volume rule).
+        with pytest.raises(ValueError, match="only contain"):
+            validate_window_name("build\n")
+
 
 class TestNewWindow:
     async def test_creates_window_auto_name(self):

--- a/src/klangk/klangkd-tests/tests/test_wshandler.py
+++ b/src/klangk/klangkd-tests/tests/test_wshandler.py
@@ -7599,6 +7599,23 @@ class TestTerminalWindowHandlers:
             await conn.handle_terminal_new_window({"name": "dup"})
         sent = sock.send_json.call_args[0][0]
         assert sent["type"] == "error"
+        # The validator's wording reaches the client (#3279).
+        assert sent["message"] == "already exists"
+
+    async def test_new_window_terminal_error(self):
+        sock = _mock_sock()
+        conn = _base_conn(ws=sock, perms=("code-in-isolation",))
+        conn.container_id = "cid"
+        conn._user_home = "/home/alice"
+        with patch.object(
+            _mock_term,
+            "new_window",
+            side_effect=RuntimeError("boom"),
+        ):
+            await conn.handle_terminal_new_window({"name": "build"})
+        sent = sock.send_json.call_args[0][0]
+        assert sent["type"] == "error"
+        assert sent["message"] == "Failed to create window"
 
     async def test_select_window_by_index(self):
         sock = _mock_sock()
@@ -7930,6 +7947,25 @@ class TestTerminalWindowHandlers:
             )
         sent = sock.send_json.call_args[0][0]
         assert sent["type"] == "error"
+        # The validator's wording reaches the client (#3279).
+        assert sent["message"] == "already exists"
+
+    async def test_rename_window_terminal_error(self):
+        sock = _mock_sock()
+        conn = _base_conn(ws=sock, perms=("code-in-isolation",))
+        conn.container_id = "cid"
+        conn._user_home = "/home/alice"
+        with patch.object(
+            _mock_term,
+            "rename_window",
+            side_effect=RuntimeError("boom"),
+        ):
+            await conn.handle_terminal_rename_window(
+                {"index": 0, "name": "build"}
+            )
+        sent = sock.send_json.call_args[0][0]
+        assert sent["type"] == "error"
+        assert sent["message"] == "Failed to rename window"
 
     async def test_rename_shared_window_broadcasts_shared_terminals(
         self, user, app_state


### PR DESCRIPTION
## Summary

Terminal tab names are tmux window names, and `rename_window` passes the
new name positionally in the tmux argv. tmux has no `--` separator for
command arguments, so a name like `-dev` is parsed as a flag and the
rename fails with `unknown flag -dev` — while creating a tab named `-dev`
(`new_window -n "$lbl"`) succeeds, leaving the user able to *create* but
never *rename to* such a name.

Fixes #3279, same class as #3018 (leading-dash tokens reaching a CLI
parser):

- `_SAFE_WINDOW_NAME` now requires the first character to be
  alphanumeric (mirroring `VOLUME_NAME_PATTERN` from #3018) and is
  anchored with `\Z` instead of `$` so a trailing newline cannot slip
  through Python `re`'s before-trailing-newline match — matching the
  strict-anchor semantics the volume rule gets from pydantic-core.
- The validator's error message states the start rule ("Window name
  must start with a letter or digit and may only contain …").
- The `terminal_new_window` / `terminal_rename_window` handlers now
  surface that wording to the client instead of swallowing the
  `ValueError` behind a generic "Failed to rename window" frame
  (infrastructure failures still get the generic text + traceback log;
  `close` routes through the same helper).
- Rename targets the window by stable `@N` id / index, so windows
  *named* with a leading dot/underscore before this change can still be
  renamed away — only the new name is validated.

## Testing

- New `TestValidateWindowName` cases: leading `-`/`.`/`_`/space
  rejected (verified load-bearing — all six inputs pass the old regex),
  trailing-newline rejected.
- `test_wshandler` error tests split: `ValueError` asserts the surfaced
  validator message; `RuntimeError` asserts the generic frame (both
  branches covered).
- Full Python suite the CI way: 8094 passed, 100% branch coverage.
