### PR TITLE
Derive fuzz startup budget from podman bringup budget (#3412)

### DIFF
--- a/.github/workflows/fuzz-daily.yml
+++ b/.github/workflows/fuzz-daily.yml
@@ -17,7 +17,9 @@ concurrency:
 jobs:
   fuzz:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    # 40 min headroom: worst case ~570 s server-start wait (#3412) + a
+    # 10 min fuzz run + ~5 min of devenv/image setup, all inside the job.
+    timeout-minutes: 40
     env:
       # Use system podman on Ubuntu runners (nix podman lacks SUID newuidmap)
       KLANGKD_PODMAN_BIN: /usr/bin/podman

--- a/scripts/fuzz-api.py
+++ b/scripts/fuzz-api.py
@@ -42,7 +42,7 @@ import uuid
 
 import httpx
 
-from fuzzlib import configure_logging, draw_seed, uds_login
+from fuzzlib import configure_logging, draw_seed, server_start_budget, uds_login
 
 logger = logging.getLogger("fuzz")
 
@@ -728,15 +728,16 @@ def start_server(data_dir: str) -> tuple[subprocess.Popen, TeeReader, str]:
     return proc, tee, uds_path
 
 
-def wait_for_server(uds_path: str, timeout: float = 120) -> None:
+def wait_for_server(uds_path: str, timeout: float | None = None) -> None:
     """Poll /health until the server is up (over the UDS).
 
-    The 120 s budget covers a cold CI runner: uvicorn boot (~8 s),
-    migrations + seeding (~3 s), then ``prewarm_podman()`` (its first
-    ``podman create`` alone can take ~20–30 s). Good days land at
-    ~23 s total; the old 30 s deadline failed whenever the runner
-    booted slower than that (#3368).
+    ``timeout`` defaults to :func:`fuzzlib.server_start_budget`, so the
+    wait always outlasts the server's own podman give-up point on any
+    host; the fixed wall clocks that preceded it (#3368) crossed it on
+    slow CI runner days.
     """
+    if timeout is None:
+        timeout = server_start_budget()
     deadline = time.monotonic() + timeout
     while time.monotonic() < deadline:
         try:
@@ -750,7 +751,7 @@ def wait_for_server(uds_path: str, timeout: float = 120) -> None:
         except (httpx.ConnectError, httpx.HTTPError):
             pass
         time.sleep(0.3)
-    raise TimeoutError("Server did not start in time")
+    raise TimeoutError(f"Server did not start in time (budget {timeout:.0f}s)")
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/fuzz-idle.py
+++ b/scripts/fuzz-idle.py
@@ -69,7 +69,7 @@ from dataclasses import dataclass, field
 
 import httpx
 
-from fuzzlib import configure_logging, draw_seed
+from fuzzlib import configure_logging, draw_seed, server_start_budget
 import websockets
 
 logger = logging.getLogger("fuzz-idle")
@@ -217,8 +217,15 @@ class Server:
         except httpx.HTTPError:
             return False
 
-    def _wait_ready(self, timeout: float = 90) -> None:
-        deadline = time.monotonic() + timeout
+    def _resolve_ready_timeout(self, timeout: float | None) -> float:
+        """Effective ready budget: caller-pinned, else the shared derived
+        startup budget (#3412 — a fixed 90 s sat below the server's
+        prewarm give-up point on slow hosts)."""
+        return timeout if timeout is not None else server_start_budget()
+
+    def _wait_ready(self, timeout: float | None = None) -> None:
+        budget = self._resolve_ready_timeout(timeout)
+        deadline = time.monotonic() + budget
         with httpx.Client(base_url=self.url, timeout=2) as client:
             while time.monotonic() < deadline:
                 if self.proc is not None and self.proc.poll() is not None:
@@ -229,7 +236,7 @@ class Server:
                     return
                 time.sleep(0.5)
         raise RuntimeError(
-            f"klangkd not healthy within {timeout}s:\n{self._read_log()[-4000:]}"
+            f"klangkd not healthy within {budget}s:\n{self._read_log()[-4000:]}"
         )
 
     def _read_log(self) -> str:

--- a/scripts/fuzzlib.py
+++ b/scripts/fuzzlib.py
@@ -8,6 +8,27 @@ import random
 import httpx
 
 
+def server_start_budget() -> float:
+    """Wall clock a fuzz harness allots for klangkd boot.
+
+    ``prewarm_podman()`` runs its first ``podman create`` under
+    ``podman.bringup_timeout()`` (120 s local, 240 s on CI, #3064), and
+    ``Podman._run_create`` retries once on timeout, so the prewarm worst
+    case is two full create budgets; the prewarm teardown (``podman stop``
+    then ``rm -f`` via ``remove_container``, 30 s each at the ``run()``
+    default) adds up to 60 s more; 30 s covers uvicorn boot, migrations,
+    seeding, and the startup reaps. The fixed budgets that preceded this
+    (30 s, then 120 s, #3368) sat below the server's own give-up point,
+    so a slow-but-legitimate create aborted the fuzz session with 0
+    requests sent (#3412).
+    """
+    # Lazy so --check-style entry points that never start a server need
+    # no backend import.
+    from klangk.podman import bringup_timeout
+
+    return 30 + 2 * bringup_timeout() + 60
+
+
 def configure_logging() -> None:
     """The fuzz-log posture: INFO root, per-request httpx noise suppressed."""
     logging.basicConfig(

--- a/scripts/tests/test_fuzz_start_budget.py
+++ b/scripts/tests/test_fuzz_start_budget.py
@@ -1,0 +1,42 @@
+"""Contract test: the fuzz harnesses' server-start budget must outlast the
+server's own podman give-up point (#3412).
+
+``wait_for_server`` (fuzz-api) and ``_wait_ready`` (fuzz-idle) used fixed
+wall clocks (90–120 s) while the server's ``prewarm_podman()`` runs its
+first ``podman create`` under ``bringup_timeout()`` (240 s on CI) with one
+``_run_create`` retry — up to 480 s, plus the stop+rm teardown. Whenever
+the first create was merely slow (still inside the server's budget), the
+harness aborted the session first with 0 requests sent. The shared budget
+(``fuzzlib.server_start_budget``) is derived from the same
+``bringup_timeout`` the server uses, and this test pins that coupling so
+the two can't drift apart silently again.
+"""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from fuzzlib import server_start_budget  # noqa: E402
+from klangk.podman import bringup_timeout  # noqa: E402
+
+
+def test_budget_covers_prewarm_worst_case():
+    # Two full create budgets (timeout + the one _run_create retry) plus
+    # the 60 s stop+rm tail leave room for boot, migrations, seeding, and
+    # the startup reaps.
+    assert server_start_budget() >= 2 * bringup_timeout() + 60, (
+        "the fuzz start budget no longer covers prewarm's worst case — "
+        "update fuzzlib.server_start_budget"
+    )
+
+
+def test_budget_tracks_ci_doubling(monkeypatch):
+    # bringup_timeout doubles on CI (240 s); the budget must follow it
+    # there, or slow CI runner days abort the session again (#3412).
+    monkeypatch.setenv("CI", "true")
+    assert server_start_budget() == 30 + 2 * 240.0 + 60, (
+        "expected 30 s boot + 2 x bringup_timeout(CI) + 60 s teardown — "
+        "if bringup_timeout's CI default changed, update this pin and the "
+        "budget's docstring in fuzzlib.py"
+    )


### PR DESCRIPTION
## Summary

The daily fuzz run aborted again with `TimeoutError: Server did not start in time`
([Sep 11 run](https://github.com/mcdonc/klangk/actions/runs/34589773420/job/103232145533),
0 requests sent) — the same failure mode #3368 fixed, one budget-generation later.
The structural cause: the harnesses' fixed startup wall clocks sat **below the
server's own podman give-up point**. `prewarm_podman()`'s first `podman create`
runs under `bringup_timeout()` (240 s on CI, #3064), `Podman._run_create`
retries once on timeout, and `remove_container()` then pays `podman stop` +
`rm -f` (up to 60 s more) — so a create that is merely slow, still legitimate
by the server's own rules, always outlived the fuzzer's deadline.

## Changes

- **`scripts/fuzzlib.py`** — new shared `server_start_budget()`: 30 s
  (uvicorn boot, migrations, seeding, reaps) + 2 × `bringup_timeout()`
  (create timeout + the one `_run_create` retry) + 60 s (stop/rm teardown)
  — 570 s on CI, 330 s locally, derived from the same `bringup_timeout`
  the server uses so it can't sit below the server's budget on any host.
- **`scripts/fuzz-api.py`** — `wait_for_server` defaults to that budget;
  the timeout error names the budget it exceeded.
- **`scripts/fuzz-idle.py`** — `_wait_ready` had the same latent bug
  (fixed 90 s); it now defaults to the shared budget too.
- **`scripts/tests/test_fuzz_start_budget.py`** — contract test pinning the
  derivation (covers the full prewarm worst case; follows the CI doubling),
  so the harness budget and `bringup_timeout` can't drift apart silently.
- **`.github/workflows/fuzz-daily.yml`** — job ceiling 30 → 40 min: the
  worst-case wait (570 s) plus a full 10 min run and image setup now fit
  inside the job, so pathological days fail through the harness's clean
  exit-1 + report path instead of a runner cancellation.

Closes #3412.

## Review note

The fresh-eyes review (attached below) also blocked an earlier cut of this
branch that added a `Podman pre-warm starting` log line to
`src/klangk/klangk/container/registry.py`: the ruff-format hook's PEP 758
rewrite of the touched file makes xenon/radon **silently skip it**, removing
it from the complexity gate. The log line is dropped and this PR now touches
no `src/klangk/` file; the toolchain conflict is filed as #3415. The review's
other findings (teardown tail missing from the budget arithmetic, the
30-minute job ceiling, fuzz-idle's latent copy) are addressed above.

## Verification

- `python -m pytest scripts/tests -v` — 158 passed (incl. the 2 new contract tests)
- `python scripts/fuzz-api.py --check` — no drift
- `test-push` — selected areas green (no backend change in this PR)
- `pre-commit run xenon --all-files` — passed (no PEP 758 conversions involved)
