### PR TITLE
Docker quick-start: klangkd.yaml in place of KLANGKD_* env vars (#3313)

### DIFF
--- a/docs/deployment/docker.md
+++ b/docs/deployment/docker.md
@@ -12,30 +12,32 @@ build tools required.
 
 ## Run
 
+Set your deployment values in a `klangkd.yaml` — [Getting
+Started](../getting-started.md) has a ready-to-use file covering the auth
+settings, the admin identity, an LLM provider, and the image's structural
+settings — then mount it over the image's copy at
+`/home/klangk/etc/klangkd.yaml`:
+
 ```bash
 docker run -d \
   --name klangk \
   -p 8997:8997 \
   -v klangk-data:/home/klangk/data \
+  -v ./klangkd.yaml:/home/klangk/etc/klangkd.yaml:ro \
   --cap-add SYS_ADMIN \
   --device /dev/fuse \
   --device /dev/net/tun \
   --security-opt seccomp=unconfined \
   --security-opt systempaths=unconfined \
-  -e KLANGKD_DEFAULT_USER=you@example.com \
-  -e KLANGKD_DEFAULT_PASSWORD=changeme \
-  -e KLANGKD_AUTH_MODES=password \
-  -e KLANGKD_JWT_SECRET=$(openssl rand -hex 32) \
-  -e KLANGKD_LLM_MODELS="openai/gpt-4o::your-api-key" \
   ghcr.io/mcdonc/klangk/klangk-host:v1.0
 ```
 
-Open <http://localhost:8997> and log in with the email and password
-you set above.
+Open <http://localhost:8997> and log in with the `default_user` /
+`default_password` from your config file.
 
 The published host image uses **password auth** — the examples pin
-`KLANGKD_AUTH_MODES=password`, and that is the supported configuration
-for the image. The default mode for a local install is `none`
+`auth_modes: password` in the mounted config, and that is the supported
+configuration for the image. The default mode for a local install is `none`
 (no-login, loopback-only), but **`none` is an unsupported configuration
 with the published Docker host image.** The image publishes its port
 (`-p 8997:8997`), making it network-reachable, while `none` mode is
@@ -63,6 +65,7 @@ See [Auth Modes](../features/auth-modes.md).
 | Flag                                    | Why                                               |
 | --------------------------------------- | ------------------------------------------------- |
 | `-v klangk-data:/home/klangk/data`      | Persist workspaces and database across restarts   |
+| `-v ./klangkd.yaml:...:ro`              | Mount your `klangkd.yaml` over the image's copy   |
 | `--cap-add SYS_ADMIN`                   | Required for rootless podman inside the container |
 | `--device /dev/fuse`                    | FUSE filesystem for overlay storage               |
 | `--device /dev/net/tun`                 | pasta networking for workspace containers         |
@@ -108,6 +111,7 @@ services:
       - "8997:8997"
     volumes:
       - klangk-data:/home/klangk/data
+      - ./klangkd.yaml:/home/klangk/etc/klangkd.yaml:ro
     cap_add:
       - SYS_ADMIN
     devices:
@@ -116,13 +120,6 @@ services:
     security_opt:
       - seccomp=unconfined
       - systempaths=unconfined
-    environment:
-      KLANGKD_DEFAULT_USER: you@example.com
-      KLANGKD_DEFAULT_PASSWORD: changeme
-      KLANGKD_AUTH_MODES: password
-      KLANGKD_JWT_SECRET: change-this-to-a-random-secret
-      KLANGKD_LLM_MODELS: "openai/gemma4:31b:https://ollama.com/v1:"
-      KLANGKD_LLM_API_KEY: your-api-key
 
 volumes:
   klangk-data:
@@ -147,6 +144,6 @@ instructions.
 
 ## Next steps
 
-- [Environment Variables](../reference/environment.md) — all
-  configuration options
+- [Configuration File](../reference/klangkd-config.md) — every
+  config key and its `KLANGKD_*` env-var override
 - [Feature Activation](../features/features.md) — the default features and how to turn them on

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -8,30 +8,62 @@ use devenv if you want the most up-to-date version.
 
 You need Docker (or Podman) and an OpenAI-compatible LLM API key.
 
+klangkd reads its settings from a `klangkd.yaml` the container keeps
+at `/home/klangk/etc/klangkd.yaml`. Save this file next to your
+terminal, replacing the secret, the credentials, and the LLM provider
+values:
+
+```yaml
+# klangkd.yaml
+# --- Deployment settings ---
+auth_modes: password
+# Generate your own: openssl rand -hex 32
+jwt_secret: paste-the-openssl-output-here
+default_user: you@example.com # first-boot admin identity
+default_password: changeme # that identity's password
+# LLM provider — see LLM Proxy for all forms
+llm-models:
+  - model_name: "*" # single provider, all its models
+    params:
+      api-base: https://api.openai.com/v1 # or http://localhost:11434 (Ollama)
+      api-key: your-key-here
+
+# --- Structural settings ---
+# The container mount below replaces the config file baked into the
+# image, so keep these values: they point klangkd at the image's data
+# volume, the embedded workspace image, and its version file.
+port: 8997
+listen: 0.0.0.0
+egress_port: 8995
+data_dir: /home/klangk/data
+customize_dir: /home/klangk/custom
+image_name: klangk-workspace
+version_file: /home/klangk/version.json
+state_dir: /tmp/klangk-state
+```
+
+Then run the container, mounting your config over the image's copy:
+
 ```bash
 docker run -d \
   --name klangk \
   -p 8997:8997 \
   -v klangk-data:/home/klangk/data \
+  -v ./klangkd.yaml:/home/klangk/etc/klangkd.yaml:ro \
   --cap-add SYS_ADMIN \
   --device /dev/fuse \
   --device /dev/net/tun \
   --security-opt seccomp=unconfined \
   --security-opt systempaths=unconfined \
-  -e KLANGKD_DEFAULT_USER=you@example.com \
-  -e KLANGKD_DEFAULT_PASSWORD=changeme \
-  -e KLANGKD_AUTH_MODES=password \
-  -e KLANGKD_JWT_SECRET=$(openssl rand -hex 32) \
-  -e KLANGKD_LLM_MODELS="openai/gemma4:31b:https://ollama.com/v1:" \
   ghcr.io/mcdonc/klangk/klangk-host:v1.0
 ```
 
-Open <http://localhost:8997> and log in with the email and password
-you set above.
+Open <http://localhost:8997> and log in with the `default_user` /
+`default_password` you set above.
 
 > A Docker container publishes its port (`-p 8997:8997`), making it
-> network-reachable, so the published host image uses
-> `KLANGKD_AUTH_MODES=password` — that is the supported configuration for
+> network-reachable, so the quick-start config sets
+> `auth_modes: password` — that is the supported configuration for
 > the image. The default mode is `none` (no-login, loopback-only), which is
 > **unsupported with the published Docker host image**: it is meant for
 > local dev on your own machine, where the port is not published, and it
@@ -74,8 +106,10 @@ llm-models:
       api-key: your-key-here
 ```
 
-The seeded dev config runs `auth_modes: password` with
-`admin@example.com` / `admin123abc` — change them in `klangkd.yaml`
+The seeded dev config runs `auth_modes: password`. Two keys set the
+first-boot admin identity: `default_user` (the admin's email) and
+`default_password` (that identity's password) — the seed sets
+`admin@example.com` / `admin123abc`. Change both in `klangkd.yaml`
 before first boot, or set a real password afterwards with
 `klangk admin users set-password`.
 
@@ -102,20 +136,24 @@ instructions.
 
 ## Logging in
 
-With the Docker examples above (`KLANGKD_AUTH_MODES=password`) and the
-seeded devenv config (also `password` mode), log in with the email you
-configured (`admin@example.com` / `admin123abc` in dev) and the password
-you set. The default user is in the `admins` group and can manage other
-users and groups via the Admin page.
+With the Docker examples above (`auth_modes: password` in your
+`klangkd.yaml`) and the seeded devenv config (also `password` mode),
+log in with the email you configured (`admin@example.com` /
+`admin123abc` in dev) and the password you set. The default user is in
+the `admins` group and can manage other users and groups via the Admin
+page.
 
 A bare `klangkd` (e.g. a `pip install klangk` install with no config) uses
 the default `none` auth mode — there is **nothing to log in with**: open
-the page and you're already in, as the default user
-(`KLANGKD_DEFAULT_USER`). The CLI likewise needs no `klangk login`.
+the page and you're already in, as the default user (`default_user`,
+which defaults to `<unixuser>@example.com`). The CLI likewise needs no
+`klangk login`.
 
 See [Auth Modes](features/auth-modes.md) for the full picture, including how
 to switch modes.
 
-> **Configuration file:** For production deployments, a YAML config file is
-> recommended over env vars. See
-> [Configuration File](reference/klangkd-config.md) for the full reference.
+> **Configuration file:** Every `klangkd.yaml` key also has a
+> `KLANGKD_*` environment-variable form, and an env var overrides the
+> file — handy for one-off tweaks without rewriting the config. See
+> [Configuration File](reference/klangkd-config.md) for the full
+> reference.


### PR DESCRIPTION
## Summary

The Docker quick-start in `docs/getting-started.md` configured klangkd entirely through `-e KLANGKD_*` flags, while `docs/reference/klangkd-config.md` documents the YAML config file as the primary substrate and the page itself recommends a config file for production. The quick-start now shows a complete `klangkd.yaml` (deployment settings plus the image's structural keys) and mounts it over the image's copy at `/home/klangk/etc/klangkd.yaml`:

- The mounted file replaces the config baked into the image, so the example carries the structural keys the image bakes in (`port`, `listen`, `egress_port`, `data_dir`, `customize_dir`, `image_name`, `version_file`, `state_dir`) — with a comment explaining why they must be kept.
- The devenv section now names **`default_user`** (the first-boot admin identity) and **`default_password`** (that identity's password) instead of saying only "change them in `klangkd.yaml`".
- The "Logging in" section and the closing config note reference the config keys (`auth_modes`, `default_user`) and state the env-var override relationship positively.
- `docs/deployment/docker.md` duplicates the same run command, so its `docker run`, flags table, docker-compose example, and "Next steps" link now use the mounted config too (compose's `environment:` block is gone).

Related: #2147 (docs-wide klangkd.yaml-first pass) — this is its getting-started/docker-chapter slice.

## Verification

- `devenv shell -- build-docs` passes (the 2 unresolved-link warnings in `reference/environment.md` are pre-existing on main, untouched here).
- Docs-only change: no code paths touched, no changelog entry (doc churn has no user-visible effect).
