### PR TITLE
Fix fuzz daily run: startup timeout and missing sidecar image (#3368)

### DIFF
--- a/.github/workflows/fuzz-daily.yml
+++ b/.github/workflows/fuzz-daily.yml
@@ -26,7 +26,10 @@ jobs:
 
       - uses: ./.github/actions/devenv-setup
         with:
-          build-tasks: klangk:build-workspace-image
+          # The sidecar image must be present too: workspace start/restart
+          # attaches it, and with the image missing podman tries to pull it
+          # from docker.io and the restart endpoint returns a raw 500 (#3368).
+          build-tasks: klangk:build-workspace-image klangk:build-network-sidecar
 
       - name: Run fuzzer (10 min)
         run: |

--- a/scripts/fuzz-api.py
+++ b/scripts/fuzz-api.py
@@ -733,9 +733,9 @@ def wait_for_server(uds_path: str, timeout: float = 120) -> None:
 
     The 120 s budget covers a cold CI runner: uvicorn boot (~8 s),
     migrations + seeding (~3 s), then ``prewarm_podman()`` (its first
-    ``podman create`` alone can take ~20–30 s). Warm runs finish in
-    ~23 s; the old 30 s deadline failed whenever the runner booted
-    slower than that (#3368).
+    ``podman create`` alone can take ~20–30 s). Good days land at
+    ~23 s total; the old 30 s deadline failed whenever the runner
+    booted slower than that (#3368).
     """
     deadline = time.monotonic() + timeout
     while time.monotonic() < deadline:

--- a/scripts/fuzz-api.py
+++ b/scripts/fuzz-api.py
@@ -728,8 +728,15 @@ def start_server(data_dir: str) -> tuple[subprocess.Popen, TeeReader, str]:
     return proc, tee, uds_path
 
 
-def wait_for_server(uds_path: str, timeout: float = 30) -> None:
-    """Poll /health until the server is up (over the UDS)."""
+def wait_for_server(uds_path: str, timeout: float = 120) -> None:
+    """Poll /health until the server is up (over the UDS).
+
+    The 120 s budget covers a cold CI runner: uvicorn boot (~8 s),
+    migrations + seeding (~3 s), then ``prewarm_podman()`` (its first
+    ``podman create`` alone can take ~20–30 s). Warm runs finish in
+    ~23 s; the old 30 s deadline failed whenever the runner booted
+    slower than that (#3368).
+    """
     deadline = time.monotonic() + timeout
     while time.monotonic() < deadline:
         try:


### PR DESCRIPTION
Fixes #3368.

## Summary

Two changes to the daily fuzz run, matching the issue's two open problems:

1. **`scripts/fuzz-api.py` — raise the `wait_for_server` boot budget from 30 s
   to 120 s.** A cold `ubuntu-latest` runner spends ~8 s on the uvicorn boot,
   ~3 s on migrations + seeding, then 12–30 s in `prewarm_podman()` (its own
   docstring allows ~20–30 s for the first `podman create`). Good days landed
   at ~23 s and squeaked under the old deadline; Sep 7/8 crossed it and the
   run aborted with 0 requests sent. The 120 s budget covers the slow path
   while staying small against the 10-minute session.

2. **`.github/workflows/fuzz-daily.yml` — build the network sidecar image
   alongside the workspace image** (`build-tasks: klangk:build-workspace-image
   klangk:build-network-sidecar`). `netfilter_enabled` defaults to true and
   the fuzz env doesn't override it, so workspace start/restart that attaches
   the sidecar tried to pull `klangk-network-sidecar` from docker.io and
   surfaced a raw 500 (observed Sep 6 on `POST /api/v1/workspaces/{id}/restart`).
   The build task tags the image with exactly the name the backend's
   `network_sidecar_image` default expects, so the attach path now exercises
   the real container flow instead of failing. Same task combination the
   sandbox E2E workflow already uses.

The third item in the issue — ~50 false-green daily runs (Jul 18 – Sep 5,
login-body drift + aborts not counted as failures) — was already fixed by
`7422a6cfd` (login posts `identifier`; aborts set `tracker.runner_error` →
exit 1). This PR verifies those fixes are in place; no new change needed.

## Testing

- `scripts/tests` suite: 146 passed (CI invocation).
- `pre-commit run xenon --all-files`: passed (the fuzzer script is in the
  graded set).
- The real proof is the next scheduled run; the change is otherwise
  unexercisable locally without a cold stock runner.
