### PR TITLE
Pin fips fetch properties before the jose import in the boot gate (#3350)

### DIFF
--- a/src/klangk/klangk/fips.py
+++ b/src/klangk/klangk/fips.py
@@ -510,20 +510,6 @@ def _enable_fips_fetch_properties() -> tuple[bool, str]:
     return True, "ambient fetches require fips=yes"
 
 
-def _pinned_jose_linkage() -> tuple[bool, str]:
-    """Pin fetches to fips=yes, then verify jose's crypto linkage.
-
-    Order matters (#3350): without the pin, ``cryptography``'s
-    default-provider load makes the MD5-refusal half of the linkage
-    check observe the unvalidated provider and fail on a healthy
-    image.
-    """
-    pin_ok, pin_detail = _enable_fips_fetch_properties()
-    if not pin_ok:
-        return False, pin_detail
-    return verify_jose_crypto_linkage()
-
-
 def verify_jose_crypto_linkage() -> tuple[bool, str]:
     """Prove jose's HS256 route stays inside the validated OpenSSL.
 
@@ -604,25 +590,41 @@ def verify_process_fips(settings) -> None:
     backend = an unprovisioned crypto route) and aborts
     unconditionally; the cryptography↔libcrypto linkage is
     deployment-dependent and follows the same warn/abort posture as
-    the process probe, and runs after it — ambient fetches are pinned
-    to ``fips=yes`` in between (#3350), which is only safe once the
-    fips provider is verified active.
+    the process probe. Ambient fetches are pinned to ``fips=yes``
+    before any of it (#3350) — the pin's no-fips-provider guard keeps
+    it a no-op where it would not hold.
     """
     if not getattr(settings, "fips_mode", False):
         return
-    # Verify the JWT signing path before anything else — this is a
-    # code-level invariant (wrong backend = wrong crypto boundary),
-    # not a deployment-dependent OpenSSL posture, so it aborts
-    # unconditionally (#3175 Gap 2).
+    # Pin ambient fetches FIRST (#3350): importing cryptography (jose
+    # pulls it in below) loads OpenSSL's default provider, after which
+    # every property-less fetch — the _hashlib MD5 probe included — is
+    # served from it. The pin's internal guard makes this a no-op
+    # wherever the fips provider is not active, so pinning before the
+    # posture probes is safe on control hosts too.
+    pin_ok, pin_detail = _enable_fips_fetch_properties()
+    if pin_ok:
+        logger.info("FIPS fetch properties pinned: %s", pin_detail)
+    else:
+        logger.debug("FIPS fetch properties not pinned: %s", pin_detail)
+    _verify_jwt_route()
+
+
+def _verify_jwt_route() -> None:
+    """Verify the JWT signing route after the pin is in place.
+
+    Order (#3175, #3350): the jose backend binding is a code-level
+    invariant (wrong backend = wrong crypto boundary) and aborts
+    unconditionally; the process posture probe and the cryptography
+    linkage follow the warn-on-host / abort-in-container posture —
+    both must run with the fetch-property pin already set, because
+    the jose import below is what loads the default provider.
+    """
     jose_ok, jose_detail = verify_jose_backend()
     if jose_ok:
         logger.info("FIPS jose backend verified: %s", jose_detail)
     else:
         raise ConfigurationError(f"KLANGKD_FIPS_MODE: {jose_detail}")
-    # Posture before linkage (#3350): the fetch-property pin (and the
-    # linkage MD5 check behind it) is only safe to apply once the fips
-    # provider is verified active — pinning without it would fail every
-    # fetch in the process.
     version = ssl.OPENSSL_VERSION
     ok, detail = probe_process()
     if not ok:
@@ -633,7 +635,7 @@ def verify_process_fips(settings) -> None:
         version,
         detail,
     )
-    link_ok, link_detail = _pinned_jose_linkage()
+    link_ok, link_detail = verify_jose_crypto_linkage()
     if link_ok:
         logger.info("FIPS jose crypto linkage verified: %s", link_detail)
     else:

--- a/src/klangk/klangkd-tests/tests/test_fips.py
+++ b/src/klangk/klangkd-tests/tests/test_fips.py
@@ -474,50 +474,51 @@ class TestVerifyProcessFips:
         assert any("refusing to start" in r.message for r in caplog.records)
         probe.assert_called_once()
 
-    def test_pin_failure_warns_on_control_host(self, caplog):
-        """Cannot pin fetch properties on the operator's host — posture
-        warning, linkage checks skipped (they would observe the
-        default-provider pollution and misreport a healthy host)."""
-        with (
-            self._jose_ok(),
-            patch.object(
-                fips,
-                "_enable_fips_fetch_properties",
-                return_value=(False, "cannot pin fips fetch properties"),
-            ),
-            patch.object(fips, "probe_process", return_value=(True, "x")),
-            patch.object(fips, "running_in_container", return_value=False),
-        ):
-            with caplog.at_level(logging.WARNING):
-                fips.verify_process_fips(self._settings(True))
-        assert any(
-            "cannot pin fips fetch properties" in r.message
-            for r in caplog.records
-        )
-
-    def test_pin_failure_in_container_refuses_boot(self, caplog):
+    def test_pin_skip_is_debug_not_posture(self, caplog):
+        """A skipped pin (no fips provider — the guard) is not itself a
+        posture failure: the process probe decides that afterwards."""
         link = MagicMock(return_value=(True, "linkage ok"))
         with (
             self._jose_ok(),
             patch.object(
                 fips,
                 "_enable_fips_fetch_properties",
-                return_value=(
-                    False,
-                    "EVP_default_properties_enable_fips failed",
-                ),
+                return_value=(False, "fips provider not active; pin skipped"),
             ),
             patch.object(fips, "verify_jose_crypto_linkage", link),
             patch.object(fips, "probe_process", return_value=(True, "x")),
-            patch.object(fips, "running_in_container", return_value=True),
+            patch.object(fips, "running_in_container", return_value=False),
         ):
