### PR TITLE
docs: consolidate repeated information across documentation files

### DIFF
--- a/docs/deployment/docker.md
+++ b/docs/deployment/docker.md
@@ -37,28 +37,13 @@ Open <http://localhost:8997> and log in with the `default_user` /
 
 The published host image uses **password auth** — the examples pin
 `auth_modes: password` in the mounted config, and that is the supported
-configuration for the image. The default mode for a local install is `none`
-(no-login, loopback-only), but **`none` is an unsupported configuration
-with the published Docker host image.** The image publishes its port
-(`-p 8997:8997`), making it network-reachable, while `none` mode is
-loopback-only by design — it freely issues an admin token with no
-password, so its entire security model is "only the operator's loopback
-can reach it." Two independent gates refuse it in Docker:
-
-1. **Bind-safety gate.** `none` mode won't boot on a non-loopback bind
-   (publishing the port requires binding a non-loopback address like
-   `0.0.0.0`). Setting `KLANGKD_ALLOW_INSECURE_NO_AUTH=1` overrides this —
-   but only to warn you and expose a free-admin-token endpoint to the
-   whole network.
-2. **Proxy `/auth/local` ACL.** Even past the bind gate, a host browser
-   reaching the container through the published port-forward appears at
-   the container as the Docker bridge/gateway IP (e.g. `172.17.0.1`),
-   not `127.0.0.1`, so the loopback-only ACL denies `/api/v1/auth/local`
-   with `403`.
-
-For a no-login single-user experience, run klangk locally (devenv, or
-the bare binary on your own machine) instead of the published image.
-See [Auth Modes](../features/auth-modes.md).
+configuration for the image. **`none` mode is unsupported with the
+published Docker host image** — it is loopback-only by design, and the
+image publishes its port, making it network-reachable. Two independent
+gates (bind-safety and the proxy ACL) refuse `none` in Docker. For a
+no-login single-user experience, run klangk locally (devenv, or the
+bare binary) instead of the published image. See
+[Auth Modes](../features/auth-modes.md) for the full explanation.
 
 ## What the flags do
 

--- a/docs/features/admin-management.md
+++ b/docs/features/admin-management.md
@@ -23,18 +23,10 @@ The Users tab lists all registered accounts. From here you can:
 
 [![Admin groups panel](../assets/admin/groups.png)](../assets/admin/groups.png)
 
-The Groups tab lets you organize users into named groups. Groups are
-used for sharing workspaces and controlling access via
-[ACL rules](authorization.md).
-
-- **Create groups** — give the group a name and optional description.
-- **Manage members** — add or remove users from a group.
-- **Delete groups** — removing a group also removes any ACL entries
-  that reference it.
-
-The `admins` group is created automatically on first startup and
-grants access to this Admin page. The default user is added to it
-automatically.
+The Groups tab lets you organize users into named groups — create
+groups, manage members, and delete groups (which also removes any ACL
+entries referencing them). See [Authorization — Groups](authorization.md#groups)
+for the built-in groups and how groups interact with the ACL system.
 
 ## Server
 

--- a/docs/features/sandbox.md
+++ b/docs/features/sandbox.md
@@ -302,12 +302,9 @@ default — it is the ceiling that permits the opt-in) in the server's
 
 ### Where the service command runs (and how to install for it)
 
-A `service-command` does **not** run in the workspace owner's shell.
-It runs in a dedicated `service` tmux session whose `$HOME` is
-**always `/home/klangk`** — the shared home, under both home layouts
-(exposed as the constant `$KLANGKWS_AGENT_HOME`) — not the owner's
-per-handle home. The owner interacts with it through the **Service**
-terminal tab in the web UI.
+The [service command](service-command.md) runs in a dedicated `service`
+tmux session whose `$HOME` is **always `/home/klangk`** (exposed as
+`$KLANGKWS_AGENT_HOME`), not the owner's per-handle home.
 
 This matters for setup scripts: anything the service command needs at
 runtime — env exports in `~/.profile`, binaries installed under

