### PR TITLE
Fix macOS flake: stop mocking whole stop_background_workers step (#3396)

### DIFF
--- a/src/klangk/klangkd-tests/tests/test_main.py
+++ b/src/klangk/klangkd-tests/tests/test_main.py
@@ -2695,10 +2695,18 @@ class TestMainEntryCallback2910:
             patch.object(util_mod.Util, "check_pid_file", return_value=None),
             patch.object(util_mod.Util, "write_pid_file"),
             patch.object(util_mod.Util, "remove_pid_file") as mock_remove,
-            # Make stop_background_workers blow up — runtime_shutdown
-            # and process_shutdown must still run.
-            patch(
-                "klangk.lifecycle.stop_background_workers",
+            # Make the stop_background_workers step blow up —
+            # runtime_shutdown and process_shutdown must still run.
+            # Fail the *last* worker stop awaited inside the step (the
+            # proxy watchdog's), not the whole step: mocking the whole
+            # step leaves every background-worker task running past
+            # loop close, and on slow (macOS) runners an in-flight
+            # aiosqlite delivery then hits the closed loop — the #1250
+            # hazard, refiled as #3396 — with the thread exception
+            # landing on whichever test runs next on the worker.
+            patch.object(
+                app.state.proxy_watchdog,
+                "stop",
                 new_callable=AsyncMock,
                 side_effect=RuntimeError("sweeper exploded"),
             ),


### PR DESCRIPTION
## Summary

`test_teardown_step_failure_does_not_skip_remaining` exercised the
failing-teardown-step path by replacing the whole `stop_background_workers`
step with a raising `AsyncMock`. The real lifespan startup had already
started ~9 background workers (sweepers, idle monitor, evictor, deciders,
coordinator, sidecar connections) as asyncio tasks, and the mock meant none
of them was ever stopped. At loop close pytest-asyncio cancelled the
still-pending sweeper tasks mid-aiosqlite-op; the aiosqlite worker threads
then delivered their results into the closed loop and died with
`RuntimeError: Event loop is closed`. pytest's `threadexception` plugin
collects that at the *next* test's setup, so the error landed on the
innocent `test_pre_yield_startup_failure_never_yields[init_db-RuntimeError]`
— the #1250 hazard class, flaking only on the slow macOS runner.

The test now fails only the **last** worker stop awaited inside the step
(`proxy_watchdog.stop`) instead of the whole step:

- the first lifespan teardown step still raises, so `runtime_shutdown` and
  `process_shutdown` still run (the behavior under test), and
- every other worker gets its real `stop()` awaited before the loop closes,
  so no task survives to loop close and the race is gone.

Closes #3396.

## Verification

- Targeted: `pytest src/klangk/klangkd-tests/tests/test_main.py -k "TestMainEntryCallback2910 or TestAppLifecycleAudit or teardown_step_failure"` — 60 passed.
- `test-push` (full klangkd + klangkc suites, `-n auto`) — 8272 passed.
- CI run that failed: https://github.com/mcdonc/klangk/actions/runs/34403584826
