### PR TITLE
fmtk e2e: isolate-wedge test must reach login from any state (#3413)

### DIFF
--- a/src/frontend/e2e-tests/fmtk/test_harness_recovery.py
+++ b/src/frontend/e2e-tests/fmtk/test_harness_recovery.py
@@ -34,8 +34,24 @@ def gone_error() -> FmtkError:
     )
 
 
-def test_isolate_wedge_recovery(harness, app):
+def at_login(harness, app) -> None:
+    """Land on the usable login form from any prior state — the core
+    suite runs the smoke scenario first and it ends logged in (#3413) —
+    then dismiss any leftover login-banner dialog."""
+    app.ensure_tab_at_app()
+    app.navigate("/login")
+    if not app.has_text("Log In", 5000):
+        try:
+            app.dart_logout()
+        except FmtkError:
+            harness.restart_app()
     app.wait_for_login_page()
+    app.dismiss_login_banner()
+    app.wait_for_text("Email or handle")
+
+
+def test_isolate_wedge_recovery(harness, app):
+    at_login(harness, app)
 
     # the tab is on the app origin with the isolate attached: a gone
     # sighting arms the marker and keeps declining inside the window


### PR DESCRIPTION
Fixes #3413.

## What changed

`test_isolate_wedge_recovery` now opens with the suite's `at_login(harness,
app)` preamble (the same one `test_features.py`, `test_auth.py`,
`test_admin.py`, `test_files.py`, `test_settings.py`, and
`test_user_settings.py` each carry): route to `/login`, end a leftover session
via `dart_logout()` (or restart a dead app), wait for the login page, dismiss
any leftover banner dialog. Previously it opened with a bare
`app.wait_for_login_page()` and assumed a logged-out starting state.

## Why

The suite split (#3404) gave `fmtk-e2e-core.yml` an explicit file order with
`test_smoke.py` first. The smoke scenario ends logged in as
`fmtk-admin@example.com`, and the session-scoped `app` fixture carries that
logged-in tab into the next test — so the recovery test's opening wait for the
login surface timed out after 90 s (`HarnessTimeout: login page never
appeared`). Both runs of the workflow since the split failed the same way
(runs [34586024875](https://github.com/mcdonc/klangk/actions/runs/34586024875/job/103220321976)
and [34524549235](https://github.com/mcdonc/klangk/actions/runs/34524549235)).
Before the split, alphabetical collection ran the recovery test ahead of smoke,
so it always started from the fresh logged-out session the `FMTK_E2E_FRESH=1`
boot produces.

The per-test `at_login` preamble makes the test self-sufficient from any prior
state instead of depending on collection order — the same property the six
suites that follow smoke in the core order already have (they passed in both
failing runs while inheriting smoke's logged-in tab).

## Verification

Ran the exact CI order against the real stack locally (headless Chrome, real
backend, fresh fixture):

```
test-fmtk-e2e src/frontend/e2e-tests/fmtk/test_smoke.py \
  src/frontend/e2e-tests/fmtk/test_harness_recovery.py -v
→ 2 passed in 544.79s
```

The recovery test exercised its real wedge-recovery leg (the flutter run
restarted after the outlived window) and then drove the fresh app to the login
page.
