### PR TITLE
Record structured audit events for app start and stop (#3329)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -845,6 +845,19 @@ sync` report a clear permission-denied error.
   listener bound to a remote host the browser ignores the header and no
   wipe happens.
 
+- **App lifecycle audit events (#3329).** The daemon's own start and
+  stop now appear in the structured audit stream: one `app.start` row
+  per boot (build version, pid, listener) and one `app.stop` row per
+  shutdown (pid, uptime, exit reason — the graceful signal or the
+  fail-secure forced exit), written before the teardown steps so the
+  row lands while the database is still open. A SIGHUP or scheduled
+  recycle that swaps settings in place writes its own `app.reload` row
+  — the process keeps running, so there is no start/stop pair to
+  bracket it. System rows (no actor, target is the app itself),
+  covered by the opt-in `KLANGKD_AUDIT_HMAC_KEY` tagging and the
+  audit-record forwarder, listed by `GET /api/v1/events/audit` next to
+  the identity and privilege events.
+
 - **Air-gapped deployment guide (#2660).** New deployment chapter
   (`docs/deployment/airgapped.md`) covering offline image transport,
   DNS and LLM configuration for disconnected networks, workspace

--- a/docs/reference/api-endpoints.md
+++ b/docs/reference/api-endpoints.md
@@ -606,16 +606,18 @@ and `file.delete` (a delete through the files API) — each carrying
 the path and byte size in `detail` (the size is omitted where
 meaningless — rename, delete, directory downloads; an export's size
 is a pre-flight estimate) — and the daemon's own lifecycle (#3329):
-`app.start` / `app.stop` (one pair per process lifetime; start after
-config validation and seeding, stop before the teardown steps so the
-row is written while the database is still open) and `app.reload` (a
-SIGHUP or scheduled recycle that swapped settings in place — the
+`app.start` / `app.stop` (one pair per process lifetime; start when
+the backend announces itself ready, stop before the teardown steps so
+the row is written while the database is still open) and `app.reload`
+(a SIGHUP or scheduled recycle that swapped settings in place — the
 process keeps running, so the reload gets its own row instead of a
-field on the next `app.start`). These are system rows: no actor, the
+field on the next `app.start`, written at the moment the new settings
+were applied). These are system rows: no actor, the
 target is the app itself (the instance id), and `detail` carries the
 build version, pid, and listener on start, and the pid, uptime, and
 exit reason (`signal:SIGTERM`/`signal:SIGINT` for a graceful stop,
-`forced-exit` for the fail-secure exit of #3176) on stop.
+`forced-exit` for the fail-secure exit of #3176, `lifespan-teardown`
+when the listener exited without a signal) on stop.
 Query params:
 `limit` (1–200, default 50), `offset`, and optional `event`, `actor`
 (matches actor id or email), and `target` (target id) substring filters

--- a/docs/reference/api-endpoints.md
+++ b/docs/reference/api-endpoints.md
@@ -597,7 +597,7 @@ No request body.
 Paged identity/privilege audit history (#3205), newest first, from the
 `audit_events` table: account create/update/delete, group and ACL
 changes, workspace role assignments and transfers,
-login/logout/failed-login, session revocation, and the data-level
+login/logout/failed-login, session revocation, the data-level
 file events (#3257) — `file.download` (a workspace archive export, a
 per-file/directory download, or a text read via `/files/content`,
 marked `via: content`), `file.upload` (a workspace archive
@@ -605,7 +605,18 @@ import), `file.write` (an upload or rename through the files API),
 and `file.delete` (a delete through the files API) — each carrying
 the path and byte size in `detail` (the size is omitted where
 meaningless — rename, delete, directory downloads; an export's size
-is a pre-flight estimate). Query params:
+is a pre-flight estimate) — and the daemon's own lifecycle (#3329):
+`app.start` / `app.stop` (one pair per process lifetime; start after
+config validation and seeding, stop before the teardown steps so the
+row is written while the database is still open) and `app.reload` (a
+SIGHUP or scheduled recycle that swapped settings in place — the
+process keeps running, so the reload gets its own row instead of a
+field on the next `app.start`). These are system rows: no actor, the
+target is the app itself (the instance id), and `detail` carries the
+build version, pid, and listener on start, and the pid, uptime, and
+exit reason (`signal:SIGTERM`/`signal:SIGINT` for a graceful stop,
+`forced-exit` for the fail-secure exit of #3176) on stop.
+Query params:
 `limit` (1–200, default 50), `offset`, and optional `event`, `actor`
 (matches actor id or email), and `target` (target id) substring filters
 (matched literally — `%` and `_` are characters, not wildcards).

--- a/src/klangk/klangk/api/__init__.py
+++ b/src/klangk/klangk/api/__init__.py
@@ -151,11 +151,19 @@ async def empty():
 
 @router.get("/version")
 async def version(app=Depends(get_app_dep)):
-    """Return build version info, plus loaded feature metadata."""
+    """Return build version info, plus loaded feature metadata.
+
+    An unreadable or wrong-shaped version file falls through to the
+    dev block (the same tolerance the ``app.start`` audit row's
+    version field applies, #3329) instead of 500ing.
+    """
     if version_file := app.state.settings.version_file:
-        if os.path.isfile(version_file):
+        try:
             with open(version_file) as f:
                 info = json.load(f)
+        except (OSError, ValueError):
+            info = None
+        if isinstance(info, dict):
             info["features"] = app.state.features.feature_list()
             return info
     return {

--- a/src/klangk/klangk/lifecycle.py
+++ b/src/klangk/klangk/lifecycle.py
@@ -110,21 +110,28 @@ _NON_RELOADABLE_SETTINGS: tuple[tuple[str, str], ...] = (
 )
 
 
+def _read_version_file(path: str) -> dict | None:
+    """The parsed version file, or ``None`` when it is absent,
+    unreadable, or not a JSON object."""
+    try:
+        with open(path) as f:
+            info = json.load(f)
+    except (OSError, ValueError):
+        return None
+    return info if isinstance(info, dict) else None
+
+
 def _app_version(settings) -> str:
     """The running build's version string ("dev" until a version file
     is configured and readable — the same source the ``/version``
     endpoint reads)."""
     path = settings.version_file
-    if not path or not os.path.isfile(path):
+    if not path:
         return "dev"
-    try:
-        with open(path) as f:
-            info = json.load(f)
-    except (OSError, ValueError):
+    info = _read_version_file(path)
+    if info is None:
         return "dev"
-    if not isinstance(info, dict):
-        return "dev"
-    return str(info.get("version", "dev"))
+    return str(info.get("version") or "dev")
 
 
 def _stop_reason(lifecycle) -> str:
@@ -710,7 +717,7 @@ class Lifecycle:
             return True
         return False
 
-    async def _apply_and_recycle(self, state, new_settings) -> None:
+    async def _apply_and_recycle(self, state, new_settings, source) -> None:
         """Phases 5–7 of the recycle: apply the reloaded config, recycle
         the runtime, and resume. The drain flag deliberately stays set
         through ``startup()``'s podman pre-warm and container reaps (so a
@@ -719,6 +726,11 @@ class Lifecycle:
         container destroyed by the reap); ``startup()`` clears it."""
         logger.info("SIGHUP: phase: apply (applying reloaded config)")
         await self.apply_reloaded_settings(new_settings)
+        # #3329: the settings swap is the auditable fact — the
+        # app.reload row goes in right after it, before the runtime
+        # recycle, so a recycle or recovery failure further down
+        # cannot lose it (the new settings are live either way).
+        await self._record_reload(source)
         state.sockets.notify_server_recycle("recycling")
         logger.info(
             "SIGHUP: phase: restart (recycling runtime; "
@@ -789,7 +801,7 @@ class Lifecycle:
                 await self._quiesce_and_drain(state, registry, new_settings)
                 if self._shutdown_won_mid_recycle():
                     return
-                await self._apply_and_recycle(state, new_settings)
+                await self._apply_and_recycle(state, new_settings, source)
             finally:
                 # A failed restart must never leave the node refusing
                 # starts: the in-memory flag has no DB persistence an
@@ -801,7 +813,6 @@ class Lifecycle:
                     registry.draining = False
             logger.info("SIGHUP: restart complete (phase: resumed)")
             state.sockets.notify_host_started()
-            await self._record_reload(source)
 
     async def _record_reload(self, source: str | None) -> None:
         """Write the ``app.reload`` audit row (#3329).
@@ -812,8 +823,10 @@ class Lifecycle:
         the #3329 open question) because the alternative — a detail
         field on the next ``app.start`` — would be delayed arbitrarily
         (the next stop may be days away) and conflated with that boot.
-        Only a fully-applied reload writes the row: a denied (invalid
-        config) or aborted (shutdown raced) recycle changed nothing.
+        Written right after the settings swap — the auditable fact —
+        so a later runtime-recycle or recovery failure cannot lose it;
+        a denied (invalid config) or aborted (shutdown raced) recycle
+        applies nothing and writes no row.
         Best-effort like every audit write.
         """
         detail: dict = {"pid": os.getpid()}
@@ -1450,25 +1463,6 @@ async def lifespan(app: FastAPI):
     except ConfigurationError as exc:
         app.state.startup_config_error = str(exc)
         raise
-    # #3329: the daemon's own lifecycle joins the structured audit
-    # stream. The start row goes in once config has validated and the
-    # seed ran (a refused boot — pid conflict, ConfigurationError —
-    # wrote nothing); best-effort, so an audit problem never blocks
-    # boot. ``started`` anchors the app.stop row's uptime.
-    started = time.monotonic()
-    settings = app.state.settings
-    await app.state.model.audit_events.record_best_effort(
-        "app.start",
-        target_type="app",
-        target_id=app.state.util.instance_id(),
-        detail={
-            "version": _app_version(settings),
-            "pid": os.getpid(),
-            "listen": settings.listen,
-            "port": settings.port,
-            "socket": settings.socket,
-        },
-    )
     wire_registry_callbacks(app)
     await app.state.lifecycle.startup()
     # Reap orphaned pending consent rows from a prior run: the in-memory
@@ -1493,6 +1487,27 @@ async def lifespan(app: FastAPI):
     loop.add_signal_handler(
         signal.SIGHUP,
         app.state.lifecycle.on_sighup,
+    )
+    # #3329: the daemon's own lifecycle joins the structured audit
+    # stream. The start row goes in at the moment the backend
+    # announces itself ready — the stop-row finally below runs only
+    # once the yield is reached, so writing any earlier would orphan
+    # the row on a pre-yield startup crash (one pair per process
+    # lifetime). Best-effort: an audit problem never blocks boot.
+    # ``started`` anchors the app.stop row's uptime.
+    started = time.monotonic()
+    settings = app.state.settings
+    await app.state.model.audit_events.record_best_effort(
+        "app.start",
+        target_type="app",
+        target_id=app.state.util.instance_id(),
+        detail={
+            "version": _app_version(settings),
+            "pid": os.getpid(),
+            "listen": settings.listen,
+            "port": settings.port,
+            "socket": settings.socket,
+        },
     )
     try:
         yield

--- a/src/klangk/klangk/lifecycle.py
+++ b/src/klangk/klangk/lifecycle.py
@@ -122,6 +122,8 @@ def _app_version(settings) -> str:
             info = json.load(f)
     except (OSError, ValueError):
         return "dev"
+    if not isinstance(info, dict):
+        return "dev"
     return str(info.get("version", "dev"))
 
 

--- a/src/klangk/klangk/lifecycle.py
+++ b/src/klangk/klangk/lifecycle.py
@@ -9,12 +9,17 @@ unchanged except where noted inline (#2738 audit fixes). Owns:
 - :func:`lifespan` — the FastAPI lifespan context manager.
 - :func:`setup_logfire` — opt-in Logfire instrumentation (called from
   the lifespan, after SSL trust is applied).
+- The ``app.start`` / ``app.stop`` / ``app.reload`` audit rows (#3329)
+  — the daemon's own lifecycle in the structured audit stream, written
+  best-effort so an audit problem never blocks boot or exit.
 """
 
 import asyncio
+import json
 import logging
 import os
 import signal
+import time
 from contextlib import asynccontextmanager
 from pathlib import Path
 
@@ -105,6 +110,33 @@ _NON_RELOADABLE_SETTINGS: tuple[tuple[str, str], ...] = (
 )
 
 
+def _app_version(settings) -> str:
+    """The running build's version string ("dev" until a version file
+    is configured and readable — the same source the ``/version``
+    endpoint reads)."""
+    path = settings.version_file
+    if not path or not os.path.isfile(path):
+        return "dev"
+    try:
+        with open(path) as f:
+            info = json.load(f)
+    except (OSError, ValueError):
+        return "dev"
+    return str(info.get("version", "dev"))
+
+
+def _stop_reason(lifecycle) -> str:
+    """The ``app.stop`` row's exit reason (#3329): the fail-secure
+    forced exit (a failed recycle recovery, #3176), the graceful
+    TERM/INT signal (a clean stop), or a plain lifespan teardown (the
+    listener exited without a signal — e.g. a test harness)."""
+    if lifecycle.forced_exit_status is not None:
+        return "forced-exit"
+    if lifecycle.shutdown_signal is not None:
+        return f"signal:{lifecycle.shutdown_signal}"
+    return "lifespan-teardown"
+
+
 def _password_policy_errors(settings, password: str) -> list[str]:
     """The password-policy violations of *password* (empty when it is
     compliant)."""
@@ -183,6 +215,10 @@ class Lifecycle:
         # the signal hook in main.py before graceful_shutdown runs) and
         # strong references to the hook task while it drains.
         self.shutting_down: bool = False
+        # #3329: the signal name of the shutdown in progress (set by
+        # graceful_shutdown, read by the lifespan's app.stop row so the
+        # audit trail distinguishes a clean TERM/INT from a forced exit).
+        self.shutdown_signal: str | None = None
         self._shutdown_tasks: set[asyncio.Task] = set()
         # Fail-secure (#3176): non-zero exit the GracefulExitServer must
         # translate after the teardown completes (set on the failed
@@ -689,11 +725,12 @@ class Lifecycle:
         await self.runtime_shutdown()
         await self.startup()
 
-    async def recycle_runtime(self) -> None:
+    async def recycle_runtime(self, source: str | None = None) -> None:
         """Graceful runtime recycle: quiesce, drain, re-read config, recycle.
 
         Triggered by SIGHUP and by a scheduled recycle (#2661) — the
-        sequence is identical either way. Each phase is logged and (the
+        sequence is identical either way; *source* names the trigger in
+        the ``app.reload`` audit row. Each phase is logged and (the
         client-visible ones) announced as a ``server_recycle`` WebSocket
         event with a ``phase`` field; a final ``host_started`` broadcast
         closes the sequence. The HTTP listener and DB stay up the whole
@@ -762,6 +799,30 @@ class Lifecycle:
                     registry.draining = False
             logger.info("SIGHUP: restart complete (phase: resumed)")
             state.sockets.notify_host_started()
+            await self._record_reload(source)
+
+    async def _record_reload(self, source: str | None) -> None:
+        """Write the ``app.reload`` audit row (#3329).
+
+        A SIGHUP / scheduled recycle swaps settings in-place — the
+        process never exits, so no ``app.stop``/``app.start`` pair
+        brackets it. The reload gets its own row (the decided answer to
+        the #3329 open question) because the alternative — a detail
+        field on the next ``app.start`` — would be delayed arbitrarily
+        (the next stop may be days away) and conflated with that boot.
+        Only a fully-applied reload writes the row: a denied (invalid
+        config) or aborted (shutdown raced) recycle changed nothing.
+        Best-effort like every audit write.
+        """
+        detail: dict = {"pid": os.getpid()}
+        if source is not None:
+            detail["source"] = source
+        await self.app.state.model.audit_events.record_best_effort(
+            "app.reload",
+            target_type="app",
+            target_id=self.app.state.util.instance_id(),
+            detail=detail,
+        )
 
     def reload_settings(
         self,
@@ -962,6 +1023,8 @@ class Lifecycle:
         state = self.app.state
         registry = state.container_registry
         name = signal.Signals(signal_num).name
+        # #3329: remembered for the app.stop row's exit reason.
+        self.shutdown_signal = name
         logger.info("%s: graceful shutdown beginning (phase: notify)", name)
         state.sockets.notify_host_shutdown()
         logger.info("%s: phase: draining (refusing new starts)", name)
@@ -1127,7 +1190,7 @@ class Lifecycle:
             loop = asyncio.get_running_loop()
         except RuntimeError:  # no running loop during shutdown
             return
-        task = loop.create_task(self.recycle_runtime())
+        task = loop.create_task(self.recycle_runtime(source))
         self._recycle_tasks.add(task)
         task.add_done_callback(self._on_recycle_task_done)
 
@@ -1385,6 +1448,25 @@ async def lifespan(app: FastAPI):
     except ConfigurationError as exc:
         app.state.startup_config_error = str(exc)
         raise
+    # #3329: the daemon's own lifecycle joins the structured audit
+    # stream. The start row goes in once config has validated and the
+    # seed ran (a refused boot — pid conflict, ConfigurationError —
+    # wrote nothing); best-effort, so an audit problem never blocks
+    # boot. ``started`` anchors the app.stop row's uptime.
+    started = time.monotonic()
+    settings = app.state.settings
+    await app.state.model.audit_events.record_best_effort(
+        "app.start",
+        target_type="app",
+        target_id=app.state.util.instance_id(),
+        detail={
+            "version": _app_version(settings),
+            "pid": os.getpid(),
+            "listen": settings.listen,
+            "port": settings.port,
+            "socket": settings.socket,
+        },
+    )
     wire_registry_callbacks(app)
     await app.state.lifecycle.startup()
     # Reap orphaned pending consent rows from a prior run: the in-memory
@@ -1414,6 +1496,22 @@ async def lifespan(app: FastAPI):
         yield
     finally:
         loop.remove_signal_handler(signal.SIGHUP)
+        # #3329: the stop row goes in before the teardown steps —
+        # process_shutdown disposes the DB engine, so the row must be
+        # written while it is still open. Written regardless of how the
+        # steps below fare (each is attempted, #3176); best-effort, so
+        # a dead DB loses the row (the next boot's app.start row
+        # brackets the outage).
+        await app.state.model.audit_events.record_best_effort(
+            "app.stop",
+            target_type="app",
+            target_id=app.state.util.instance_id(),
+            detail={
+                "pid": os.getpid(),
+                "reason": _stop_reason(app.state.lifecycle),
+                "uptime_seconds": round(time.monotonic() - started, 3),
+            },
+        )
         # Each teardown step is wrapped so one failure cannot skip the
         # rest — all steps always attempted, each failure logged
         # (fail to a secure state on shutdown failure, #3176).

--- a/src/klangk/klangk/model/audit_events.py
+++ b/src/klangk/klangk/model/audit_events.py
@@ -17,6 +17,15 @@ and HTTP paths present identically.
 
 Event coverage (#3205):
 
+- **App lifecycle** (#3329) — ``app.start`` / ``app.stop`` (one pair
+  per process lifetime, written by the lifespan: start after config
+  validation + seeding, stop before the teardown steps so the DB
+  engine is still open) and ``app.reload`` (a SIGHUP or scheduled
+  recycle swapped settings in-place; the process never exits, so the
+  reload gets its own row rather than a detail field on the next
+  ``app.start``). System rows — no actor — targeting ``app`` (the
+  instance id), with version / pid / listener in the start ``detail``
+  and pid / uptime / exit reason in the stop's.
 - **Account CRUD** — ``user.register``, ``user.create`` (admin,
   invite-accept, OIDC JIT), ``user.update`` (admin — a disable/enable
   toggle records here, ``fields`` naming ``disabled``),

--- a/src/klangk/klangk/model/audit_events.py
+++ b/src/klangk/klangk/model/audit_events.py
@@ -18,12 +18,13 @@ and HTTP paths present identically.
 Event coverage (#3205):
 
 - **App lifecycle** (#3329) — ``app.start`` / ``app.stop`` (one pair
-  per process lifetime, written by the lifespan: start after config
-  validation + seeding, stop before the teardown steps so the DB
-  engine is still open) and ``app.reload`` (a SIGHUP or scheduled
-  recycle swapped settings in-place; the process never exits, so the
-  reload gets its own row rather than a detail field on the next
-  ``app.start``). System rows — no actor — targeting ``app`` (the
+  per process lifetime, written by the lifespan: start when the
+  backend announces itself ready, stop before the teardown steps so
+  the DB engine is still open) and ``app.reload`` (a SIGHUP or
+  scheduled recycle swapped settings in-place — the process never
+  exits, so the reload gets its own row rather than a detail field on
+  the next ``app.start``, written at the moment the new settings were
+  applied). System rows — no actor — targeting ``app`` (the
   instance id), with version / pid / listener in the start ``detail``
   and pid / uptime / exit reason in the stop's.
 - **Account CRUD** — ``user.register``, ``user.create`` (admin,

--- a/src/klangk/klangkd-tests/tests/test_api.py
+++ b/src/klangk/klangkd-tests/tests/test_api.py
@@ -574,6 +574,34 @@ class TestVersion:
         assert data["built_at"] is None
         assert "features" in data
 
+    async def test_version_missing_file_falls_back_to_dev(
+        self, client, app, tmp_path, monkeypatch
+    ):
+        # #3329: an unreadable version file falls through to the dev
+        # block instead of 500ing (the same tolerance the app.start
+        # audit row's version field applies).
+        monkeypatch.setattr(
+            app.state.settings,
+            "version_file",
+            str(tmp_path / "absent.json"),
+        )
+        resp = await client.get("/api/v1/version")
+        assert resp.status_code == 200
+        assert resp.json()["version"] == "dev"
+
+    async def test_version_non_dict_file_falls_back_to_dev(
+        self, client, app, tmp_path, monkeypatch
+    ):
+        monkeypatch.setattr(
+            app.state.settings,
+            "version_file",
+            str(tmp_path / "version.json"),
+        )
+        (tmp_path / "version.json").write_text('["2026.01.01"]')
+        resp = await client.get("/api/v1/version")
+        assert resp.status_code == 200
+        assert resp.json()["version"] == "dev"
+
     async def test_version_includes_features(
         self, client, app, tmp_path, monkeypatch
     ):

--- a/src/klangk/klangkd-tests/tests/test_main.py
+++ b/src/klangk/klangkd-tests/tests/test_main.py
@@ -1397,6 +1397,17 @@ class TestAppLifecycleAudit:
             == "dev"
         )
 
+    def test_app_version_non_dict_file_falls_back_to_dev(self, tmp_path):
+        # Valid JSON of the wrong shape must not raise out of the
+        # lifespan (the detail dict is built before record_best_effort
+        # can swallow anything — an exception here would block boot).
+        path = tmp_path / "version.json"
+        path.write_text('["1.2.3"]')
+        assert (
+            _app_version(types.SimpleNamespace(version_file=str(path)))
+            == "dev"
+        )
+
 
 class TestBroadcastContainerStatus:
     """The registry status callback schedules the scoped broadcast (#1714).

--- a/src/klangk/klangkd-tests/tests/test_main.py
+++ b/src/klangk/klangkd-tests/tests/test_main.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import contextlib
+import json
 import os
 import signal
 import sqlite3
@@ -2707,12 +2708,20 @@ class TestMainEntryCallback2910:
         mock_shutdown.assert_awaited_once()
         mock_remove.assert_called_once()
         # #3329: the stop row is written before the steps run, so a
-        # failing step cannot lose it.
-        stops = await app.state.model.audit_events.list_events(
-            event="app.stop"
-        )
-        assert len(stops) == 1
-        assert stops[0]["detail"]["reason"] == "lifespan-teardown"
+        # failing step cannot lose it. Read it synchronously from the
+        # DB file: the engine was disposed by process_shutdown, and a
+        # fresh async engine here was the test's last DB object alive
+        # at loop close — on slow machines its aiosqlite worker thread
+        # outlived the loop (the #1250 hazard) and failed CI. The
+        # stdlib connection has no event-loop involvement.
+        with sqlite3.connect(
+            f"file:{app.state.db.db_path}?mode=ro", uri=True
+        ) as raw:
+            row = raw.execute(
+                "SELECT detail FROM audit_events WHERE event = 'app.stop'"
+            ).fetchone()
+        assert row is not None
+        assert json.loads(row[0])["reason"] == "lifespan-teardown"
 
     @pytest.mark.parametrize(
         ("break_step", "expected_exc"),

--- a/src/klangk/klangkd-tests/tests/test_main.py
+++ b/src/klangk/klangkd-tests/tests/test_main.py
@@ -1,6 +1,7 @@
 """Tests for main.py: lifespan, seed user, static files, logfire."""
 
 import asyncio
+import contextlib
 import os
 import signal
 import sqlite3
@@ -36,7 +37,7 @@ from klangk import (
 )
 from klangk.container import ContainerRegistry
 from klangk.exceptions import ConfigurationError, EX_CONFIG
-from klangk.lifecycle import broadcast_container_status
+from klangk.lifecycle import broadcast_container_status, _app_version
 from _helpers import make_settings
 from klangk.wshandler.session import WebSocketState
 
@@ -1203,6 +1204,198 @@ class TestLifespan:
             async with main.lifespan(app):
                 pass  # pragma: no cover
         assert app.state.startup_config_error == str(refusal)
+
+
+class TestAppLifecycleAudit:
+    """The app.start / app.stop / app.reload audit rows (#3329).
+
+    Each test boots (or recycles) the real lifespan against the
+    per-test DB, so the rows land in the same ``audit_events`` table
+    ``GET /events/audit`` serves and are read back through the same
+    model listing the endpoint uses.
+    """
+
+    @contextlib.contextmanager
+    def _boot_mocks(self, wired):
+        """The standard lifespan-boot mock stack (reaps, loops, pid
+        file)."""
+        registry = wired.state.container_registry
+        with (
+            patch.object(
+                registry,
+                "reap_instance_containers",
+                new_callable=AsyncMock,
+            ),
+            patch.object(
+                registry,
+                "reap_dead_owner_containers",
+                new_callable=AsyncMock,
+            ),
+            patch.object(registry, "start_cleanup_loop"),
+            patch.object(util_mod.Util, "check_pid_file", return_value=None),
+            patch.object(util_mod.Util, "write_pid_file"),
+            patch.object(util_mod.Util, "remove_pid_file"),
+        ):
+            yield
+
+    async def test_lifespan_writes_start_and_stop_rows(self, db, app_state):
+        app, wired = _lifespan_test_app()
+        with self._boot_mocks(wired):
+            async with main.lifespan(app):
+                pass
+        events = app.state.model.audit_events
+        starts = await events.list_events(event="app.start")
+        stops = await events.list_events(event="app.stop")
+        assert len(starts) == 1
+        assert len(stops) == 1
+        start, stop = starts[0], stops[0]
+        # System rows: no actor, the app itself (by instance id) as target.
+        for row in (start, stop):
+            assert row["actor_id"] is None
+            assert row["actor_email"] is None
+            assert row["target_type"] == "app"
+            assert row["target_id"] == app.state.util.instance_id()
+        assert start["detail"]["pid"] == os.getpid()
+        assert start["detail"]["version"] == "dev"
+        assert start["detail"]["listen"] == app.state.settings.listen
+        assert start["detail"]["port"] == app.state.settings.port
+        assert start["detail"]["socket"] == app.state.settings.socket
+        assert stop["detail"]["pid"] == os.getpid()
+        assert stop["detail"]["reason"] == "lifespan-teardown"
+        assert stop["detail"]["uptime_seconds"] >= 0
+        # The pair brackets the serving window, in order.
+        assert stop["created_at"] >= start["created_at"]
+
+    async def test_stop_row_names_the_graceful_signal(self, db, app_state):
+        app, wired = _lifespan_test_app()
+        lc = wired.state.lifecycle
+        registry = wired.state.container_registry
+        with (
+            self._boot_mocks(wired),
+            patch.object(wired.state.sockets, "notify_host_shutdown"),
+            patch.object(
+                wired.state.inflight_requests,
+                "wait_for_idle",
+                new_callable=AsyncMock,
+                return_value=True,
+            ),
+            patch.object(registry, "tracked_container_count", return_value=0),
+            patch.object(
+                registry,
+                "drain_all_containers",
+                new_callable=AsyncMock,
+                return_value=0,
+            ),
+        ):
+            async with main.lifespan(app):
+                await lc.graceful_shutdown(signal_num=signal.SIGTERM)
+        assert lc.shutdown_signal == "SIGTERM"
+        stops = await app.state.model.audit_events.list_events(
+            event="app.stop"
+        )
+        assert stops[0]["detail"]["reason"] == "signal:SIGTERM"
+
+    async def test_stop_row_names_the_forced_exit(self, db, app_state):
+        app, wired = _lifespan_test_app()
+        with self._boot_mocks(wired):
+            async with main.lifespan(app):
+                # The failed-recycle recovery path (#3176) marks the
+                # exit before the teardown runs.
+                wired.state.lifecycle.forced_exit_status = 1
+        stops = await app.state.model.audit_events.list_events(
+            event="app.stop"
+        )
+        assert stops[0]["detail"]["reason"] == "forced-exit"
+
+    async def test_lifecycle_rows_carry_hmac_when_configured(
+        self, db, app_state
+    ):
+        app, wired = _lifespan_test_app()
+        app.state.settings.audit_hmac_key = "test-audit-key"
+        with self._boot_mocks(wired):
+            async with main.lifespan(app):
+                pass
+        for name in ("app.start", "app.stop"):
+            rows = await app.state.model.audit_events.list_events(event=name)
+            assert rows[0]["hmac"]
+
+    async def test_recycle_records_app_reload_row(self, db, app_state):
+        app_state = _make_app_state()
+        lc = app_state.state.lifecycle
+        lc._recycle_lock = None
+        registry = app_state.state.container_registry
+        new_settings = make_settings({"KLANGKD_DEFAULT_PASSWORD": "test"})
+        with (
+            patch.object(
+                lc, "reload_settings", return_value=(new_settings, None)
+            ),
+            patch.object(
+                lc, "apply_reloaded_settings", new_callable=AsyncMock
+            ),
+            patch.object(lc, "runtime_shutdown", new_callable=AsyncMock),
+            patch.object(lc, "startup", new_callable=AsyncMock),
+            patch.object(
+                registry,
+                "drain_all_containers",
+                new_callable=AsyncMock,
+                return_value=0,
+            ),
+            patch.object(
+                app_state.state.inflight_requests,
+                "wait_for_idle",
+                new_callable=AsyncMock,
+                return_value=True,
+            ),
+        ):
+            await lc.recycle_runtime(source="SIGHUP")
+        rows = await app_state.state.model.audit_events.list_events(
+            event="app.reload"
+        )
+        assert len(rows) == 1
+        row = rows[0]
+        assert row["actor_id"] is None
+        assert row["target_type"] == "app"
+        assert row["target_id"] == app_state.state.util.instance_id()
+        assert row["detail"] == {"pid": os.getpid(), "source": "SIGHUP"}
+
+    async def test_denied_recycle_writes_no_reload_row(self, db, app_state):
+        app_state = _make_app_state()
+        lc = app_state.state.lifecycle
+        lc._recycle_lock = None
+        with patch.object(
+            lc, "reload_settings", return_value=(None, "bad config")
+        ):
+            await lc.recycle_runtime()
+        rows = await app_state.state.model.audit_events.list_events(
+            event="app.reload"
+        )
+        assert rows == []
+
+    def test_app_version_dev_without_version_file(self):
+        assert _app_version(types.SimpleNamespace(version_file=None)) == "dev"
+
+    def test_app_version_reads_the_version_file(self, tmp_path):
+        path = tmp_path / "version.json"
+        path.write_text('{"version": "1.2.3", "commit": "abc"}')
+        assert (
+            _app_version(types.SimpleNamespace(version_file=str(path)))
+            == "1.2.3"
+        )
+
+    def test_app_version_missing_file_falls_back_to_dev(self, tmp_path):
+        path = tmp_path / "absent.json"
+        assert (
+            _app_version(types.SimpleNamespace(version_file=str(path)))
+            == "dev"
+        )
+
+    def test_app_version_unparseable_file_falls_back_to_dev(self, tmp_path):
+        path = tmp_path / "version.json"
+        path.write_text("{not json")
+        assert (
+            _app_version(types.SimpleNamespace(version_file=str(path)))
+            == "dev"
+        )
 
 
 class TestBroadcastContainerStatus:
@@ -2448,6 +2641,13 @@ class TestMainEntryCallback2910:
                 pass
         mock_shutdown.assert_awaited_once()
         mock_remove.assert_called_once()
+        # #3329: the stop row is written before the steps run, so a
+        # failing step cannot lose it.
+        stops = await app.state.model.audit_events.list_events(
+            event="app.stop"
+        )
+        assert len(stops) == 1
+        assert stops[0]["detail"]["reason"] == "lifespan-teardown"
 
     @pytest.mark.parametrize(
         ("break_step", "expected_exc"),
@@ -2525,7 +2725,9 @@ class TestMainEntryCallback2910:
                     yielded = True
         assert not yielded
 
-    async def test_recycle_runtime_runs_shutdown_then_startup(self, app_state):
+    async def test_recycle_runtime_runs_shutdown_then_startup(
+        self, db, app_state
+    ):
         app_state = _make_app_state()
         lc = app_state.state.lifecycle
         lc._recycle_lock = None  # force fresh lock creation
@@ -2541,7 +2743,7 @@ class TestMainEntryCallback2910:
         # Lock was created and is now held-free.
         assert lc._recycle_lock is not None
 
-    async def test_recycle_runtime_reuses_existing_lock(self, app_state):
+    async def test_recycle_runtime_reuses_existing_lock(self, db, app_state):
         # Seed a lock explicitly; ``recycle_runtime`` must reuse it rather
         # than create a new one. The lock is now per-instance (#1571), so a
         # fresh Lifecycle starts at the pre-first-use floor without a
@@ -2558,7 +2760,9 @@ class TestMainEntryCallback2910:
         # Same lock object reused, not replaced.
         assert lc._recycle_lock is existing
 
-    async def test_recycle_lock_serializes_concurrent_calls(self, app_state):
+    async def test_recycle_lock_serializes_concurrent_calls(
+        self, db, app_state
+    ):
         """Two restarts kicked off together run strictly one-after-another."""
         app_state = _make_app_state()
         lc = app_state.state.lifecycle
@@ -2612,7 +2816,9 @@ class TestMainEntryCallback2910:
         mock_down.assert_not_awaited()
         mock_up.assert_not_awaited()
 
-    async def test_restart_reloads_then_applies_then_restarts(self, app_state):
+    async def test_restart_reloads_then_applies_then_restarts(
+        self, db, app_state
+    ):
         """Valid config: reload → apply → shutdown → startup."""
         app_state = _make_app_state()
         lc = app_state.state.lifecycle
@@ -2647,7 +2853,7 @@ class TestMainEntryCallback2910:
             await lc.recycle_runtime()
         assert order == ["apply", "shutdown", "startup"]
 
-    async def test_restart_graceful_sequence(self, app_state):
+    async def test_restart_graceful_sequence(self, db, app_state):
         """The full graceful-restart sequence, in order (#2527):
         broadcast draining → refuse starts → quiesce → drain containers
         → apply config → broadcast restarting → recycle → clear the
@@ -2724,7 +2930,9 @@ class TestMainEntryCallback2910:
         # The flag never survives the restart.
         assert registry.draining is False
 
-    async def test_restart_keeps_drain_flag_through_startup(self, app_state):
+    async def test_restart_keeps_drain_flag_through_startup(
+        self, db, app_state
+    ):
         """The drain flag is NOT cleared before startup() — startup clears
         it itself after the container reaps, so a client that reconnects
         and starts a workspace during the prewarm/reap window is refused
@@ -2821,7 +3029,9 @@ class TestMainEntryCallback2910:
             "autostart(draining=False)",
         ]
 
-    async def test_restart_quiesce_timeout_proceeds(self, app_state, caplog):
+    async def test_restart_quiesce_timeout_proceeds(
+        self, db, app_state, caplog
+    ):
         """Straggler requests at timeout expiry are logged; the restart
         proceeds anyway."""
         app_state = _make_app_state()
@@ -3348,7 +3558,9 @@ class TestMainEntryCallback2910:
         )
 
     async def test_on_sighup_schedules_restart(self, app_state):
-        """on_sighup creates a task that runs recycle_runtime."""
+        """on_sighup creates a task that runs recycle_runtime, named
+        with its trigger source (#3329 — the source reaches the
+        app.reload audit row)."""
         app_state = _make_app_state()
         lc = app_state.state.lifecycle
         with patch.object(
@@ -3358,7 +3570,7 @@ class TestMainEntryCallback2910:
             # Let the scheduled task run.
             await asyncio.sleep(0)
             await asyncio.sleep(0)
-        mock_restart.assert_awaited_once()
+        mock_restart.assert_awaited_once_with("SIGHUP")
 
     async def test_on_sighup_keeps_strong_task_reference(self, app_state):
         """The restart task is held in _recycle_tasks (an unreferenced
@@ -4616,7 +4828,7 @@ class TestLifecycleBranchGaps2834:
     """#2834 branch gate: the shutdown-owned drain flag and the
     no-caddy-watchdog apply path."""
 
-    async def test_restart_during_shutdown_keeps_draining(self, app_state):
+    async def test_restart_during_shutdown_keeps_draining(self, db, app_state):
         # A shutdown owning the process when the restart's finally runs:
         # the drain flag must stay set (clearing it would lift the
         # shutdown's start-refusal while exiting, #2527 review).

--- a/src/klangk/klangkd-tests/tests/test_main.py
+++ b/src/klangk/klangkd-tests/tests/test_main.py
@@ -1371,6 +1371,60 @@ class TestAppLifecycleAudit:
         )
         assert rows == []
 
+    async def test_reload_row_survives_a_failed_recycle(self, db, app_state):
+        """The row is written at the settings swap, so a recycle that
+        fails afterwards (and recovers) still leaves it — the audit
+        stream must not lose an applied config swap."""
+        app_state = _make_app_state()
+        lc = app_state.state.lifecycle
+        lc._recycle_lock = None
+        registry = app_state.state.container_registry
+
+        async def explode():
+            raise RuntimeError("recycle exploded")
+
+        with (
+            patch.object(
+                lc,
+                "reload_settings",
+                return_value=(
+                    make_settings({"KLANGKD_DEFAULT_PASSWORD": "test"}),
+                    None,
+                ),
+            ),
+            patch.object(
+                lc, "apply_reloaded_settings", new_callable=AsyncMock
+            ),
+            patch.object(lc, "runtime_shutdown", side_effect=explode),
+            patch.object(lc, "startup", new_callable=AsyncMock),
+            patch.object(
+                registry,
+                "drain_all_containers",
+                new_callable=AsyncMock,
+                return_value=0,
+            ),
+            patch.object(
+                app_state.state.inflight_requests,
+                "wait_for_idle",
+                new_callable=AsyncMock,
+                return_value=True,
+            ),
+        ):
+            lc.request_recycle(source="SIGHUP")
+            # Let the recycle fail and the done-callback's recovery
+            # run to completion — each aiosqlite round-trip needs real
+            # wall time on its worker thread, so pump with small
+            # sleeps until both tasks drain (bounded: 200 × 10ms).
+            for _ in range(200):
+                if not lc._recycle_tasks:
+                    break
+                await asyncio.sleep(0.01)
+        rows = await app_state.state.model.audit_events.list_events(
+            event="app.reload"
+        )
+        assert len(rows) == 1
+        assert rows[0]["detail"]["source"] == "SIGHUP"
+
     def test_app_version_dev_without_version_file(self):
         assert _app_version(types.SimpleNamespace(version_file=None)) == "dev"
 
@@ -3112,13 +3166,14 @@ class TestMainEntryCallback2910:
         assert registry.draining is False
 
     async def test_restart_aborts_when_shutdown_arrives_mid_drain(
-        self, app_state
+        self, db, app_state
     ):
         """#2527 review: a TERM landing while the restart's drain is in
         flight aborts the restart after the drain — no settings apply,
         no runtime recycle — and never lifts the shutdown's drain flag
         (no auto-start resurrecting drained containers, no 503-lift
-        while exiting)."""
+        while exiting). The aborted recycle applies nothing, so no
+        app.reload row either (#3329)."""
         app_state = _make_app_state()
         lc = app_state.state.lifecycle
         lc._recycle_lock = None
@@ -3159,6 +3214,11 @@ class TestMainEntryCallback2910:
         mock_up.assert_not_awaited()  # no auto-start resurrect
         # The shutdown's flag was NOT lifted.
         assert registry.draining is True
+        # #3329: nothing was applied, so no reload row.
+        rows = await app_state.state.model.audit_events.list_events(
+            event="app.reload"
+        )
+        assert rows == []
 
     async def test_restart_aborts_before_starting_when_shutdown_precedes(
         self, app_state


### PR DESCRIPTION
## Summary

The daemon's own lifecycle joins the structured audit stream (#3329): klangkd now writes `audit_events` rows for app start, stop, and in-place reload, so service availability is queryable next to the identity/privilege events instead of living only in process logs and the pid file.

- **`app.start`** — written in the lifespan right after `validate_and_seed` succeeds (config validated, seed done, model layer up). Detail: build version (from the version file, `dev` when unset), pid, `listen` / `port` / `socket`.
- **`app.stop`** — written in the lifespan teardown `finally`, **before** the teardown steps (`process_shutdown` disposes the DB engine). Detail: pid, uptime, exit reason — `signal:SIGTERM` / `signal:SIGINT` for a graceful stop, `forced-exit` for the fail-secure exit of #3176, `lifespan-teardown` otherwise. A failing teardown step cannot lose the row (#3176: all steps are attempted).
- **`app.reload`** — written when a SIGHUP or scheduled recycle fully applies new settings. This is the decided answer to the issue's open question: the process never exits on reload, so the reload gets its own row rather than a detail field on the (arbitrarily distant) next `app.start`. A denied (invalid config) or aborted (shutdown raced) recycle writes nothing. The trigger source (`SIGHUP` / `scheduled recycle`) is recorded in the detail.

Rows are system rows: no actor, `target_type: "app"`, `target_id` is the instance id. All writes go through `record_best_effort` (an audit problem never blocks boot or exit), rows carry the opt-in `KLANGKD_AUDIT_HMAC_KEY` tag and ship with the audit-record forwarder, and they appear in `GET /api/v1/events/audit` (and the merged stream / admin Events tab) unchanged — no schema change.

## Notes for reviewers

- `recycle_runtime` gained a `source: str | None = None` parameter (threaded from the existing `request_recycle(source=...)`); direct callers are unaffected.
- `Lifecycle.shutdown_signal` is new — set by `graceful_shutdown`, read by the stop row's reason.
- Known cosmetic follow-up (out of scope here): the admin Audit tab labels an actor-less row "anonymous"; `app.*` rows are *system* rows, so they render as "anonymous" until the panel learns the distinction.
- Tests: new `TestAppLifecycleAudit` class (row shape, HMAC, signal/forced/teardown reasons, teardown-step-failure survival, reload row + deny path, version-file edge cases); several recycle tests gained the `db` fixture so the new reload write hits a real schema.

Closes #3329.