--- a/docs/features/the-shell.md
+++ b/docs/features/the-shell.md
@@ -34,28 +34,11 @@ fighting permissions. Collaboration just works.
 
 ### Home directory layouts
 
-Even though everyone shares the same UNIX user, a workspace controls
-who sees whose files via its **home layout** — a setting chosen when
-the workspace is created (see
-[Workspaces](workspaces.md#home-directory-layout)):
-
-- **Shared home** (the default) — every member's shell, exec session,
-  and the service share the single `/home/klangk` as `$HOME`, with one
-  `.bash_history` and one set of dotfiles. What one member installs or
-  configures (`.profile`, `~/.local/bin`, nix profiles) is immediately
-  on every member's `PATH` — the point of the default.
-- **Per-handle home** — each member gets a private `$HOME` at
-  `/home/<handle>/` — a symlink to `.users/<user-id>/` on the
-  bind-mounted home volume. This means:
-  - Your dotfiles (`.bashrc`, `.gitconfig`, `.vimrc`) are yours alone
-  - Your bash history is separate from other members'
-  - Your AI agent config (`.pi/agent/`, `.claude/`) is per-user
-
-Under both layouts your project files live directly in your home
-(`~`) — there is no separate shared project directory — and `/home/klangk`
-(the shared home) is created and populated from the image skeleton
-when the container is first created, on every start path (including
-[auto-start](auto-start.md) on server boot).
+A workspace chooses between a **shared home** (`/home/klangk` for
+everyone) and a **per-handle home** (each member gets a private
+`/home/<handle>/`). See
+[Workspaces — Home directory layout](workspaces.md#home-directory-layout)
+for the full explanation, ceiling behavior, and CLI flags.
 
 The [service command](service-command.md) session always runs with
 `HOME=/home/klangk` — under both layouts — so environment setup that

--- a/docs/features/workspaces.md
+++ b/docs/features/workspaces.md
@@ -86,26 +86,10 @@ open terminals keep their layout until they end.
 ## Auto-start
 
 Workspaces with **auto-start** enabled start their containers
-automatically when the Klangk server starts. This is useful for
-service workspaces where a long-running process (configured via
-[Service Command](service-command.md)) should be available
-immediately — without waiting for a user to connect.
-
-Auto-start requires the server to have `KLANGKD_ALLOW_AUTOSTART`
-set to `1`/`true`/`yes`. When disabled (the default), the
-auto-start option is hidden in the UI, CLI, and API.
-
-Toggle auto-start from the workspace **Settings** tab, or via the
-CLI:
-
-```bash
-klangk edit my-project --auto-start
-klangk edit my-project --no-auto-start
-```
-
-When the server starts, it starts containers for all auto-start
-workspaces. If the workspace has a service command, the command
-is already running by the time any user connects.
+automatically when the Klangk server starts — useful for service
+workspaces that should be available before any user connects. See
+[Auto-Start](auto-start.md) for the full details, server
+configuration, and CLI usage.
 
 ## What's inside a workspace
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -61,15 +61,11 @@ docker run -d \
 Open <http://localhost:8997> and log in with the `default_user` /
 `default_password` you set above.
 
-> A Docker container publishes its port (`-p 8997:8997`), making it
-> network-reachable, so the quick-start config sets
-> `auth_modes: password` — that is the supported configuration for
-> the image. The default mode is `none` (no-login, loopback-only), which is
-> **unsupported with the published Docker host image**: it is meant for
-> local dev on your own machine, where the port is not published, and it
-> freely issues an admin token with no password. For the no-login
-> single-user experience, run klangk locally via devenv (below) instead.
-> See [Auth Modes](features/auth-modes.md).
+> The quick-start config sets `auth_modes: password` — that is the
+> supported configuration for the Docker image. The default `none` mode
+> is loopback-only and **unsupported with the published image**. For a
+> no-login single-user experience, run klangk locally via devenv
+> (below). See [Auth Modes](features/auth-modes.md).
 
 ## Run Using devenv
 

--- a/docs/reference/environment.md
+++ b/docs/reference/environment.md
@@ -6,15 +6,7 @@
 
 `$DEVENV_STATE` refers to `<project root>/.devenv/state` — this is where devenv stores runtime data.
 
-For local development, settings live in `klangkd.yaml` (gitignored; `devenv.nix` seeds it from `klangkd.yaml.devenv` on first shell entry). Environment variables override config-file values.
-
-**`file:` prefix:** Any env var can be prefixed with `file:` to read the value from a file (e.g. `KLANGKD_JWT_SECRET=file:/run/secrets/jwt`). The file contents are stripped of leading/trailing whitespace. This works with secret management tools like agenix/sops that write decrypted secrets to files. If the file cannot be read, construction **fails** with a `ValidationError` (fail-fast at boot, not silently at use time).
-
-**`cmd:` prefix:** Any env var can be prefixed with `cmd:` to resolve the value by running a shell command and using its stdout (e.g. `KLANGKD_JWT_SECRET=cmd:aws secretsmanager get-secret-value --secret-id klangk/jwt | jq -r .SecretString`). The stdout is stripped of leading/trailing whitespace. This lets values be fetched from external sources (vault CLIs, cloud secret managers, decryption tools) without materializing them to disk or a plain env var. The command runs via the shell (so pipes work) with a short timeout; only values an operator explicitly prefixes with `cmd:` are ever executed. If the command fails (non-zero exit, timeout, or execution error), construction **fails** with a `ValidationError` (fail-fast at boot).
-
-> **Note:** the prefixes are applied by the config resolver wherever a `KLANGK_*` value is read, including model entries in `KLANGKD_LLM_MODELS` (dict-format `api-key` and `api-base` values support `file:`/`cmd:` indirection). A small number of vars are read raw by design (e.g. `KLANGKD_TRUSTED_PROXY_CIDRS`, which is a public CIDR list, not a secret).
-
-**`file:`/`cmd:` resolution** happens **once, at construction** — `KlangkSettings` runs every string field through its resolver in a `model_validator(mode="after")` before the object leaves `__init__`. Every `settings.field` read thereafter returns the already-resolved value; there is no per-call resolver wrapper. A bad reference (`file:/nonexistent`, `cmd:false`) aborts boot with a `ValidationError` rather than silently degrading to `None`/empty at use time. The resolver itself is private (`_resolve_indirection`); the public `resolve_indirection` function was removed. Feature-declared config keys (the `KLANGKWS_FEATURE_*` keys the build emits into `features.json` — not `KlangkSettings` fields) are still resolved per-call by `resolve_dynamic_config`, since their names aren't known at settings construction.
+For local development, settings live in `klangkd.yaml` (gitignored; `devenv.nix` seeds it from `klangkd.yaml.devenv` on first shell entry). Environment variables override config-file values. Both env vars and config-file values support `file:` and `cmd:` prefixes for secret indirection — see [Configuration File — `file:` and `cmd:` resolution](klangkd-config.md#file-and-cmd-resolution) for the full precedence rules and resolution semantics.
 
 > **Removed in 2.X:** `KLANGKD_PROXY_ENGINE` is gone — Caddy is the
 > sole reverse-proxy engine. The env var is no longer recognized (silently


### PR DESCRIPTION
## Summary

- Replace duplicated explanations in 7 docs files with cross-references to their canonical locations (auth-modes.md, klangkd-config.md, workspaces.md, auto-start.md, authorization.md, service-command.md)
- Net reduction of 71 lines (-100/+29) with no information lost

## Test plan

- [x] All cross-reference anchor targets verified to exist
- [x] Pre-commit hooks (markdownlint, prettier) pass
- [ ] Skim rendered docs to confirm links resolve