### PR TITLE
Stop disposing app-singleton tool plugins on workspace close (#3406) (#3408) [backport]

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -34,6 +34,16 @@ operators or integrators to act when upgrading.
 ## \[Unreleased]
 
 ### Fixed
+- **Opening a second workspace no longer corrupts the app or strands git
+  authentication (#3406).** Closing a workspace page disposed the app-wide
+  feature plugins, so the next workspace opened in the same session
+  threw "A `<Feature>` was used after being disposed" while building
+  the app bar and left the page unrenderable for the rest of the
+  session; in release builds the git-credential feature's message
+  listener stayed cancelled, so every later browser-based git
+  authorization in the session waited forever. The workspace page now
+  releases only per-workspace feature-tab resources on close; the
+  plugin registry owns the features' lifetime.
 
 - **Workspace page no longer throws during teardown under a live config
   reload (#3402).** A `workspacesChanged` push arriving while the

--- a/src/frontend/lib/workspace/workspace_page.dart
+++ b/src/frontend/lib/workspace/workspace_page.dart
@@ -587,15 +587,21 @@ class _WorkspacePageState extends State<WorkspacePage> {
   void dispose() {
     _markingSub?.cancel();
     _consent?.dispose();
-    for (final feature in _features) {
-      feature.dispose();
-    }
-    // Mirror tool plugins: release feature-tab resources on workspace close
-    // (#1975). The registry is a singleton populated once in main(), so this
-    // calls per-tab dispose() — not disposeAll() — to avoid clearing tabs
-    // that the next workspace page (same app session) will reuse. Tab plugins
-    // with real resources must
-    // tolerate being re-registered, same as tool plugins already do.
+    // Tool plugins are app-boot singletons: the registry is populated once
+    // in main() and every workspace page in the session reuses the same
+    // instances. Calling dispose() here would hard-dispose the ChangeNotifier
+    // most features mix in — ChangeNotifier.dispose is terminal, so the next
+    // workspace open throws "A <Feature> was used after being disposed" while
+    // building its app-bar icon, corrupting the widget tree for the rest of
+    // the session (#3406). Tool plugins hold no per-workspace resources; the
+    // registry owns their lifetime.
+    //
+    // Feature tabs do hold per-workspace resources, so they are released on
+    // workspace close (#1975). The tab registry is likewise a singleton, so
+    // this calls per-tab dispose() — not disposeAll() — and the next
+    // workspace page reuses the same instances: a tab plugin with real
+    // resources must tolerate being reused after dispose — re-arm them
+    // lazily in build().
     for (final tab in _featureTabs) {
       tab.dispose();
     }


### PR DESCRIPTION
Backport of #3408 to `stable/2.0` (squash commit 208da6909, changelog entry moved into this branch's `[Unreleased]` section).

Stops `WorkspacePage.dispose()` from disposing the app-boot singleton tool plugins: the next workspace open in the same session threw "A <Feature> was used after being disposed" and corrupted the widget tree for the rest of the session, and in release builds browser git-authorization hung after one workspace close. Details, review, and verification in #3408.
