### PR TITLE
Add PyPI project links to the klangk wheel (#3369)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -840,6 +840,11 @@ sync` report a clear permission-denied error.
 
 ### Added
 
+- **PyPI project links (#3369).** The `klangk` wheel now carries
+  `project.urls` — Homepage, Documentation, Repository, Issues, and
+  Changelog — so the PyPI project and release pages show the sidebar
+  links. Changelog points at the docs-rendered changelog page.
+
 - **`host` and `instance` fields on JSON log records (#3330).** Every
   JSON log line (console in `KLANGKD_LOG_FORMAT=json` and the
   `KLANGKD_LOG_FILE` sink) now carries `host` (the emitting machine's

--- a/src/klangk/pyproject.toml
+++ b/src/klangk/pyproject.toml
@@ -36,6 +36,18 @@ dependencies = [
     "litellm>=1.60.0",
 ]
 
+# PyPI sidebar links ("Project links" on the project page and each
+# release page). The keys map to the sidebar labels PyPI renders:
+# Repository -> "Source", Issues -> "Bug Tracker". Changelog points at
+# the docs-rendered /changes/ page (docs/changes.md, the single source
+# of truth for release notes) rather than a raw GitHub blob.
+[project.urls]
+Homepage = "https://github.com/mcdonc/klangk"
+Documentation = "https://mcdonc.github.io/klangk/"
+Repository = "https://github.com/mcdonc/klangk"
+Issues = "https://github.com/mcdonc/klangk/issues"
+Changelog = "https://mcdonc.github.io/klangk/changes/"
+
 # Test toolchain — opt in via `pip install klangk[test]` or
 # `uv sync --extra test`. Kept out of the runtime ``dependencies`` so a
 # production ``pip install klangk`` doesn't pull pytest + its transitive


### PR DESCRIPTION
## Summary

Adds `[project.urls]` to `src/klangk/pyproject.toml` so the PyPI project page
and release pages show the "Project links" sidebar: Homepage, Documentation,
Repository (rendered "Source"), Issues (rendered "Bug Tracker"), and
Changelog (pointing at the docs-rendered `/changes/` page, the single source
of truth for release notes, rather than a raw GitHub blob).

`klangk` is the only wheel published to PyPI (`klangksidecar` ships only in
its container image), so the section belongs there alone.

## Verification

- `uv build --sdist` → PKG-INFO carries all five `Project-URL` entries.
- `scripts/tests/test_wheel_metadata.py` passes (3 passed).
- Changelog entry added under `## \[Unreleased]` → Added.

Closes #3369.
