### PR TITLE
Provision the published network sidecar image in dist-smoke (#3343)

### DIFF
--- a/.github/workflows/dist-smoke.yml
+++ b/.github/workflows/dist-smoke.yml
@@ -76,15 +76,17 @@ jobs:
   #   - Caddyfile render broken → caddy rejects the config
   #   - UDS upstream misconfigured → caddy 502s
   #   - Missing transitive dep in pyproject.toml → import fails fast
+  #   - Published network sidecar image unpullable → workspace start
+  #     fails closed (pulled from GHCR by the container phase, #3343)
   #
-  # NOTE: currently expected to FAIL until #1709 (klangkd's caddy child
-  # can't coexist with another caddy on the host / bootstrap binds 2019
-  # instead of the UDS) is fixed. The dist-smoke gate is intentionally
-  # decoupled from release.yml — release.yml publishes without waiting
-  # on this workflow so the release pipeline isn't held hostage to the
-  # smoke being green. A maintainer runs this against a release-candidate
-  # branch before tagging; if it fails on a non-#1709 cause, that's a
-  # real release-blocker worth investigating before tagging.
+  # NOTE: the container phase provisions the network sidecar image from
+  # GHCR (newest published calver tag) — fresh workspaces default to
+  # egress_mode=interactive and fail closed without it (#3343). The
+  # dist-smoke gate is intentionally decoupled from release.yml —
+  # release.yml publishes without waiting on this workflow so the release
+  # pipeline isn't held hostage to the smoke being green. A maintainer runs
+  # this against a release-candidate branch before tagging; any failure is
+  # a real release-blocker worth investigating before tagging.
   dist-smoke-test:
     runs-on: ubuntu-latest
     timeout-minutes: 15

--- a/docs/deployment/packaged.md
+++ b/docs/deployment/packaged.md
@@ -20,6 +20,57 @@ and serves an API-only app (the UI is not mounted). This makes a misconfigured
 override — or a wheel built without the frontend artifact — obvious rather
 than silent.
 
+## Container images for workspaces
+
+The wheel carries the server, the CLI, and the web UI. Workspace containers
+come from **container images**, which live in the local podman image store —
+the wheel ships none. A workspace start needs both of these images:
+
+| Image           | Setting (default)                                  | Purpose                                                                                                                                                                                                                             |
+| --------------- | -------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Workspace       | `image_name` (`klangk-workspace`)                  | The environment your code runs in (the container `klangkd` creates per workspace).                                                                                                                                                  |
+| Network sidecar | `network_sidecar_image` (`klangk-network-sidecar`) | The FQDN egress-filtering companion. Fresh workspaces default to `egress_mode=interactive`, which makes the sidecar mandatory: a start whose sidecar image is missing refuses to run and the API answers `500` with the pull error. |
+
+Both images publish to GHCR under `ghcr.io/mcdonc/klangk/`, tagged with
+immutable version tags only — `vX.Y.Z` release tags and
+`YYYY.MM.DD-<commit>` continuous tags (see
+[Building Images](../development/building-images.md) for the publishing
+conventions). `klangkd` resolves both settings' short names against the local
+image store (the workspace image is created with pull policy `never`), so
+pull a published tag and retag it onto the short name:
+
+```bash
+# Release tags pair with the released wheel of the same version;
+# continuous tags track main.
+WS_TAG=v2026.06.10
+podman pull ghcr.io/mcdonc/klangk/klangk-workspace:$WS_TAG
+podman tag  ghcr.io/mcdonc/klangk/klangk-workspace:$WS_TAG klangk-workspace:latest
+
+# Pick the newest continuous tag from
+# https://github.com/mcdonc/klangk/pkgs/container/klangk%2Fklangk-network-sidecar
+SIDECAR_TAG=2026.09.07-49bf897
+podman pull ghcr.io/mcdonc/klangk/klangk-network-sidecar:$SIDECAR_TAG
+podman tag  ghcr.io/mcdonc/klangk/klangk-network-sidecar:$SIDECAR_TAG klangk-network-sidecar:latest
+```
+
+Pick the workspace and sidecar tags built from the same commit as your
+wheel when you can: the three components evolve together, and a release
+tag (`vX.Y.Z`) matches the wheel cut from that tag.
+
+With a checkout of the repository, the devenv tasks build and tag both
+images locally instead:
+
+```bash
+devenv shell -- build-workspace-image
+devenv shell -- build-network-sidecar
+```
+
+Both settings take a fully-qualified reference too
+(`KLANGKD_IMAGE_NAME=ghcr.io/mcdonc/klangk/klangk-workspace:v2026.06.10`),
+which still requires the image in the local store — pull it first. See the
+[configuration reference](../reference/klangkd-config.md) for the full
+settings surface.
+
 ## Building the wheel (operators releasing klangk)
 
 The Flutter web build (`src/frontend/build/web/`) is gitignored, so it exists

--- a/scripts/dist-smoke-test.sh
+++ b/scripts/dist-smoke-test.sh
@@ -35,6 +35,8 @@
 #   - Caddyfile render broken → caddy rejects the config
 #   - UDS upstream misconfigured → caddy 502s
 #   - Missing transitive dep in pyproject.toml → import fails fast
+#   - Published network sidecar image unpullable → the CLI-phase
+#     workspace start fails closed (the image is pulled from GHCR, #3343)
 #
 # Usage:
 #   scripts/dist-smoke-test.sh <path/to/klangk-*.whl>
@@ -214,11 +216,40 @@ fi
 #    podman is absent (e.g. lightweight CI runners that only test the
 #    frontend).
 #
+#    The start needs TWO images: the workspace image (built minimally
+#    below) and the network sidecar image. Fresh workspaces default to
+#    egress_mode=interactive, which makes the sidecar required and
+#    fail-closed (#3343), so the phase also provisions the sidecar from
+#    GHCR (pulled + retagged below; see the block itself for detail).
+#
 #    The CLI auto-discovers the co-located klangkd via the UDS socket
 #    when KLANGKD_STATE_DIR is set, and auto-logs in when the server is
 #    in "none" auth mode. But the running server uses "password" mode
 #    (for the Playwright login test above), so we restart with "none"
 #    mode for the CLI phase.
+
+# Newest published sidecar tag from GHCR's v2 API (anonymous pull token).
+# Tags are immutable calver-commit refs (YYYY.MM.DD-<shortsha>, #3140) —
+# :latest stays unpublished by the stock-image convention — so the
+# calver-filtered sort picks the newest publish. Prints the tag, or
+# returns nonzero with a message when the listing is unreachable or
+# carries no calver tag.
+newest_sidecar_tag() {
+  local name="$1" token tag
+  if ! token=$(curl -sf "https://ghcr.io/token?scope=repository:${name}:pull" |
+    python3 -c 'import json,sys; print(json.load(sys.stdin)["token"])'); then
+    echo "error: could not obtain a GHCR pull token for $name — is ghcr.io reachable?" >&2
+    return 1
+  fi
+  tag=$(curl -sf -H "Authorization: Bearer $token" "https://ghcr.io/v2/${name}/tags/list" |
+    grep -oE '[0-9]{4}\.[0-9]{2}\.[0-9]{2}-[0-9a-f]+' | sort -V | tail -1) || true
+  if [ -z "$tag" ]; then
+    echo "error: no calver tag listed for ghcr.io/$name — ghcr.io unreachable, or nothing published yet (#3343)" >&2
+    return 1
+  fi
+  printf '%s\n' "$tag"
+}
+
 KLANGK="$VENV_DIR/bin/klangk"
 SKIP_CONTAINER_SMOKE="${SKIP_CONTAINER_SMOKE:-}"
 if [ -n "$SKIP_CONTAINER_SMOKE" ]; then
@@ -251,6 +282,33 @@ DOCKERFILE
   if [ -n "${SKIP_CONTAINER_SMOKE:-}" ]; then
     true # skip — message already printed above
   else
+    # Provision the network sidecar image the start below requires: the
+    # unqualified default (klangk-network-sidecar) resolves from local
+    # storage, so the published GHCR image is pulled and retagged to it.
+    # A local build from the devenv task (klangk:build-network-sidecar)
+    # already satisfies the image-exists check and skips the pull.
+    # KLANGKBUILD_SIDECAR_REF pins an exact published reference instead
+    # of the newest tag (validating a branch against a chosen image).
+    # Unlike the smoke workspace-image build above, a failure here is
+    # fatal: the start below fail-closes without the sidecar, and a
+    # silently skipped phase would report green without testing anything
+    # (#3343).
+    SIDECAR_IMAGE="${KLANGKD_NETWORK_SIDECAR_IMAGE:-klangk-network-sidecar}"
+    if ! podman image exists "localhost/$SIDECAR_IMAGE:latest" 2>/dev/null; then
+      SIDECAR_NAME="mcdonc/klangk/klangk-network-sidecar"
+      if [ -n "${KLANGKBUILD_SIDECAR_REF:-}" ]; then
+        SIDECAR_REF="${KLANGKBUILD_SIDECAR_REF}"
+      else
+        SIDECAR_REF="$(newest_sidecar_tag "$SIDECAR_NAME")" || exit 1
+      fi
+      echo "=== pulling network sidecar image ghcr.io/$SIDECAR_NAME:$SIDECAR_REF ==="
+      if ! podman pull "ghcr.io/$SIDECAR_NAME:$SIDECAR_REF"; then
+        echo "error: sidecar image pull failed — an egress-filtered workspace cannot start without it (#3343)" >&2
+        exit 1
+      fi
+      podman tag "ghcr.io/$SIDECAR_NAME:$SIDECAR_REF" "localhost/$SIDECAR_IMAGE:latest"
+    fi
+
     echo "=== restarting klangkd in none-auth mode for CLI smoke ==="
     # Stop the password-mode server
     kill "$KLANGKD_PID" 2>/dev/null || true

--- a/scripts/tests/test_dist_smoke_sidecar.py
+++ b/scripts/tests/test_dist_smoke_sidecar.py
@@ -1,0 +1,141 @@
+"""Contract tests for the dist-smoke sidecar-image provisioning (#3343).
+
+Fresh workspaces default to ``egress_mode=interactive``, which makes the
+FQDN network sidecar required and fail-closed: without a local
+``klangk-network-sidecar`` image, podman resolves the unqualified default
+against docker.io/quay.io and ``klangk start`` 500s — dist-smoke run
+https://github.com/mcdonc/klangk/actions/runs/34172862442 was red for
+exactly that reason. #3140 publishes the image to GHCR under immutable
+calver-commit tags, and ``scripts/dist-smoke-test.sh`` bridges the two:
+it discovers the newest tag via the anonymously readable GHCR v2 API,
+pulls it, and retags it to the short name the server resolves from local
+storage. A future edit that drops any half of that silently turns the
+release gate red again (or worse, green while skipping the phase) — these
+tests make it loud, in the grep-contract spirit of
+``test_seeded_password_policy.py`` (#3341).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_SMOKE_SH = _REPO_ROOT / "scripts" / "dist-smoke-test.sh"
+_WORKFLOW = _REPO_ROOT / ".github" / "workflows" / "dist-smoke.yml"
+_SIDECAR_REPO = "mcdonc/klangk/klangk-network-sidecar"
+
+
+def test_smoke_pulls_and_retags_published_sidecar():
+    """The smoke must bridge GHCR's published sidecar to the short name.
+
+    The server resolves the unqualified ``klangk-network-sidecar`` default
+    against local storage, so the phase pulls the published FQ reference
+    and retags it onto ``localhost/$SIDECAR_IMAGE:latest`` — dropping
+    either half reproduces the #3343 500.
+    """
+    text = _SMOKE_SH.read_text()
+    assert f'SIDECAR_NAME="{_SIDECAR_REPO}"' in text, (
+        "dist-smoke no longer names the published network sidecar image "
+        "repo — the CLI-phase workspace start fail-closes (#3343)"
+    )
+    assert 'podman pull "ghcr.io/$SIDECAR_NAME:$SIDECAR_REF"' in text, (
+        "dist-smoke no longer pulls the published network sidecar image "
+        "from GHCR — the CLI-phase workspace start fail-closes (#3343)"
+    )
+    assert (
+        'SIDECAR_IMAGE="${KLANGKD_NETWORK_SIDECAR_IMAGE:-klangk-network-sidecar}"'
+        in text
+    ), (
+        "dist-smoke no longer retags onto the server's default sidecar "
+        "image short name (#3343)"
+    )
+    assert (
+        'podman tag "ghcr.io/$SIDECAR_NAME:$SIDECAR_REF" '
+        '"localhost/$SIDECAR_IMAGE:latest"' in text
+    ), (
+        "dist-smoke pulls the sidecar but never retags it to the short "
+        "name the server resolves from local storage (#3343)"
+    )
+
+
+def test_sidecar_tag_discovery_filters_calver():
+    """Tag discovery must keep the calver filter and version sort.
+
+    GHCR carries only immutable tags; without the ``YYYY.MM.DD-<sha>``
+    filter a plain ``max()`` could pick a differently-shaped tag (e.g. a
+    ``vX.Y.Z`` release tag) and defeat the "newest publish" intent.
+    """
+    text = _SMOKE_SH.read_text()
+    assert "newest_sidecar_tag()" in text, (
+        "dist-smoke no longer discovers the newest published sidecar tag "
+        "from the GHCR API (#3343)"
+    )
+    # The literal bash pattern as it appears in the script: calver date
+    # groups with backslash-escaped dots, hyphen, short commit sha.
+    calver_grep = "grep -oE '[0-9]{4}\\.[0-9]{2}\\.[0-9]{2}-[0-9a-f]+'"
+    assert calver_grep in text, (
+        "dist-smoke's sidecar tag discovery lost its calver-commit filter "
+        "(YYYY.MM.DD-<sha>) — sorting over unfiltered tags can pick a "
+        "non-calver reference (#3343)"
+    )
+    assert "sort -V" in text, (
+        "dist-smoke's sidecar tag discovery lost its version sort (#3343)"
+    )
+
+
+def test_sidecar_pull_failure_is_fatal():
+    """A sidecar pull failure must abort, not skip the container phase.
+
+    The workspace-image build failure path sets SKIP_CONTAINER_SMOKE=1 and
+    skips; the sidecar path must not — a skipped phase reports green while
+    nothing was tested, and the start below would 500 anyway.
+    """
+    text = _SMOKE_SH.read_text()
+    start = text.index("SIDECAR_IMAGE=")
+    end = text.index("restarting klangkd in none-auth mode", start)
+    block = text[start:end]
+    assert "exit 1" in block, (
+        "dist-smoke's sidecar provisioning no longer fails hard when the "
+        "pull fails — it must be a release-blocker signal, not a skip "
+        "(#3343)"
+    )
+    assert "SKIP_CONTAINER_SMOKE=1" not in block, (
+        "dist-smoke's sidecar provisioning skips the container phase on "
+        "failure — a silent skip reports green without testing the start "
+        "(#3343)"
+    )
+
+
+def test_sidecar_provisioned_before_start():
+    """The sidecar must be provisioned before the CLI starts a workspace.
+
+    Provisioning after the start (or after the klangkd restart) leaves the
+    very first start attempt failing closed.
+    """
+    text = _SMOKE_SH.read_text()
+    assert text.index("=== pulling network sidecar image") < text.index(
+        "=== CLI: start workspace ==="
+    ), (
+        "dist-smoke provisions the network sidecar after the workspace "
+        "start that needs it (#3343)"
+    )
+
+
+def test_workflow_note_reports_gate_as_authoritative():
+    """The workflow header must not carry the stale expected-FAIL note.
+
+    The #1709-era "currently expected to FAIL" note predates both that fix
+    and the #3343 sidecar provisioning; keeping it teaches maintainers to
+    ignore a red gate (#3343).
+    """
+    text = _WORKFLOW.read_text()
+    assert "expected to FAIL" not in text, (
+        "dist-smoke.yml still tells maintainers the gate is expected to "
+        "fail — with #1709 fixed and the sidecar provisioned (#3343), any "
+        "failure is a release-blocker worth investigating"
+    )
+    assert _SIDECAR_REPO in text or "GHCR" in text, (
+        "dist-smoke.yml's container-phase note should mention the GHCR "
+        "sidecar provisioning so the run's image provenance is documented "
+        "(#3343)"
+    )


### PR DESCRIPTION
## Summary

`klangk start` in the dist-smoke container phase fail-closed 500ing on a missing `klangk-network-sidecar` image: fresh workspaces default to `egress_mode=interactive`, the start arms the FQDN sidecar, and the runner had no such image — podman resolved the unqualified default against docker.io/quay.io and the start refused to run (#3343, last green run 2026-07-22).

Since #3140 the image publishes to `ghcr.io/mcdonc/klangk/klangk-network-sidecar` under immutable `YYYY.MM.DD-<commit>` tags, so the smoke now bridges the two:

- **`scripts/dist-smoke-test.sh`** discovers the newest calver tag via the anonymously readable GHCR v2 API, pulls it, and retags it onto `localhost/klangk-network-sidecar:latest` — the short name the server's unqualified default resolves from local storage (same mechanism the minimal workspace image already uses). A pull failure is **fatal** (release-blocker signal), unlike the workspace-image build path which skips: a skipped phase would report green while nothing was tested. `KLANGKBUILD_SIDECAR_REF` pins an exact published reference instead of the newest tag (validating a branch against a chosen image); a locally built sidecar image satisfies the image-exists check and skips the pull.
- **`.github/workflows/dist-smoke.yml`** drops the stale "#1709-era expected to FAIL" note — #1709 is fixed, caddy starts cleanly, and the sidecar is now provisioned; any remaining failure is a real release-blocker.
- **`docs/deployment/packaged.md`** gains a "Container images for workspaces" section: a `pip install klangk` deployment needs the workspace and sidecar images in the local podman store, with the GHCR pull + retag commands, the devenv build alternative, and the fail-closed behavior of an interactive-mode workspace without its sidecar.
- **`scripts/tests/test_dist_smoke_sidecar.py`** pins the mechanics grep-contract style (pull + retag onto the short name, calver tag filter, fatal-not-skip failure, provisioning before the start, stale workflow note gone), so a silent regression is loud in seconds instead of 10 minutes into the wheel-build job.

Validated live: tag discovery returns `2026.09.07-49bf897`, the pull + retag succeed under rootless podman, and the full `scripts/tests` suite passes (143 tests). The standalone dist-smoke workflow is running against this branch: https://github.com/mcdonc/klangk/actions/runs/34175984766

Closes #3343.
