### PR TITLE
Fix fmtk E2E: pendingRedirect leak, invite snackbar race (#3321)

### DIFF
--- a/src/frontend/e2e-tests/fmtk/conftest.py
+++ b/src/frontend/e2e-tests/fmtk/conftest.py
@@ -63,8 +63,27 @@ def app(harness: Harness):
 
 
 @pytest.fixture(autouse=True)
-def no_app_errors(app):
+def no_app_errors(app, request):
     """Every test must leave the app error-free (drained post-test)."""
     yield
+    if request.node.rep_call and request.node.rep_call.failed:
+        try:
+            from fmtkharness import find_nodes, node_labels
+
+            nodes = find_nodes(app.snapshot(), lambda n: True)
+            all_text = []
+            for n in nodes:
+                all_text.extend(node_labels(n))
+            unique = list(dict.fromkeys(all_text))[:60]
+            print(f"\n[SNAPSHOT on failure] visible text: {unique}")
+        except Exception as exc:
+            print(f"\n[SNAPSHOT failed] {exc}")
     errors = app.app_errors()
     assert not errors, f"uncaught app errors during test: {errors}"
+
+
+@pytest.hookimpl(tryfirst=True, hookwrapper=True)
+def pytest_runtest_makereport(item, call):
+    outcome = yield
+    rep = outcome.get_result()
+    setattr(item, f"rep_{rep.when}", rep)

--- a/src/frontend/e2e-tests/fmtk/fmtkharness.py
+++ b/src/frontend/e2e-tests/fmtk/fmtkharness.py
@@ -1335,7 +1335,14 @@ class FmtkClient:
     def logout(self) -> None:
         """Tap the app-bar logout icon (its tooltip is the semantic
         label; icon-only fallback: the rightmost button — logout is the
-        last app-bar action) and wait for the login surface."""
+        last app-bar action) and wait for the login surface.
+
+        After the login page appears, poll until the Dart AuthService
+        reports ``isLoggedIn == false``.  The server's ``Clear-Site-Data:
+        "storage"`` header (added in #3335) tells the browser to wipe
+        localStorage asynchronously — the login form can render before
+        the wipe completes, so a login fired immediately after the page
+        appears may lose its new JWT to the deferred wipe."""
         if self.has_text("Log In", 2000):
             return  # already logged out
         try:
@@ -1343,6 +1350,20 @@ class FmtkClient:
         except FmtkError:
             self.tap_rightmost_button()
         self.wait_for_login_page()
+        self._wait_logged_out()
+
+    def _wait_logged_out(self, timeout: float = 10) -> None:
+        """Spin until the Dart AuthService has no token."""
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            try:
+                result = self.auth_eval("return auth!.isLoggedIn.toString();")
+                if result == "false":
+                    return
+            except FmtkError:
+                pass  # evaluator may fail transiently during teardown
+            time.sleep(0.5)
+        raise HarnessTimeout("AuthService still logged-in after logout")
 
     def tap_rightmost_button(self) -> None:
         """Tap the button with the greatest right edge (ties: topmost).

--- a/src/frontend/e2e-tests/fmtk/test_admin.py
+++ b/src/frontend/e2e-tests/fmtk/test_admin.py
@@ -383,8 +383,18 @@ def invite_via_dialog(app, email: str) -> None:
             break
     assert email_field, "invite dialog email field not found"
     app.enter_text(email_field, email)
+    # wait for the dialog rebuild after the text change — the button is
+    # disabled until canInvite recomputes, which requires a setState
+    # rebuild triggered by the text field's onChanged callback
+    app.wait_for_text(email)
     app.tap_button_exact("Send Invitation")
-    app.wait_for_text(f"Invitation sent to {email}")
+    # the dialog closes and _inviteUser fires the POST; the confirmation
+    # is the snackbar "Invitation sent to <email>", but the snackbar
+    # auto-dismisses in 4s and the concurrent _loadInvitations rebuild
+    # can race the SnackBar off the scaffold before wait_for catches it —
+    # wait for the dialog to close instead (the caller waits for the
+    # invitation row in the list)
+    app.wait_gone("Invite User")
 
 
 # --- scenarios ---------------------------------------------------------
@@ -583,9 +593,11 @@ def test_invitations_status_resend_revoke(harness, app):
     invite_via_dialog(app, INVITE_EMAIL)
     app.wait_for_text(INVITE_EMAIL)
     app.wait_for_text("Status: pending")
-    # --- resend answers with its own snackbar
+    # --- resend: the button fires a POST; verify the email arrived in
+    # the SMTP sink rather than the transient snackbar (same race as the
+    # initial invite — the SnackBar auto-dismisses under load)
     tap_row_button(app, INVITE_EMAIL, index=0)
-    app.wait_for_text(f"Invitation resent to {INVITE_EMAIL}")
+    harness.smtp.token_for("accept-invite", INVITE_EMAIL)
 
     # a second invitation, then revoked: its emailed token must stop
     # working (the canonical happy-path acceptance lives in the auth

--- a/src/frontend/lib/app_guards.dart
+++ b/src/frontend/lib/app_guards.dart
@@ -85,8 +85,10 @@ String? guardAuth({
 /// (saveToken's, then its finally-block's). Consuming on the first
 /// evaluation made the second — still re-parsing `/login` — see a null
 /// stash and win the navigation with the `/workspaces` fallback (#2670).
-/// The cross-session leak is instead cut where it originates:
-/// `_clearToken()` clears the stash on logout / any session-ending 401.
+/// The cross-session leak is cut in `_clearToken()`: explicit logout
+/// clears `pendingRedirect` AFTER `notifyListeners()` — so guardAuth's
+/// re-stash from the bounce is overwritten — while token-expiry paths
+/// preserve the stash so the same user resumes where they were (#3321).
 ///
 /// Returns the redirect target, or null to allow.
 String? guardLoggedInPublicRoute({

--- a/src/frontend/lib/auth/auth_service.dart
+++ b/src/frontend/lib/auth/auth_service.dart
@@ -281,7 +281,7 @@ class AuthService extends ChangeNotifier {
             (data['default_classification_banner'] as String? ?? '').trim();
         _netfilterDefaultDomains =
             (data['netfilter_default_domains'] as List?)?.cast<String>() ??
-                const [];
+            const [];
         _netfilterEnabled = (data['netfilter_enabled'] as bool?) ?? false;
         _nixAvailable = (data['nix_available'] as bool?) ?? false;
         _sudoAvailable = (data['sudo_available'] as bool?) ?? false;
@@ -342,10 +342,8 @@ class AuthService extends ChangeNotifier {
     if (_token == null) return;
     final hasKey = await dpopBackend.ensureKey();
     if (tokenBound && !hasKey) {
-      debugPrint(
-        '[AuthService] bound token without a key; forcing re-login',
-      );
-      await _clearToken();
+      debugPrint('[AuthService] bound token without a key; forcing re-login');
+      await _clearToken(preserveRedirect: true);
       return;
     }
     if (!tokenBound && hasKey) {
@@ -419,7 +417,7 @@ class AuthService extends ChangeNotifier {
         );
         _isAdmin = data['is_admin'] == true;
       } else if (resp.statusCode == 401) {
-        await _clearToken();
+        await _clearToken(preserveRedirect: true);
       }
     } catch (e) {
       // coverage:ignore-start
@@ -524,7 +522,7 @@ class AuthService extends ChangeNotifier {
     _bindRetryTimer = null;
   }
 
-  Future<void> _clearToken() async {
+  Future<void> _clearToken({bool preserveRedirect = false}) async {
     _refreshTimer?.cancel();
     _refreshTimer = null;
     _token = null;
@@ -532,22 +530,27 @@ class AuthService extends ChangeNotifier {
     _groups = [];
     _isAdmin = false;
     _mustChangePassword = false;
-    // The pending redirect belongs to the session being cleared; drop it
-    // so the next login can never inherit the old session's destination
-    // (#2670). If the user was on a protected page, guardAuth re-stashes
-    // the current URI on the redirect that follows, preserving the
-    // same-user "resume where you were" behavior after a token expiry.
-    pendingRedirect = null;
     _stopPermissionRefresh();
     _stopBindRetry();
     await clearToken();
     notifyListeners();
+    // Clear pendingRedirect AFTER notifyListeners: the notification
+    // triggers the router's redirect evaluation, and guardAuth
+    // re-stashes the current protected URI during the bounce to /login.
+    // For explicit logout (!preserveRedirect) the stash must not
+    // survive — a different user may log in next and should land on
+    // /workspaces, not the previous user's admin page (#3321).
+    // Token-expiry and 401 paths pass preserveRedirect=true so the
+    // same user resumes where they were after re-login (#2670).
+    if (!preserveRedirect) {
+      pendingRedirect = null;
+    }
   }
 
   Map<String, String> get _authHeaders => {
-        'Content-Type': 'application/json',
-        if (_token != null) 'Authorization': 'Bearer $_token',
-      };
+    'Content-Type': 'application/json',
+    if (_token != null) 'Authorization': 'Bearer $_token',
+  };
 
   /// Auth headers for one request, carrying a fresh DPoP proof when
   /// the token is bound (#3218). [method] is the HTTP verb and [path]
@@ -590,10 +593,7 @@ class AuthService extends ChangeNotifier {
     try {
       final response = await _client.post(
         Uri.parse('$_baseUrl/api/v1/auth/register'),
-        headers: {
-          'Content-Type': 'application/json',
-          ...await mintHeaders(),
-        },
+        headers: {'Content-Type': 'application/json', ...await mintHeaders()},
         body: jsonEncode({'email': email, 'password': password}),
       );
       if (response.statusCode == 200) {
@@ -622,10 +622,7 @@ class AuthService extends ChangeNotifier {
     try {
       final response = await _client.post(
         Uri.parse('$_baseUrl/api/v1/auth/login'),
-        headers: {
-          'Content-Type': 'application/json',
-          ...await mintHeaders(),
-        },
+        headers: {'Content-Type': 'application/json', ...await mintHeaders()},
         body: jsonEncode({'identifier': email, 'password': password}),
       );
       if (response.statusCode == 200) {
@@ -706,7 +703,7 @@ class AuthService extends ChangeNotifier {
   /// waiting for the next token refresh.
   Future<void> _handleAuthFailure(http.Response response) async {
     if (response.statusCode == 401) {
-      await _clearToken();
+      await _clearToken(preserveRedirect: true);
       return;
     }
     if (response.statusCode != 403 || _token == null) return;
@@ -794,8 +791,11 @@ class AuthService extends ChangeNotifier {
     return response;
   }
 
-  Future<http.Response> authPost(String path,
-      {String? body, bool mint = false}) async {
+  Future<http.Response> authPost(
+    String path, {
+    String? body,
+    bool mint = false,
+  }) async {
     final response = await _withStepUp(
       () async => await _client.post(
         Uri.parse('$_baseUrl$path'),
@@ -882,7 +882,7 @@ class AuthService extends ChangeNotifier {
           await _saveToken(newToken);
         }
       } else if (response.statusCode == 401) {
-        await _clearToken();
+        await _clearToken(preserveRedirect: true);
       }
     } catch (e) {
       // Network error — retry in 60 seconds

--- a/src/frontend/test/auth_service_test.dart
+++ b/src/frontend/test/auth_service_test.dart
@@ -955,7 +955,7 @@ void main() {
     });
 
     test(
-      'clears pendingRedirect when a 401 clears the token (#2670)',
+      'preserves pendingRedirect when a 401 clears the token (#3321)',
       () async {
         testAuthHttpClientOverride = MockClient((request) async {
           if (request.url.path.contains('/api/v1/auth/logout')) {
@@ -971,7 +971,7 @@ void main() {
         pendingRedirect = '/admin/users';
         await service.authGet('/api/v1/workspaces');
         expect(service.isLoggedIn, isFalse);
-        expect(pendingRedirect, isNull);
+        expect(pendingRedirect, '/admin/users');
       },
     );
   });


### PR DESCRIPTION
## Summary

- **pendingRedirect leak** (`auth_service.dart`): `_clearToken` now accepts `preserveRedirect`. Explicit logout clears the stash AFTER `notifyListeners()` (so guardAuth's re-stash is overwritten); 401/token-expiry paths preserve it so the user resumes where they were after re-login.
- **Invite snackbar race** (`test_admin.py`): Replaced transient snackbar waits (`wait_for_text("Invitation sent to...")`) with stable signals — dialog close (`wait_gone("Invite User")`) and SMTP sink verification (`smtp.token_for`).
- **Clear-Site-Data logout race** (`fmtkharness.py`): `logout()` now polls `AuthService.isLoggedIn` after the login page renders, ensuring the browser's async `Clear-Site-Data: "storage"` wipe (#3335) has settled before the next login attempt.
- **Unit test update** (`auth_service_test.dart`): 401 now preserves `pendingRedirect` instead of clearing it.
- **Snapshot-on-failure** (`conftest.py`): Failed tests dump the semantic tree's visible text for faster diagnosis.

## Test plan

- [x] `test-frontend`: 1340/1340 pass (auth_service pendingRedirect tests updated)
- [x] fmtk E2E admin: 6/6 pass (was 3/6)
- [x] fmtk E2E auth: 10/10 pass (was 8/10)
- [x] fmtk E2E oidc: 6/6 pass (was 3/6)
- [x] fmtk E2E settings: 6/6 pass
- [x] fmtk E2E network: 4/4 pass
- [x] fmtk E2E features: 3/3 pass
- [x] fmtk E2E files: 6/6 pass
- [x] fmtk E2E sharing: 4/7 pass in isolation (last 3 fail from pre-existing backend crash)

Closes #3321