### PR TITLE
Address open CodeQL code-scanning alerts (#3390)

### DIFF
--- a/scripts/fmtk-seed.py
+++ b/scripts/fmtk-seed.py
@@ -279,7 +279,8 @@ def main() -> None:
     print(
         f"\nfixture ready on {args.url} — workspace {WORKSPACE_NAME} "
         f"({ws_id[:8]}…)\n"
-        f"logins (password {FIXTURE_PASSWORD} for all):\n"
+        "logins (password: the FIXTURE_PASSWORD constant in this"
+        " script; fmtk-up prints it ready to paste):\n"
         "  fmtk-admin@example.com          -> admins group + owner:"
         " everything\n"
         "  fmtk-collaborator@example.com   -> collaborators bucket\n"


### PR DESCRIPTION
## Summary

Triages the five open alerts on the [code-scanning dashboard](https://github.com/mcdonc/klangk/security/code-scanning) (#3390): one fixed in code, four dismissed as false positives with written justifications on the dashboard.

## Fixed in code

- **Alert #230** (`py/clear-text-logging-sensitive-data`, high) — `scripts/fmtk-seed.py` interpolated `FIXTURE_PASSWORD` into its summary print. The summary now points at the constant instead; `fmtk-up`'s banner (scripts/fmtk-up.sh:216) already prints the password ready to paste, so the value stays one step away for the harness workflow while the seed output no longer echoes a password-named value. The alert resolves automatically when this lands and analysis re-runs.

## Dismissed as false positives

- **Alert #213** (`py/clear-text-logging-sensitive-data`, high) — `features/git-credential/tools/git-credential-klangk` prints `password=...` to stdout. Stdout is the git credential helper protocol channel (git reads `key=value` lines from the helper's stdout), not a log; the helper's diagnostics go through `_debug`, which redacts credentials via `_redact`.
- **Alert #209** (`py/url-redirection`, medium) — `api/auth.py` callback redirects to `cli_redirect`. The value is re-validated at callback time by `_valid_cli_redirect` (parsed URL; `http` scheme; no userinfo; hostname exactly `localhost` or `127.0.0.1`; explicit port) — the RFC 8252 loopback redirect pattern for the CLI login. See the guard's own docstring for the #936/#2571 hardening history.
- **Alerts #207/#208** (`py/cookie-injection`, medium) — the OIDC state cookie. The name reaches `set_cookie` only after `get_provider(provider_id)` resolves it to a configured provider (404 otherwise). The value is JSON of server-generated secrets (`state`, `verifier`) plus `cli_redirect`/`binding_jwk`, each already 400-validated by `_validate_login_params` before the cookie is built. Starlette also routes `set_cookie` through `http.cookies.SimpleCookie`, which quotes and octal-escapes control characters, so header splitting is not reachable through this path.
