### PR TITLE
Skip the FIPS fetch pin on non-Linux platforms (#3364)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -2609,6 +2609,14 @@ git-credential` (#1700).** `pig-latin` removed; `word-count` dormant.
 
 ### Fixed
 
+- **FIPS fetch pin is Linux-only (#3364).** Under
+  `KLANGKD_FIPS_MODE`, the startup step that pins ambient OpenSSL
+  fetches to `fips=yes` (#3350) now runs only on Linux, where
+  OpenSSL's FIPS provider exists. On macOS it previously loaded the
+  system libcrypto through ctypes, which aborts the whole process at
+  load time on current macOS; the backend now logs a skip notice
+  instead. This is also what unblocks the macOS test job, whose
+  worker was killed by the same load.
 - **Environment-variable reference page (#3339).** The table on
   `docs/reference/environment.md` listed every variable twice: a stale
   copy of the table (missing five variables added since, carrying an

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -2612,11 +2612,10 @@ git-credential` (#1700).** `pig-latin` removed; `word-count` dormant.
 - **FIPS fetch pin is Linux-only (#3364).** Under
   `KLANGKD_FIPS_MODE`, the startup step that pins ambient OpenSSL
   fetches to `fips=yes` (#3350) now runs only on Linux, where
-  OpenSSL's FIPS provider exists. On macOS it previously loaded the
-  system libcrypto through ctypes, which aborts the whole process at
-  load time on current macOS; the backend now logs a skip notice
-  instead. This is also what unblocks the macOS test job, whose
-  worker was killed by the same load.
+  OpenSSL's FIPS provider exists. On other platforms the step is
+  skipped and the regular process-posture check still governs
+  startup; on macOS the previous ctypes load of the system libcrypto
+  aborted the whole process at load time.
 - **Environment-variable reference page (#3339).** The table on
   `docs/reference/environment.md` listed every variable twice: a stale
   copy of the table (missing five variables added since, carrying an

--- a/src/klangk/klangk/fips.py
+++ b/src/klangk/klangk/fips.py
@@ -471,6 +471,28 @@ def _crypto_md5_refused() -> bool:
     return False
 
 
+def _load_fips_pin_symbols() -> tuple:
+    """Load libcrypto's FIPS pin entry points (#3350).
+
+    Returns ``(enable, provider_available, error)`` — the two ctypes
+    entry points on success, or the load failure detail.
+    """
+    import ctypes  # allow-deferred-import
+    import ctypes.util  # allow-deferred-import
+
+    try:
+        lib = ctypes.CDLL(
+            ctypes.util.find_library("crypto") or "libcrypto.so.3"
+        )
+        return (
+            lib.EVP_default_properties_enable_fips,
+            (lib.OSSL_PROVIDER_available),
+            None,
+        )
+    except (OSError, AttributeError) as exc:
+        return None, None, f"cannot pin fips fetch properties ({exc})"
+
+
 def _enable_fips_fetch_properties() -> tuple[bool, str]:
     """Pin ambient fetches to the fips provider (#3350).
 
@@ -484,24 +506,29 @@ def _enable_fips_fetch_properties() -> tuple[bool, str]:
     provider. The helper refuses to pin unless the fips provider is
     active in the default library context — pinning without it would
     fail every fetch in the process.
+
+    The pin is Linux-only (#3364): on macOS the ctypes load of the
+    system libcrypto aborts the process outright (Apple's load-time
+    check rejects ``dlopen``-loaded libcrypto), and every platform we
+    otherwise support reaches this helper only through OpenSSL 3 on
+    Linux hosts. ``sys.platform`` is read at call time so tests can
+    exercise the skip.
     """
     import ctypes  # allow-deferred-import
-    import ctypes.util  # allow-deferred-import
+    import sys  # allow-deferred-import
 
-    try:
-        lib = ctypes.CDLL(
-            ctypes.util.find_library("crypto") or "libcrypto.so.3"
-        )
-        enable = lib.EVP_default_properties_enable_fips
-        provider_active = lib.OSSL_PROVIDER_available
-    except (OSError, AttributeError) as exc:
-        return False, f"cannot pin fips fetch properties ({exc})"
+    if sys.platform != "linux":
+        return False, "fips fetch pin is Linux-only; pin skipped"
+
+    enable, provider_available, load_error = _load_fips_pin_symbols()
+    if load_error is not None:
+        return False, load_error
     # Never pin without the fips provider: the flag makes every fetch
     # require fips=yes, so on a process without it all ciphers and
     # digests would stop loading (poisoning the whole process).
-    provider_active.restype = ctypes.c_int
-    provider_active.argtypes = [ctypes.c_void_p, ctypes.c_char_p]
-    if not provider_active(None, b"fips"):
+    provider_available.restype = ctypes.c_int
+    provider_available.argtypes = [ctypes.c_void_p, ctypes.c_char_p]
+    if not provider_available(None, b"fips"):
         return False, "fips provider not active; pin skipped"
     enable.restype = ctypes.c_int
     enable.argtypes = [ctypes.c_void_p, ctypes.c_int]

--- a/src/klangk/klangk/fips.py
+++ b/src/klangk/klangk/fips.py
@@ -56,7 +56,9 @@ klangkd therefore pins ambient fetches to ``fips=yes`` first
 (``EVP_default_properties_enable_fips`` — the same call
 cryptography's own ``enable_fips`` makes; #3350) once the process
 posture probe confirms the fips provider is active, and only then
-runs the cryptography linkage checks.
+runs the cryptography linkage checks. The pin itself is Linux-only
+(#3364): off Linux the step is skipped before any libcrypto is
+touched.
 
 **Dual-maintenance note** (#2626 review): :data:`PROBE_SCRIPT` (the
 self-contained snippet run inside containers via ``python3 -c``)
@@ -486,7 +488,7 @@ def _load_fips_pin_symbols() -> tuple:
         )
         return (
             lib.EVP_default_properties_enable_fips,
-            (lib.OSSL_PROVIDER_available),
+            lib.OSSL_PROVIDER_available,
             None,
         )
     except (OSError, AttributeError) as exc:
@@ -514,11 +516,12 @@ def _enable_fips_fetch_properties() -> tuple[bool, str]:
     Linux hosts. ``sys.platform`` is read at call time so tests can
     exercise the skip.
     """
-    import ctypes  # allow-deferred-import
     import sys  # allow-deferred-import
 
     if sys.platform != "linux":
         return False, "fips fetch pin is Linux-only; pin skipped"
+
+    import ctypes  # allow-deferred-import
 
     enable, provider_available, load_error = _load_fips_pin_symbols()
     if load_error is not None:
@@ -619,7 +622,8 @@ def verify_process_fips(settings) -> None:
     deployment-dependent and follows the same warn/abort posture as
     the process probe. Ambient fetches are pinned to ``fips=yes``
     before any of it (#3350) — the pin's no-fips-provider guard keeps
-    it a no-op where it would not hold.
+    it a no-op where it would not hold, and the step is skipped
+    entirely off Linux (#3364).
     """
     if not getattr(settings, "fips_mode", False):
         return
@@ -628,7 +632,8 @@ def verify_process_fips(settings) -> None:
     # every property-less fetch — the _hashlib MD5 probe included — is
     # served from it. The pin's internal guard makes this a no-op
     # wherever the fips provider is not active, so pinning before the
-    # posture probes is safe on control hosts too.
+    # posture probes is safe on control hosts too; off Linux the
+    # guard skips the step before any libcrypto load (#3364).
     pin_ok, pin_detail = _enable_fips_fetch_properties()
     if pin_ok:
         logger.info("FIPS fetch properties pinned: %s", pin_detail)

--- a/src/klangk/klangkd-tests/tests/test_fips.py
+++ b/src/klangk/klangkd-tests/tests/test_fips.py
@@ -763,13 +763,19 @@ class TestEnableFipsFetchProperties:
     def test_non_linux_platform_is_noop(self, monkeypatch):
         """Non-Linux platforms skip the pin before any ctypes load
         (#3364): on macOS the dlopen of system libcrypto aborts the
-        process, so the guard must fire before CDLL is ever touched."""
+        process, so the guard must fire before CDLL is ever touched.
+
+        Only ``ctypes.CDLL`` is patched: patching
+        ``ctypes.util.find_library`` would lazily import
+        ``ctypes.util`` while ``sys.platform`` is patched to "darwin",
+        and Python 3.14's ``ctypes/util.py`` resolves dyld symbols at
+        import time under that platform — an import error on Linux
+        (an order-dependent failure whenever no earlier test on the
+        same worker imported ``ctypes.util`` first).
+        """
         cdll = MagicMock()
         monkeypatch.setattr(sys, "platform", "darwin")
-        with (
-            patch("ctypes.util.find_library", return_value="libcrypto.so.3"),
-            patch("ctypes.CDLL", cdll),
-        ):
+        with patch("ctypes.CDLL", cdll):
             ok, detail = fips._enable_fips_fetch_properties()
         assert ok is False
         assert "Linux-only" in detail

--- a/src/klangk/klangkd-tests/tests/test_fips.py
+++ b/src/klangk/klangkd-tests/tests/test_fips.py
@@ -365,6 +365,7 @@ class TestVerifyProcessFips:
     def test_on_verified(self, caplog):
         with (
             self._jose_ok(),
+            self._pin_ok(),
             self._linkage_ok(),
             patch.object(fips, "probe_process", return_value=(True, "x")),
             patch.object(fips, "running_in_container", return_value=False),
@@ -694,6 +695,12 @@ class TestEnableFipsFetchProperties:
     """The ambient fetch-property pin (#3350): ctypes plumbing around
     EVP_default_properties_enable_fips."""
 
+    @pytest.fixture(autouse=True)
+    def _linux_platform(self, monkeypatch):
+        """Force the Linux path: the pin helper skips non-Linux
+        platforms (#3364), and these tests exercise the ctypes path."""
+        monkeypatch.setattr(sys, "platform", "linux")
+
     def _lib(self, enable_result, provider=1):
         lib = MagicMock()
         lib.EVP_default_properties_enable_fips.return_value = enable_result
@@ -752,6 +759,21 @@ class TestEnableFipsFetchProperties:
             ok, detail = fips._enable_fips_fetch_properties()
         assert ok is False
         assert "cannot pin" in detail
+
+    def test_non_linux_platform_is_noop(self, monkeypatch):
+        """Non-Linux platforms skip the pin before any ctypes load
+        (#3364): on macOS the dlopen of system libcrypto aborts the
+        process, so the guard must fire before CDLL is ever touched."""
+        cdll = MagicMock()
+        monkeypatch.setattr(sys, "platform", "darwin")
+        with (
+            patch("ctypes.util.find_library", return_value="libcrypto.so.3"),
+            patch("ctypes.CDLL", cdll),
+        ):
+            ok, detail = fips._enable_fips_fetch_properties()
+        assert ok is False
+        assert "Linux-only" in detail
+        cdll.assert_not_called()
 
 
 class TestVerifyJoseCryptoLinkage:


### PR DESCRIPTION
# Skip the FIPS fetch pin on non-Linux platforms (#3364)

## Problem

Since #3353, every macOS backend-test run that actually executes the suite crashes a pytest-xdist worker with a native `abort()`:

```
WARNING: .../Python is loading libcrypto in an unsafe way
Fatal Python error: Aborted
  fips.py in _enable_fips_fetch_properties
  fips.py in verify_process_fips
  test_fips.py::TestVerifyProcessFips::test_on_verified
/usr/lib/libcrypto.dylib at __report_load → abort()
```

`_enable_fips_fetch_properties` ctypes-dlopens whatever `ctypes.util.find_library("crypto")` resolves. On the macos-26-arm64 runner that is Apple's `/usr/lib/libcrypto.dylib`, whose `__report_load` initializer aborts processes that load system libcrypto via raw `dlopen` (older macOS only warned). `except (OSError, AttributeError)` cannot catch SIGABRT, so the whole worker dies.

Every macOS run since `1e3206f05` that executed the tests has failed this way (runs 34190665976, 34190491919, 34193683238, 34203168016); the green ones in between were paths-filter skips. The same abort would kill a real backend started with `KLANGKD_FIPS_MODE=true` on macOS.

## Fix

- `_enable_fips_fetch_properties` returns a skip notice before any ctypes load when `sys.platform != "linux"` — the OpenSSL 3 FIPS-provider pin is a Linux concept. `sys.platform` is read at call time so tests can exercise the guard (and the Linux coverage gate needs both branch outcomes).
- The ctypes symbol loading moved into `_load_fips_pin_symbols` to keep both functions at xenon rank A.
- `test_on_verified` patches the pin (its container sibling already did).
- `TestEnableFipsFetchProperties` forces the Linux platform via an autouse fixture and gains `test_non_linux_platform_is_noop`, which asserts `ctypes.CDLL` is never touched off Linux.

## Testing

Full backend suite the CI way (`-n auto`, coverage): 8238 passed, 100% branch coverage. `pre-commit run xenon --all-files`: clean.

Issue: #3364
