### PR TITLE
Re-enable the skipped Gitea git-auth fmtk e2e scenarios (#3402)

### DIFF
--- a/.github/workflows/fmtk-e2e-core.yml
+++ b/.github/workflows/fmtk-e2e-core.yml
@@ -1,12 +1,12 @@
-name: "E2E: fmtk Frontend Tests"
+name: "E2E: fmtk Frontend Tests (core)"
 
 on:
   schedule:
-    # Daily at 05:23 UTC — deliberately off the 06:00–06:43 UTC cluster
-    # (fuzz-daily, frontend-e2e-cross-browser, the CDK pentests) so this
-    # suite is not queued behind them. Scheduled runs use stock runners:
-    # the `inputs` context is empty on `schedule`, so the `runner` input
-    # below coalesces to ubuntu-latest (#3300).
+    # Daily at 05:23 UTC — off the 06:00–06:43 UTC cluster (fuzz-daily,
+    # frontend-e2e-cross-browser, the CDK pentests) so this suite is not
+    # queued behind them. Scheduled runs use stock runners: the `inputs`
+    # context is empty on `schedule`, so the `runner` input below
+    # coalesces to ubuntu-latest (#3300).
     - cron: "23 5 * * *"
   workflow_dispatch:
     inputs:
@@ -23,6 +23,13 @@ on:
   # fixed, a PR-triggered run could also red any backend PR through the
   # src/klangk/** paths filter (#3266); validate a PR branch by
   # dispatching this workflow on it.
+  #
+  # The fmtk suite is split across three workflows so each run fits the
+  # 60-minute job budget — one stack boot plus a module group each
+  # (#3402): this one covers the app-shell surfaces (login flows, config
+  # swaps, settings, features, harness recovery); the sibling workflows
+  # cover workspaces/terminals/files/sharing and the external-party flows
+  # (network, OIDC, Gitea git-auth).
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
@@ -32,9 +39,7 @@ jobs:
   # fmtk-driven browser e2e (#3232/#3231): boots the fmtk-up scratch stack
   # (headless Chrome under CI — no DISPLAY) and drives the debug frontend
   # through the fmtk CLI. The frontend compiles from source via
-  # `flutter run --debug`; the suites start real workspace containers, so
-  # CI builds the workspace image and the network sidecar (interactive
-  # egress fail-closes without the sidecar) before running them.
+  # `flutter run --debug`; this group starts no workspace containers.
   test-fmtk-e2e:
     runs-on: ${{ inputs.runner == 'nix' && 'nix' || 'ubuntu-latest' }}
     timeout-minutes: 60
@@ -54,14 +59,20 @@ jobs:
       - uses: ./.github/actions/e2e-suite
         with:
           run: "true"
-          suite: test-fmtk-e2e
-          suite-name: fmtk
+          suite: >-
+            test-fmtk-e2e
+            src/frontend/e2e-tests/fmtk/test_smoke.py
+            src/frontend/e2e-tests/fmtk/test_harness_recovery.py
+            src/frontend/e2e-tests/fmtk/test_features.py
+            src/frontend/e2e-tests/fmtk/test_user_settings.py
+            src/frontend/e2e-tests/fmtk/test_settings.py
+          suite-name: fmtk-core
 
       - name: Upload harness logs
         if: always()
         uses: actions/upload-artifact@v7
         with:
-          name: fmtk-e2e-logs
+          name: fmtk-e2e-core-logs
           retention-days: 7
           path: |
             .devenv/state/fmtk/klangkd.log

--- a/.github/workflows/fmtk-e2e-flows.yml
+++ b/.github/workflows/fmtk-e2e-flows.yml
@@ -1,6 +1,14 @@
 name: "E2E: fmtk Frontend Tests (flows)"
 
 on:
+  # TEMPORARY (#3402): a workflow_dispatch target must be registered
+  # from the default branch, and this file is not on main until the PR
+  # merges — this pull_request trigger runs the flows group on THIS PR
+  # only (a PR event reads the workflow file from the PR's merge ref).
+  # REMOVE BEFORE MERGE: the schedule + dispatch below take over on
+  # main, and the suite is deliberately not PR-triggered (#3300).
+  pull_request:
+    branches: [main]
   schedule:
     # Daily at 05:39 UTC — off the 06:00–06:43 UTC cluster, staggered
     # behind the fmtk core and workspaces groups so the three sibling

--- a/.github/workflows/fmtk-e2e-flows.yml
+++ b/.github/workflows/fmtk-e2e-flows.yml
@@ -1,14 +1,6 @@
 name: "E2E: fmtk Frontend Tests (flows)"
 
 on:
-  # TEMPORARY (#3402): a workflow_dispatch target must be registered
-  # from the default branch, and this file is not on main until the PR
-  # merges — this pull_request trigger runs the flows group on THIS PR
-  # only (a PR event reads the workflow file from the PR's merge ref).
-  # REMOVE BEFORE MERGE: the schedule + dispatch below take over on
-  # main, and the suite is deliberately not PR-triggered (#3300).
-  pull_request:
-    branches: [main]
   schedule:
     # Daily at 05:39 UTC — off the 06:00–06:43 UTC cluster, staggered
     # behind the fmtk core and workspaces groups so the three sibling

--- a/.github/workflows/fmtk-e2e-flows.yml
+++ b/.github/workflows/fmtk-e2e-flows.yml
@@ -1,0 +1,66 @@
+name: "E2E: fmtk Frontend Tests (flows)"
+
+on:
+  schedule:
+    # Daily at 05:39 UTC — off the 06:00–06:43 UTC cluster, staggered
+    # behind the fmtk core and workspaces groups so the three sibling
+    # workflows do not stampede the queue. Scheduled runs use stock
+    # runners (#3300).
+    - cron: "39 5 * * *"
+  workflow_dispatch:
+    inputs:
+      runner:
+        description: "Runner kind: stock (ubuntu-latest) or the self-hosted nix VM"
+        type: choice
+        options: [stock, nix]
+        default: stock
+  # No pull_request/push triggers and no path gating (#3300) — the daily
+  # schedule carries the regression signal; validate a PR branch by
+  # dispatching this workflow on it. Suite split rationale: #3402.
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  # fmtk-driven browser e2e (#3232/#3231) — the external-party flow group:
+  # admin/user management, auth flows, network egress, the OIDC SSO chain
+  # (in-process fake IdP), and the Gitea git-credential browser flow
+  # (#3385 — boots its own real Gitea beside the stack). CI builds the
+  # workspace image and the network sidecar (the git-auth scenarios start
+  # a real workspace container) before running them.
+  test-fmtk-e2e:
+    runs-on: ${{ inputs.runner == 'nix' && 'nix' || 'ubuntu-latest' }}
+    timeout-minutes: 60
+    env:
+      FMTK_E2E_FRESH: "1"
+    steps:
+      - uses: actions/checkout@v7
+
+      # Stock runners only (see backend-e2e-tests.yml).
+      - uses: ./.github/actions/devenv-setup
+        if: inputs.runner != 'nix'
+
+      - uses: ./.github/actions/e2e-suite
+        with:
+          run: "true"
+          suite: >-
+            test-fmtk-e2e
+            src/frontend/e2e-tests/fmtk/test_admin.py
+            src/frontend/e2e-tests/fmtk/test_auth.py
+            src/frontend/e2e-tests/fmtk/test_network.py
+            src/frontend/e2e-tests/fmtk/test_oidc.py
+            src/frontend/e2e-tests/fmtk/test_gitea_git_auth.py
+          suite-name: fmtk-flows
+
+      - name: Upload harness logs
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: fmtk-e2e-flows-logs
+          retention-days: 7
+          path: |
+            .devenv/state/fmtk/klangkd.log
+            .devenv/state/fmtk/caddy.log
+            .devenv/state/fmtk/flutter-e2e.log
+            .devenv/state/fmtk/gitea.log

--- a/.github/workflows/fmtk-e2e-workspaces.yml
+++ b/.github/workflows/fmtk-e2e-workspaces.yml
@@ -1,0 +1,62 @@
+name: "E2E: fmtk Frontend Tests (workspaces)"
+
+on:
+  schedule:
+    # Daily at 05:31 UTC — off the 06:00–06:43 UTC cluster, staggered
+    # behind the fmtk core group so the three sibling workflows do not
+    # stampede the queue. Scheduled runs use stock runners (#3300).
+    - cron: "31 5 * * *"
+  workflow_dispatch:
+    inputs:
+      runner:
+        description: "Runner kind: stock (ubuntu-latest) or the self-hosted nix VM"
+        type: choice
+        options: [stock, nix]
+        default: stock
+  # No pull_request/push triggers and no path gating (#3300) — the daily
+  # schedule carries the regression signal; validate a PR branch by
+  # dispatching this workflow on it. Suite split rationale: #3402.
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  # fmtk-driven browser e2e (#3232/#3231) — the workspace-container group:
+  # files, terminals, sharing, and the workspace lifecycle itself (start,
+  # stop, import, idle auto-stop). CI builds the workspace image and the
+  # network sidecar (interactive egress fail-closes without the sidecar)
+  # before running them.
+  test-fmtk-e2e:
+    runs-on: ${{ inputs.runner == 'nix' && 'nix' || 'ubuntu-latest' }}
+    timeout-minutes: 60
+    env:
+      FMTK_E2E_FRESH: "1"
+    steps:
+      - uses: actions/checkout@v7
+
+      # Stock runners only (see backend-e2e-tests.yml).
+      - uses: ./.github/actions/devenv-setup
+        if: inputs.runner != 'nix'
+
+      - uses: ./.github/actions/e2e-suite
+        with:
+          run: "true"
+          suite: >-
+            test-fmtk-e2e
+            src/frontend/e2e-tests/fmtk/test_files.py
+            src/frontend/e2e-tests/fmtk/test_terminals.py
+            src/frontend/e2e-tests/fmtk/test_sharing.py
+            src/frontend/e2e-tests/fmtk/test_workspaces.py
+          suite-name: fmtk-workspaces
+
+      - name: Upload harness logs
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: fmtk-e2e-workspaces-logs
+          retention-days: 7
+          path: |
+            .devenv/state/fmtk/klangkd.log
+            .devenv/state/fmtk/caddy.log
+            .devenv/state/fmtk/flutter-e2e.log

--- a/devenv.nix
+++ b/devenv.nix
@@ -760,9 +760,19 @@ in
   # fmtk CLI, and swaps server config via SIGHUP/restart. The first run in
   # a cold worktree pays the flutter debug compile; the backend + proxy are
   # kept across runs (fmtk-down stops them). FMTK_E2E_FRESH=1 wipes first.
+  # Positional args (test paths / -k selectors) replace the default whole-
+  # directory run — the CI workflows split the modules across parallel
+  # stacks so each run fits the job timeout (#3402).
   scripts.test-fmtk-e2e.exec = ''
     cd $DEVENV_ROOT
-    exec ${venvPython} -m pytest src/frontend/e2e-tests/fmtk -v --no-cov "$@"
+    # Bare invocation runs the whole directory; explicit paths replace it
+    # (the CI module groups); bare flags (-k, --collect-only) keep the
+    # default directory — falling through to the repo-root testpaths would
+    # silently run the backend suites instead.
+    if [ $# -eq 0 ] || [ "''${1#-}" != "$1" ]; then
+      set -- src/frontend/e2e-tests/fmtk "$@"
+    fi
+    exec ${venvPython} -m pytest "$@" -v --no-cov
   '';
 
   scripts.serve-docs.exec = ''

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -2645,6 +2645,14 @@ git-credential` (#1700).** `pig-latin` removed; `word-count` dormant.
 
 ### Fixed
 
+- **Cancel in a git authorization dialog now fails the git operation
+  (#3402).** Cancelling the workspace's git-authorization dialog (or
+  denying the app on the provider's approval page) during a Gitea
+  browser-flow clone exits the credential helper with an error, so git
+  tries its next configured helper and otherwise reports a fatal
+  authentication failure — the documented contract. Previously the
+  helper re-prompted with the manual token dialog, leaving the clone
+  waiting on a dialog nobody asked for.
 - **SSO login completes under an every-visit login banner
   (#3371).** With `login_banner_every_visit` on, the browser's
   return from the identity provider carried a one-time login code

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -2645,6 +2645,14 @@ git-credential` (#1700).** `pig-latin` removed; `word-count` dormant.
 
 ### Fixed
 
+- **Workspace page no longer throws during teardown under a live config
+  reload (#3402).** A `workspacesChanged` push arriving while the
+  workspace page was deactivating — a SIGHUP reload resetting the
+  workspace socket just as the page is navigated away — ran the
+  classification-marking re-resolve on the deactivated element and
+  surfaced as an uncaught "deactivated widget" error in the browser
+  console. The listener now returns early once the page is no longer
+  mounted.
 - **Cancel in a git authorization dialog now fails the git operation
   (#3402).** Cancelling the workspace's git-authorization dialog (or
   denying the app on the provider's approval page) during a Gitea

--- a/docs/gitea.md
+++ b/docs/gitea.md
@@ -113,8 +113,9 @@ expires (Gitea's default access-token lifetime is one hour), so the
 authorization window appears once per tab session. The cache lives in
 the tab's memory: closing or reloading the tab clears it, and the next
 clone opens the authorization window again. Cancelling the dialog, or
-denying the application on Gitea's approval page, falls back to the
-manual token dialog.
+denying the application on Gitea's approval page, fails the git
+operation: git tries any other configured credential helper, then
+reports a fatal authentication error.
 
 ## What happens under the hood
 

--- a/features/git-credential/tools/git-credential-klangk
+++ b/features/git-credential/tools/git-credential-klangk
@@ -641,7 +641,7 @@ def _handle_auth_code_flow(cred, browser_id, provider):
     """Run the browser authorization-code flow (#3385): open the authorize
     popup through the bridge, receive the code from the callback page,
     exchange it container-side. Returns (username, password,
-    token-response) or None."""
+    token-response) or None; exits 1 on a user cancellation."""
     verifier, challenge = make_pkce_pair()
     state = secrets.token_urlsafe(32)
     url = authorize_url(provider, challenge, state)
@@ -659,10 +659,19 @@ def _handle_auth_code_flow(cred, browser_id, provider):
 
 
 def _finish_auth_code_flow(cred, browser_id, provider, verifier, state, resp):
-    """Validate the browser's answer and exchange the code."""
+    """Validate the browser's answer and exchange the code.
+
+    A user cancellation exits 1 from here (the documented contract:
+    git tries its next helper or fails — GIT_TERMINAL_PROMPT=0 makes
+    the failure immediate). The PAT dialog is NOT shown after the user
+    declined the authorization: re-prompting a "no" with a different
+    credential form strands the clone on a dialog nobody asked for
+    (#3385 follow-up)."""
     resp = _unwrap_bridge_response(resp)
     if resp.get("error"):
         _debug(f"authorization flow: {resp['error']}")
+        if resp["error"] == "cancelled":
+            sys.exit(1)
         return None
     if resp.get("state") != state:
         _debug("authorization flow: state mismatch, discarding")

--- a/scripts/tests/test_fmtk_harness.py
+++ b/scripts/tests/test_fmtk_harness.py
@@ -531,19 +531,47 @@ def assert_suite_files_present(suite_dir: Path) -> None:
 
 def test_e2e_suite_wiring():
     """The fmtk-driven e2e suite (#3232): devenv script, library, tests,
-    and CI workflow must all exist together."""
+    and the CI workflow split must all exist together."""
     nix = _DEVENV_NIX.read_text()
     assert "scripts.test-fmtk-e2e.exec" in nix, (
         "devenv.nix must define the test-fmtk-e2e script"
     )
     assert_suite_files_present(_REPO_ROOT / "src/frontend/e2e-tests/fmtk")
-    workflow = _REPO_ROOT / ".github/workflows/fmtk-e2e-tests.yml"
-    assert workflow.is_file(), "the fmtk e2e CI workflow is missing"
-    assert "test-fmtk-e2e" in workflow.read_text()
+    workflows = _fmtk_workflow_texts()
     # the suites start real containers (workspace + network sidecar, the
     # interactive-egress gate fail-closes without the sidecar image) — CI
     # must build both images, not run image-less smoke suites only
-    wf = workflow.read_text()
-    assert 'build-tasks: ""' not in wf, (
-        "the fmtk e2e workflow must build the workspace + sidecar images"
-    )
+    for name, text in workflows.items():
+        assert "test-fmtk-e2e" in text, f"{name} must run the suite script"
+        assert 'build-tasks: ""' not in text, (
+            f"{name} must build the workspace + sidecar images"
+        )
+
+
+def test_every_fmtk_module_rides_exactly_one_workflow():
+    """The suite is split across the workflows so each run fits the job
+    timeout (#3402) — a module no workflow lists would silently drop out
+    of CI, and one listed twice would double its runtime."""
+    workflows = _fmtk_workflow_texts()
+    listed = "\n".join(workflows.values())
+    suite_dir = _REPO_ROOT / "src/frontend/e2e-tests/fmtk"
+    modules = sorted(path.name for path in suite_dir.glob("test_*.py"))
+    for module in modules:
+        count = listed.count(f"fmtk/{module}")
+        assert count == 1, (
+            f"{module} must ride exactly one fmtk workflow (found {count})"
+        )
+
+
+def _fmtk_workflow_texts() -> dict[str, str]:
+    """The three fmtk e2e workflow files (#3402 split), name -> text."""
+    texts: dict[str, str] = {}
+    for name in (
+        "fmtk-e2e-core.yml",
+        "fmtk-e2e-workspaces.yml",
+        "fmtk-e2e-flows.yml",
+    ):
+        path = _REPO_ROOT / ".github/workflows" / name
+        assert path.is_file(), f"the fmtk e2e CI workflow {name} is missing"
+        texts[name] = path.read_text()
+    return texts

--- a/src/frontend/e2e-tests/fmtk/fmtkharness.py
+++ b/src/frontend/e2e-tests/fmtk/fmtkharness.py
@@ -683,9 +683,11 @@ def cdp_tabs() -> list[dict]:
 
 
 def cdp_app_tab() -> dict:
-    """The app tab — the one non-internal page Chrome has. When the SSO
-    chain is mid-flight the same tab sits at the backend or IdP origin;
-    it stays "the app tab" the whole way (#3242)."""
+    """The first non-internal page tab (Chrome lists targets newest-first,
+    so this is the most recently opened one). Correct for the single-tab
+    flows — the SSO chains navigate the tab in place; the git-auth
+    popup era needs identity-based selection instead
+    (:func:`cdp_main_app_tab`)."""
     tabs = cdp_tabs()
     if not tabs:
         raise FmtkError("no page tab in the driven chrome")
@@ -746,18 +748,40 @@ def cdp_close_tab(tab: dict) -> None:
         pass  # already gone
 
 
-def cdp_close_extra_tabs() -> None:
-    """Close every driven-Chrome page tab except the first (the app
-    tab — Chrome lists targets in creation order, and the app tab
-    predates any popup the suites opened).
+def cdp_main_app_tab() -> dict | None:
+    """The tab the fmtk eval pipe should drive once a multi-tab flow is
+    over: the one on the app origin that is not the git-auth popup.
+
+    Position cannot identify it — Chrome's ``/json/list`` ordering is
+    newest-first, so ``tabs[0]`` is the popup the moment one exists —
+    so the URL must: the app tab sits on the proxy origin at a normal
+    route, while the popup either sits on the provider's origin or
+    carries the flow's ``?code=`` landing / ``/git-auth-callback``
+    route. None when no tab qualifies (the caller must not close
+    anything then — closing the last tab takes the browser down)."""
+    for tab in cdp_tabs():
+        url = tab["url"]
+        if (
+            url.startswith(proxy_origin())
+            and "/git-auth-callback" not in url
+            and "?code=" not in url
+        ):
+            return tab
+    return None
+
+
+def cdp_close_extra_tabs(keep: dict) -> None:
+    """Close every driven-Chrome page tab except ``keep`` (by target
+    id — order-independent).
 
     The git-auth authorize popup is a second app instance at the proxy
     origin (#3385); one still open when the eval pipe is restored (a
     failed flow) keeps a second Flutter isolate registered, and every
     later fmtk exec then races the two for "the" isolate. Closing down
-    to exactly one app tab makes the post-flow state deterministic."""
-    for tab in cdp_tabs()[1:]:
-        cdp_close_tab(tab)
+    to exactly the kept tab makes the post-flow state deterministic."""
+    for tab in cdp_tabs():
+        if tab["id"] != keep["id"]:
+            cdp_close_tab(tab)
 
 
 def cdp_mouse_click(tab: dict, x: float, y: float) -> None:
@@ -1694,17 +1718,22 @@ class FmtkClient:
         different signature than the isolate wedge, so exec()'s
         recovery does not fire) while the app tab itself keeps
         working. The cure, in order: close every tab except the app
-        tab, full-page load the app tab back onto the app origin (a
-        page load re-attaches the VM service, #3242), and poll the
-        toolkit until it answers — a fixed sleep cannot cover a slow
-        CI boot. A load that has not re-attached by the deadline falls
-        back to a fresh flutter run (the permanent-wedge cure,
+        tab (identified by URL — Chrome lists targets newest-first, so
+        position would pick the popup), full-page load the app tab
+        back onto the app origin (a page load re-attaches the VM
+        service, #3242), and poll the toolkit until it answers — a
+        fixed sleep cannot cover a slow CI boot. A load that has not
+        re-attached by the deadline falls back to a fresh flutter run
+        (the permanent-wedge cure,
         :meth:`FlutterRun.recover_from_wedge`), which waits for the
-        toolkit itself.
+        toolkit itself. A Chrome that died outright also lands in the
+        fallback: the whole CDP preamble is best-effort.
         """
         self.flutter.isolate_gone_since = None
-        cdp_close_extra_tabs()
         try:
+            keep = cdp_main_app_tab()
+            if keep is not None:
+                cdp_close_extra_tabs(keep)
             cdp_eval(f"location.href='{proxy_origin()}/'")
         except (FmtkError, OSError, ValueError):
             pass  # chrome/tab gone — the restart below boots a fresh one

--- a/src/frontend/e2e-tests/fmtk/fmtkharness.py
+++ b/src/frontend/e2e-tests/fmtk/fmtkharness.py
@@ -889,13 +889,29 @@ def ensure_feature_manifest() -> None:
         # klangk_features at the stub — the app compiles with no
         # features and the bridge answers "Unknown action" for every
         # feature op until pub get rewrites it.
-        subprocess.run(
+        pub_get = subprocess.run(
             ["flutter", "pub", "get"],
             cwd=REPO_ROOT / "src" / "frontend",
-            check=True,
             capture_output=True,
+            text=True,
             timeout=600,
+            # Same guard as scripts/flutterbuildweb.sh: a transitive git
+            # dependency (ag-ui, via the pinned lock) carries git-LFS
+            # objects — a test fixture image its own e2e apps use, never
+            # needed to compile the Dart package — and unauthenticated
+            # CI cannot fetch it (#1691-class). Pointer files suffice.
+            env={**os.environ, "GIT_LFS_SKIP_SMUDGE": "1"},
         )
+        if pub_get.returncode != 0:
+            # check=True would raise a bare CalledProcessError that
+            # discards the captured output — the only place the cause
+            # lives on a headless CI runner (a 69 here has meant
+            # everything from a pub.dev outage to an unwritable pub
+            # cache; the stderr names which).
+            raise FmtkError(
+                f"flutter pub get failed (rc={pub_get.returncode}): "
+                f"{(pub_get.stdout + pub_get.stderr)[-2000:]}"
+            )
     emitted = REPO_ROOT / "src" / "frontend" / "build" / "web" / "features.json"
     if not emitted.is_file():
         subprocess.run(

--- a/src/frontend/e2e-tests/fmtk/fmtkharness.py
+++ b/src/frontend/e2e-tests/fmtk/fmtkharness.py
@@ -732,6 +732,34 @@ def cdp_eval_tab(tab: dict, js: str) -> object:
     return result.get("value")
 
 
+def cdp_close_tab(tab: dict) -> None:
+    """Close one page tab over the CDP HTTP endpoint (best effort —
+    a tab that closed itself between the listing and the close is
+    fine)."""
+    try:
+        req = urllib.request.Request(
+            f"http://127.0.0.1:{cdp_port()}/json/close/{tab['id']}",
+            method="PUT",
+        )
+        urllib.request.urlopen(req, timeout=10)
+    except OSError:
+        pass  # already gone
+
+
+def cdp_close_extra_tabs() -> None:
+    """Close every driven-Chrome page tab except the first (the app
+    tab — Chrome lists targets in creation order, and the app tab
+    predates any popup the suites opened).
+
+    The git-auth authorize popup is a second app instance at the proxy
+    origin (#3385); one still open when the eval pipe is restored (a
+    failed flow) keeps a second Flutter isolate registered, and every
+    later fmtk exec then races the two for "the" isolate. Closing down
+    to exactly one app tab makes the post-flow state deterministic."""
+    for tab in cdp_tabs()[1:]:
+        cdp_close_tab(tab)
+
+
 def cdp_mouse_click(tab: dict, x: float, y: float) -> None:
     """A trusted mouse click at page coordinates in a tab.
 
@@ -1655,6 +1683,58 @@ class FmtkClient:
         load."""
         if not self.app_tab_at_origin():
             cdp_eval(f"location.href='{proxy_origin()}{path}'")
+
+    def restore_eval_pipe(self, timeout: float = 240) -> None:
+        """Deterministically re-attach the fmtk eval pipe (#3402).
+
+        The git-auth authorize popup boots a second app instance at
+        the proxy origin; its registration and teardown break the
+        flutter tool's dwds connection to the app tab — every later
+        fmtk exec then fails with "printed no JSON envelope" (a
+        different signature than the isolate wedge, so exec()'s
+        recovery does not fire) while the app tab itself keeps
+        working. The cure, in order: close every tab except the app
+        tab, full-page load the app tab back onto the app origin (a
+        page load re-attaches the VM service, #3242), and poll the
+        toolkit until it answers — a fixed sleep cannot cover a slow
+        CI boot. A load that has not re-attached by the deadline falls
+        back to a fresh flutter run (the permanent-wedge cure,
+        :meth:`FlutterRun.recover_from_wedge`), which waits for the
+        toolkit itself.
+        """
+        self.flutter.isolate_gone_since = None
+        cdp_close_extra_tabs()
+        try:
+            cdp_eval(f"location.href='{proxy_origin()}/'")
+        except (FmtkError, OSError, ValueError):
+            pass  # chrome/tab gone — the restart below boots a fresh one
+        if self.pipe_answers(timeout):
+            return
+        print(
+            "[fmtk] the eval pipe did not re-attach after the page load "
+            "— restarting the flutter run",
+            flush=True,
+        )
+        self.flutter.recover_from_wedge()
+
+    def pipe_answers(self, timeout: float) -> bool:
+        """Whether a fmtk exec answers within ``timeout``.
+
+        The same boot-wait shape as :meth:`FlutterRun.wait_toolkit`,
+        against the live client: ``get_app_errors`` only answers once
+        dwds has attached the app isolate AND the toolkit bootstrap
+        registered — success proves the whole eval pipe is back."""
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            try:
+                # raw_exec, not exec: this poll IS the restore wait —
+                # exec()'s wedge recovery would restart the launch it
+                # waits for.
+                self.raw_exec("get_app_errors", {"count": 1})
+                return True
+            except (FmtkError, subprocess.TimeoutExpired):
+                time.sleep(2)
+        return False
 
     def parse_envelope(self, stdout: str, name: str, stderr: str) -> dict:
         try:

--- a/src/frontend/e2e-tests/fmtk/test_gitea_git_auth.py
+++ b/src/frontend/e2e-tests/fmtk/test_gitea_git_auth.py
@@ -5,16 +5,25 @@ The whole chain runs on real surfaces: a private repo clone in the
 workspace terminal invokes ``git-credential-klangk`` (baked into the
 image), which relays ``auth_flow_start`` over the browser bridge; the
 feature's authorization dialog appears in the app tab; the popup is
-opened by a REAL click on the dialog's "Reopen" link (CDP Input events
-pass Chrome's popup gesture gate — a bare ``window.open`` evaluate
-would be blocked; the http authorize URL is never auto-opened, the
-feature auto-opens https only); Gitea's login + authorize forms are
-driven in the popup tab over CDP; Gitea redirects the popup to the
-proxy origin root with ``?code&state``, the SPA boots to
+opened from the app tab with ``window.open`` at the pending authorize
+URL read from the feature state (the driven Chrome runs with popup
+blocking disabled — the dialog's "Reopen" link is a RichText span,
+not a semantic tappable, and a synthetic CDP pointer click at its
+bounds corrupts the widget build scope); Gitea's login + authorize
+forms are driven in the popup tab over CDP; Gitea redirects the popup
+to the proxy origin root with ``?code&state``, the SPA boots to
 ``/git-auth-callback`` and posts the code to the opener; the helper
 exchanges the code CONTAINER-side (``host.containers.internal`` — the
 same host-gateway pattern the bridge URL itself uses) and git finishes
 the clone.
+
+The popup's app boot breaks the flutter tool's dwds eval pipe to the
+app tab for the rest of the scenario (every fmtk exec fails with no
+JSON envelope), so the popup legs drive over CDP only and the
+completion asserts read host-side podman-exec sentinels;
+``app.restore_eval_pipe()`` re-attaches the pipe deterministically
+before the post-test machinery (the conftest app-errors drain, the
+next scenario) needs it (#3402).
 
 The cancel leg runs the same relay up to the dialog and cancels from
 the app side: git fails with terminal prompts disabled, proving the
@@ -46,6 +55,7 @@ from fmtkharness import (
     FIXTURE_PASSWORD,
     FmtkError,
     Gitea,
+    cdp_close_tab,
     cdp_eval,
     cdp_eval_tab,
     cdp_tabs,
@@ -312,22 +322,6 @@ def wait_clone_sentinel(gitea, timeout: float = 300) -> None:
     raise AssertionError("the clone never completed (no sentinel file)")
 
 
-def restore_eval_pipe(app) -> None:
-    """Reload the app tab so dwds re-attaches.
-
-    The popup's app boot breaks the flutter tool's debug connection to
-    the app tab (every later fmtk exec fails with no JSON envelope).
-    A full page load re-attaches the VM service (#3242) — the post-test
-    app-errors check (conftest) and the next scenario need it. The
-    workspace page unmounts on reload; the fixture's API delete owns
-    the workspace, so nothing is lost."""
-    try:
-        cdp_eval("location.reload()")
-    except FmtkError:
-        return  # tab already gone; the next login boots fresh anyway
-    time.sleep(20)  # the dev-mode app boot + dwds re-attach
-
-
 def trace_tabs(label: str) -> None:
     try:
         from fmtkharness import cdp_tabs
@@ -485,9 +479,7 @@ def retire_popup_after_landing(popup: dict, timeout: float = 120) -> None:
     app (the page posts in initState); a short grace covers the post,
     then the tab is closed so the second isolate goes away before any
     later eval."""
-    import urllib.request
-
-    from fmtkharness import PROXY_PORT, cdp_port
+    from fmtkharness import PROXY_PORT
 
     origin = f"http://127.0.0.1:{PROXY_PORT}"
     deadline = time.monotonic() + timeout
@@ -502,14 +494,7 @@ def retire_popup_after_landing(popup: dict, timeout: float = 120) -> None:
         time.sleep(1)
     if landed:
         time.sleep(5)  # the callback page posts to the opener in initState
-    try:
-        req = urllib.request.Request(
-            f"http://127.0.0.1:{cdp_port()}/json/close/{popup['id']}",
-            method="PUT",
-        )
-        urllib.request.urlopen(req, timeout=10)
-    except OSError:
-        pass  # already gone
+    cdp_close_tab(popup)
 
 
 def cdp_tabs_url(tab: dict) -> str:
@@ -598,12 +583,6 @@ def _proxy_port() -> str:
 # --- scenarios ---------------------------------------------------------
 
 
-@pytest.mark.skip(
-    reason="the full flow passes live (clone + popup + grant + exchange "
-    "+ cache reuse, witnessed twice) but the run is not yet CI-stable: "
-    "the authorize popup boots a second app that breaks the dwds eval "
-    "pipe mid-run on this harness (#3385 follow-up)"
-)
 def test_browser_flow_clones_private_repo_and_reuses_cache(
     harness, app, gitea, provider_workspace
 ):
@@ -642,50 +621,52 @@ def test_browser_flow_clones_private_repo_and_reuses_cache(
     trace_tabs("dialog-up")
 
     # open the popup (http authorize URL is never auto-opened — the
-    # https gate) and drive Gitea's login + grant forms in it
-    open_authorize_popup(app, pending_authorize_url(app))
-    trace_tabs("popup-opened")
-    popup = wait_gitea_popup(gitea)
-    gitea_login_and_authorize(gitea, popup)
-    trace_tabs("granted")
-    retire_popup_after_landing(popup)
-    trace_tabs("retired")
+    # https gate) and drive Gitea's login + grant forms in it; from
+    # here on the eval pipe is at risk, so the flow runs under a
+    # finally that restores it — even a failed leg must leave the
+    # post-test machinery (app-errors drain, the next scenario) a
+    # working pipe (#3402)
+    authorize_url = pending_authorize_url(app)
+    try:
+        open_authorize_popup(app, authorize_url)
+        trace_tabs("popup-opened")
+        popup = wait_gitea_popup(gitea)
+        gitea_login_and_authorize(gitea, popup)
+        trace_tabs("granted")
+        retire_popup_after_landing(popup)
+        trace_tabs("retired")
 
-    # the popup lands on the proxy origin, boots to the callback page,
-    # delivers the code to the opener and closes itself; the helper
-    # exchanges container-side and git finishes the clone — all without
-    # the (now dead) eval pipe. The sentinel file proves the clone.
-    wait_clone_sentinel(gitea)
-    trace_tabs("clone-ok")
+        # the popup lands on the proxy origin, boots to the callback page,
+        # delivers the code to the opener and closes itself; the helper
+        # exchanges container-side and git finishes the clone — all without
+        # the (now dead) eval pipe. The sentinel file proves the clone.
+        wait_clone_sentinel(gitea)
+        trace_tabs("clone-ok")
 
-    # the cached credential serves the next credentialed operation with
-    # no new browser flow: a fresh git from the host side shares the
-    # pane's browser id (tmux global env), so its credential fill hits
-    # the app tab's cache. A cache miss would hang the helper waiting
-    # for a fresh authorization — the timeout turns that into rc!=0.
-    probe = subprocess.run(
-        _podman_exec(
-            gitea,
-            [
-                "bash",
-                "-lc",
-                f"timeout 30 git -C {CLONE_DIR} ls-remote origin"
-                " >/dev/null; echo rc=$?",
-            ],
-        ),
-        capture_output=True,
-        text=True,
-        timeout=60,
-    )
-    assert "rc=0" in probe.stdout, probe.stdout + probe.stderr
-    restore_eval_pipe(app)
+        # the cached credential serves the next credentialed operation with
+        # no new browser flow: a fresh git from the host side shares the
+        # pane's browser id (tmux global env), so its credential fill hits
+        # the app tab's cache. A cache miss would hang the helper waiting
+        # for a fresh authorization — the timeout turns that into rc!=0.
+        probe = subprocess.run(
+            _podman_exec(
+                gitea,
+                [
+                    "bash",
+                    "-lc",
+                    f"timeout 30 git -C {CLONE_DIR} ls-remote origin"
+                    " >/dev/null; echo rc=$?",
+                ],
+            ),
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+        assert "rc=0" in probe.stdout, probe.stdout + probe.stderr
+    finally:
+        app.restore_eval_pipe()
 
 
-@pytest.mark.skip(
-    reason="same harness instability as the happy path — the scenario "
-    "itself (dialog -> Cancel -> git fatal) never touches the popup; "
-    "re-enable with the happy path (#3385 follow-up)"
-)
 def test_cancel_in_the_dialog_fails_the_clone(harness, app, provider_workspace):
     login_admin(harness, app)
     open_scratch_workspace(app, WS_NAME)

--- a/src/frontend/e2e-tests/fmtk/test_gitea_git_auth.py
+++ b/src/frontend/e2e-tests/fmtk/test_gitea_git_auth.py
@@ -680,6 +680,9 @@ def test_cancel_in_the_dialog_fails_the_clone(harness, app, provider_workspace):
     )
     app.wait_for_text("Sign in to 127.0.0.1", 60000)
     app.tap_button_exact("Cancel")
+    # the dialog unwound on the app side (the buffer assert below
+    # proves the container side: git's fatal + the marker echo)
+    app.wait_gone("Waiting for authorization...", 15)
 
     buffer = buffer_until(
         app, lambda b: re.search(f"^{CANCEL_OK}$", b, re.M), timeout=90

--- a/src/frontend/lib/workspace/workspace_page.dart
+++ b/src/frontend/lib/workspace/workspace_page.dart
@@ -173,9 +173,17 @@ class _WorkspacePageState extends State<WorkspacePage> {
     // #2768: re-resolve the effective marking when the workspace row
     // changes (the server notifies on a classification_banner edit, so
     // the banner updates live after saving in the settings panel).
+    // The mounted guard is load-bearing: the event can arrive while
+    // this page is deactivating (a SIGHUP-driven ws reset pushes it as
+    // the router swaps pages), and _fetchWorkspaceName reads the
+    // element's ancestors synchronously — an unguarded call there is
+    // an uncaught "deactivated widget" error (#3402 CI run).
     _markingSub = context.read<WsClient>().workspacesChanged.listen(
-          (_) => _fetchWorkspaceName(),
-        );
+      (_) {
+        if (!mounted) return;
+        _fetchWorkspaceName();
+      },
+    );
     WidgetsBinding.instance.addPostFrameCallback((_) => _connectToWorkspace());
   }
 

--- a/src/klangk/klangkd-tests/tests/test_git_credential.py
+++ b/src/klangk/klangkd-tests/tests/test_git_credential.py
@@ -2009,19 +2009,22 @@ class TestAuthorizationCodeFlow:
         # No exchange happened: the mismatched code was discarded.
         assert _BridgeHandler.forms == []
 
-    def test_user_cancel_falls_back_to_pat_dialog(
+    def test_user_cancel_exits_1_without_pat_dialog(
         self, bridge_server, fake_browser_id
     ):
         base = self._setup(bridge_server)
         _BridgeHandler.op_handlers = {
             "auth_flow_start": lambda p: {"error": "cancelled"},
         }
-        _BridgeHandler.op_bodies["get"] = json.dumps(
-            {"username": "u", "password": "p"}
-        ).encode()
         result = self._run(bridge_server, fake_browser_id, base)
-        assert result.returncode == 0
-        assert "username=u" in result.stdout
+        # A declined authorization is a "no", not a prompt for a
+        # different credential form: exit 1 so git fails (or tries its
+        # next helper) instead of hanging on a PAT dialog nobody
+        # dismissed (#3385 follow-up — the cancel e2e leg pins this).
+        assert result.returncode == 1
+        assert result.stdout == ""
+        ops = [r["operation"] for r in _BridgeHandler.requests]
+        assert "get" not in ops
         assert _BridgeHandler.forms == []
 
 


### PR DESCRIPTION
Re-enables the two fmtk e2e scenarios for the Gitea git-credential browser flow that #3401 landed skipped, and fixes the helper behavior the cancel leg exposed (closes #3402).

## The deterministic eval-pipe restore

The authorize popup boots a second app instance at the proxy origin; its registration and teardown break the flutter tool's dwds connection to the app tab. Every later fmtk exec then fails with "printed no JSON envelope" — a different signature than the isolate wedge, so the harness's wedge recovery does not fire. #3401 papered over this with a page reload plus a fixed 20-second sleep.

`FmtkClient.restore_eval_pipe()` now owns the restore:

- close every tab except the app tab — a popup still open keeps a second Flutter isolate registered, and every later fmtk exec then races the two for "the" isolate;
- full-page load the app tab back onto the app origin (a page load re-attaches the VM service);
- poll the toolkit until it answers, with a deadline — a fixed sleep cannot cover a slow CI boot;
- fall back to a fresh flutter run (the permanent-wedge cure) when the reload misses the deadline.

The happy-path scenario runs the popup legs under a `finally` that restores the pipe, so the conftest app-errors drain and the next scenario always receive a working pipe, green or failed.

## The helper fix the cancel leg exposed

`git-credential-klangk` treated a cancelled browser authorization like an unavailable flow and fell through to the PAT (username/password) dialog — leaving the clone hanging on a dialog nobody asked for until the 15-minute bridge timeout. The helper's header already documented the intended contract ("falls through (exit 1) when the bridge is unreachable or the user cancels"); `_finish_auth_code_flow` now delivers it: a `cancelled` answer exits 1, so git tries its next configured helper and otherwise reports the fatal authentication failure (`GIT_TERMINAL_PROMPT=0` makes it immediate). A provider-side denial reaches the helper as the same `cancelled` answer, so both decline paths behave identically.

The pinned unit test (`test_user_cancel_exits_1_without_pat_dialog`), `docs/gitea.md`, and the changelog now state the fail-the-operation behavior.

## The CI dispatches surfaced two boot/app blockers (both fixed here)

- **`flutter pub get` at harness boot now skips the git-LFS smudge** (`GIT_LFS_SKIP_SMUDGE=1`, the same guard `scripts/flutterbuildweb.sh` already carries): the resolve's transitive git dependency (ag-ui) carries LFS objects unauthenticated CI cannot fetch, and `ensure_feature_manifest` (#3401) ran its pub get without the guard — the first post-#3401 CI attempt died at boot with a bare exit 69. The failure now also folds the captured pub output into the raised error instead of discarding it.
- **The workspace page no longer throws "Looking up a deactivated widget's ancestor is unsafe"**: a `workspacesChanged` push (a SIGHUP-driven ws reset) arriving while the page deactivates ran the marking re-resolve's synchronous `context.read` on the dead element. The git-auth module's fixture SIGHUP with the previous module's workspace page still mounted triggered it on CI — the uncaught error then failed both scenarios through the app-errors drain. The listener returns early once unmounted (the page's established listener pattern). Full-suite ordering only: running the module alone (as on a dev machine) never mounts the prior page, which is why local runs stayed green.

## The fmtk CI suite is now three workflows

The single fmtk workflow overran the 60-minute job budget on stock runners (53+ minutes, twice cancelled). The suite is split into three workflows, each one stack boot plus a runtime-balanced module group (measured from CI outcome timestamps): **core** (smoke, harness recovery, features, user/user settings, settings), **workspaces** (files, terminals, sharing, workspaces), and **flows** (admin, auth, network, OIDC, Gitea git-auth) — staggered daily schedules at 05:23/05:31/05:39 UTC, distinct log artifacts. `test-fmtk-e2e` takes positional module paths (a flags-only invocation keeps the default directory, so `-k` debugging cannot silently fall through to the backend testpaths), and the harness contract test pins that every module rides exactly one workflow.

## Verification

- `python -m pytest src/frontend/e2e-tests/fmtk/test_gitea_git_auth.py -v --no-cov` green three consecutive runs (one on a fresh stack, `FMTK_E2E_FRESH=1`) with the workspace image rebuilt from this tree — CI builds the image from the tree each run, so the fixed helper ships automatically.
- Full backend suite: 8272 passed, 100% branch coverage (`klangkd-tests` + `klangkc-tests`, `-n auto`).
- **The flows fmtk workflow ran on this branch on a stock runner (29 minutes end to end, well inside the 60-minute budget): both re-enabled scenarios PASSED** — the full happy-path chain (dialog → popup → Gitea grant → callback → container-side exchange → clone sentinel → cache-reuse probe → deterministic pipe restore) and the cancel leg. The run's 6 failures/3 errors are the same `test_auth`/`test_network` tests that fail identically without this branch and that main's daily fmtk runs have failed with since Sept 7 — pre-existing stock-runner dwds flakiness, out of scope here.

A fresh-eyes adversarial review ran before the PR (attached as the first comment). Its one blocking finding — Chrome's `/json/list` is newest-first, so the restore's close-extra-tabs step would have closed the app tab instead of the popup on failed-flow paths — is addressed in the second commit: the app tab is now identified by URL and closed-for by target id, the CDP preamble is fully best-effort so a dead Chrome reaches the restart fallback, and the cancel scenario asserts the dialog unwinds on the app side before the buffer assert. Its remaining findings were nits (worst-case restore timing, changelog section choice) and explicit verifications of the helper exit placement, the error-value cut, and the mid-flow `finally` semantics.
