### PR TITLE
Pin ambient OpenSSL fetches to fips=yes under KLANGKD_FIPS_MODE (#3350)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -4003,6 +4003,12 @@ users(id)`, so the decider handler passing the decider's email violated the
 - **FIPS host image builds again under `cryptography` 50 (#3350).** The
   self-check `RUN` in the FIPS host Dockerfile read the OpenSSL binding
   through a private module attribute that `cryptography` 50 no longer
-  exposes, which aborted the image build and stopped `klangk-host` and
-  `klangk-host-fips` from publishing. The probe now imports the backend
-  the same way the runtime verification in `klangk.fips` does.
+  exposes, aborting the build; it now imports the backend the same way
+  the runtime verification in `klangk.fips` does, and each check prints
+  a numbered marker so a failure names its check. `cryptography` also
+  loads OpenSSL's default provider at import, which kept MD5 fetchable
+  through it under the fips-only image config — the image probe and
+  the startup gate now pin ambient fetches to `fips=yes`
+  (`EVP_default_properties_enable_fips`, the same call
+  `cryptography`'s own `enable_fips` makes) before the cryptography
+  checks, keeping MD5 refused and approved algorithms working.

--- a/docs/deployment/fips.md
+++ b/docs/deployment/fips.md
@@ -239,15 +239,15 @@ Complete list of cryptographic operations klangkd performs, the module
 each routes through, and the FIPS validation status under the FIPS
 image:
 
-| Operation                     | Algorithm                            | Code path                                                                                       | Module                                                                   | FIPS-validated?                                 |
-| ----------------------------- | ------------------------------------ | ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------ | ----------------------------------------------- |
-| Password hashing              | PBKDF2-HMAC-SHA512 (600k iterations) | `hashlib.pbkdf2_hmac` (`auth.py`)                                                               | OpenSSL `_hashlib` → libcrypto → FIPS provider                           | Yes (CMVP #4985)                                |
-| JWT signing/verification      | HMAC-SHA256 (HS256)                  | `python-jose` → `cryptography` backend → `cryptography.hazmat.primitives.hmac.HMAC` (`auth.py`) | distro libcrypto, via the FIPS image's `cryptography` relink (see below) | Yes (CMVP #4985)                                |
-| DPoP proof verification      | ECDSA P-256 (ES256) + SHA-256        | `cryptography` directly — `ec.EllipticCurvePublicNumbers.verify` + `hashlib.sha256` (`dpop.py`, #3218; deliberately not jose's EC route, which could bind to the pure-Python `ecdsa` package) | distro libcrypto, via the FIPS image's `cryptography` relink (see below) | Yes (CMVP #4985)                                |
-| Outbound TLS                  | TLS 1.2/1.3                          | `ssl` module / `httpx` (LLM proxy, OIDC, SMTP)                                                  | OpenSSL `_ssl` → libcrypto → FIPS provider                               | Yes (CMVP #4985)                                |
-| CA fingerprinting (allowlist) | SHA-256 (cert DER)                   | `cryptography` `Certificate.fingerprint` (`ssl_trust.py`, #3198)                                | distro libcrypto, via the FIPS image's `cryptography` relink (see below) | Yes (CMVP #4985)                                |
-| Password timing equalization  | HMAC comparison                      | `hmac.compare_digest` (`auth.py`)                                                               | C-level constant-time compare (no crypto module)                         | N/A (comparison only)                           |
-| Token identifiers             | UUID4                                | `uuid.uuid4` / `secrets.token_bytes`                                                            | OS `urandom`                                                             | N/A (randomness source, not a crypto algorithm) |
+| Operation                     | Algorithm                            | Code path                                                                                                                                                                                     | Module                                                                   | FIPS-validated?                                 |
+| ----------------------------- | ------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------ | ----------------------------------------------- |
+| Password hashing              | PBKDF2-HMAC-SHA512 (600k iterations) | `hashlib.pbkdf2_hmac` (`auth.py`)                                                                                                                                                             | OpenSSL `_hashlib` → libcrypto → FIPS provider                           | Yes (CMVP #4985)                                |
+| JWT signing/verification      | HMAC-SHA256 (HS256)                  | `python-jose` → `cryptography` backend → `cryptography.hazmat.primitives.hmac.HMAC` (`auth.py`)                                                                                               | distro libcrypto, via the FIPS image's `cryptography` relink (see below) | Yes (CMVP #4985)                                |
+| DPoP proof verification       | ECDSA P-256 (ES256) + SHA-256        | `cryptography` directly — `ec.EllipticCurvePublicNumbers.verify` + `hashlib.sha256` (`dpop.py`, #3218; deliberately not jose's EC route, which could bind to the pure-Python `ecdsa` package) | distro libcrypto, via the FIPS image's `cryptography` relink (see below) | Yes (CMVP #4985)                                |
+| Outbound TLS                  | TLS 1.2/1.3                          | `ssl` module / `httpx` (LLM proxy, OIDC, SMTP)                                                                                                                                                | OpenSSL `_ssl` → libcrypto → FIPS provider                               | Yes (CMVP #4985)                                |
+| CA fingerprinting (allowlist) | SHA-256 (cert DER)                   | `cryptography` `Certificate.fingerprint` (`ssl_trust.py`, #3198)                                                                                                                              | distro libcrypto, via the FIPS image's `cryptography` relink (see below) | Yes (CMVP #4985)                                |
+| Password timing equalization  | HMAC comparison                      | `hmac.compare_digest` (`auth.py`)                                                                                                                                                             | C-level constant-time compare (no crypto module)                         | N/A (comparison only)                           |
+| Token identifiers             | UUID4                                | `uuid.uuid4` / `secrets.token_bytes`                                                                                                                                                          | OS `urandom`                                                             | N/A (randomness source, not a crypto algorithm) |
 
 **JWT module boundary (#3175):** the JWT row above holds because the
 FIPS host image **rebuilds `cryptography` from source against the
@@ -256,17 +256,29 @@ _private_ OpenSSL that never reads `OPENSSL_CONF` and cannot load the
 validated provider. This is the industry posture (Red Hat ships
 distro-linked `python3-cryptography`; Chainguard's FIPS images relink
 it; pyca's own docs direct FIPS users to `pip install --no-binary
-cryptography`). The relink is proven twice: at image build time
-(cryptography's OpenSSL version must equal the process's, MD5 through
-cryptography must be refused, and a jose HS256 sign/verify round-trip
-must succeed under the active provider), and at klangkd startup under
-`KLANGKD_FIPS_MODE` — klangkd verifies that python-jose binds its
-`cryptography` backend (a silent fallback to another backend would be
-an unprovisioned, unverified route and aborts the boot) and that
-cryptography's OpenSSL is the process's own provider-gated library
-(identity check + MD5 refusal; a mismatched linkage follows the same
-warn-on-host / abort-in-container posture as the process OpenSSL
-probe).
+cryptography`). One wrinkle (#3350): `cryptography` unconditionally
+loads OpenSSL's _default_ provider at import (its rust init calls
+`OSSL_PROVIDER_load(NULL, "default")`), so property-less fetches in
+any process that imported it — MD5 among them — are served from that
+unvalidated provider even under a fips-only activation config. The
+countermeasure is `EVP_default_properties_enable_fips` — the same
+call `cryptography`'s own `enable_fips` makes — which requires
+`fips=yes` on every subsequent fetch: MD5 is refused again while
+approved algorithms keep working through the fips provider. The
+relink and the pin are proven together: at image build time (each
+probe check prints a numbered marker; the cryptography checks pin
+fetches first — cryptography's OpenSSL version must equal the
+process's, MD5 through cryptography must be refused, and a jose HS256
+sign/verify round-trip must succeed under the active provider), and
+at klangkd startup under `KLANGKD_FIPS_MODE` — once the process
+posture probe confirms the fips provider is active, klangkd pins
+ambient fetches to `fips=yes` and then verifies that python-jose
+binds its `cryptography` backend (a silent fallback to another
+backend would be an unprovisioned, unverified route and aborts the
+boot) and that cryptography's OpenSSL is the process's own
+provider-gated library (identity check + MD5 refusal; a failed pin or
+mismatched linkage follows the same warn-on-host / abort-in-container
+posture as the process OpenSSL probe).
 
 **Outside the module:** a _stock_ host image (or any deployment using
 the PyPI `cryptography` wheel) signs JWTs on the wheel's private

--- a/src/containers/host/Dockerfile.fips
+++ b/src/containers/host/Dockerfile.fips
@@ -179,8 +179,11 @@ WORKDIR /home/klangk
 #   4. the real auth KDF still works: hashlib.pbkdf2_hmac("sha512", ...);
 #   5. cryptography loads the SAME libcrypto as the process (a
 #      bundled-OpenSSL wheel would report its private version);
-#   6. the provider gates cryptography's fetches: MD5 through it must
-#      be refused;
+#   6. the provider gates cryptography's fetches: with ambient fetches
+#      pinned to fips=yes (EVP_default_properties_enable_fips — the
+#      same call cryptography's own enable_fips makes; cryptography
+#      loads the default provider at import, so without the pin MD5
+#      is served from it), MD5 through cryptography must be refused;
 #   7. end-to-end JWT: jose HS256 sign+verify works under the active
 #      provider (HMAC-SHA256 is approved);
 #   8. env-stripped activation (stock config path, no environment).
@@ -205,10 +208,17 @@ RUN echo 'fips check 1/8: FIPS provider active' && \
 assert backend.openssl_version_text() == ssl.OPENSSL_VERSION, \
 (backend.openssl_version_text(), ssl.OPENSSL_VERSION)" && \
     echo 'fips check 6/8: cryptography md5 refused' && \
+    python3 -c "import ctypes, ctypes.util; \
+lc = ctypes.CDLL(ctypes.util.find_library('crypto') or 'libcrypto.so.3'); \
+lc.EVP_default_properties_enable_fips.restype = ctypes.c_int; \
+assert lc.EVP_default_properties_enable_fips(None, 1) == 1" && \
     ! python3 -c "import cryptography.hazmat.primitives.hashes as h; \
 d = h.Hash(h.MD5()); d.update(b'x'); d.finalize()" 2>/dev/null && \
     echo 'fips check 7/8: jose HS256 roundtrip' && \
-    python3 -c "import jose.jwt as jwt; key = 'f' * 32; \
+    python3 -c "import ctypes, ctypes.util; \
+lc = ctypes.CDLL(ctypes.util.find_library('crypto') or 'libcrypto.so.3'); \
+assert lc.EVP_default_properties_enable_fips(None, 1) == 1; \
+import jose.jwt as jwt; key = 'f' * 32; \
 token = jwt.encode({'probe': 1}, key, algorithm='HS256'); \
 assert jwt.decode(token, key, algorithms=['HS256'])['probe'] == 1" && \
     echo 'fips check 8/8: env-stripped activation' && \

--- a/src/klangk/klangk/fips.py
+++ b/src/klangk/klangk/fips.py
@@ -47,6 +47,16 @@ linkage to the process's own provider-gated OpenSSL
 asserts *equality* of two version texts (same library loaded), never
 a specific version, so the genericity rule above still holds. These
 checks are host-side only — workspace containers run no jose.
+Because ``cryptography`` unconditionally loads OpenSSL's *default*
+provider at import (its rust init calls ``OSSL_PROVIDER_load(NULL,
+"default")``), property-less fetches in any process that imported it
+— MD5 among them — are served from that unvalidated provider even
+under a fips-only activation config. Under ``KLANGKD_FIPS_MODE``
+klangkd therefore pins ambient fetches to ``fips=yes`` first
+(``EVP_default_properties_enable_fips`` — the same call
+cryptography's own ``enable_fips`` makes; #3350) once the process
+posture probe confirms the fips provider is active, and only then
+runs the cryptography linkage checks.
 
 **Dual-maintenance note** (#2626 review): :data:`PROBE_SCRIPT` (the
 self-contained snippet run inside containers via ``python3 -c``)
@@ -461,6 +471,59 @@ def _crypto_md5_refused() -> bool:
     return False
 
 
+def _enable_fips_fetch_properties() -> tuple[bool, str]:
+    """Pin ambient fetches to the fips provider (#3350).
+
+    ``cryptography`` loads OpenSSL's default provider at import, so
+    property-less fetches — MD5 among them — are served from the
+    unvalidated default provider even under a fips-only activation
+    config. ``EVP_default_properties_enable_fips`` (the same call
+    cryptography's own ``enable_fips`` makes) requires ``fips=yes``
+    on every subsequent fetch, restoring refusal of non-approved
+    algorithms while approved ones keep working through the fips
+    provider. The helper refuses to pin unless the fips provider is
+    active in the default library context — pinning without it would
+    fail every fetch in the process.
+    """
+    import ctypes  # allow-deferred-import
+    import ctypes.util  # allow-deferred-import
+
+    try:
+        lib = ctypes.CDLL(
+            ctypes.util.find_library("crypto") or "libcrypto.so.3"
+        )
+        enable = lib.EVP_default_properties_enable_fips
+        provider_active = lib.OSSL_PROVIDER_available
+    except (OSError, AttributeError) as exc:
+        return False, f"cannot pin fips fetch properties ({exc})"
+    # Never pin without the fips provider: the flag makes every fetch
+    # require fips=yes, so on a process without it all ciphers and
+    # digests would stop loading (poisoning the whole process).
+    provider_active.restype = ctypes.c_int
+    provider_active.argtypes = [ctypes.c_void_p, ctypes.c_char_p]
+    if not provider_active(None, b"fips"):
+        return False, "fips provider not active; pin skipped"
+    enable.restype = ctypes.c_int
+    enable.argtypes = [ctypes.c_void_p, ctypes.c_int]
+    if not enable(None, 1):
+        return False, "EVP_default_properties_enable_fips failed"
+    return True, "ambient fetches require fips=yes"
+
+
+def _pinned_jose_linkage() -> tuple[bool, str]:
+    """Pin fetches to fips=yes, then verify jose's crypto linkage.
+
+    Order matters (#3350): without the pin, ``cryptography``'s
+    default-provider load makes the MD5-refusal half of the linkage
+    check observe the unvalidated provider and fail on a healthy
+    image.
+    """
+    pin_ok, pin_detail = _enable_fips_fetch_properties()
+    if not pin_ok:
+        return False, pin_detail
+    return verify_jose_crypto_linkage()
+
+
 def verify_jose_crypto_linkage() -> tuple[bool, str]:
     """Prove jose's HS256 route stays inside the validated OpenSSL.
 
@@ -541,7 +604,9 @@ def verify_process_fips(settings) -> None:
     backend = an unprovisioned crypto route) and aborts
     unconditionally; the cryptography↔libcrypto linkage is
     deployment-dependent and follows the same warn/abort posture as
-    the process probe.
+    the process probe, and runs after it — ambient fetches are pinned
+    to ``fips=yes`` in between (#3350), which is only safe once the
+    fips provider is verified active.
     """
     if not getattr(settings, "fips_mode", False):
         return
@@ -554,19 +619,22 @@ def verify_process_fips(settings) -> None:
         logger.info("FIPS jose backend verified: %s", jose_detail)
     else:
         raise ConfigurationError(f"KLANGKD_FIPS_MODE: {jose_detail}")
-    link_ok, link_detail = verify_jose_crypto_linkage()
+    # Posture before linkage (#3350): the fetch-property pin (and the
+    # linkage MD5 check behind it) is only safe to apply once the fips
+    # provider is verified active — pinning without it would fail every
+    # fetch in the process.
+    version = ssl.OPENSSL_VERSION
+    ok, detail = probe_process()
+    if not ok:
+        _posture_failure("process OpenSSL FIPS enforcement", detail)
+        return
+    logger.info(
+        "FIPS mode enabled: OpenSSL %s, provider enforcement verified (%s)",
+        version,
+        detail,
+    )
+    link_ok, link_detail = _pinned_jose_linkage()
     if link_ok:
         logger.info("FIPS jose crypto linkage verified: %s", link_detail)
     else:
         _posture_failure("jose cryptography linkage", link_detail)
-    version = ssl.OPENSSL_VERSION
-    ok, detail = probe_process()
-    if ok:
-        logger.info(
-            "FIPS mode enabled: OpenSSL %s, provider enforcement verified "
-            "(%s)",
-            version,
-            detail,
-        )
-        return
-    _posture_failure("process OpenSSL FIPS enforcement", detail)

--- a/src/klangk/klangkd-tests/tests/test_fips.py
+++ b/src/klangk/klangkd-tests/tests/test_fips.py
@@ -355,6 +355,13 @@ class TestVerifyProcessFips:
             return_value=(True, "linkage ok"),
         )
 
+    def _pin_ok(self):
+        return patch.object(
+            fips,
+            "_enable_fips_fetch_properties",
+            return_value=(True, "ambient fetches require fips=yes"),
+        )
+
     def test_on_verified(self, caplog):
         with (
             self._jose_ok(),
@@ -370,6 +377,7 @@ class TestVerifyProcessFips:
         """A passing probe boots fine inside a container too (#2628)."""
         with (
             self._jose_ok(),
+            self._pin_ok(),
             self._linkage_ok(),
             patch.object(fips, "probe_process", return_value=(True, "x")),
             patch.object(fips, "running_in_container", return_value=True),
@@ -382,6 +390,7 @@ class TestVerifyProcessFips:
         """Not containerized → warn-only posture (the operator's host)."""
         with (
             self._jose_ok(),
+            self._pin_ok(),
             self._linkage_ok(),
             patch.object(
                 fips, "probe_process", return_value=(False, "md5 not rejected")
@@ -403,6 +412,7 @@ class TestVerifyProcessFips:
         """
         with (
             self._jose_ok(),
+            self._pin_ok(),
             self._linkage_ok(),
             patch.object(
                 fips, "probe_process", return_value=(False, "md5 not rejected")
@@ -423,6 +433,7 @@ class TestVerifyProcessFips:
         probe = MagicMock(return_value=(True, "md5 rejected"))
         with (
             self._jose_ok(),
+            self._pin_ok(),
             patch.object(
                 fips,
                 "verify_jose_crypto_linkage",
@@ -440,11 +451,13 @@ class TestVerifyProcessFips:
 
     def test_linkage_failure_in_container_refuses_boot(self, caplog):
         """Inside an image we ship, an unlinked cryptography means the
-        JWT path would sign outside the validated module — abort before
-        the OpenSSL probe even runs."""
+        JWT path would sign outside the validated module — abort. The
+        process probe runs first (#3350): the fetch-property pin is only
+        safe once the fips provider is verified active."""
         probe = MagicMock(return_value=(True, "md5 rejected"))
         with (
             self._jose_ok(),
+            self._pin_ok(),
             patch.object(
                 fips,
                 "verify_jose_crypto_linkage",
@@ -459,7 +472,52 @@ class TestVerifyProcessFips:
                 ):
                     fips.verify_process_fips(self._settings(True))
         assert any("refusing to start" in r.message for r in caplog.records)
-        probe.assert_not_called()
+        probe.assert_called_once()
+
+    def test_pin_failure_warns_on_control_host(self, caplog):
+        """Cannot pin fetch properties on the operator's host — posture
+        warning, linkage checks skipped (they would observe the
+        default-provider pollution and misreport a healthy host)."""
+        with (
+            self._jose_ok(),
+            patch.object(
+                fips,
+                "_enable_fips_fetch_properties",
+                return_value=(False, "cannot pin fips fetch properties"),
+            ),
+            patch.object(fips, "probe_process", return_value=(True, "x")),
+            patch.object(fips, "running_in_container", return_value=False),
+        ):
+            with caplog.at_level(logging.WARNING):
+                fips.verify_process_fips(self._settings(True))
+        assert any(
+            "cannot pin fips fetch properties" in r.message
+            for r in caplog.records
+        )
+
+    def test_pin_failure_in_container_refuses_boot(self, caplog):
+        link = MagicMock(return_value=(True, "linkage ok"))
+        with (
+            self._jose_ok(),
+            patch.object(
+                fips,
+                "_enable_fips_fetch_properties",
+                return_value=(
+                    False,
+                    "EVP_default_properties_enable_fips failed",
+                ),
+            ),
+            patch.object(fips, "verify_jose_crypto_linkage", link),
+            patch.object(fips, "probe_process", return_value=(True, "x")),
+            patch.object(fips, "running_in_container", return_value=True),
+        ):
+            with caplog.at_level(logging.ERROR):
+                with pytest.raises(
+                    ConfigurationError, match="cryptography linkage"
+                ):
+                    fips.verify_process_fips(self._settings(True))
+        assert any("refusing to start" in r.message for r in caplog.records)
+        link.assert_not_called()
 
 
 class TestRunningInContainer:
@@ -619,6 +677,104 @@ class TestVerifyProcessFipsJoseGate:
             "jose backend verified" in r.message for r in caplog.records
         )
         assert any("FIPS mode enabled" in r.message for r in caplog.records)
+
+
+class TestEnableFipsFetchProperties:
+    """The ambient fetch-property pin (#3350): ctypes plumbing around
+    EVP_default_properties_enable_fips."""
+
+    def _lib(self, enable_result, provider=1):
+        lib = MagicMock()
+        lib.EVP_default_properties_enable_fips.return_value = enable_result
+        lib.OSSL_PROVIDER_available.return_value = provider
+        return lib
+
+    def test_pin_skipped_without_fips_provider(self):
+        """No fips provider active -> refuse to pin: the flag would make
+        every fetch in the process fail (#3350)."""
+        lib = self._lib(1, provider=0)
+        with (
+            patch("ctypes.util.find_library", return_value="libcrypto.so.3"),
+            patch("ctypes.CDLL", return_value=lib),
+        ):
+            ok, detail = fips._enable_fips_fetch_properties()
+        assert ok is False
+        assert "not active" in detail
+        lib.EVP_default_properties_enable_fips.assert_not_called()
+
+    def test_pin_succeeds(self):
+        lib = self._lib(1)
+        with (
+            patch("ctypes.util.find_library", return_value="libcrypto.so.3"),
+            patch("ctypes.CDLL", return_value=lib),
+        ):
+            ok, detail = fips._enable_fips_fetch_properties()
+        assert ok is True
+        assert "fips=yes" in detail
+        lib.EVP_default_properties_enable_fips.assert_called_once()
+
+    def test_enable_returns_zero_is_failure(self):
+        lib = self._lib(0)
+        with (
+            patch("ctypes.util.find_library", return_value="libcrypto.so.3"),
+            patch("ctypes.CDLL", return_value=lib),
+        ):
+            ok, detail = fips._enable_fips_fetch_properties()
+        assert ok is False
+        assert "failed" in detail
+
+    def test_missing_library_is_failure(self):
+        with (
+            patch("ctypes.util.find_library", return_value=None),
+            patch("ctypes.CDLL", side_effect=OSError("no libcrypto")),
+        ):
+            ok, detail = fips._enable_fips_fetch_properties()
+        assert ok is False
+        assert "cannot pin" in detail
+
+    def test_missing_symbol_is_failure(self):
+        lib = MagicMock(spec=[])  # no EVP_default_properties_enable_fips
+        with (
+            patch("ctypes.util.find_library", return_value="libcrypto.so.3"),
+            patch("ctypes.CDLL", return_value=lib),
+        ):
+            ok, detail = fips._enable_fips_fetch_properties()
+        assert ok is False
+        assert "cannot pin" in detail
+
+
+class TestPinnedJoseLinkage:
+    def test_pin_failure_short_circuits(self):
+        link = MagicMock(return_value=(True, "linked"))
+        with (
+            patch.object(
+                fips,
+                "_enable_fips_fetch_properties",
+                return_value=(False, "cannot pin"),
+            ),
+            patch.object(fips, "verify_jose_crypto_linkage", link),
+        ):
+            ok, detail = fips._pinned_jose_linkage()
+        assert ok is False
+        assert detail == "cannot pin"
+        link.assert_not_called()
+
+    def test_pin_then_linkage(self):
+        with (
+            patch.object(
+                fips,
+                "_enable_fips_fetch_properties",
+                return_value=(True, "ambient fetches require fips=yes"),
+            ),
+            patch.object(
+                fips,
+                "verify_jose_crypto_linkage",
+                return_value=(True, "linkage ok"),
+            ),
+        ):
+            ok, detail = fips._pinned_jose_linkage()
+        assert ok is True
+        assert detail == "linkage ok"
 
 
 class TestVerifyJoseCryptoLinkage:


### PR DESCRIPTION
## Summary

Closes the #3350 loop. Root cause of the two silent FIPS host image failures (now proven by the instrumented probe from #3352 — the log names check 6): **`cryptography` unconditionally loads OpenSSL's default provider at import** (its rust init calls `OSSL_PROVIDER_load(NULL, "default")`; `src/rust/src/lib.rs` in 50.0.1). Property-less fetches in any process that imported it — MD5 among them — are served from that unvalidated provider even under the image's fips+base-only config. That's why checks 2/3 (no cryptography import) refuse MD5 while check 6 gets it served.

The countermeasure is `EVP_default_properties_enable_fips` — the same call `cryptography`'s own `enable_fips` makes. Verified on `debian:trixie-slim` (the image base): with the default provider explicitly loaded, MD5 digest-init succeeds; after the flag, it returns 0 (refused) while approved algorithms keep working.

- `klangkd` applies the pin at startup under `KLANGKD_FIPS_MODE`, after the process posture probe confirms the fips provider is active (reordered: jose backend → process probe → pin → linkage). The helper itself refuses to pin unless `OSSL_PROVIDER_available(NULL, "fips")` — pinning without the provider fails every fetch in the process (this exact poisoning surfaced as `LIBRARY_HAS_NO_CIPHERS` in an intermediate local run and is now impossible by construction).
- The Dockerfile probe's cryptography checks pin the same way, so the build-time proof matches runtime behavior. All eight checks keep their semantics; markers stay.
- `docs/deployment/fips.md`, module docstrings, and the #3350 changelog entry document the true mechanism (an earlier draft blamed the legacy name table — disproven by adversarial review + reproduction; `EVP_DigestInit` on a legacy handle routes through an implicit provider fetch that honors the loaded set).

Refs #3350.

## Testing

- `test_fips.py`: 71 passed; `klangk/fips.py` at 100% line+branch coverage (new helpers fully unit-tested incl. the no-provider guard, CDLL/symbol failures, pin-short-circuit).
- `scripts/tests`: 143 passed.
- Triage note: a full local `-n auto` run of the branch showed ~14–46 auth/TLS test failures; the identical suite on clean `origin/main` passes 8230. The failures trace to an intermediate revision where the pin lacked the provider guard and could poison a worker process (`ssl.SSLError: LIBRARY_HAS_NO_CIPHERS`); with the guard the worktree suite passes standalone. Per the user's call, CI is authoritative for the full-suite signal.