-            with caplog.at_level(logging.ERROR):
-                with pytest.raises(
-                    ConfigurationError, match="cryptography linkage"
-                ):
-                    fips.verify_process_fips(self._settings(True))
-        assert any("refusing to start" in r.message for r in caplog.records)
-        link.assert_not_called()
+            with caplog.at_level(logging.DEBUG):
+                fips.verify_process_fips(self._settings(True))
+        assert any("pin skipped" in r.message for r in caplog.records)
+        link.assert_called_once()
+
+    def test_pin_runs_before_jose_import(self):
+        """The pin must precede verify_jose_backend — jose's
+        cryptography import loads the default provider (#3350)."""
+        calls = []
+        with (
+            patch.object(
+                fips,
+                "_enable_fips_fetch_properties",
+                side_effect=lambda: (calls.append("pin"), (True, "pinned"))[1],
+            ),
+            patch.object(
+                fips,
+                "verify_jose_backend",
+                side_effect=lambda: (calls.append("jose"), (True, "jose ok"))[
+                    1
+                ],
+            ),
+            patch.object(fips, "probe_process", return_value=(True, "x")),
+            patch.object(
+                fips, "verify_jose_crypto_linkage", return_value=(True, "l")
+            ),
+            patch.object(fips, "running_in_container", return_value=False),
+        ):
+            fips.verify_process_fips(self._settings(True))
+        assert calls == ["pin", "jose"]
 
 
 class TestRunningInContainer:
@@ -647,6 +648,11 @@ class TestVerifyProcessFipsJoseGate:
         with (
             patch.object(
                 fips,
+                "_enable_fips_fetch_properties",
+                return_value=(True, "pinned"),
+            ),
+            patch.object(
+                fips,
                 "verify_jose_backend",
                 return_value=(False, "wrong backend"),
             ),
@@ -661,6 +667,11 @@ class TestVerifyProcessFipsJoseGate:
     def test_jose_passes_then_process_probe_runs(self, caplog):
         linkage = MagicMock(return_value=(True, "linkage ok"))
         with (
+            patch.object(
+                fips,
+                "_enable_fips_fetch_properties",
+                return_value=(True, "pinned"),
+            ),
             patch.object(
                 fips,
                 "verify_jose_backend",
@@ -741,40 +752,6 @@ class TestEnableFipsFetchProperties:
             ok, detail = fips._enable_fips_fetch_properties()
         assert ok is False
         assert "cannot pin" in detail
-
-
-class TestPinnedJoseLinkage:
-    def test_pin_failure_short_circuits(self):
-        link = MagicMock(return_value=(True, "linked"))
-        with (
-            patch.object(
-                fips,
-                "_enable_fips_fetch_properties",
-                return_value=(False, "cannot pin"),
-            ),
-            patch.object(fips, "verify_jose_crypto_linkage", link),
-        ):
-            ok, detail = fips._pinned_jose_linkage()
-        assert ok is False
-        assert detail == "cannot pin"
-        link.assert_not_called()
-
-    def test_pin_then_linkage(self):
-        with (
-            patch.object(
-                fips,
-                "_enable_fips_fetch_properties",
-                return_value=(True, "ambient fetches require fips=yes"),
-            ),
-            patch.object(
-                fips,
-                "verify_jose_crypto_linkage",
-                return_value=(True, "linkage ok"),
-            ),
-        ):
-            ok, detail = fips._pinned_jose_linkage()
-        assert ok is True
-        assert detail == "linkage ok"
 
 
 class TestVerifyJoseCryptoLinkage:


### PR DESCRIPTION
## Summary

Fixes the runtime boot-gate failure inside the built FIPS image (continuous run 34191976857 — the *image* was fine: all 8 probe checks passed, `FIPS-RUNTIME-OK`). `verify_process_fips` ran `verify_jose_backend` — which imports jose → cryptography → **the default provider loads** — before the fetch-property pin, so the subsequent `_hashlib` MD5 posture probe was served by the default provider: "md5 not rejected", abort-in-container.

The pin now runs at the very top of `verify_process_fips`, before anything can import cryptography:

- The helper's internal no-fips-provider guard keeps the early pin a no-op on hosts where it would not hold (a skipped pin logs at debug; the process probe still decides posture — unchanged warn/abort semantics).
- `_pinned_jose_linkage` folds away — the pin is already set when the linkage check runs.
- New regression test asserts the ordering: pin strictly before `verify_jose_backend`.

Refs #3350 (follows #3353, #3355).

## Testing

- `test_fips.py`: 70 passed; `klangk/fips.py` 100% line+branch coverage.
