### PR TITLE
Add Clear-Site-Data: "storage" header to the logout response (#3328)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -835,6 +835,14 @@ sync` report a clear permission-denied error.
   `data_dir` change applies after the restart the reload warning already
   asks for.
 
+- **`Clear-Site-Data: "storage"` on logout (#3328).** The
+  `POST /api/v1/auth/logout` response now carries the header on every
+  path (live token, anonymous token, OIDC logout redirect), so the
+  browser wipes the origin's web storage — localStorage, IndexedDB,
+  cache storage, and service worker registrations — when a session ends.
+  Browsers apply it in secure contexts (HTTPS or localhost), where
+  klangkd serves the frontend.
+
 - **Air-gapped deployment guide (#2660).** New deployment chapter
   (`docs/deployment/airgapped.md`) covering offline image transport,
   DNS and LLM configuration for disconnected networks, workspace

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -840,8 +840,10 @@ sync` report a clear permission-denied error.
   path (live token, anonymous token, OIDC logout redirect), so the
   browser wipes the origin's web storage — localStorage, IndexedDB,
   cache storage, and service worker registrations — when a session ends.
-  Browsers apply it in secure contexts (HTTPS or localhost), where
-  klangkd serves the frontend.
+  Browsers apply the header only in secure contexts: an HTTPS listener
+  (`KLANGKD_TLS_HOSTNAME` set) or a localhost bind. On a plain-HTTP
+  listener bound to a remote host the browser ignores the header and no
+  wipe happens.
 
 - **Air-gapped deployment guide (#2660).** New deployment chapter
   (`docs/deployment/airgapped.md`) covering offline image transport,

--- a/src/klangk/klangk/api/auth.py
+++ b/src/klangk/klangk/api/auth.py
@@ -1196,14 +1196,18 @@ async def logout(
     credentials: HTTPAuthorizationCredentials | None = Depends(auth.security),
 ):
     # #3328: tell the browser to wipe the origin's web storage
-    # (localStorage, IndexedDB, cache storage, service worker
-    # registrations) when the session ends, so session remnants are not
-    # left readable by the next user of the browser profile. Browsers honor
-    # the header only in secure contexts (HTTPS or localhost), which matches
-    # how klangkd serves the frontend; non-browser clients ignore it. The
-    # "storage" directive alone is the right scope: session auth is a Bearer
-    # token revoked server-side, and the only cookie klangkd sets is the
-    # short-lived OIDC handshake cookie that expires on its own.
+    # (localStorage, sessionStorage, IndexedDB, cache storage, service
+    # worker registrations — in every same-origin tab) when the session
+    # ends, so session remnants are not left readable by the next user
+    # of the browser profile. Browsers honor the header only in secure
+    # contexts: an HTTPS listener (KLANGKD_TLS_HOSTNAME set) or a
+    # localhost bind. A plain-HTTP listener on a remote host is an
+    # insecure context, and the browser silently ignores the header
+    # there — no wipe happens. Non-browser clients ignore it either way.
+    # The "storage" directive alone is the right scope: session auth is
+    # a Bearer token revoked server-side, and the only cookie klangkd
+    # sets is the short-lived OIDC handshake cookie that expires on its
+    # own.
     response.headers["Clear-Site-Data"] = '"storage"'
     # Logout only invalidates credentials -- it deliberately does NOT stop the
     # user's containers. Per #301/#1235 the idle timeout is the only thing

--- a/src/klangk/klangk/api/auth.py
+++ b/src/klangk/klangk/api/auth.py
@@ -16,6 +16,7 @@ from fastapi import (
     Depends,
     HTTPException,
     Request,
+    Response,
 )
 from fastapi.responses import (
     JSONResponse,
@@ -1190,9 +1191,20 @@ async def _oidc_logout_url(request: Request, user: dict) -> str | None:
 @router.post("/auth/logout")
 async def logout(
     request: Request,
+    response: Response,
     user: dict | None = Depends(auth.get_current_user_lenient),
     credentials: HTTPAuthorizationCredentials | None = Depends(auth.security),
 ):
+    # #3328: tell the browser to wipe the origin's web storage
+    # (localStorage, IndexedDB, cache storage, service worker
+    # registrations) when the session ends, so session remnants are not
+    # left readable by the next user of the browser profile. Browsers honor
+    # the header only in secure contexts (HTTPS or localhost), which matches
+    # how klangkd serves the frontend; non-browser clients ignore it. The
+    # "storage" directive alone is the right scope: session auth is a Bearer
+    # token revoked server-side, and the only cookie klangkd sets is the
+    # short-lived OIDC handshake cookie that expires on its own.
+    response.headers["Clear-Site-Data"] = '"storage"'
     # Logout only invalidates credentials -- it deliberately does NOT stop the
     # user's containers. Per #301/#1235 the idle timeout is the only thing
     # that stops containers (plus the explicit

--- a/src/klangk/klangkd-tests/tests/test_api.py
+++ b/src/klangk/klangkd-tests/tests/test_api.py
@@ -1321,6 +1321,9 @@ class TestAuthRoutes:
             resp = await client.post("/api/v1/auth/logout", headers=headers)
         assert resp.status_code == 200
         assert resp.json()["status"] == "ok"
+        # #3328: every logout response tells the browser to wipe the
+        # origin's web storage.
+        assert resp.headers["Clear-Site-Data"] == '"storage"'
         mock_stop.assert_not_called()
 
     async def test_logout_kicks_live_sockets(self, client, app, user):
@@ -1391,6 +1394,9 @@ class TestAuthRoutes:
         resp = await client.post("/api/v1/auth/logout")
         assert resp.status_code == 200
         assert resp.json()["status"] == "ok"
+        # #3328: the anonymous path carries the header too — the browser
+        # must clear storage even when there was no live token.
+        assert resp.headers["Clear-Site-Data"] == '"storage"'
 
     async def test_logout_idempotent_revoked_token(self, client, user):
         """Second logout with the already-blocklisted token: still 200
@@ -16837,6 +16843,10 @@ class TestOIDCLogout:
             resp.json()["oidc_logout_url"]
             == "https://idp.example.com/logout?x=1"
         )
+        # #3328: the OIDC logout-redirect path carries the header too. The
+        # response is same-origin JSON (the frontend performs the IdP
+        # redirect itself), so the header applies.
+        assert resp.headers["Clear-Site-Data"] == '"storage"'
 
     async def test_logout_no_redirect_for_local_user(self, client, user):
         """Local user gets no oidc_logout_url."""


### PR DESCRIPTION
Adds `Clear-Site-Data: "storage"` to the `POST /api/v1/auth/logout` response (#3328), so the browser wipes the origin's web storage (localStorage, sessionStorage, IndexedDB, cache storage, and service worker registrations) when a session ends. At logout the frontend drops only what it knows about; residual origin data — a legacy `localStorage` key, an orphaned service worker registration, cached responses — otherwise survives the logout and stays readable by whoever uses that browser profile next.

## What changed

- `src/klangk/klangk/api/auth.py` — the `logout` route injects a `Response` and sets `Clear-Site-Data: '"storage"'` unconditionally, so the header rides every return path: the live-token path, the idempotent anonymous/dead-token path (#2687), and the OIDC `logout_redirect` variant. The response is always same-origin JSON (the frontend performs the IdP redirect itself), and browsers ignore the header on cross-origin responses, so the OIDC flow is unaffected.
- `src/klangk/klangkd-tests/tests/test_api.py` — the three logout tests covering those paths now assert the header.
- `docs/changes.md` — Added entry under `[Unreleased]`.

## Scope notes

- The `"storage"` directive alone is deliberate: session auth is a Bearer token (revoked server-side by blocklisting), and the only cookie klangkd sets is the 10-minute OIDC handshake cookie that expires on its own — so `"cookies"` and `"cache"` stay out.
- Browsers honor the header only in secure contexts (HTTPS or localhost), which matches how klangkd serves the frontend.

## Known scope notes (from fresh-eyes review)

- The frontend skips the logout POST when no token is in memory (`auth_service.dart`, refresh-401 and WS-kick paths), so on those flows the browser never receives the header. The backend anonymous path is idempotent (#2687) precisely so such a call is safe; making the browser send a tokenless POST before its local wipe is a possible frontend follow-up.
- The wipe is per-origin, not per-session: logging out tab A clears a concurrent tab B's IndexedDB DPoP key and (in browsers that clear it origin-wide) its sessionStorage token. Tab B self-heals into a clean re-login (`_restoreBinding`); this is a deliberate trade-off under the shared-profile threat model the issue targets.

## Testing

- Full backend suite the CI way (`-n auto`, coverage gate): 8178 passed, 100% coverage.
- Manual browser check of storage/SW clearing after logout: to be done before merge (acceptance criterion) — the header only acts in secure contexts.
