### PR TITLE
Add PyPI project links to the klangk wheel metadata (#3369)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -33,6 +33,13 @@ operators or integrators to act when upgrading.
 
 ## \[Unreleased]
 
+### Added
+
+- **PyPI project links (#3369).** The `klangk` wheel now carries
+  `project.urls` — Homepage, Documentation, Repository, Issues, and
+  Changelog — so the PyPI project and release pages show the sidebar
+  links. Changelog points at the docs-rendered changelog page.
+
 ## \[v2.0a2] - 2026-09-08
 
 ### Fixed

--- a/src/klangk/pyproject.toml
+++ b/src/klangk/pyproject.toml
@@ -36,6 +36,18 @@ dependencies = [
     "litellm>=1.60.0",
 ]
 
+# PyPI sidebar links ("Project links" on the project page and each
+# release page). The keys map to the sidebar labels PyPI renders:
+# Repository -> "Source", Issues -> "Bug Tracker". Changelog points at
+# the docs-rendered /changes/ page (docs/changes.md, the single source
+# of truth for release notes) rather than a raw GitHub blob.
+[project.urls]
+Homepage = "https://github.com/mcdonc/klangk"
+Documentation = "https://mcdonc.github.io/klangk/"
+Repository = "https://github.com/mcdonc/klangk"
+Issues = "https://github.com/mcdonc/klangk/issues"
+Changelog = "https://mcdonc.github.io/klangk/changes/"
+
 # Test toolchain — opt in via `pip install klangk[test]` or
 # `uv sync --extra test`. Kept out of the runtime ``dependencies`` so a
 # production ``pip install klangk`` doesn't pull pytest + its transitive


### PR DESCRIPTION
Backport of #3370 to stable/2.0 (issue #3369). Identical code diff (`src/klangk/pyproject.toml`); the changelog entry is placed under `[Unreleased]` (stable's Unreleased was empty when v2.0a2 was cut, so the cherry-pick needed the section re-added) instead of main's location.

## Summary

The `klangk` wheel now carries `project.urls` — Homepage, Documentation, Repository, Issues, and Changelog — so the PyPI project and release pages show the sidebar links. Changelog points at the docs-rendered changelog page.

Merged to main as 8e64ac61b; all 12 CI checks green there.
