### PR TITLE
dart format: verify-only pre-commit hook + CI formatting check (#3376)

### DIFF
--- a/.github/workflows/frontend-tests.yml
+++ b/.github/workflows/frontend-tests.yml
@@ -69,6 +69,15 @@ jobs:
         # own real pub gets.
         run: flutter pub get
 
+      # Dart formatting is enforced by CI (#3376): the pre-commit hook only
+      # verifies (and skips unresolved packages), so this check — run after
+      # pub get, when the resolved language version drives the formatter —
+      # is the authoritative gate.
+      - name: Check Dart formatting
+        if: steps.filter.outputs.frontend == 'true'
+        working-directory: src/frontend
+        run: dart format --output=none --set-exit-if-changed lib test
+
       - name: Run tests with coverage
         if: steps.filter.outputs.frontend == 'true'
         working-directory: src/frontend
@@ -89,13 +98,16 @@ jobs:
           export GIT_LFS_SKIP_SMUDGE=1
           for pubspec in features/*/klangk/pubspec.yaml; do
             dir=$(dirname "$pubspec")
-            if [ -d "$dir/test" ]; then
-              echo "=== Testing $dir ==="
-              cd "$dir"
-              flutter pub get
+            echo "=== Checking $dir ==="
+            cd "$dir"
+            flutter pub get
+            if [ -d test ]; then
+              dart format --output=none --set-exit-if-changed lib test
               flutter test
-              cd "$GITHUB_WORKSPACE"
+            else
+              dart format --output=none --set-exit-if-changed lib
             fi
+            cd "$GITHUB_WORKSPACE"
           done
 
       - name: Skip notice

--- a/devenv.nix
+++ b/devenv.nix
@@ -808,10 +808,16 @@ in
       pass_filenames = false;
     };
     # Dart
+    # Dart — verify only, never rewrite mid-commit. A rewrite-mode dart
+    # format silently flipped short→tall in fresh worktrees (no .dart_tool
+    # → the toolchain's latest language version wins) and wedged prek's
+    # stash rollback during cherry-picks (#3376). The wrapper skips files
+    # whose package is not yet resolved; CI runs the check after pub get.
+    # Format with `dart format` yourself before committing.
     dart-format = {
       enable = true;
-      name = "dart format";
-      entry = "dart format";
+      name = "dart format (verify)";
+      entry = "scripts/dart-format-verify.sh";
       files = "\\.dart$";
       language = "system";
       pass_filenames = true;

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -2268,6 +2268,19 @@ stop)`) and a `server: stop at 23:00 (in 1h 12m)` status line in the
 
 ### Changed
 
+- **`dart format` pre-commit hook verifies instead of rewriting
+  (#3376).** The hook now runs `dart format --output=none
+--set-exit-if-changed` via `scripts/dart-format-verify.sh` and fails
+  on unformatted files instead of silently rewriting them mid-commit —
+  rewrite mode flipped short→tall style in fresh worktrees (where no
+  `.dart_tool` exists to resolve the language version) and wedged prek's
+  stash rollback during cherry-picks. Files whose package has no
+  `.dart_tool` yet are skipped with a notice; run `dart format` yourself
+  before committing. The frontend CI workflow now checks formatting
+  after `pub get` (src/frontend `lib`+`test` and every feature package
+  with tests), and the five files that were off-canonical at the pinned
+  language version were reformatted.
+
 - **`GET /events` renamed to `GET /events/containers` (#3205).**
   The container start/stop history moved under the `/events`
   resource's Containers stream now that the identity/privilege audit

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -40,6 +40,21 @@ operators or integrators to act when upgrading.
   Changelog — so the PyPI project and release pages show the sidebar
   links. Changelog points at the docs-rendered changelog page.
 
+### Changed
+
+- **`dart format` pre-commit hook verifies instead of rewriting
+  (#3376).** The hook now runs `dart format --output=none
+--set-exit-if-changed` via `scripts/dart-format-verify.sh` and fails
+  on unformatted files instead of silently rewriting them mid-commit —
+  rewrite mode flipped short→tall style in fresh worktrees (where no
+  `.dart_tool` exists to resolve the language version) and wedged prek's
+  stash rollback during cherry-picks. Files whose package has no
+  `.dart_tool` yet are skipped with a notice; run `dart format` yourself
+  before committing. The frontend CI workflow now checks formatting
+  after `pub get` (src/frontend `lib`+`test` and every feature package
+  with tests), and the five files that were off-canonical at the pinned
+  language version were reformatted.
+
 ## \[v2.0a2] - 2026-09-08
 
 ### Fixed
@@ -2267,19 +2282,6 @@ stop)`) and a `server: stop at 23:00 (in 1h 12m)` status line in the
   `KLANGKD_ALLOW_INSECURE_NO_AUTH`.
 
 ### Changed
-
-- **`dart format` pre-commit hook verifies instead of rewriting
-  (#3376).** The hook now runs `dart format --output=none
---set-exit-if-changed` via `scripts/dart-format-verify.sh` and fails
-  on unformatted files instead of silently rewriting them mid-commit —
-  rewrite mode flipped short→tall style in fresh worktrees (where no
-  `.dart_tool` exists to resolve the language version) and wedged prek's
-  stash rollback during cherry-picks. Files whose package has no
-  `.dart_tool` yet are skipped with a notice; run `dart format` yourself
-  before committing. The frontend CI workflow now checks formatting
-  after `pub get` (src/frontend `lib`+`test` and every feature package
-  with tests), and the five files that were off-canonical at the pinned
-  language version were reformatted.
 
 - **`GET /events` renamed to `GET /events/containers` (#3205).**
   The container start/stop history moved under the `/events`

--- a/docs/development/pre-commit.md
+++ b/docs/development/pre-commit.md
@@ -6,13 +6,13 @@ Pre-commit hooks run automatically on `git commit` via [git-hooks.nix](https://g
 - **check-executables-have-shebangs** — ensures executable scripts have a shebang line
 - **deferred-imports** — flags non-module-scope imports
 - **check-toml** — TOML syntax validation
-- **dart format** — Dart formatting
+- **dart format (verify)** — fails on Dart files that are not canonically formatted instead of rewriting them; run `dart format` yourself before committing. The hook skips files whose package has no `.dart_tool` yet (run `flutter pub get` there); the frontend CI workflow checks formatting for `src/frontend` and every feature package after `pub get`
 - **markdownlint** — Markdown linting
 - **nixfmt** — Nix formatting
 - **prettier** — TypeScript, JavaScript, and YAML formatting
 - **ruff format** — Python formatting
 - **ruff check --fix** — Python linting with auto-fix
-- **xenon** — Python complexity gate (rank B; see AGENTS.md)
+- **xenon** — Python complexity gate (rank A; see AGENTS.md)
 - **binary-integrity** — protects generated binary artifacts from drift
 - **shellcheck** — shell script linting
 - **shfmt** — shell script formatting

--- a/features/boingball/klangk/lib/feature.dart
+++ b/features/boingball/klangk/lib/feature.dart
@@ -117,14 +117,10 @@ void _playBoingSound({required double panX, bool isFloor = true}) {
     ((web.Event _) {
       final data = reader.result;
       if (data == null) return;
-      ctx
-          .decodeAudioData(data as JSArrayBuffer)
-          .toDart
-          .then((audio) {
-            _boingBuf = audio;
-            play(audio);
-          })
-          .catchError(_ignoreDecodeFailure);
+      ctx.decodeAudioData(data as JSArrayBuffer).toDart.then((audio) {
+        _boingBuf = audio;
+        play(audio);
+      }).catchError(_ignoreDecodeFailure);
     }).toJS,
   );
   reader.readAsArrayBuffer(web.Blob([bytes.toJS].toJS));
@@ -522,7 +518,7 @@ class _BoingBallPainter extends CustomPainter {
   static const _shadowColor = Color(0x44000000);
 
   _BoingBallPainter({required this.state, required this.ballFrac})
-    : super(repaint: state);
+      : super(repaint: state);
 
   @override
   void paint(Canvas canvas, Size size) {

--- a/features/celebrate/klangk/lib/confetti.dart
+++ b/features/celebrate/klangk/lib/confetti.dart
@@ -75,15 +75,15 @@ class _Particle {
   final double rotation;
 
   _Particle(Random r)
-    : x = r.nextDouble(),
-      startY = -r.nextDouble() * 0.3,
-      speed = 0.5 + r.nextDouble() * 0.8,
-      wobbleSpeed = 2 + r.nextDouble() * 6,
-      wobbleAmount = 10 + r.nextDouble() * 20,
-      size = 4 + r.nextDouble() * 8,
-      color = _ConfettiOverlayState
-          ._colors[r.nextInt(_ConfettiOverlayState._colors.length)],
-      rotation = r.nextDouble() * pi * 2;
+      : x = r.nextDouble(),
+        startY = -r.nextDouble() * 0.3,
+        speed = 0.5 + r.nextDouble() * 0.8,
+        wobbleSpeed = 2 + r.nextDouble() * 6,
+        wobbleAmount = 10 + r.nextDouble() * 20,
+        size = 4 + r.nextDouble() * 8,
+        color = _ConfettiOverlayState
+            ._colors[r.nextInt(_ConfettiOverlayState._colors.length)],
+        rotation = r.nextDouble() * pi * 2;
 }
 
 class _ConfettiPainter extends CustomPainter {

--- a/features/soliplex/klangk/lib/soliplex_tools.dart
+++ b/features/soliplex/klangk/lib/soliplex_tools.dart
@@ -45,7 +45,7 @@ final SoliplexServerRegistry soliplexServers = SoliplexServerRegistry(
 /// soliplex_client transport in `_streamRun` is coverage-ignored; this is not).
 class CitationAccumulator {
   CitationAccumulator({sox.CitationExtractor? extractor})
-    : _extractor = extractor ?? sox.CitationExtractor();
+      : _extractor = extractor ?? sox.CitationExtractor();
 
   final sox.CitationExtractor _extractor;
 
@@ -205,8 +205,8 @@ class SoliplexClient {
   /// the URL shape is testable without a live server.
   String uploadsUrl(String roomId, {String? threadId}) =>
       (threadId == null || threadId.isEmpty)
-      ? '$_baseUrl/api/v1/uploads/$roomId'
-      : '$_baseUrl/api/v1/uploads/$roomId/thread/$threadId';
+          ? '$_baseUrl/api/v1/uploads/$roomId'
+          : '$_baseUrl/api/v1/uploads/$roomId/thread/$threadId';
 
   /// Build the single-file GET URL. soliplex puts a literal `/file/` segment
   /// before the filename on BOTH the room and thread download routes:
@@ -227,8 +227,8 @@ class SoliplexClient {
   /// and :313). This asymmetry with the GET routes is deliberate on the server.
   String uploadPostUrl(String roomId, {String? threadId}) =>
       (threadId == null || threadId.isEmpty)
-      ? '$_baseUrl/api/v1/uploads/$roomId'
-      : '$_baseUrl/api/v1/uploads/$roomId/$threadId';
+          ? '$_baseUrl/api/v1/uploads/$roomId'
+          : '$_baseUrl/api/v1/uploads/$roomId/$threadId';
 
   /// List files uploaded to a [roomId], or to a thread within it when
   /// [threadId] is given. Normalizes the soliplex `RoomUploads`/`ThreadUploads`
@@ -297,8 +297,7 @@ class SoliplexClient {
       final text = utf8.decode(bytes);
       if (text.length > maxTextBytes) {
         return (
-          content:
-              '${text.substring(0, maxTextBytes)}\n'
+          content: '${text.substring(0, maxTextBytes)}\n'
               '...[truncated: ${text.length} chars total, '
               'showing first $maxTextBytes]',
           base64: false,
@@ -392,9 +391,14 @@ class SoliplexClient {
     }
     final runId = runs.keys.first;
 
-    final text = await _streamRun(roomId, threadId, runId, [
-      sox.UserMessage(id: _messageId(0), content: question),
-    ], onChunk);
+    final text = await _streamRun(
+        roomId,
+        threadId,
+        runId,
+        [
+          sox.UserMessage(id: _messageId(0), content: question),
+        ],
+        onChunk);
     return (text: text, threadId: threadId);
   }
 
@@ -513,9 +517,8 @@ class SoliplexClient {
           }
         }
       }
-      final answer = buffer.isNotEmpty
-          ? buffer.toString()
-          : '(No response from Soliplex)';
+      final answer =
+          buffer.isNotEmpty ? buffer.toString() : '(No response from Soliplex)';
       // CITATIONS PROTOTYPE: append a compact Sources list when any were seen.
       // formatSources returns '' when empty, so this is a no-op otherwise.
       return answer + formatSources(citations.sources);

--- a/scripts/dart-format-verify.sh
+++ b/scripts/dart-format-verify.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# dart format verify wrapper for the pre-commit hook (#3376).
+#
+# dart format resolves a file's language version — and therefore its short
+# vs tall output style — from the enclosing package's
+# .dart_tool/package_config.json. Without it (a fresh worktree, before the
+# first flutter pub get) the toolchain's latest language version wins and
+# the same file formats differently, so verifying in that state would flag
+# every file. Files whose package is not yet resolved are skipped with a
+# notice; CI runs the same check after pub get and is the authoritative
+# gate.
+set -euo pipefail
+
+resolved=()
+for f in "$@"; do
+  # Canonicalize first: prek passes repo-root-relative paths, and a bare
+  # relative walk converges on "." instead of "/" for package-less files
+  # (a tracked root-level .dart would hang the loop forever).
+  pkg_dir=$(realpath -m -- "$(dirname -- "$f")")
+  while [ "$pkg_dir" != "/" ] && [ ! -f "$pkg_dir/pubspec.yaml" ]; do
+    pkg_dir=$(dirname -- "$pkg_dir")
+  done
+  if [ -f "$pkg_dir/.dart_tool/package_config.json" ]; then
+    resolved+=("$f")
+  else
+    echo "dart-format: skipping $f ($pkg_dir not resolved; run flutter pub get there)"
+  fi
+done
+
+if [ "${#resolved[@]}" -gt 0 ]; then
+  dart format --output=none --set-exit-if-changed "${resolved[@]}"
+fi

--- a/src/frontend/lib/auth/auth_service.dart
+++ b/src/frontend/lib/auth/auth_service.dart
@@ -281,7 +281,7 @@ class AuthService extends ChangeNotifier {
             (data['default_classification_banner'] as String? ?? '').trim();
         _netfilterDefaultDomains =
             (data['netfilter_default_domains'] as List?)?.cast<String>() ??
-            const [];
+                const [];
         _netfilterEnabled = (data['netfilter_enabled'] as bool?) ?? false;
         _nixAvailable = (data['nix_available'] as bool?) ?? false;
         _sudoAvailable = (data['sudo_available'] as bool?) ?? false;
@@ -548,9 +548,9 @@ class AuthService extends ChangeNotifier {
   }
 
   Map<String, String> get _authHeaders => {
-    'Content-Type': 'application/json',
-    if (_token != null) 'Authorization': 'Bearer $_token',
-  };
+        'Content-Type': 'application/json',
+        if (_token != null) 'Authorization': 'Bearer $_token',
+      };
 
   /// Auth headers for one request, carrying a fresh DPoP proof when
   /// the token is bound (#3218). [method] is the HTTP verb and [path]

--- a/src/frontend/lib/workspace/workspace_page.dart
+++ b/src/frontend/lib/workspace/workspace_page.dart
@@ -174,8 +174,8 @@ class _WorkspacePageState extends State<WorkspacePage> {
     // changes (the server notifies on a classification_banner edit, so
     // the banner updates live after saving in the settings panel).
     _markingSub = context.read<WsClient>().workspacesChanged.listen(
-      (_) => _fetchWorkspaceName(),
-    );
+          (_) => _fetchWorkspaceName(),
+        );
     WidgetsBinding.instance.addPostFrameCallback((_) => _connectToWorkspace());
   }
 
@@ -192,8 +192,7 @@ class _WorkspacePageState extends State<WorkspacePage> {
     // permission list must be loaded by then.
     await _fetchPermissions();
     try {
-      final ws =
-          await _findWorkspace(auth, '/api/v1/workspaces') ??
+      final ws = await _findWorkspace(auth, '/api/v1/workspaces') ??
           await _findWorkspace(auth, '/api/v1/workspaces/shared');
       if (ws != null && mounted) {
         final name = ws['name'] as String?;
@@ -278,9 +277,8 @@ class _WorkspacePageState extends State<WorkspacePage> {
       featureRegistry: _featureRegistry,
       // #2710: on a deploy that disabled the browser-delegate bridge, the
       // tab never subscribes to bridge requests.
-      browserDelegateEnabled: context
-          .read<AuthService>()
-          .browserDelegateEnabled,
+      browserDelegateEnabled:
+          context.read<AuthService>().browserDelegateEnabled,
       onConnected: ({required bool connected, String? error}) {
         if (!mounted) return;
         if (!connected) {
@@ -331,8 +329,7 @@ class _WorkspacePageState extends State<WorkspacePage> {
         final deletedUserId = msg['user_id'] as String? ?? '';
         final deletedWindow = msg['window_name'] as String? ?? '';
         final deletedWid = msg['window_id'] as String? ?? '';
-        final wasViewing =
-            _activeSharedTerminal != null &&
+        final wasViewing = _activeSharedTerminal != null &&
             _activeSharedTerminal!['user_id'] == deletedUserId &&
             _activeSharedTerminal!['window_id'] == deletedWid;
         if (wasViewing) {
@@ -439,17 +436,15 @@ class _WorkspacePageState extends State<WorkspacePage> {
       // Snapshot the previous window ids BEFORE reassigning, so we can tell a
       // switch to an existing window apart from a brand-new window becoming
       // active.
-      final prevWindowIds = _prevTerminalWindows
-          .map((w) => w['id'] as String?)
-          .toSet();
+      final prevWindowIds =
+          _prevTerminalWindows.map((w) => w['id'] as String?).toSet();
       _prevTerminalWindows = wsClient.terminalWindows;
       _prevSharedTerminals = wsClient.sharedTerminals;
       // Track selected own-window: initialize on first message, or
       // reset if the selected window was closed.
       if (wsClient.terminalWindows.isNotEmpty) {
-        final ids = wsClient.terminalWindows
-            .map((w) => w['id'] as String?)
-            .toSet();
+        final ids =
+            wsClient.terminalWindows.map((w) => w['id'] as String?).toSet();
         // Follow tmux's active window on a switch to an EXISTING window (or
         // the first load) so the Flutter tab matches the status-bar selection
         // (#2171) — but NOT when a brand-new window just became active. The
@@ -462,8 +457,7 @@ class _WorkspacePageState extends State<WorkspacePage> {
             break;
           }
         }
-        final followActive =
-            activeId != null &&
+        final followActive = activeId != null &&
             (prevWindowIds.isEmpty || prevWindowIds.contains(activeId));
         if (followActive) {
           _selectedOwnWindowId = activeId;
@@ -771,9 +765,8 @@ class _WorkspacePageState extends State<WorkspacePage> {
               canEditAcl: _hasPerm('share-advanced'),
             )
           : null,
-      consentRules: _consent != null
-          ? ConsentRulesPanel(service: _consent!)
-          : null,
+      consentRules:
+          _consent != null ? ConsentRulesPanel(service: _consent!) : null,
       terminalKey: _terminalKey,
       fileViewerKey: _fileViewerKey,
       initialFile: widget.initialFile,


### PR DESCRIPTION
Backport of #3379 (main: `5da03331f`) to `stable/2.0` — the branch where the original prek stash-rollback wedge happened.

All nine content files (wrapper script, devenv hook entry, workflow, docs, 5 reformatted `.dart` files) are byte-identical blobs to the reviewed, CI-green main commit — verified with `git rev-parse <sha>:<path>` comparison. The only stable-specific difference is `docs/changes.md`: the cherry-pick auto-merged the entry into the wrong section (`## [v2.0a1]`); this PR places it under `## [Unreleased]`.

The cherry-pick itself double-served as proof: `git cherry-pick --continue` in a fresh worktree ran the new verify-only hook without incident — the exact operation that used to wedge (#3376).

Fixes #3376 on stable/2.0 (main side already fixed by #3379).
