### PR TITLE
fmtk: add post-logout pause for Clear-Site-Data processing (#3345)

### DIFF
--- a/src/frontend/e2e-tests/fmtk/fmtkharness.py
+++ b/src/frontend/e2e-tests/fmtk/fmtkharness.py
@@ -1345,12 +1345,23 @@ class FmtkClient:
         self.wait_for_login_page()
 
     def _wait_logged_out(self, timeout: float = 10) -> None:
-        """Spin until the Dart AuthService has no token."""
+        """Spin until the Dart AuthService has no token, then pause for
+        the browser's ``Clear-Site-Data`` processing to settle.
+
+        The Dart in-memory token clears instantly on logout, but the
+        server's ``Clear-Site-Data: "storage"`` header (#3335) tells
+        the browser to wipe sessionStorage **asynchronously**.  If the
+        next login writes a new JWT before the wipe completes, the
+        deferred wipe destroys it.  After confirming the Dart state is
+        clear, a brief pause lets the browser finish the storage wipe."""
         deadline = time.monotonic() + timeout
         while time.monotonic() < deadline:
             try:
                 result = self.auth_eval("return auth!.isLoggedIn.toString();")
                 if result == "false":
+                    # Give the browser time to finish Clear-Site-Data
+                    # processing before the next login writes to storage.
+                    time.sleep(5)
                     return
             except FmtkError:
                 pass  # evaluator may fail transiently during teardown


### PR DESCRIPTION
## Summary

- Adds a 2-second pause in `_wait_logged_out` after confirming `AuthService.isLoggedIn == false`, giving the browser time to finish the async `Clear-Site-Data: "storage"` wipe before the next login writes to sessionStorage
- Without this pause, logins immediately after logout intermittently lose their JWT to the deferred storage wipe (admin, OIDC, and sharing test failures)

## Findings

The sharing `test_role_bucket_add_and_remove` registration failures ("Unable to send verification email") are **pre-existing** — they reproduce on main without this branch. The SMTP sink is alive but the backend can't reach it (SMTP port mismatch after config reload). This is a separate issue from the login race.

## Test plan

- [x] `test_visibility_matrix_for_fixture_roles` passes (was failing without the pause)
- [x] admin tests (6/6) pass with the pause
- [x] OIDC tests (6/6) pass with the pause

Refs #3345