### PR TITLE
fmtk-seed: stop printing the fixture password (#3390) (#3391) [backport]

### DIFF
--- a/scripts/fmtk-seed.py
+++ b/scripts/fmtk-seed.py
@@ -279,7 +279,8 @@ def main() -> None:
     print(
         f"\nfixture ready on {args.url} — workspace {WORKSPACE_NAME} "
         f"({ws_id[:8]}…)\n"
-        f"logins (password {FIXTURE_PASSWORD} for all):\n"
+        "logins (password: the FIXTURE_PASSWORD constant in this"
+        " script; fmtk-up prints it ready to paste):\n"
         "  fmtk-admin@example.com          -> admins group + owner:"
         " everything\n"
         "  fmtk-collaborator@example.com   -> collaborators bucket\n"


### PR DESCRIPTION
Backport of #3391 (fmtk-seed: stop printing the fixture password) to stable/2.0, from issue #3390. Also clears CodeQL alert #230 on this branch's analysis once merged.

Original triage: fix for #230; alerts #213/#209/#208/#207 dismissed as false positives with written justifications.
