### PR TITLE
Stop disposing app-singleton tool plugins on workspace close (#3406)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -2645,6 +2645,16 @@ git-credential` (#1700).** `pig-latin` removed; `word-count` dormant.
 
 ### Fixed
 
+- **Opening a second workspace no longer corrupts the app or strands git
+  authentication (#3406).** Closing a workspace page disposed the app-wide
+  feature plugins, so the next workspace opened in the same session
+  threw "A `<Feature>` was used after being disposed" while building
+  the app bar and left the page unrenderable for the rest of the
+  session; in release builds the git-credential feature's message
+  listener stayed cancelled, so every later browser-based git
+  authorization in the session waited forever. The workspace page now
+  releases only per-workspace feature-tab resources on close; the
+  plugin registry owns the features' lifetime.
 - **Workspace page no longer throws during teardown under a live config
   reload (#3402).** A `workspacesChanged` push arriving while the
   workspace page was deactivating — a SIGHUP reload resetting the

--- a/src/frontend/lib/workspace/workspace_page.dart
+++ b/src/frontend/lib/workspace/workspace_page.dart
@@ -587,15 +587,21 @@ class _WorkspacePageState extends State<WorkspacePage> {
   void dispose() {
     _markingSub?.cancel();
     _consent?.dispose();
-    for (final feature in _features) {
-      feature.dispose();
-    }
-    // Mirror tool plugins: release feature-tab resources on workspace close
-    // (#1975). The registry is a singleton populated once in main(), so this
-    // calls per-tab dispose() — not disposeAll() — to avoid clearing tabs
-    // that the next workspace page (same app session) will reuse. Tab plugins
-    // with real resources must
-    // tolerate being re-registered, same as tool plugins already do.
+    // Tool plugins are app-boot singletons: the registry is populated once
+    // in main() and every workspace page in the session reuses the same
+    // instances. Calling dispose() here would hard-dispose the ChangeNotifier
+    // most features mix in — ChangeNotifier.dispose is terminal, so the next
+    // workspace open throws "A <Feature> was used after being disposed" while
+    // building its app-bar icon, corrupting the widget tree for the rest of
+    // the session (#3406). Tool plugins hold no per-workspace resources; the
+    // registry owns their lifetime.
+    //
+    // Feature tabs do hold per-workspace resources, so they are released on
+    // workspace close (#1975). The tab registry is likewise a singleton, so
+    // this calls per-tab dispose() — not disposeAll() — and the next
+    // workspace page reuses the same instances: a tab plugin with real
+    // resources must tolerate being reused after dispose — re-arm them
+    // lazily in build().
     for (final tab in _featureTabs) {
       tab.dispose();
     }


### PR DESCRIPTION
Fixes #3406.

## What changed

`WorkspacePage.dispose()` no longer calls `dispose()` on the tool plugins it holds. Those plugins are app-boot singletons — `ToolPluginRegistry` is populated once in `main()` and every workspace page in the same app session reuses the same instances. Four of the five shipped features mix in `ChangeNotifier` without overriding `dispose()`, so the call resolved to `ChangeNotifier.dispose()`, which is terminal. Two visible consequences of the old code:

- **Debug builds**: the next workspace open threw `A <Feature> was used after being disposed` while building its app-bar icon, and the follow-on `Duplicate GlobalKeys` / wrong-build-scope failures left the widget tree unrenderable for the rest of the session. This is the #3406 failure class: since #3318 (Sept 7) seeded feature-laden workspaces onto every fmtk module's path, the nightly e2e suites failed every test after the first workspace re-open in a session (environment theories refuted in the issue — identical runner image and flutter pin across the green→red boundary).
- **Release builds**: `GitCredentialFeature.dispose()` cancelled its message subscription, which arms lazily with `??=` and never re-arms — after one workspace close, every later browser-based git authorization in the session waited forever.

The plugin registry owns the features' lifetime; the workspace page keeps releasing per-workspace feature-**tab** resources on close (#1975).

## Verification

- Local repro before the fix: `test_workspaces.py` 8 failed / 3 passed / 8 errors with 8 `used after being disposed` hits in the flutter log.
- After the fix: `test_workspaces.py` **11/11 passed** (6:58), `test_settings.py` + `test_user_settings.py` **11/11 passed** (12:32) — the two deterministic-red module sets from the stock-runner dispatches.
- Frontend unit suite: 1357 passed (`flutter test --coverage`).

## Fresh-eyes review

Approve verdict with no blocking findings; the wording/accuracy fixes it raised (changelog sentence, release-mode framing, tab-lifecycle comment) are folded into the amended commit. One follow-up it flagged: the tab-plugin lifecycle contract (#1975's per-tab dispose vs the singleton registry) deserves its own reconciling issue — nothing implements `WorkspaceTabPlugin` today, so it is latent.
