### PR TITLE
Exempt the OIDC callback from the every-visit banner gate (#3371)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -2627,8 +2627,10 @@ git-credential` (#1700).** `pig-latin` removed; `word-count` dormant.
   that the banner gate discarded by redirecting to the consent page
   first, so single sign-on could never finish (the code expires in 60
   seconds and the redirect replaces the URL). The OIDC callback page
-  now redeems the code before the banner is shown, and the banner is
-  accepted on the next navigation as usual.
+  now redeems the code before the banner is shown, and the user is
+  sent to the consent page on the next navigation as usual. A failed
+  code exchange shows the error with a “Go to Login” button instead
+  of stranding the browser on the callback page.
 - **FIPS images pin ambient OpenSSL fetches to `fips=yes` (#3359).**
   The activation config in the FIPS workspace and FIPS host images
   now sets `default_properties = fips=yes`, so every process in the

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -2621,6 +2621,14 @@ git-credential` (#1700).** `pig-latin` removed; `word-count` dormant.
 
 ### Fixed
 
+- **SSO login completes under an every-visit login banner
+  (#3371).** With `login_banner_every_visit` on, the browser's
+  return from the identity provider carried a one-time login code
+  that the banner gate discarded by redirecting to the consent page
+  first, so single sign-on could never finish (the code expires in 60
+  seconds and the redirect replaces the URL). The OIDC callback page
+  now redeems the code before the banner is shown, and the banner is
+  accepted on the next navigation as usual.
 - **FIPS images pin ambient OpenSSL fetches to `fips=yes` (#3359).**
   The activation config in the FIPS workspace and FIPS host images
   now sets `default_properties = fips=yes`, so every process in the

--- a/src/frontend/e2e-tests/fmtk/test_oidc.py
+++ b/src/frontend/e2e-tests/fmtk/test_oidc.py
@@ -354,8 +354,10 @@ def test_sso_completes_under_every_visit_banner(harness, app, oidc_stack):
         approve_at_idp(oidc_stack, app, 0)
 
         # the callback reloads the app with the banner pending again —
-        # the code is redeemed anyway and the guards land on /consent
-        # (not /login): the session exists as soon as it is accepted
+        # the code is redeemed before the banner gate redirects. Both
+        # the fixed and the pre-fix flow land on /consent; what the fix
+        # changes is that the session survives the accept — the pre-fix
+        # code was dropped, so accepting led back to /login (the loop)
         wait_landed(app, "I Accept")
         app.tap_label("I Accept")
         app.wait_for_text("No workspaces yet")

--- a/src/frontend/e2e-tests/fmtk/test_oidc.py
+++ b/src/frontend/e2e-tests/fmtk/test_oidc.py
@@ -159,6 +159,33 @@ def return_tab_to_login(app) -> None:
     wait_for_app(app, "Email or handle")
 
 
+def hard_reload_login(app) -> None:
+    """Force a full page load of the app at /#/login.
+
+    A hash-only navigation from a running app is same-document — the
+    page keeps its boot-time config fetch, so a swapped-in banner (or a
+    swapped-out one) would never be seen. The about:blank detour makes
+    the return a real document load.
+    """
+    cdp_eval("location.href='about:blank'")
+    cdp_eval(f"location.href='{app_origin()}/#/login'")
+
+
+def wait_settled(app, timeout: float = 90) -> None:
+    """Wait for a settled app surface: the login form or the workspace
+    list (either may come out of a post-restore reload, depending on
+    whether a session survived the scenario)."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        try:
+            if app.has_text("Log In", 3000) or app.has_text("Owned by Me", 3000):
+                return
+        except Exception:  # noqa: BLE001 — dwds re-attach races
+            pass
+        time.sleep(2)
+    raise AssertionError("the app settled on neither login form nor workspace list")
+
+
 def body_text() -> str:
     return str(cdp_eval("document.body.innerText"))
 
@@ -281,33 +308,6 @@ def test_sso_approve_provisions_and_lands(harness, app, oidc_stack):
     assert entry.get("provider") == "fmtk-idp", entry
     # the IdP saw the whole leg: authorize -> approve -> PKCE-checked token
     assert ("token", IDP_EMAIL) in oidc_stack.events, oidc_stack.events
-
-
-def hard_reload_login(app) -> None:
-    """Force a full page load of the app at /#/login.
-
-    A hash-only navigation from a running app is same-document — the
-    page keeps its boot-time config fetch, so a swapped-in banner (or a
-    swapped-out one) would never be seen. The about:blank detour makes
-    the return a real document load.
-    """
-    cdp_eval("location.href='about:blank'")
-    cdp_eval(f"location.href='{app_origin()}/#/login'")
-
-
-def wait_settled(app, timeout: float = 90) -> None:
-    """Wait for a settled app surface: the login form or the workspace
-    list (either may come out of a post-restore reload, depending on
-    whether a session survived the scenario)."""
-    deadline = time.monotonic() + timeout
-    while time.monotonic() < deadline:
-        try:
-            if app.has_text("Log In", 3000) or app.has_text("Owned by Me", 3000):
-                return
-        except Exception:  # noqa: BLE001 — dwds re-attach races
-            pass
-        time.sleep(2)
-    raise AssertionError("the app settled on neither login form nor workspace list")
 
 
 def test_sso_completes_under_every_visit_banner(harness, app, oidc_stack):

--- a/src/frontend/e2e-tests/fmtk/test_oidc.py
+++ b/src/frontend/e2e-tests/fmtk/test_oidc.py
@@ -283,6 +283,92 @@ def test_sso_approve_provisions_and_lands(harness, app, oidc_stack):
     assert ("token", IDP_EMAIL) in oidc_stack.events, oidc_stack.events
 
 
+def hard_reload_login(app) -> None:
+    """Force a full page load of the app at /#/login.
+
+    A hash-only navigation from a running app is same-document — the
+    page keeps its boot-time config fetch, so a swapped-in banner (or a
+    swapped-out one) would never be seen. The about:blank detour makes
+    the return a real document load.
+    """
+    cdp_eval("location.href='about:blank'")
+    cdp_eval(f"location.href='{app_origin()}/#/login'")
+
+
+def wait_settled(app, timeout: float = 90) -> None:
+    """Wait for a settled app surface: the login form or the workspace
+    list (either may come out of a post-restore reload, depending on
+    whether a session survived the scenario)."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        try:
+            if app.has_text("Log In", 3000) or app.has_text("Owned by Me", 3000):
+                return
+        except Exception:  # noqa: BLE001 — dwds re-attach races
+            pass
+        time.sleep(2)
+    raise AssertionError("the app settled on neither login form nor workspace list")
+
+
+def test_sso_completes_under_every_visit_banner(harness, app, oidc_stack):
+    """#3371: an every-visit banner must not turn SSO into a loop.
+
+    The callback lands on a fresh app load at #/oidc-complete?code=...
+    with the banner required again; the one-time code must be redeemed
+    despite that (the banner gate exempts the route while logged out),
+    the banner accepted on landing, and the login then completes —
+    instead of the pre-fix loop where the guard dropped the code and
+    bounced back to /consent, then /login, then the IdP again.
+    """
+    original = {
+        key: harness.config.get(key, default)
+        for key, default in (
+            ("login_banner", ""),
+            ("login_banner_title", ""),
+            ("login_banner_every_visit", "false"),
+        )
+    }
+    try:
+        harness.backend.swap_settings(
+            {
+                "auth_modes": "both",
+                "oidc_providers": [oidc_stack.provider_entry()],
+                "login_banner": "fmtk every-visit banner text",
+                "login_banner_title": "Fmtk Notice",
+                "login_banner_every_visit": "true",
+            },
+            apply="restart",
+            verify=False,
+        )
+        harness.backend.wait_config_value("auth_modes", "both")
+        harness.backend.wait_config_value("login_banner_every_visit", True)
+
+        # fresh load: the banner gate forces /consent before the login
+        # form; accept, then the SSO button is on the re-mounted form
+        hard_reload_login(app)
+        wait_for_app(app, "I Accept")
+        app.tap_label("I Accept")
+        wait_for_app(app, PROVIDER_LABEL)
+
+        tap_sso(app, oidc_stack)
+        approve_at_idp(oidc_stack, app, 0)
+
+        # the callback reloads the app with the banner pending again —
+        # the code is redeemed anyway and the guards land on /consent
+        # (not /login): the session exists as soon as it is accepted
+        wait_landed(app, "I Accept")
+        app.tap_label("I Accept")
+        app.wait_for_text("No workspaces yet")
+        assert app.has_text(IDP_EMAIL, 10000), "the SSO user's email chip"
+        app.logout()
+    finally:
+        harness.backend.swap_settings(original, apply="restart", verify=False)
+        # leave the tab on a clean surface for the next scenario — the
+        # running app's in-memory config is stale until a real reload
+        hard_reload_login(app)
+        wait_settled(app)
+
+
 def test_sso_deny_keeps_login_page_and_no_user(harness, app, oidc_stack):
     status, listing = harness.admin_api("GET", "/api/v1/users?page_size=1")
     users_before = listing["total"]

--- a/src/frontend/lib/app_guards.dart
+++ b/src/frontend/lib/app_guards.dart
@@ -25,17 +25,37 @@ const Set<String> publicRoutes = {
   '/consent',
 };
 
+/// Routes allowed through while a banner is pending.
+///
+/// `/consent` is the banner page itself. `/oidc-complete` is exempt
+/// for logged-out users only (#3371): the OIDC callback lands there
+/// with a one-time login code in the URL (60s TTL), and a redirect
+/// would replace the URL and destroy the code — making SSO login an
+/// endless loop (consent → login → IdP → consent) whenever
+/// `login_banner_every_visit` is set. `OidcCompletePage` redeems the
+/// code first; the minted session flips `isLoggedIn`, the guards
+/// re-run, and the banner gate then sends the now-logged-in user to
+/// `/consent` before any app route loads. A logged-in user hitting
+/// `/oidc-complete` gets no exemption — the code is redundant next to
+/// the live session, and the banner must come first.
+bool bannerExempt({required bool isLoggedIn, required String loc}) =>
+    loc == '/consent' || (!isLoggedIn && loc == '/oidc-complete');
+
 /// Banner gate.
 ///
 /// When a banner must be accepted, force every route to `/consent`
-/// (allowing `/consent` itself). When no banner is pending, a visit to
-/// `/consent` bounces to `/login` — the consent page is only meaningful
-/// while a banner is required.
+/// (allowing the exemptions in [bannerExempt]). When no banner is
+/// pending, a visit to `/consent` bounces to `/login` — the consent
+/// page is only meaningful while a banner is required.
 ///
 /// Returns the redirect target, or null to allow.
-String? guardBanner({required bool bannerRequired, required String loc}) {
+String? guardBanner({
+  required bool bannerRequired,
+  required bool isLoggedIn,
+  required String loc,
+}) {
   if (bannerRequired) {
-    return loc == '/consent' ? null : '/consent';
+    return bannerExempt(isLoggedIn: isLoggedIn, loc: loc) ? null : '/consent';
   }
   if (loc == '/consent') {
     return '/login';
@@ -168,7 +188,8 @@ String? guardRoot({required bool isLoggedIn, required String loc}) {
 /// is passed separately so [guardLoggedInPublicRoute] can exclude them.
 ///
 /// While a banner is pending, the banner gate is **terminal**: `/consent`
-/// is the only legal location, for logged-out and logged-in users alike.
+/// is the only legal location (plus the `/oidc-complete` exemption, see
+/// [bannerExempt]), for logged-out and logged-in users alike.
 /// Falling through to the guards below would let [guardLoggedInPublicRoute]
 /// bounce a logged-in user off `/consent` (a public route) straight back
 /// into the banner gate — the `/consent => /workspaces => /consent`
@@ -185,9 +206,9 @@ String? evaluateGuards({
   required bool canAccessAdmin,
 }) {
   if (bannerRequired) {
-    return guardBanner(bannerRequired: true, loc: loc);
+    return guardBanner(bannerRequired: true, isLoggedIn: isLoggedIn, loc: loc);
   }
-  return guardBanner(bannerRequired: false, loc: loc) ??
+  return guardBanner(bannerRequired: false, isLoggedIn: isLoggedIn, loc: loc) ??
       guardAuth(
         isLoggedIn: isLoggedIn,
         loc: loc,

--- a/src/frontend/lib/auth/oidc_complete_page.dart
+++ b/src/frontend/lib/auth/oidc_complete_page.dart
@@ -9,8 +9,11 @@ import '../widgets/klangk_logo.dart';
 
 /// Landing page after OIDC callback. The backend redirected here with a
 /// one-time login code (#3201 — the session JWT never rides the URL);
-/// this page redeems the code for the token via POST, saves it, and the
-/// GoRouter redirect then navigates to /workspaces.
+/// this page redeems the code for the token via POST and saves it. The
+/// router's redirect then takes over: /workspaces directly, or /consent
+/// first while a login banner is pending (#3371 — the route is exempt
+/// from the banner gate while logged out precisely so this redemption
+/// can run).
 class OidcCompletePage extends StatefulWidget {
   final String code;
 

--- a/src/frontend/lib/auth/oidc_complete_page.dart
+++ b/src/frontend/lib/auth/oidc_complete_page.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
 import 'package:provider/provider.dart';
 import 'auth_service.dart';
 import '../utils/page_title.dart';
@@ -65,6 +66,11 @@ class _OidcCompletePageState extends State<OidcCompletePage> {
   @override
   Widget build(BuildContext context) {
     if (_error != null) {
+      // Failed exchange (expired/replayed code, backend restart): the
+      // message stays visible and the button gives the recovery path —
+      // with a pending every-visit banner the login route bounces to
+      // /consent first, so the flow restarts cleanly instead of
+      // stranding the user here (#3371 review).
       return Scaffold(
         body: Center(
           child: Card(
@@ -76,9 +82,20 @@ class _OidcCompletePageState extends State<OidcCompletePage> {
                 children: [
                   const KlangkLogo(height: 80),
                   const SizedBox(height: 24),
-                  Text(_error!,
-                      style: TextStyle(
-                          color: Theme.of(context).colorScheme.error)),
+                  Text(
+                    _error!,
+                    textAlign: TextAlign.center,
+                    style:
+                        TextStyle(color: Theme.of(context).colorScheme.error),
+                  ),
+                  const SizedBox(height: 24),
+                  SizedBox(
+                    width: double.infinity,
+                    child: FilledButton(
+                      onPressed: () => context.go('/login'),
+                      child: const Text('Go to Login'),
+                    ),
+                  ),
                 ],
               ),
             ),

--- a/src/frontend/test/app_guards_test.dart
+++ b/src/frontend/test/app_guards_test.dart
@@ -16,29 +16,65 @@ void main() {
   group('guardBanner', () {
     test('forces /consent when a banner is required', () {
       expect(
-        guardBanner(bannerRequired: true, loc: '/workspaces'),
+        guardBanner(
+            bannerRequired: true, isLoggedIn: false, loc: '/workspaces'),
         '/consent',
       );
       expect(
-        guardBanner(bannerRequired: true, loc: '/workspace/x'),
+        guardBanner(
+            bannerRequired: true, isLoggedIn: true, loc: '/workspace/x'),
         '/consent',
       );
     });
 
     test('allows /consent itself when a banner is required', () {
-      expect(guardBanner(bannerRequired: true, loc: '/consent'), isNull);
+      expect(
+        guardBanner(bannerRequired: true, isLoggedIn: false, loc: '/consent'),
+        isNull,
+      );
+    });
+
+    test('allows /oidc-complete when a banner is required, logged out (#3371)',
+        () {
+      // The OIDC callback carries a one-time login code in the URL; a
+      // redirect here destroys it (and the IdP round-trip cannot be
+      // replayed), so the code must be redeemed before the banner gate
+      // takes over.
+      expect(
+        guardBanner(
+            bannerRequired: true, isLoggedIn: false, loc: '/oidc-complete'),
+        isNull,
+      );
+    });
+
+    test('no /oidc-complete exemption once logged in (#3371)', () {
+      // After the code is redeemed the session is live; the banner gate
+      // reclaims the route so the guards cannot strand the user on the
+      // (spinner-only) complete page.
+      expect(
+        guardBanner(
+            bannerRequired: true, isLoggedIn: true, loc: '/oidc-complete'),
+        '/consent',
+      );
     });
 
     test('bounces /consent to /login when no banner is pending', () {
-      expect(guardBanner(bannerRequired: false, loc: '/consent'), '/login');
+      expect(
+        guardBanner(bannerRequired: false, isLoggedIn: false, loc: '/consent'),
+        '/login',
+      );
     });
 
     test('allows other routes when no banner is pending', () {
       expect(
-        guardBanner(bannerRequired: false, loc: '/workspaces'),
+        guardBanner(
+            bannerRequired: false, isLoggedIn: false, loc: '/workspaces'),
         isNull,
       );
-      expect(guardBanner(bannerRequired: false, loc: '/login'), isNull);
+      expect(
+        guardBanner(bannerRequired: false, isLoggedIn: false, loc: '/login'),
+        isNull,
+      );
     });
   });
 
@@ -456,6 +492,46 @@ void main() {
           bannerRequired: true,
           loc: '/workspaces',
           currentUri: '/workspaces',
+          publicRoutes: routes,
+          featurePaths: featurePaths,
+          canAccessAdmin: false,
+        ),
+        '/consent',
+      );
+    });
+
+    test('banner gate exempts the logged-out OIDC callback (#3371)', () {
+      // Logged-out landing on /oidc-complete?code=... with an every-visit
+      // banner: the page must mount and redeem the one-time code — not be
+      // bounced to /consent, which would drop the code and loop the SSO
+      // flow forever.
+      expect(
+        evaluateGuards(
+          mustChangePassword: false,
+          isLoggedIn: false,
+          bannerRequired: true,
+          loc: '/oidc-complete',
+          currentUri: '/oidc-complete?code=abc',
+          publicRoutes: routes,
+          featurePaths: featurePaths,
+          canAccessAdmin: false,
+        ),
+        isNull,
+      );
+    });
+
+    test('banner gate reclaims /oidc-complete once logged in (#3371)', () {
+      // After the exchange mints the session, the guards re-run with
+      // isLoggedIn true and the banner gate sends the user to /consent
+      // before any app route loads — the page is never stranded on the
+      // spinner.
+      expect(
+        evaluateGuards(
+          mustChangePassword: false,
+          isLoggedIn: true,
+          bannerRequired: true,
+          loc: '/oidc-complete',
+          currentUri: '/oidc-complete?code=abc',
           publicRoutes: routes,
           featurePaths: featurePaths,
           canAccessAdmin: false,

--- a/src/frontend/test/oidc_complete_page_test.dart
+++ b/src/frontend/test/oidc_complete_page_test.dart
@@ -7,26 +7,54 @@ import 'package:http/http.dart' as http;
 import 'package:http/testing.dart';
 import 'package:provider/provider.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+import 'package:klangk_frontend/app_guards.dart';
 import 'package:klangk_frontend/auth/auth_service.dart';
 import 'package:klangk_frontend/auth/oidc_complete_page.dart';
 import 'package:klangk_plugin_api/klangk_plugin_api.dart';
 
-http.Client _mockClient({int exchangeStatus = 400}) {
+http.Client _mockClient({
+  int exchangeStatus = 400,
+  String? accessToken,
+  String bannerText = '',
+}) {
   return MockClient((request) async {
     if (request.url.path.contains('/api/v1/config')) {
       return http.Response(
-        jsonEncode({'registration_enabled': true}),
+        jsonEncode({
+          'registration_enabled': true,
+          'login_banner': bannerText,
+        }),
         200,
       );
     }
     if (request.url.path.contains('/api/v1/auth/oidc/exchange')) {
+      if (accessToken != null) {
+        return http.Response(
+          jsonEncode({'access_token': accessToken}),
+          200,
+        );
+      }
       return http.Response(
         jsonEncode({'detail': 'Login code is invalid or expired.'}),
         exchangeStatus,
       );
     }
+    if (request.url.path.contains('/api/v1/my-permissions')) {
+      return http.Response(
+        jsonEncode({'permissions': {}, 'groups': [], 'is_admin': false}),
+        200,
+      );
+    }
     return http.Response('Not found', 404);
   });
+}
+
+/// A JWT-shaped token whose claims are exactly [claims] (no `exp` by
+/// default, so no token-refresh timer is scheduled in tests).
+String _jwt(Map<String, dynamic> claims) {
+  String enc(Map<String, dynamic> m) =>
+      base64Url.encode(utf8.encode(jsonEncode(m))).replaceAll('=', '');
+  return '${enc({'alg': 'HS256', 'typ': 'JWT'})}.${enc(claims)}.sig';
 }
 
 void main() {
@@ -41,11 +69,22 @@ void main() {
     testAuthHttpClientOverride = null;
   });
 
-  /// Minimal router so the error card's "Go to Login" button can be
-  /// exercised for real (it navigates via context.go).
+  /// The app's real redirect wiring (evaluateGuards, see app.dart), so
+  /// the page is exercised under the actual guard precedence.
   Widget buildApp(AuthService auth, {required String code}) {
     final router = GoRouter(
       initialLocation: '/oidc-complete',
+      refreshListenable: auth,
+      redirect: (context, state) => evaluateGuards(
+        isLoggedIn: auth.isLoggedIn,
+        bannerRequired: auth.bannerRequired,
+        mustChangePassword: auth.mustChangePassword,
+        loc: state.matchedLocation,
+        currentUri: state.uri.toString(),
+        publicRoutes: publicRoutes,
+        featurePaths: const {},
+        canAccessAdmin: auth.canAdminSection,
+      ),
       routes: [
         GoRoute(
           path: '/oidc-complete',
@@ -57,6 +96,14 @@ void main() {
         GoRoute(
           path: '/login',
           builder: (_, __) => const Scaffold(body: Text('login page')),
+        ),
+        GoRoute(
+          path: '/consent',
+          builder: (_, __) => const Scaffold(body: Text('consent page')),
+        ),
+        GoRoute(
+          path: '/workspaces',
+          builder: (_, __) => const Scaffold(body: Text('workspace list')),
         ),
       ],
     );
@@ -95,6 +142,80 @@ void main() {
       expect(find.text('Missing login code.'), findsOneWidget);
       expect(find.text('Go to Login'), findsOneWidget);
       expect(find.text('Login code exchange failed.'), findsNothing);
+    });
+
+    testWidgets('malformed 200 body maps to the stable error (#3223)',
+        (tester) async {
+      testAuthHttpClientOverride = MockClient((request) async {
+        if (request.url.path.contains('/api/v1/config')) {
+          return http.Response(
+            jsonEncode({'registration_enabled': true}),
+            200,
+          );
+        }
+        if (request.url.path.contains('/api/v1/auth/oidc/exchange')) {
+          // 200 with a non-JSON body: jsonDecode throws inside the
+          // try, exercising the catch's stable-message path
+          return http.Response('<html>gateway oops</html>', 200);
+        }
+        return http.Response('Not found', 404);
+      });
+
+      final auth = AuthService();
+      await tester.pumpWidget(buildApp(auth, code: 'fresh-code'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Login code exchange failed.'), findsOneWidget);
+      expect(find.text('Go to Login'), findsOneWidget);
+      expect(find.byType(CircularProgressIndicator), findsNothing);
+    });
+
+    testWidgets(
+        'redeems the code under a pending banner, then the '
+        'guards send the session to /consent (#3371)', (tester) async {
+      final token = _jwt({'sub': 'user-1'});
+      testAuthHttpClientOverride =
+          _mockClient(accessToken: token, bannerText: 'Accept these terms.');
+
+      final auth = AuthService();
+      // let the constructor's config fetch land before the router is
+      // built (app.dart gates router creation on auth.initialized) —
+      // driven with pumps: a real Future.delayed never fires inside a
+      // testWidgets FakeAsync zone
+      await tester.pumpWidget(const SizedBox());
+      await tester.pump();
+      expect(auth.bannerRequired, isTrue);
+
+      await tester.pumpWidget(buildApp(auth, code: 'fresh-code'));
+      // the banner-pending exemption let the page mount and redeem…
+      await tester.pumpAndSettle();
+
+      expect(auth.isLoggedIn, isTrue);
+      expect(auth.token, token);
+      // …and the re-run guards then hand the session to /consent before
+      // any app route loads — not /workspaces, not /login
+      expect(find.text('consent page'), findsOneWidget);
+      expect(find.text('workspace list'), findsNothing);
+      expect(find.text('Go to Login'), findsNothing);
+    });
+
+    testWidgets('redeems the code and lands on /workspaces with no banner',
+        (tester) async {
+      final token = _jwt({'sub': 'user-1'});
+      testAuthHttpClientOverride = _mockClient(accessToken: token);
+
+      final auth = AuthService();
+      await tester.pumpWidget(const SizedBox());
+      await tester.pump();
+      expect(auth.bannerRequired, isFalse);
+
+      await tester.pumpWidget(buildApp(auth, code: 'fresh-code'));
+      await tester.pumpAndSettle();
+
+      expect(auth.isLoggedIn, isTrue);
+      // logged in on the public /oidc-complete route -> public-route
+      // guard bounces to /workspaces
+      expect(find.text('workspace list'), findsOneWidget);
     });
   });
 }

--- a/src/frontend/test/oidc_complete_page_test.dart
+++ b/src/frontend/test/oidc_complete_page_test.dart
@@ -1,0 +1,100 @@
+import 'dart:convert';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:provider/provider.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:klangk_frontend/auth/auth_service.dart';
+import 'package:klangk_frontend/auth/oidc_complete_page.dart';
+import 'package:klangk_plugin_api/klangk_plugin_api.dart';
+
+http.Client _mockClient({int exchangeStatus = 400}) {
+  return MockClient((request) async {
+    if (request.url.path.contains('/api/v1/config')) {
+      return http.Response(
+        jsonEncode({'registration_enabled': true}),
+        200,
+      );
+    }
+    if (request.url.path.contains('/api/v1/auth/oidc/exchange')) {
+      return http.Response(
+        jsonEncode({'detail': 'Login code is invalid or expired.'}),
+        exchangeStatus,
+      );
+    }
+    return http.Response('Not found', 404);
+  });
+}
+
+void main() {
+  setUp(() {
+    testBaseUrlOverride = 'http://localhost:8997';
+    SharedPreferences.setMockInitialValues({});
+    testAuthHttpClientOverride = null;
+  });
+
+  tearDown(() {
+    testBaseUrlOverride = null;
+    testAuthHttpClientOverride = null;
+  });
+
+  /// Minimal router so the error card's "Go to Login" button can be
+  /// exercised for real (it navigates via context.go).
+  Widget buildApp(AuthService auth, {required String code}) {
+    final router = GoRouter(
+      initialLocation: '/oidc-complete',
+      routes: [
+        GoRoute(
+          path: '/oidc-complete',
+          builder: (_, __) => ChangeNotifierProvider.value(
+            value: auth,
+            child: OidcCompletePage(code: code),
+          ),
+        ),
+        GoRoute(
+          path: '/login',
+          builder: (_, __) => const Scaffold(body: Text('login page')),
+        ),
+      ],
+    );
+    return MaterialApp.router(routerConfig: router);
+  }
+
+  group('OidcCompletePage', () {
+    testWidgets(
+        'failed exchange shows the error with a recovery '
+        'button that reaches /login (#3371)', (tester) async {
+      testAuthHttpClientOverride = _mockClient();
+
+      final auth = AuthService();
+      await tester.pumpWidget(buildApp(auth, code: 'stale-code'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Login code exchange failed.'), findsOneWidget);
+      expect(find.text('Go to Login'), findsOneWidget);
+
+      // the recovery path: the button navigates away instead of
+      // stranding the browser on the callback page (a banner-pending
+      // deploy bounces /login to /consent in the real router)
+      await tester.tap(find.text('Go to Login'));
+      await tester.pumpAndSettle();
+      expect(find.text('login page'), findsOneWidget);
+    });
+
+    testWidgets('missing code shows the error with the recovery button',
+        (tester) async {
+      testAuthHttpClientOverride = _mockClient();
+
+      final auth = AuthService();
+      await tester.pumpWidget(buildApp(auth, code: ''));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Missing login code.'), findsOneWidget);
+      expect(find.text('Go to Login'), findsOneWidget);
+      expect(find.text('Login code exchange failed.'), findsNothing);
+    });
+  });
+}


### PR DESCRIPTION
Fixes #3371.

## Problem

With `login_banner_every_visit: true`, an OIDC login could never complete. The IdP redirects the browser back to a fresh page load at `#/oidc-complete?code=<one-time>`; the banner guard (`guardBanner` in `src/frontend/lib/app_guards.dart`) is terminal while a banner is pending and redirected to `/consent` before `OidcCompletePage` mounted. GoRouter's redirect replaces the committed location, destroying the one-time login code (60s TTL, #3201) — so the user accepted the banner, landed on `/login`, clicked the SSO button again, and looped forever. `POST /api/v1/auth/oidc/exchange` never fired.

## Fix

Exempt `/oidc-complete` from the banner gate **for logged-out users only** (new `bannerExempt()` helper):

- The callback page mounts and redeems the code first.
- The minted session flips `isLoggedIn`; the guards re-run on `notifyListeners`, and the banner gate then sends the now-logged-in user to `/consent` — the banner still gates every app route, on the next navigation as designed.
- A logged-in user gets no exemption: the code is redundant next to a live session, and the guard must reclaim the route or the user would be stranded on the spinner-only complete page.

No backend change; the 60s TTL stays as is because the code is now redeemed immediately on landing.

## Tests

- Unit (`src/frontend/test/app_guards_test.dart`): `guardBanner` allows `/oidc-complete` while logged out with a banner pending; sends logged-in users to `/consent`; `evaluateGuards` precedence cases for both.
- Unit (`src/frontend/test/oidc_complete_page_test.dart`, new): failed/missing code shows the error with a working "Go to Login" recovery button (fresh-eyes review follow-up — the dead-end error card is now the common failure mode for every-visit deployments, and a reload replays the same consumed code).
- E2E (`src/frontend/e2e-tests/fmtk/test_oidc.py::test_sso_completes_under_every_visit_banner`): swaps in `login_banner` + `login_banner_every_visit` + SSO, accepts the banner, runs the full IdP round-trip, and asserts the login completes (workspaces list + email chip) after accepting the banner on landing. Verified to fail on the pre-fix code (loop — never reaches the workspaces list) and pass with the fix.
- Changelog entry under `## \[Unreleased]` → Fixed.
