### PR TITLE
Pin ambient OpenSSL fetches to fips=yes in the FIPS images (#3359)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -2609,6 +2609,16 @@ git-credential` (#1700).** `pig-latin` removed; `word-count` dormant.
 
 ### Fixed
 
+- **FIPS images pin ambient OpenSSL fetches to `fips=yes` (#3359).**
+  The activation config in the FIPS workspace and FIPS host images
+  now sets `default_properties = fips=yes`, so every process in the
+  container requires the fips property on provider-less algorithm
+  fetches, and Node's `crypto.getFips()` reports FIPS mode as active.
+  In the FIPS workspace image this un-breaks the pi coding agent:
+  jiti (its TypeScript extension loader) chooses its cache-key hash
+  from `crypto.getFips()` and previously picked MD5 — refused by the
+  fips provider — which failed every extension load with
+  `error:0308010C` until `pi -ne` was used.
 - **FIPS fetch pin is Linux-only (#3364).** Under
   `KLANGKD_FIPS_MODE`, the startup step that pins ambient OpenSSL
   fetches to `fips=yes` (#3350) now runs only on Linux, where

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -2618,7 +2618,10 @@ git-credential` (#1700).** `pig-latin` removed; `word-count` dormant.
   jiti (its TypeScript extension loader) chooses its cache-key hash
   from `crypto.getFips()` and previously picked MD5 — refused by the
   fips provider — which failed every extension load with
-  `error:0308010C` until `pi -ne` was used.
+  `error:0308010C` until `pi -ne` was used. The configs also set
+  `config_diagnostics = 1`: a config that fails to parse now aborts
+  the process instead of silently falling back to the default
+  provider.
 - **FIPS fetch pin is Linux-only (#3364).** Under
   `KLANGKD_FIPS_MODE`, the startup step that pins ambient OpenSSL
   fetches to `fips=yes` (#3350) now runs only on Linux, where

--- a/docs/deployment/fips.md
+++ b/docs/deployment/fips.md
@@ -39,7 +39,14 @@ workspace image and
    module's self-tests and writes the module MAC data;
 4. writes an activation config that loads the `fips` and `base`
    providers and **not** the `default` provider — so non-approved
-   algorithms (MD5, DES, …) are rejected rather than silently available;
+   algorithms (MD5, DES, …) are rejected rather than silently
+   available — and pins ambient fetches to `fips=yes`
+   (`default_properties` in the `alg_section`), the config-level form
+   of the countermeasure klangkd applies in its own process (#3350).
+   The pin also makes Node's `crypto.getFips()` report `1`, so
+   FIPS-aware libraries select approved algorithms — without it,
+   jiti (pi's TypeScript extension loader) computed its cache-key
+   hash with MD5 and every pi extension failed to load (#3359);
 5. exports `OPENSSL_CONF` (and `OPENSSL_MODULES`, needed by Node.js)
    image-wide and in `/etc/profile.d/` so login shells reached through
    `sudo -i` / `su` are covered too;
@@ -132,12 +139,12 @@ workspace containers are gated. Boundary notes for this deployment:
 
 Inside the workspace container:
 
-| Component                                                         | Covered?           | Why                                                                                                                                                                                                                                                                                                                                                                  |
-| ----------------------------------------------------------------- | ------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `openssl` CLI, curl, git (https), distro python `_ssl`/`_hashlib` | **Yes**            | Dynamically link the distro `libcrypto.so.3`, which loads the FIPS provider via `OPENSSL_CONF`.                                                                                                                                                                                                                                                                      |
-| Node.js `crypto`/`tls` (including the pi coding agent)            | **Yes**            | Node's bundled libcrypto reads the `nodejs_conf` config section (the image aliases it) and loads the validated `fips.so` via `OPENSSL_MODULES`. Verified: `createHash('md5')` is rejected, TLS and approved digests route through the provider. No Node rebuild is involved — provider-based FIPS is a runtime configuration of the OpenSSL that Node already links. |
-| CPython's `hashlib.md5()`                                         | **No — by design** | CPython falls back to its built-in `_md5` module when the provider refuses; that code never touches OpenSSL and no provider can gate it. This is PEP 452's `usedforsecurity` behavior: legacy non-security MD5 (etags, cache keys) keeps working. Klangk itself does not call MD5 anywhere.                                                                          |
-| Statically-linked crypto in third-party tooling users install     | **No**             | Outside the provider model entirely; such tools bring their own crypto.                                                                                                                                                                                                                                                                                              |
+| Component                                                         | Covered?           | Why                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
+| ----------------------------------------------------------------- | ------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `openssl` CLI, curl, git (https), distro python `_ssl`/`_hashlib` | **Yes**            | Dynamically link the distro `libcrypto.so.3`, which loads the FIPS provider via `OPENSSL_CONF`.                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| Node.js `crypto`/`tls` (including the pi coding agent)            | **Yes**            | Node's bundled libcrypto reads the `nodejs_conf` config section (the image aliases it) and loads the validated `fips.so` via `OPENSSL_MODULES`. Verified: `createHash('md5')` is rejected, TLS and approved digests route through the provider, and the config-level fetch pin makes `crypto.getFips()` report `1` — jiti (pi's TS extension loader) relies on that to pick SHA-256 for its cache-key hash (#3359). No Node rebuild is involved — provider-based FIPS is a runtime configuration of the OpenSSL that Node already links. |
+| CPython's `hashlib.md5()`                                         | **No — by design** | CPython falls back to its built-in `_md5` module when the provider refuses; that code never touches OpenSSL and no provider can gate it. This is PEP 452's `usedforsecurity` behavior: legacy non-security MD5 (etags, cache keys) keeps working. Klangk itself does not call MD5 anywhere.                                                                                                                                                                                                                                              |
+| Statically-linked crypto in third-party tooling users install     | **No**             | Outside the provider model entirely; such tools bring their own crypto.                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
 
 **Out of scope (the deploying organization's responsibility):** TLS
 termination at the reverse proxy, kernel crypto (dm-crypt, IPsec), key
@@ -264,7 +271,12 @@ unvalidated provider even under a fips-only activation config. The
 countermeasure is `EVP_default_properties_enable_fips` — the same
 call `cryptography`'s own `enable_fips` makes — which requires
 `fips=yes` on every subsequent fetch: MD5 is refused again while
-approved algorithms keep working through the fips provider. The
+approved algorithms keep working through the fips provider. The FIPS
+images set the same pin config-wide since #3359
+(`default_properties = fips=yes` in the activation config), so every
+process in the container starts with ambient fetches already pinned;
+klangkd's runtime pin stays in place as the control-host path and is
+idempotent under the image pin. The
 relink and the pin are proven together: at image build time (each
 probe check prints a numbered marker; the cryptography checks pin
 fetches first — cryptography's OpenSSL version must equal the

--- a/src/containers/host/Dockerfile.fips
+++ b/src/containers/host/Dockerfile.fips
@@ -134,9 +134,13 @@ RUN openssl fipsinstall -module /usr/lib/x86_64-linux-gnu/ossl-modules/fips.so \
 # env_reset-style launchers). The pin requires fips=yes on every
 # property-less algorithm fetch image-wide — the config-level form
 # of the countermeasure klangkd applies in its own process (#3350,
-# where the rationale lives). No nodejs_conf alias: the host image
+# where the rationale lives). config_diagnostics = 1 aborts a
+# process on a config that fails to parse instead of silently
+# proceeding on the implicitly-activated default provider (the
+# upstream README-FIPS belt). No nodejs_conf alias: the host image
 # has no node (see the workspace variant for why that one needs it).
 RUN printf '%s\n' \
+      'config_diagnostics = 1' \
       'openssl_conf = openssl_init' \
       '' \
       '.include /etc/ssl/fipsmodule.cnf' \

--- a/src/containers/host/Dockerfile.fips
+++ b/src/containers/host/Dockerfile.fips
@@ -126,12 +126,16 @@ COPY --from=fips-builder /opt/ossl-fips/lib/ossl-modules/fips.so \
 RUN openssl fipsinstall -module /usr/lib/x86_64-linux-gnu/ossl-modules/fips.so \
       -out /etc/ssl/fipsmodule.cnf
 
-# Activation config: fips + base, no default provider, written directly
-# to the STOCK path (/etc/ssl/openssl.cnf, replacing the distro file) so
-# environment-less lookups still activate FIPS (supervisord does not
-# strip the environment, but be robust to env_reset-style launchers).
-# No nodejs_conf alias: the host image has no node (see the workspace
-# variant for why that one needs it).
+# Activation config: fips + base, no default provider, and ambient
+# fetches pinned to fips=yes (alg_section/default_properties),
+# written directly to the STOCK path (/etc/ssl/openssl.cnf, replacing
+# the distro file) so environment-less lookups still activate FIPS
+# (supervisord does not strip the environment, but be robust to
+# env_reset-style launchers). The pin requires fips=yes on every
+# property-less algorithm fetch image-wide — the config-level form
+# of the countermeasure klangkd applies in its own process (#3350,
+# where the rationale lives). No nodejs_conf alias: the host image
+# has no node (see the workspace variant for why that one needs it).
 RUN printf '%s\n' \
       'openssl_conf = openssl_init' \
       '' \
@@ -139,6 +143,7 @@ RUN printf '%s\n' \
       '' \
       '[openssl_init]' \
       'providers = provider_sect' \
+      'alg_section = algorithm_sect' \
       '' \
       '[provider_sect]' \
       'fips = fips_sect' \
@@ -146,6 +151,9 @@ RUN printf '%s\n' \
       '' \
       '[base_sect]' \
       'activate = 1' \
+      '' \
+      '[algorithm_sect]' \
+      'default_properties = fips=yes' \
       > /etc/ssl/openssl.cnf
 
 # Image-wide activation. Reaches klangkd (supervisord child), podman

--- a/src/containers/workspace/Dockerfile.fips
+++ b/src/containers/workspace/Dockerfile.fips
@@ -114,6 +114,11 @@ RUN openssl fipsinstall -module /usr/lib/x86_64-linux-gnu/ossl-modules/fips.so \
 # property-less algorithm fetch image-wide — the same countermeasure
 # klangkd applies in its own process (#3350), here at config level.
 #
+# config_diagnostics = 1 (the upstream README-FIPS belt): a config
+# that fails to parse aborts the process instead of libcrypto
+# silently proceeding on the implicitly-activated default provider —
+# non-FIPS crypto with no error.
+#
 # The config is written directly to the STOCK path (/etc/ssl/openssl.cnf,
 # replacing the distro file) so that environment-less lookups —
 # sudoers env_reset strips OPENSSL_CONF for non-login `sudo <cmd>`
@@ -121,6 +126,7 @@ RUN openssl fipsinstall -module /usr/lib/x86_64-linux-gnu/ossl-modules/fips.so \
 # there) — still activate FIPS instead of silently falling back to
 # the default provider.
 RUN printf '%s\n' \
+      'config_diagnostics = 1' \
       'openssl_conf = openssl_init' \
       'nodejs_conf = openssl_init' \
       '' \
@@ -160,13 +166,25 @@ RUN printf '%s\n' \
 # system CLI and node (nodejs_conf section + OPENSSL_MODULES), plus
 # the env-stripped case (env -i simulates sudo env_reset — the stock
 # config path must keep FIPS active with no environment at all).
-RUN openssl list -providers | grep -q 'OpenSSL FIPS Provider' && \
-    ! echo hello | openssl md5 > /dev/null 2>&1 && \
+# Mirrors the host image's #3350 discipline: each check echoes a
+# numbered marker BEFORE it runs, so the last marker printed names
+# the failing check, and expected-failure links keep stderr quiet
+# (refusal noise) but let stdout through — an unexpectedly-fetchable
+# MD5 prints its digest as evidence.
+RUN echo 'fips check 1/7: FIPS provider active' && \
+    openssl list -providers | grep -q 'OpenSSL FIPS Provider' && \
+    echo 'fips check 2/7: CLI md5 refused' && \
+    ! echo hello | openssl md5 2>/dev/null && \
+    echo 'fips check 3/7: node md5 refused' && \
     ! node -e "require('crypto').createHash('md5').update('x').digest('hex')" \
-      > /dev/null 2>&1 && \
+      2>/dev/null && \
+    echo 'fips check 4/7: env-stripped provider activation' && \
     env -i /usr/bin/openssl list -providers \
       | grep -q 'OpenSSL FIPS Provider' && \
-    ! env -i /usr/bin/sh -c 'echo hello | openssl md5' > /dev/null 2>&1 && \
+    echo 'fips check 5/7: env-stripped md5 refused' && \
+    ! env -i /usr/bin/sh -c 'echo hello | openssl md5' 2>/dev/null && \
+    echo 'fips check 6/7: sha256 fetch works' && \
     node -e "require('crypto').createHash('sha256').update('x').digest('hex')" \
-      > /dev/null 2>&1 && \
+      > /dev/null && \
+    echo 'fips check 7/7: node getFips reports fips mode' && \
     node -e "process.exit(require('crypto').getFips() ? 0 : 1)"

--- a/src/containers/workspace/Dockerfile.fips
+++ b/src/containers/workspace/Dockerfile.fips
@@ -97,13 +97,22 @@ COPY --from=fips-builder /opt/ossl-fips/lib/ossl-modules/fips.so \
 RUN openssl fipsinstall -module /usr/lib/x86_64-linux-gnu/ossl-modules/fips.so \
       -out /etc/ssl/fipsmodule.cnf
 
-# Activation config: fips + base, no default provider. The include
-# references the fipsinstall-generated section — redefining [fips_sect]
-# here would clobber the module MAC and silently fall back to default.
-# nodejs_conf alias: node ignores `openssl_conf` and reads only the
-# section named `nodejs_conf` (BUILDING.md, --openssl-conf-name); both
-# keys point at the same section so one config serves system OpenSSL
-# and node's bundled libcrypto.
+# Activation config: fips + base, no default provider, and ambient
+# fetches pinned to fips=yes (alg_section/default_properties, #3359).
+# The include references the fipsinstall-generated section — redefining
+# [fips_sect] here would clobber the module MAC and silently fall back
+# to default. nodejs_conf alias: node ignores `openssl_conf` and reads
+# only the section named `nodejs_conf` (BUILDING.md,
+# --openssl-conf-name); both keys point at the same section so one
+# config serves system OpenSSL and node's bundled libcrypto.
+#
+# The default_properties pin does two things. (1) It makes
+# `crypto.getFips()` report 1 in node — jiti (pi's TS extension
+# loader) chooses its cache-key hash that way and falls back to MD5
+# when it sees 0, which the fips provider refuses, so every pi
+# extension failed to load (#3359). (2) It requires fips=yes on every
+# property-less algorithm fetch image-wide — the same countermeasure
+# klangkd applies in its own process (#3350), here at config level.
 #
 # The config is written directly to the STOCK path (/etc/ssl/openssl.cnf,
 # replacing the distro file) so that environment-less lookups —
@@ -119,6 +128,7 @@ RUN printf '%s\n' \
       '' \
       '[openssl_init]' \
       'providers = provider_sect' \
+      'alg_section = algorithm_sect' \
       '' \
       '[provider_sect]' \
       'fips = fips_sect' \
@@ -126,6 +136,9 @@ RUN printf '%s\n' \
       '' \
       '[base_sect]' \
       'activate = 1' \
+      '' \
+      '[algorithm_sect]' \
+      'default_properties = fips=yes' \
       > /etc/ssl/openssl.cnf
 
 # Image-wide activation. Docker/podman ENV reaches the entrypoint and
@@ -153,4 +166,7 @@ RUN openssl list -providers | grep -q 'OpenSSL FIPS Provider' && \
       > /dev/null 2>&1 && \
     env -i /usr/bin/openssl list -providers \
       | grep -q 'OpenSSL FIPS Provider' && \
-    ! env -i /usr/bin/sh -c 'echo hello | openssl md5' > /dev/null 2>&1
+    ! env -i /usr/bin/sh -c 'echo hello | openssl md5' > /dev/null 2>&1 && \
+    node -e "require('crypto').createHash('sha256').update('x').digest('hex')" \
+      > /dev/null 2>&1 && \
+    node -e "process.exit(require('crypto').getFips() ? 0 : 1)"


### PR DESCRIPTION
# Pin ambient OpenSSL fetches to fips=yes in the FIPS images

Fixes #3359.

## What changed

The activation config in `src/containers/workspace/Dockerfile.fips` and
`src/containers/host/Dockerfile.fips` now declares an `alg_section` with
`default_properties = fips=yes`, so every libcrypto in the container requires
the fips property on provider-less algorithm fetches at init — the
config-level form of the `EVP_default_properties_enable_fips` pin klangkd
already applies in its own process (#3350). The workspace build-time proof
was rebuilt in the host image's #3350 style — numbered markers, stdout-
preserving expected-failure links — and gains two checks: a SHA-256 sanity
fetch and `node getFips()` must report FIPS mode active. Both configs also
set `config_diagnostics = 1` so a config that fails to parse aborts the
process instead of silently proceeding on the default provider.

## Why

In the FIPS workspace image, pi failed to load every TypeScript extension:

```
Error: Failed to load extension "/opt/klangk/pi-agent/extensions/beep.ts": Failed to load extension: error:0308010C:digital envelope routines::unsupported
Hint: Start without extensions using "pi -ne".
```

Root cause (traced in the issue): jiti — pi's TS extension loader — picks its
cache-key hash algorithm from `crypto.getFips()`. Under the image's
provider-only activation (fips + base, no fetch pin), Node reported
`getFips() === 0`, so jiti computed its cache key with `createHash("md5")`,
which the fips provider refuses. With the pin, `getFips()` reports 1 and jiti
uses SHA-256.

On the host side the pin is defense-in-depth: klangkd's process-level pin
already covers its own crypto; the config pin extends the same property gate
to every process in the host container.

## Verification

- The exact config this PR emits was mounted into a live v2.0a1 FIPS
  workspace container (`klangk-host-fips:v2.0a1`, `KLANGKD_FIPS_MODE=true`,
  running `klangk-workspace-fips`): fips + base providers active, `openssl md5`
  refused, `_hashlib.openssl_md5` refused, SHA-256 fetch works, and
  `node getFips()` → 1.
- `scripts/tests` (143 tests, the build-pipeline contract suite) pass.
- A fresh-eyes adversarial review (attached as the first comment) verified
  the blast radius empirically in the live containers — SHA-1 stays
  fetchable, base-provider encoders/decoders/store-loader and TLS 1.3
  handshakes pass, the full userland sweep (ssh-keygen, gpg, venv/pip, uv,
  tmux, git) is unaffected, and the runtime pin is idempotent under the
  image pin. Verdict: ship; both findings (proof auditability,
  config_diagnostics) are addressed in the second commit.
- CI builds both FIPS images from this branch; the workspace build-time proof
  now fails the build if `getFips()` regresses.

## Design note

The pin is unconditional image posture (like the provider activation itself),
not gated on `KLANGKD_FIPS_MODE`. The runtime-dependent alternative is tracked
in #3360 with its trade-offs; per the doctrine in
`docs/deployment/fips.md` ("the image carries the posture, the gate adds
verification"), the image-level form is the right default.

## Docs

`docs/deployment/fips.md` updated in three places (what the image does, the
Node boundary-table row, the #3350 wrinkle paragraph), changelog entry under
`[Unreleased]` → Fixed.
