### PR TITLE
Reject Unicode-digit CIDR ports in allow-list specs (#3274)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -2565,6 +2565,14 @@ git-credential` (#1700).** `pig-latin` removed; `word-count` dormant.
 
 ### Fixed
 
+- **CIDR allow-list ports must be ASCII digits (#3274).** An
+  allow-list entry like `10.0.0.0/8:٤٤٣` (a port written in Unicode
+  digits) was accepted by the API, persisted, and then aborted the
+  network sidecar at workspace start: iptables rejects the port and
+  the sidecar exits before the workspace gets network. Such specs are
+  now rejected as invalid input at the API boundary, matching how
+  `host:port` specs were already treated.
+
 - **Terminal window names must start with a letter or digit (#3279).**
   Renaming a terminal tab to a name with a leading hyphen (e.g. `-dev`)
   failed as a server-side tmux error: the name is passed positionally to

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -2571,7 +2571,9 @@ git-credential` (#1700).** `pig-latin` removed; `word-count` dormant.
   network sidecar at workspace start: iptables rejects the port and
   the sidecar exits before the workspace gets network. Such specs are
   now rejected as invalid input at the API boundary, matching how
-  `host:port` specs were already treated.
+  `host:port` specs were already treated; the CLI's client-side
+  pre-check rejects them too instead of crashing on digit forms the
+  port parse cannot handle.
 
 - **Terminal window names must start with a letter or digit (#3279).**
   Renaming a terminal tab to a name with a leading hyphen (e.g. `-dev`)

--- a/src/klangk/klangk/cli/mount.py
+++ b/src/klangk/klangk/cli/mount.py
@@ -71,8 +71,18 @@ def validate_mount_spec(spec: str) -> str | None:
 # (:func:`klangk.netfilter.parse_allowed_domains`) does the authoritative
 # check (#1365, #1745, #1935).
 _ALLOWED_DOMAIN_RE = re.compile(
-    r"^[^\[\]/\s:]+(?::\d{1,5})?$"  # host or host:port (IPv4 / DNS)
+    r"^[^\[\]/\s:]+(?::[0-9]{1,5})?$"  # host or host:port (IPv4 / DNS)
 )
+
+
+def _is_port_digits(s: str) -> bool:
+    """1–5 ASCII digits — the port grammar shared by the host regex and the
+    CIDR suffix. ``\\d`` and ``str.isdigit()`` alone admit Unicode digit
+    forms (Arabic-Indic ٤٤٣ parses via ``int()``, superscript ² raises), and
+    an unbounded run hits ``int()``'s conversion limit (#3274). Duplicated
+    from ``klangk.netfilter`` — the CLI subpackage imports nothing from the
+    server."""
+    return bool(s) and s.isascii() and s.isdigit() and len(s) <= 5
 
 
 def validate_allowed_domain_spec(
@@ -115,7 +125,7 @@ def validate_allowed_domain_spec(
 
 def cidr_port_error(spec: str, port: str) -> str | None:
     """The CIDR-port range error, if *port* is not 1–65535 digits."""
-    if not port or not port.isdigit() or int(port) > 65535:
+    if not _is_port_digits(port) or int(port) > 65535:
         return f"Invalid allowed-domain {spec!r}: CIDR port must be 1–65535"
     return None
 

--- a/src/klangk/klangk/netfilter.py
+++ b/src/klangk/klangk/netfilter.py
@@ -55,12 +55,14 @@ def _has_no_whitespace(spec: str) -> bool:
     return not any(ch.isspace() for ch in spec)
 
 
-def _is_ascii_digits(s: str) -> bool:
-    """True for a non-empty run of ASCII 0-9. ``str.isdigit()`` alone also
-    admits Unicode digit forms — Arabic-Indic ٤٤٣ parses via ``int()`` but is
-    rejected by iptables, and superscript ² raises from ``int()`` — so every
-    port parse goes through this gate (#3274)."""
-    return bool(s) and s.isascii() and s.isdigit()
+def _is_port_digits(s: str) -> bool:
+    """True for a run of 1–5 ASCII digits — the port grammar shared by the
+    host regex (``[0-9]{1,5}``) and the CIDR suffix. ``str.isdigit()`` alone
+    also admits Unicode digit forms — Arabic-Indic ٤٤٣ parses via ``int()``
+    but is rejected by iptables, and superscript ² raises from ``int()`` —
+    and an unbounded digit run would hit ``int()``'s conversion limit
+    (#3274)."""
+    return bool(s) and s.isascii() and s.isdigit() and len(s) <= 5
 
 
 def _valid_host_port(host: str) -> bool:
@@ -105,7 +107,7 @@ def _valid_spec_port(spec: str) -> bool:
     if ":" not in spec:
         return True
     port_str = spec.rsplit(":", 1)[1]
-    if _is_ascii_digits(port_str) and int(port_str) > 65535:
+    if _is_port_digits(port_str) and int(port_str) > 65535:
         return False
     return True
 
@@ -118,7 +120,7 @@ def _valid_cidr_port_suffix(spec: str) -> tuple[str, str | None] | None:
     if ":" not in spec:
         return spec, None
     cidr, port = spec.rsplit(":", 1)
-    if not _is_ascii_digits(port) or int(port) > 65535:
+    if not _is_port_digits(port) or int(port) > 65535:
         return None
     return cidr, port
 

--- a/src/klangk/klangk/netfilter.py
+++ b/src/klangk/klangk/netfilter.py
@@ -55,6 +55,14 @@ def _has_no_whitespace(spec: str) -> bool:
     return not any(ch.isspace() for ch in spec)
 
 
+def _is_ascii_digits(s: str) -> bool:
+    """True for a non-empty run of ASCII 0-9. ``str.isdigit()`` alone also
+    admits Unicode digit forms — Arabic-Indic ٤٤٣ parses via ``int()`` but is
+    rejected by iptables, and superscript ² raises from ``int()`` — so every
+    port parse goes through this gate (#3274)."""
+    return bool(s) and s.isascii() and s.isdigit()
+
+
 def _valid_host_port(host: str) -> bool:
     """A ``host[:port]`` spec against the host grammar + port range."""
     return bool(_DOMAIN_RE.match(host)) and _valid_spec_port(host)
@@ -97,19 +105,20 @@ def _valid_spec_port(spec: str) -> bool:
     if ":" not in spec:
         return True
     port_str = spec.rsplit(":", 1)[1]
-    if port_str and port_str.isdigit() and int(port_str) > 65535:
+    if _is_ascii_digits(port_str) and int(port_str) > 65535:
         return False
     return True
 
 
 def _valid_cidr_port_suffix(spec: str) -> tuple[str, str | None] | None:
     """(cidr, port) with the port split off; ``None`` when the port suffix
-    is malformed (the grammar matches the host spec: 1–65535, digits
-    only)."""
+    is malformed (the grammar matches the host spec: 1–65535, ASCII digits
+    only — ``isdigit()`` alone also admits Unicode digit forms that iptables
+    rejects, #3274)."""
     if ":" not in spec:
         return spec, None
     cidr, port = spec.rsplit(":", 1)
-    if not port or not port.isdigit() or int(port) > 65535:
+    if not _is_ascii_digits(port) or int(port) > 65535:
         return None
     return cidr, port
 

--- a/src/klangk/klangkc-tests/tests/test_mount.py
+++ b/src/klangk/klangkc-tests/tests/test_mount.py
@@ -120,6 +120,18 @@ class TestValidateAllowedDomainSpec:
     def test_rejects_non_numeric_port(self):
         assert validate_allowed_domain_spec("a.com:abc") is not None
 
+    def test_rejects_non_ascii_digit_ports(self):
+        # #3274: only 1–5 ASCII digits are a port, on both paths. The host
+        # regex used \d (which matches Unicode digits), the CIDR path used
+        # isdigit() (which admits them and accepted ٤٤٣ as valid), and the
+        # superscript ² raised int()'s ValueError out of the validator.
+        # Every form must return an error string — never None, never raise.
+        assert "expected host" in validate_allowed_domain_spec("a.com:٤٤٣")
+        for spec in ("10.0.0.0/8:٤٤٣", "10.0.0.0/8:²", "10.0.0.0/8:123456"):
+            err = validate_allowed_domain_spec(spec)
+            assert err is not None
+            assert "1–65535" in err
+
     def test_strips_whitespace(self):
         assert validate_allowed_domain_spec("  github.com:443  ") is None
         assert validate_allowed_domain_spec("  10.0.0.0/8  ") is None

--- a/src/klangk/klangkd-tests/tests/test_netfilter.py
+++ b/src/klangk/klangkd-tests/tests/test_netfilter.py
@@ -112,11 +112,27 @@ class TestParseAllowedDomains:
             "10.0.0.0/8:70000",  # CIDR with port > 65535
             "2001:db8::/32",  # IPv6 CIDR — v6 disabled in containers (#1936)
             "not.a.cidr/24",  # slash but the IP literal is garbage
+            # #3274: ports are ASCII digits only — Unicode digit forms
+            # (Arabic-Indic ٤٤٣, superscript ²) are rejected on both paths.
+            # The CIDR path used to accept them (isdigit() admits Unicode
+            # decimals), persist the spec, and kill the sidecar entrypoint
+            # at start (iptables rejects the port).
+            "a.com:٤٤٣",  # host path — regex already rejects it
+            "10.0.0.0/8:٤٤٣",  # CIDR path — accepted before #3274
+            "10.0.0.0/8:²",  # isdigit()-true but int() raises
         ],
     )
     def test_invalid_specs_rejected(self, spec):
         with pytest.raises(ValueError):
             nf.parse_allowed_domains([spec])
+
+    # #3274: the CIDR validator must answer False (not propagate int()'s
+    # ValueError) for digit forms where isdigit() is true but the string
+    # is not ASCII-decimal — parse_allowed_domains turns that False into
+    # the normal "invalid entry" error, exactly like the host:port path.
+    @pytest.mark.parametrize("spec", ["10.0.0.0/8:٤٤٣", "10.0.0.0/8:²"])
+    def test_cidr_unicode_port_returns_false_not_raise(self, spec):
+        assert nf.valid_cidr_spec(spec) is False
 
     def test_error_lists_every_invalid_entry(self):
         with pytest.raises(ValueError) as exc:

--- a/src/klangk/klangkd-tests/tests/test_netfilter.py
+++ b/src/klangk/klangkd-tests/tests/test_netfilter.py
@@ -128,10 +128,13 @@ class TestParseAllowedDomains:
 
     # #3274: the CIDR validator must answer False (not propagate int()'s
     # ValueError) for digit forms where isdigit() is true but the string
-    # is not ASCII-decimal — parse_allowed_domains turns that False into
-    # the normal "invalid entry" error, exactly like the host:port path.
-    @pytest.mark.parametrize("spec", ["10.0.0.0/8:٤٤٣", "10.0.0.0/8:²"])
-    def test_cidr_unicode_port_returns_false_not_raise(self, spec):
+    # is not a 1–5 ASCII-digit run — parse_allowed_domains turns that False
+    # into the normal "invalid entry" error, exactly like the host:port
+    # path. The over-long run covers int()'s 4300-digit conversion limit.
+    @pytest.mark.parametrize(
+        "spec", ["10.0.0.0/8:٤٤٣", "10.0.0.0/8:²", "10.0.0.0/8:" + "1" * 4301]
+    )
+    def test_cidr_bad_port_returns_false_not_raise(self, spec):
         assert nf.valid_cidr_spec(spec) is False
 
     def test_error_lists_every_invalid_entry(self):

--- a/src/klangksidecar/klangksidecar/allowlist.py
+++ b/src/klangksidecar/klangksidecar/allowlist.py
@@ -32,13 +32,13 @@ SUBDOMAINS = "subdomains"
 def _split_spec_port(spec: str) -> tuple[str, int | None]:
     """Split a trailing ``:port`` off a spec -> ``(host_part, port)``; the
     port is None when absent or not numeric (then the whole spec is the host,
-    e.g. a bare IPv6 literal fragment). Only ASCII digits parse as a port
-    (#3274) — a Unicode-digit suffix stays part of the host, so ``int()``
-    can never choke on a digit form like ``²``."""
+    e.g. a bare IPv6 literal fragment). Only 1–5 ASCII digits parse as a
+    port (#3274) — a Unicode-digit suffix stays part of the host and an
+    over-long digit run can never reach ``int()``'s conversion limit."""
     if ":" not in spec:
         return spec, None
     host_part, port_part = spec.rsplit(":", 1)
-    if port_part.isascii() and port_part.isdigit():
+    if port_part.isascii() and port_part.isdigit() and len(port_part) <= 5:
         return host_part, int(port_part)
     return spec, None
 

--- a/src/klangksidecar/klangksidecar/allowlist.py
+++ b/src/klangksidecar/klangksidecar/allowlist.py
@@ -32,11 +32,13 @@ SUBDOMAINS = "subdomains"
 def _split_spec_port(spec: str) -> tuple[str, int | None]:
     """Split a trailing ``:port`` off a spec -> ``(host_part, port)``; the
     port is None when absent or not numeric (then the whole spec is the host,
-    e.g. a bare IPv6 literal fragment)."""
+    e.g. a bare IPv6 literal fragment). Only ASCII digits parse as a port
+    (#3274) — a Unicode-digit suffix stays part of the host, so ``int()``
+    can never choke on a digit form like ``²``."""
     if ":" not in spec:
         return spec, None
     host_part, port_part = spec.rsplit(":", 1)
-    if port_part.isdigit():
+    if port_part.isascii() and port_part.isdigit():
         return host_part, int(port_part)
     return spec, None
 

--- a/src/klangksidecar/tests/test_proxy.py
+++ b/src/klangksidecar/tests/test_proxy.py
@@ -113,6 +113,15 @@ class TestParseSpecs:
         monkeypatch.delenv("KLANGKNETWORK_EGRESS_ALLOW", raising=False)
         assert proxy.parse_specs() == []
 
+    def test_unicode_digit_port_not_a_port(self, proxy, monkeypatch):
+        # #3274: only ASCII digits parse as a port. A Unicode-digit suffix
+        # (Arabic-Indic ٤٤٣) stays part of the host — like any non-numeric
+        # suffix — so int() can never choke on a digit form like ². Backend
+        # validation rejects such specs at the API boundary; this gate keeps
+        # the sidecar's parse symmetric with klangk.netfilter.
+        monkeypatch.setenv("KLANGKNETWORK_EGRESS_ALLOW", "example.com:٤٤٣")
+        assert proxy.parse_specs() == [("example.com:٤٤٣", None, proxy.EXACT)]
+
 
 class TestPortsFor:
     """``ports_for`` is the allow gate (#2377 nginx-style scopes). Returns

--- a/src/klangksidecar/tests/test_proxy.py
+++ b/src/klangksidecar/tests/test_proxy.py
@@ -122,6 +122,13 @@ class TestParseSpecs:
         monkeypatch.setenv("KLANGKNETWORK_EGRESS_ALLOW", "example.com:٤٤٣")
         assert proxy.parse_specs() == [("example.com:٤٤٣", None, proxy.EXACT)]
 
+    def test_overlong_digit_run_not_a_port(self, proxy, monkeypatch):
+        # #3274 review: a port is 1–5 digits, so an over-long digit run
+        # stays part of the host — int()'s 4300-digit conversion limit can
+        # never raise from the split.
+        monkeypatch.setenv("KLANGKNETWORK_EGRESS_ALLOW", "example.com:" + "1" * 6)
+        assert proxy.parse_specs() == [("example.com:" + "1" * 6, None, proxy.EXACT)]
+
 
 class TestPortsFor:
     """``ports_for`` is the allow gate (#2377 nginx-style scopes). Returns


### PR DESCRIPTION
## Summary

Fixes #3274.

A CIDR allow-list entry with a Unicode-digit port (`10.0.0.0/8:٤٤٣` —
Arabic-Indic digits for 443) passed `parse_allowed_domains`
(`src/klangk/klangk/netfilter.py`): `_valid_cidr_port_suffix` gated the port on
`str.isdigit()`, which admits Unicode decimal digits, and `int("٤٤٣")`
succeeds (= 443). The spec was accepted as-typed and persisted; at workspace
start it flowed into `KLANGKNETWORK_EGRESS_ALLOW`, and the network sidecar's
entrypoint died at `iptables ... --dport ٤٤٣` (`invalid port/service`) — under
`set -eu`, before the nat REDIRECT rules and the proxy, leaving the workspace
(which shares the sidecar's netns) with no network until the spec was removed.
Via `KLANGKD_NETFILTER_DEFAULT_DOMAINS` this could hit every filtered workspace
on a deploy. The `host:port` path was already safe — `_DOMAIN_RE` restricts the
port to `[0-9]{1,5}` — so this closes the asymmetry the docstring already
claimed ("the grammar matches the host spec").

Companion fix: digit forms where `isdigit()` is true but `int()` raises (the
superscript `²`) made `valid_cidr_spec("10.0.0.0/8:²")` propagate `int()`'s
`ValueError` instead of returning `False`. Every caller treats a `ValueError`
as "invalid spec", so the behavior was right — the surfaced message was just
cryptic.

## Changes

- `src/klangk/klangk/netfilter.py` — new `_is_port_digits` predicate
  (1–5 ASCII digits — the port grammar the host regex already enforces);
  `_valid_cidr_port_suffix` and `_valid_spec_port` gate their port parses
  through it. Non-ASCII-digit ports are rejected as ordinary invalid entries
  on both paths, and `int()` can no longer be reached with a string it can't
  parse (Unicode digits, superscripts) or one long enough to hit its
  4300-digit conversion limit. `_valid_spec_port` is behavior-identical (it
  only runs after `_DOMAIN_RE` matched, so its port was already
  `[0-9]{1,5}`).
- `src/klangk/klangk/cli/mount.py` — the CLI's client-side mirror had the
  same bug (found in review): `cidr_port_error` used the verbatim
  `isdigit()` gate (so `10.0.0.0/8:²` crashed the CLI/TUI editors with a
  traceback and `10.0.0.0/8:٤٤٣` passed as valid), and `_ALLOWED_DOMAIN_RE`
  used `\d`, which matches Unicode digits (`a.com:٤٤٣` passed). The regex
  port is now `[0-9]{1,5}` and the gate is a duplicated `_is_port_digits`
  (the CLI subpackage imports nothing from the server).
- `src/klangksidecar/klangksidecar/allowlist.py` — `_split_spec_port` gets
  the same gate for symmetry: a Unicode-digit or over-long suffix stays part
  of the host (like any non-numeric suffix) instead of being `int()`-parsed.
- Tests: rejection cases (`a.com:٤٤٣`, `10.0.0.0/8:٤٤٣`, `10.0.0.0/8:²`)
  in both the server and CLI suites; `test_cidr_bad_port_returns_false_not_raise`
  pinning `valid_cidr_spec` returns `False` (not `int()`'s error) including
  the ≥4300-digit run; sidecar `test_unicode_digit_port_not_a_port` and
  `test_overlong_digit_run_not_a_port`.
- Changelog entry under `[Unreleased]` / Fixed.

## Testing

- Backend suite the CI way (`python -m pytest src/klangk/klangkd-tests/tests
  src/klangk/klangkc-tests/tests -v -n auto`): 8108 passed, 100% branch
  coverage.
- Sidecar unit suite (`pytest src/klangksidecar/tests -v -n auto`): 295
  passed, 100% branch coverage.
- `pre-commit run xenon --all-files`: passes (the helper extraction keeps
  `_valid_cidr_port_suffix` at rank A; the initial inline or-chain was B).
