### PR TITLE
Re-create workspace tab plugins per workspace page (#3409)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -851,6 +851,15 @@ sync` report a clear permission-denied error.
 
 ### Added
 
+- **Workspace-tab plugins are re-created per workspace page (#3409).** The
+  tab registry holds factories registered once at boot from the
+  active-feature set; each workspace page creates, owns, and disposes its
+  own tab set, so `dispose()` is terminal and a tab may mix in
+  `ChangeNotifier`. Per-workspace state belongs on the tab instance (each
+  page starts from zero), never in statics. Requires `klangk-plugin-api`
+  v0.6.0 (`register` takes a factory; `tabs`/`disposeAll` became
+  `createTabs`/`clear`); boingball (dormant) carries the first tab.
+
 - **Git authentication via the browser for Gitea hosts (#3385).** A
   `KLANGKWS_FEATURE_OAUTH_PROVIDERS` entry with
   `flow: authorization_code_pkce` runs the OAuth authorization-code

--- a/features/beep/klangk/pubspec.yaml
+++ b/features/beep/klangk/pubspec.yaml
@@ -13,5 +13,5 @@ dependencies:
   klangk_plugin_api:
     git:
       url: https://github.com/mcdonc/klangk-plugin-api.git
-      ref: v0.5.1
+      ref: v0.6.0
   web: ^1.1.0

--- a/features/bobdobbs/klangk/pubspec.yaml
+++ b/features/bobdobbs/klangk/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
   klangk_plugin_api:
     git:
       url: https://github.com/mcdonc/klangk-plugin-api.git
-      ref: v0.5.1
+      ref: v0.6.0
 
 flutter:
   assets:

--- a/features/boingball/klangk/lib/feature.dart
+++ b/features/boingball/klangk/lib/feature.dart
@@ -4,6 +4,7 @@ import 'dart:math';
 import 'dart:typed_data';
 import 'dart:ui' as ui;
 
+import 'package:flutter/foundation.dart' show ValueListenable;
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:http/http.dart' as http;
@@ -42,6 +43,54 @@ class BoingBallFeature extends ToolPlugin with ChangeNotifier {
   @override
   Widget? buildOverlay(BuildContext context) {
     return _BoingOverlay(feature: this);
+  }
+}
+
+/// Feature-contributed workspace tab (#3409 fixture): a tab with real
+/// disposable state — a `ChangeNotifier` mixin plus a live badge
+/// `ValueNotifier` — pinning the per-page tab contract end to end. Tab
+/// instances are per-workspace-page: each workspace page constructs a
+/// fresh `BoingTab` (the registry holds the factory), and this instance's
+/// [dispose] is terminal when the page closes, so the ChangeNotifier mixin
+/// is safe. The bounce counter therefore starts at zero on every workspace
+/// open — per-page state on the instance, not in statics.
+class BoingTab extends WorkspaceTabPlugin with ChangeNotifier {
+  final ValueNotifier<TabBadge?> _badge = ValueNotifier<TabBadge?>(null);
+  int _boings = 0;
+
+  @override
+  String get title => 'Boing';
+
+  @override
+  IconData get icon => Icons.sports_baseball;
+
+  @override
+  ValueListenable<TabBadge?>? get badge => _badge;
+
+  void boing() {
+    _boings++;
+    notifyListeners();
+    _badge.value = TabBadge(count: _boings);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Text('Boing bounces: $_boings'),
+          const SizedBox(height: 12),
+          FilledButton(onPressed: boing, child: const Text('Do a boing')),
+        ],
+      ),
+    );
+  }
+
+  @override
+  void dispose() {
+    _badge.dispose();
+    super.dispose(); // ChangeNotifier.dispose — terminal (#3409).
   }
 }
 

--- a/features/boingball/klangk/pubspec.yaml
+++ b/features/boingball/klangk/pubspec.yaml
@@ -13,6 +13,6 @@ dependencies:
   klangk_plugin_api:
     git:
       url: https://github.com/mcdonc/klangk-plugin-api.git
-      ref: v0.5.1
+      ref: v0.6.0
   http: ^1.2.0
   web: ^1.1.0

--- a/features/celebrate/klangk/pubspec.yaml
+++ b/features/celebrate/klangk/pubspec.yaml
@@ -13,4 +13,4 @@ dependencies:
   klangk_plugin_api:
     git:
       url: https://github.com/mcdonc/klangk-plugin-api.git
-      ref: v0.5.1
+      ref: v0.6.0

--- a/features/git-credential/klangk/pubspec.lock
+++ b/features/git-credential/klangk/pubspec.lock
@@ -79,11 +79,11 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: "v0.5.1"
-      resolved-ref: "441f9d4f75988bbb022727439b5c2939bc5ab96e"
+      ref: "v0.6.0"
+      resolved-ref: "0df64c3c8f6b253f3ba9cfa30f8600600c4717b9"
       url: "https://github.com/mcdonc/klangk-plugin-api.git"
     source: git
-    version: "0.5.1"
+    version: "0.6.0"
   leak_tracker:
     dependency: transitive
     description:

--- a/features/git-credential/klangk/pubspec.yaml
+++ b/features/git-credential/klangk/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
   klangk_plugin_api:
     git:
       url: https://github.com/mcdonc/klangk-plugin-api.git
-      ref: v0.5.1
+      ref: v0.6.0
 
 dev_dependencies:
   flutter_test:

--- a/features/soliplex/klangk/pubspec.yaml
+++ b/features/soliplex/klangk/pubspec.yaml
@@ -53,7 +53,7 @@ dependencies:
   klangk_plugin_api:
     git:
       url: https://github.com/mcdonc/klangk-plugin-api.git
-      ref: v0.5.1
+      ref: v0.6.0
 
 dev_dependencies:
   flutter_lints: ^6.0.0

--- a/scripts/import_dart_features.py
+++ b/scripts/import_dart_features.py
@@ -57,7 +57,7 @@ FEATURE_API_DEP = {
     "klangk_plugin_api": {
         "git": {
             "url": "https://github.com/mcdonc/klangk-plugin-api.git",
-            "ref": "v0.5.1",
+            "ref": "v0.6.0",
         }
     }
 }
@@ -341,6 +341,17 @@ def named_constructor_lines(features: list, classes_key: str, label: str) -> lis
     return lines
 
 
+def named_factory_lines(features: list, classes_key: str, label: str) -> list[str]:
+    """The ``    (name: ..., label: Cls.new),`` lines for one named-record
+    factory aggregator — constructor tear-offs, so each consumer creates a
+    fresh instance per workspace page (#3409)."""
+    lines = []
+    for p in features:
+        for cls in p[classes_key]:
+            lines.append(f"    (name: {p['name']!r}, {label}: {cls}.new),")
+    return lines
+
+
 def generate_dart(features):
     """Generate klangk_features.dart source as a string."""
     lines = [
@@ -369,17 +380,17 @@ def generate_dart(features):
     lines.append("}")
     lines.append("")
     lines.append(
-        "// ({name, tab}) records for the workspace-tab active-set filter (#1975): "
+        "// ({name, create}) records for the workspace-tab active-set filter"
+        " (#1975): a feature's tab mounts only when the feature is active. "
+        "Entries are FACTORIES, not instances: tab instances are"
+        " per-workspace-page — each page creates and owns a fresh set (#3409)."
     )
     lines.append(
-        "// a feature's tab mounts only when the feature is active. A feature may "
-    )
-    lines.append("// contribute a tab with no ToolPlugin (tab-only), or both.")
-    lines.append(
-        "List<({String name, WorkspaceTabPlugin tab})> createAllNamedWorkspaceTabs() {"
+        "List<({String name, WorkspaceTabPlugin Function() create})> "
+        "createAllNamedWorkspaceTabs() {"
     )
     lines.append("  return [")
-    lines.extend(named_constructor_lines(features, "tab_classes", "tab"))
+    lines.extend(named_factory_lines(features, "tab_classes", "create"))
     lines.append("  ];")
     lines.append("}")
     lines.append("")

--- a/scripts/stub_dart_features.sh
+++ b/scripts/stub_dart_features.sh
@@ -43,7 +43,7 @@ dependencies:
   klangk_plugin_api:
     git:
       url: https://github.com/mcdonc/klangk-plugin-api.git
-      ref: v0.5.1
+      ref: v0.6.0
 EOF
 
 cat >"$STUB_DIR/lib/klangk_features.dart" <<'EOF'
@@ -55,8 +55,9 @@ List<ToolPlugin> createAllFeatures() => [];
 List<({String name, ToolPlugin feature})> createAllNamedFeatures() => [];
 // Empty named-workspace-tabs list — the active-set filter in main.dart
 // iterates this (createAllNamedWorkspaceTabs) and mounts no feature tabs
-// (#1975).
-List<({String name, WorkspaceTabPlugin tab})> createAllNamedWorkspaceTabs() => [];
+// (#1975). Entries are factories (#3409): tab instances are created fresh
+// per workspace page by the page itself.
+List<({String name, WorkspaceTabPlugin Function() create})> createAllNamedWorkspaceTabs() => [];
 EOF
 
 # Write overrides file and symlink into frontend

--- a/scripts/tests/test_build_pipeline.py
+++ b/scripts/tests/test_build_pipeline.py
@@ -74,9 +74,12 @@ EXPECTED_DART_FEATURES = {
     "soliplex": "SoliplexFeature",
 }
 
-# Dart features that declare ONLY a WorkspaceTabPlugin (no ToolPlugin) → the
-# tab class emitted into createAllNamedWorkspaceTabs (#1976).
-EXPECTED_DART_TAB_FEATURES: dict[str, str] = {}
+# Dart features that declare a WorkspaceTabPlugin (tab-only, or both a
+# tab and a ToolPlugin) → the tab class emitted as a FACTORY into
+# createAllNamedWorkspaceTabs (#1976; factories per #3409).
+EXPECTED_DART_TAB_FEATURES = {
+    "boingball": "BoingTab",
+}
 
 # All features with a klangk/ Dart package (tool or tab) — used to tell Dart
 # features from TS-only ones (word-count, browser-fetch have no klangk/).
@@ -191,9 +194,11 @@ def assert_not_imported(source: str, name: str) -> None:
 
 
 def assert_tab_emitted(source: str, name: str, cls: str) -> None:
-    """The feature's tab class is emitted into the tab aggregator."""
-    assert f"(name: '{name}', tab: {cls}())," in source, (
-        f"{cls}() not instantiated in createAllNamedWorkspaceTabs"
+    """The feature's tab class is emitted as a factory (constructor
+    tear-off) into the tab aggregator — instances are per-workspace-page
+    (#3409), so the aggregator must not instantiate."""
+    assert f"(name: '{name}', create: {cls}.new)," in source, (
+        f"{cls}.new factory not emitted into createAllNamedWorkspaceTabs"
     )
 
 
@@ -244,7 +249,8 @@ class TestPipelineRuns:
 
         # The workspace-tab aggregator (#1975) is always emitted.
         assert_tab_aggregator_present(source)
-        # Tab-only features (#1976) land in the tab aggregator.
+        # Features declaring a tab (#1976) land in the tab aggregator as
+        # factories (#3409) — boingball is the checked-in both-shape case.
         for name, cls in EXPECTED_DART_TAB_FEATURES.items():
             assert_tab_emitted(source, name, cls)
 
@@ -294,11 +300,12 @@ def assert_single_feature(
 
 
 def assert_tab_only_dart(dart: str, name: str, cls: str) -> None:
-    """The tab-only feature's class appears in the tab aggregator exactly
-    once — never leaked into createAllFeatures / createAllNamedFeatures."""
+    """The tab-only feature's class appears in the generated Dart exactly
+    once (as a factory, #3409) — never leaked into createAllFeatures /
+    createAllNamedFeatures."""
     assert "createAllNamedWorkspaceTabs()" in dart
-    assert f"(name: '{name}', tab: {cls}())," in dart
-    assert dart.count(f"{cls}()") == 1, "tab class leaked into a tool aggregator"
+    assert f"(name: '{name}', create: {cls}.new)," in dart
+    assert dart.count(cls) == 1, "tab class leaked into a tool aggregator"
 
 
 class TestWorkspaceTabAggregator:
@@ -352,7 +359,7 @@ class TestWorkspaceTabAggregator:
 
         dart = import_dart_features.generate_dart(features)
         assert "(name: 'chat', feature: ChatFeature())," in dart
-        assert "(name: 'chat', tab: ChatTab())," in dart
+        assert "(name: 'chat', create: ChatTab.new)," in dart
 
     def test_neither_component_is_skipped(self, tmp_path):
         """A feature declaring neither ToolPlugin nor WorkspaceTabPlugin is

--- a/src/frontend/e2e-tests/fmtk/test_features.py
+++ b/src/frontend/e2e-tests/fmtk/test_features.py
@@ -137,3 +137,51 @@ def test_features_enable_app_boots_with_custom_set(harness, app):
     finally:
         _clear_features_enable(harness)
         harness.restart_app()
+
+
+def test_feature_tab_recreated_across_workspace_close_reopen(harness, app):
+    """#3409: feature-tab instances are per-workspace-page.
+
+    Boingball (dormant by default) carries ``BoingTab`` — a
+    ``WorkspaceTabPlugin`` mixing in ``ChangeNotifier`` (disposable
+    state). Enable it, then within ONE app session: open the fixture
+    workspace, exercise the tab (notifyListeners + live badge), close
+    the workspace (the page disposes its tab set — terminal), and open
+    the workspace again. The reopened page must build a FRESH tab
+    instance (the per-page bounce counter reset to zero proves it), and
+    no used-after-being-disposed error may escape (the post-test error
+    drain fails the run if one does)."""
+    try:
+        harness.backend.swap_settings(
+            {"features_enable": "beep,boingball"},
+            apply="restart",
+            verify=False,
+        )
+        harness.restart_app()
+        at_login(harness, app)
+        app.login(ADMIN_EMAIL, FIXTURE_PASSWORD, expect_text="fmtk-verify")
+
+        # --- first open: fresh tab instance, disposable state exercised ---
+        app.navigate("/workspaces")
+        app.wait_for_text("fmtk-verify")
+        app.tap_button_exact("fmtk-verify")
+        app.wait_for_text("Terminal", 30000)
+        app.tap_labeled_exact("Boing")
+        app.wait_for_text("Boing bounces: 0")
+        app.tap_label("Do a boing")
+        app.wait_for_text("Boing bounces: 1")
+
+        # --- close the workspace page: its tab set is disposed (terminal) ---
+        app.navigate("/workspaces")
+        app.wait_for_text("fmtk-verify")
+
+        # --- second open in the same session: a FRESH instance serves the
+        # page (counter back to zero) — reuse of the disposed tab would
+        # either keep the counter or throw used-after-being-disposed. ---
+        app.tap_button_exact("fmtk-verify")
+        app.wait_for_text("Terminal", 30000)
+        app.tap_labeled_exact("Boing")
+        app.wait_for_text("Boing bounces: 0")
+    finally:
+        _clear_features_enable(harness)
+        harness.restart_app()

--- a/src/frontend/lib/layout/ide_layout.dart
+++ b/src/frontend/lib/layout/ide_layout.dart
@@ -46,8 +46,10 @@ class IdeLayout extends StatefulWidget {
 
   /// Feature-contributed workspace tabs (#1975). Each entry contributes a
   /// tab (title + icon + builder) to the strip; only active features' tabs
-  /// are passed in (the active-set filter lives in main.dart, which registers
-  /// into WorkspaceTabRegistry). Defaults to none.
+  /// are passed in (the active-set filter lives in main.dart, which
+  /// registers factories into WorkspaceTabRegistry — the workspace page
+  /// creates its own per-page instance set from them, #3409). Defaults to
+  /// none.
   final List<WorkspaceTabPlugin> featureTabs;
   final GlobalKey<GhosttyTerminalState>? terminalKey;
   final GlobalKey<FileViewerPanelState>? fileViewerKey;
@@ -82,8 +84,9 @@ class IdeLayout extends StatefulWidget {
 
 class IdeLayoutState extends State<IdeLayout> {
   // The selected tab's logical key: a [_TabKey] for built-in tabs, or the
-  // [WorkspaceTabPlugin] instance for a feature tab (identity-stable from
-  // the registry). Key-based selection is what makes mid-session pane
+  // [WorkspaceTabPlugin] instance for a feature tab (identity-stable for the
+  // page's lifetime — created once in the workspace page's initState,
+  // #3409). Key-based selection is what makes mid-session pane
   // mount/unmount index-free (#2886, #2975).
   Object _selected = _TabKey.terminal;
   double _debugHeight = 0; // collapsed by default
@@ -97,8 +100,8 @@ class IdeLayoutState extends State<IdeLayout> {
 
   // Feature-tab badge subscriptions (#1976): a feature tab may expose a live
   // badge (unread count) via WorkspaceTabPlugin.badge. We listen and rebuild
-  // the strip on change. Map key is the tab (identity-stable from the
-  // registry); value is the listener we add/remove.
+  // the strip on change. Map key is the tab (identity-stable for the page's
+  // lifetime, #3409); value is the listener we add/remove.
   final Map<WorkspaceTabPlugin, VoidCallback> _badgeListeners = {};
 
   static const _dividerHeight = 6.0;
@@ -129,10 +132,10 @@ class IdeLayoutState extends State<IdeLayout> {
     }
     // Re-subscribe only when the featureTabs LIST identity changes. This
     // holds because workspace_page captures _featureTabs once in initState
-    // (WorkspaceTabRegistry().tabs) and reuses that same list instance on
-    // every rebuild. If a future change recomputes featureTabs per build,
-    // switch to a content-based comparison — re-subscribing every frame
-    // would churn (#1976 review nit).
+    // (WorkspaceTabRegistry().createTabs()) and reuses that same list
+    // instance on every rebuild. If a future change recomputes featureTabs
+    // per build, switch to a content-based comparison — re-subscribing every
+    // frame would churn (#1976 review nit).
     if (!identical(widget.featureTabs, oldWidget.featureTabs)) {
       _subscribeFeatureBadges();
     }

--- a/src/frontend/lib/main.dart
+++ b/src/frontend/lib/main.dart
@@ -62,9 +62,10 @@ Future<void> main() async {
   // Feature-contributed workspace tabs (#1975): the same active-set filter
   // as tool plugins — a feature's tab mounts only when the feature is
   // active. A feature may contribute a tab with no tool handlers
-  // (tab-only), or both a tab and tool handlers. The filter lives in
-  // [registerActiveWorkspaceTabs] (a top-level helper) so it is unit-testable
-  // — the tool-plugin filter is the same shape but inlined.
+  // (tab-only), or both a tab and tool handlers. The filter registers tab
+  // FACTORIES (instances are per-workspace-page, #3409). The filter lives
+  // in [registerActiveWorkspaceTabs] (a top-level helper) so it is
+  // unit-testable — the tool-plugin filter is the same shape but inlined.
   registerActiveWorkspaceTabs(
     createAllNamedWorkspaceTabs(),
     activeFeatureNames,

--- a/src/frontend/lib/workspace/workspace_page.dart
+++ b/src/frontend/lib/workspace/workspace_page.dart
@@ -165,9 +165,11 @@ class _WorkspacePageState extends State<WorkspacePage> {
     _featureRegistry = ToolPluginRegistry();
     // Features are registered once in main() — reuse them here.
     _features = _featureRegistry.plugins.toList();
-    // Feature-contributed workspace tabs are likewise registered once in
-    // main() (active-filtered) — reuse the singleton registry (#1975).
-    _featureTabs = WorkspaceTabRegistry().tabs;
+    // Feature-contributed workspace tabs are filtered once in main()
+    // (active-set) into the singleton registry — but as FACTORIES. Each
+    // workspace page creates its own fresh tab instances from them and
+    // owns them for the page's lifetime (#1975, #3409).
+    _featureTabs = WorkspaceTabRegistry().createTabs();
     _fileRenderers = buildFileRendererRegistry(_features);
     _fetchWorkspaceName();
     // #2768: re-resolve the effective marking when the workspace row
@@ -596,12 +598,13 @@ class _WorkspacePageState extends State<WorkspacePage> {
     // the session (#3406). Tool plugins hold no per-workspace resources; the
     // registry owns their lifetime.
     //
-    // Feature tabs do hold per-workspace resources, so they are released on
-    // workspace close (#1975). The tab registry is likewise a singleton, so
-    // this calls per-tab dispose() — not disposeAll() — and the next
-    // workspace page reuses the same instances: a tab plugin with real
-    // resources must tolerate being reused after dispose — re-arm them
-    // lazily in build().
+    // Feature tabs hold per-workspace resources, so they ARE released on
+    // workspace close (#1975) — safely, because tab instances are
+    // per-workspace-page (#3409): initState created this page's set via
+    // WorkspaceTabRegistry().createTabs(), this dispose releases exactly
+    // that set, and the next workspace page builds from its own fresh
+    // instances. dispose() is therefore terminal — a tab may mix in
+    // ChangeNotifier — and reuse-after-dispose can never happen.
     for (final tab in _featureTabs) {
       tab.dispose();
     }

--- a/src/frontend/lib/workspace_tab_filter.dart
+++ b/src/frontend/lib/workspace_tab_filter.dart
@@ -1,8 +1,9 @@
 import 'package:klangk_plugin_api/klangk_plugin_api.dart';
 
-/// Registers a feature's workspace tab into the [WorkspaceTabRegistry] only
-/// when the feature is in [activeFeatureNames] — the tab analogue of the
-/// tool-plugin active-set filter inlined in `main()` (#1975).
+/// Registers a feature's workspace-tab FACTORY into the
+/// [WorkspaceTabRegistry] only when the feature is in [activeFeatureNames]
+/// — the tab analogue of the tool-plugin active-set filter inlined in
+/// `main()` (#1975).
 ///
 /// Lives in its own module (not `main.dart`) so it is unit-testable in
 /// isolation: importing `main.dart` from a test pulls the entire app graph
@@ -12,16 +13,20 @@ import 'package:klangk_plugin_api/klangk_plugin_api.dart';
 /// API, so its transitive closure is tiny and fully coverable. `main()`
 /// passes the generated `createAllNamedWorkspaceTabs()` aggregator output.
 ///
+/// The registry holds factories, not instances (#3409): each workspace page
+/// creates its own fresh tab set from the registered factories and disposes
+/// it on close, so `WorkspaceTabPlugin.dispose()` is terminal.
+///
 /// `activeFeatureNames` is a [Set], so [Set.contains] is exact-name equality
 /// (not substring) — "git" does not activate "git-credential", same as tools.
 void registerActiveWorkspaceTabs(
-  Iterable<({String name, WorkspaceTabPlugin tab})> allTabs,
+  Iterable<({String name, WorkspaceTabPlugin Function() create})> allTabs,
   Set<String> activeFeatureNames,
 ) {
   final tabRegistry = WorkspaceTabRegistry();
   for (final entry in allTabs) {
     if (activeFeatureNames.contains(entry.name)) {
-      tabRegistry.register(entry.tab);
+      tabRegistry.register(entry.create);
     }
   }
 }

--- a/src/frontend/pubspec.yaml
+++ b/src/frontend/pubspec.yaml
@@ -42,7 +42,7 @@ dependencies:
   klangk_plugin_api:
     git:
       url: https://github.com/mcdonc/klangk-plugin-api.git
-      ref: v0.5.1
+      ref: v0.6.0
   # Path set by import_dart_features.py — do not edit this line
   klangk_features:
     path: PLACEHOLDER

--- a/src/frontend/test/workspace_tab_feature_test.dart
+++ b/src/frontend/test/workspace_tab_feature_test.dart
@@ -69,6 +69,34 @@ class _BadgedTab extends WorkspaceTabPlugin {
   void dispose() => _badge.dispose();
 }
 
+/// #3409: the canonical disposable tab — mixes in ChangeNotifier (terminal
+/// dispose) and owns a live badge notifier. Instances are per-workspace-
+/// page, so this shape is legal: each page creates its own set, uses it,
+/// and disposes it on close; nothing reuses a disposed instance.
+class _DisposableTab extends WorkspaceTabPlugin with ChangeNotifier {
+  _DisposableTab(this.title);
+  final String title;
+  final _ExposedValueNotifier<TabBadge?> _badge =
+      _ExposedValueNotifier<TabBadge?>(null);
+  bool disposed = false;
+
+  @override
+  IconData get icon => Icons.notes;
+
+  @override
+  ValueListenable<TabBadge?>? get badge => _badge;
+
+  @override
+  Widget build(BuildContext context) => Center(child: Text('$title panel'));
+
+  @override
+  void dispose() {
+    disposed = true;
+    _badge.dispose();
+    super.dispose(); // ChangeNotifier.dispose — terminal (#3409).
+  }
+}
+
 /// A stateful harness that rebuilds IdeLayout with a different feature-tab
 /// set — used to verify badge subscriptions are dropped when a tab is removed.
 class _TabsHarness extends StatefulWidget {
@@ -203,6 +231,55 @@ void main() {
 
       // Subscription dropped — no listeners remain on the tab's badge notifier.
       expect(tab._badge.hasListenersPublic, isFalse);
+    });
+  });
+
+  // #3409: the tab lifecycle contract. Tab instances are per-workspace-
+  // page — each page creates a fresh set (registry factories), builds it,
+  // and disposes it on close. dispose() is terminal, which is exactly why
+  // a ChangeNotifier mixin is legal on a tab (contrast tool plugins, whose
+  // registry-owned singletons the app never disposes, #3406). The full
+  // WorkspacePage cannot be mounted here (see workspace_overlays.dart), so
+  // this simulates two consecutive pages' exact tab lifecycle — the real
+  // page wiring is pinned by the fmtk e2e suite (test_features.py).
+  group('per-page tab lifecycle (#3409)', () {
+    testWidgets(
+        'a disposable ChangeNotifier tab serves one page; the next page '
+        'gets a fresh instance', (tester) async {
+      // --- workspace page one: create its tab set, mount, use, close ---
+      final pageOne = _DisposableTab('Notes');
+      await tester.pumpWidget(_harness(tabs: [pageOne]));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Notes'));
+      await tester.pumpAndSettle();
+      expect(find.text('Notes panel'), findsOneWidget);
+      expect(pageOne._badge.hasListenersPublic, isTrue);
+
+      // Page close: unmount, then the page's dispose loop runs (terminal).
+      // This mirrors _WorkspacePageState.dispose (workspace_page.dart) —
+      // the full page cannot be mounted here, and NOTE: that loop itself
+      // is pinned by no suite (deleting it passes everything; fresh
+      // instances come from createTabs(), not from disposal) — see the
+      // PR body's "Known limitation".
+      await tester.pumpWidget(const SizedBox());
+      pageOne.dispose();
+      expect(pageOne.disposed, isTrue);
+
+      // --- workspace page two (same session): a FRESH instance serves it ---
+      final pageTwo = _DisposableTab('Notes');
+      await tester.pumpWidget(_harness(tabs: [pageTwo]));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Notes'));
+      await tester.pumpAndSettle();
+      expect(find.text('Notes panel'), findsOneWidget);
+
+      // The fresh instance's disposable state is fully usable: the badge
+      // notifier accepts a listener-backed update and re-renders the strip.
+      pageTwo._badge.value = const TabBadge(count: 2);
+      await tester.pumpAndSettle();
+      expect(find.text('2'), findsOneWidget);
+      expect(pageTwo.disposed, isFalse);
+      addTearDown(pageTwo.dispose);
     });
   });
 }

--- a/src/frontend/test/workspace_tab_registry_test.dart
+++ b/src/frontend/test/workspace_tab_registry_test.dart
@@ -3,8 +3,8 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:klangk_frontend/workspace_tab_filter.dart';
 import 'package:klangk_plugin_api/klangk_plugin_api.dart';
 
-/// Minimal tab plugin for filter tests — identity matters (the registry keeps
-/// the same instances main() registered), so each test builds distinct ones.
+/// Minimal tab plugin for filter tests — constructible with a title so a
+/// registered factory's output is identifiable.
 class _FakeTab extends WorkspaceTabPlugin {
   _FakeTab(this.title);
   final String title;
@@ -16,69 +16,93 @@ class _FakeTab extends WorkspaceTabPlugin {
 
 void main() {
   // The registry is a process-global singleton shared between main()
-  // (register) and the workspace page (read). Reset it around each test so
-  // ordering and cross-test leakage can't matter.
-  setUp(WorkspaceTabRegistry().disposeAll);
-  tearDown(WorkspaceTabRegistry().disposeAll);
+  // (register factories) and the workspace page (create instances). Reset
+  // it around each test so ordering and cross-test leakage can't matter.
+  setUp(WorkspaceTabRegistry().clear);
+  tearDown(WorkspaceTabRegistry().clear);
 
   group('registerActiveWorkspaceTabs (active-set filter, #1975)', () {
-    test('registers only tabs whose feature is in the active set', () {
-      final a = _FakeTab('a');
-      final b = _FakeTab('b');
-      final c = _FakeTab('c');
-
+    test('registers only factories whose feature is in the active set', () {
       registerActiveWorkspaceTabs(
         [
-          (name: 'alpha', tab: a),
-          (name: 'beta', tab: b),
-          (name: 'gamma', tab: c),
+          (name: 'alpha', create: () => _FakeTab('a')),
+          (name: 'beta', create: () => _FakeTab('b')),
+          (name: 'gamma', create: () => _FakeTab('c')),
         ],
         {'alpha', 'gamma'},
       );
 
-      // Only active features' tabs land in the singleton registry, in order.
-      expect(WorkspaceTabRegistry().tabs, [a, c]);
+      // Only active features' factories land in the singleton registry,
+      // in registration order — one fresh instance per factory per page.
+      final tabs = WorkspaceTabRegistry().createTabs();
+      expect(tabs.map((t) => (t as _FakeTab).title), ['a', 'c']);
     });
 
     test('an empty active set registers nothing', () {
       registerActiveWorkspaceTabs(
-        [(name: 'alpha', tab: _FakeTab('a'))],
+        [(name: 'alpha', create: () => _FakeTab('a'))],
         <String>{},
       );
-      expect(WorkspaceTabRegistry().tabs, isEmpty);
+      expect(WorkspaceTabRegistry().createTabs(), isEmpty);
     });
 
     test('exact-name match — "git" does not activate "git-credential"', () {
       // activeFeatureNames is a Set<String>, so .contains() is exact-name
       // equality (not substring) — mirrors the tool-plugin comment in main().
-      final git = _FakeTab('git');
-      final gitCred = _FakeTab('git-credential');
-
       registerActiveWorkspaceTabs(
         [
-          (name: 'git', tab: git),
-          (name: 'git-credential', tab: gitCred),
+          (name: 'git', create: () => _FakeTab('git')),
+          (name: 'git-credential', create: () => _FakeTab('git-credential')),
         ],
         {'git'},
       );
 
-      expect(WorkspaceTabRegistry().tabs, [git]);
+      final tabs = WorkspaceTabRegistry().createTabs();
+      expect(tabs.map((t) => (t as _FakeTab).title), ['git']);
     });
 
     test(
         'main() register is visible to the workspace-page read '
         '(singleton wiring invariant)', () {
-      // workspace_page.dart reads `WorkspaceTabRegistry().tabs` from a
-      // different constructor call than main()'s register — that only works
-      // because the registry is a singleton. Register via the helper and read
-      // via a fresh instance to prove the two share state.
-      final tab = _FakeTab('wired');
+      // workspace_page.dart calls `WorkspaceTabRegistry().createTabs()`
+      // from a different constructor call than main()'s register — that
+      // only works because the registry is a singleton. Register via the
+      // helper and instantiate via a fresh instance to prove the two
+      // share state.
       registerActiveWorkspaceTabs(
-        [(name: 'wired', tab: tab)],
+        [(name: 'wired', create: () => _FakeTab('wired'))],
         {'wired'},
       );
       expect(identical(WorkspaceTabRegistry(), WorkspaceTabRegistry()), isTrue);
-      expect(WorkspaceTabRegistry().tabs.last, tab);
+      expect(
+        WorkspaceTabRegistry().createTabs().single,
+        isA<_FakeTab>(),
+      );
+    });
+  });
+
+  group('WorkspaceTabRegistry (#3409: per-page tab instances)', () {
+    test('createTabs returns FRESH instances on every call', () {
+      WorkspaceTabRegistry().register(() => _FakeTab('a'));
+      final pageOne = WorkspaceTabRegistry().createTabs();
+      final pageTwo = WorkspaceTabRegistry().createTabs();
+
+      // Same class and order, but no shared identity: a workspace page
+      // disposing its set can never poison the next page's.
+      expect(pageTwo.length, pageOne.length);
+      for (var i = 0; i < pageOne.length; i++) {
+        expect(identical(pageOne[i], pageTwo[i]), isFalse);
+      }
+    });
+
+    test('clear drops the registrations and disposes nothing', () {
+      // The registry owns factories, not instances — a page still holding
+      // tabs it created keeps them alive across a test-reset clear.
+      final owned = _FakeTab('owned');
+      WorkspaceTabRegistry().register(() => owned);
+      WorkspaceTabRegistry().clear();
+      expect(WorkspaceTabRegistry().createTabs(), isEmpty);
+      expect(owned.title, 'owned'); // untouched, still usable
     });
   });
 }


### PR DESCRIPTION
Re-creates workspace tab plugins per workspace page (#3409)
Fixes #3409.

## The contract decision

#3409 offered two contracts for `WorkspaceTabPlugin` lifecycle. This PR picks
**option 2 — fresh tab instances per workspace page, `dispose()` terminal**:

- Option 1 (reuse-after-dispose, the de-facto behavior) cannot support the
  canonical plugin shape at all: `ChangeNotifier.dispose` is terminal and
  cannot be "re-armed" in `build()` — a ChangeNotifier tab throws
  `A <TabPlugin> was used after being disposed` on the next workspace open,
  the exact landmine #3406 removed for tool plugins. The issue's own
  acceptance fixture (a ChangeNotifier tab surviving close → open) is
  unimplementable under option 1.
- Nothing implements `WorkspaceTabPlugin` in production today (only test
  fakes), so the breaking registry change is free before the first consumer.

## What changed

- **`klangk-plugin-api` v0.6.0** (mcdonc/klangk-plugin-api, branch
  `tab-factories-v0.6.0`): `WorkspaceTabRegistry` now holds factories —
  `register(WorkspaceTabPlugin Function() create)`, `createTabs()` returns
  fresh instances in registration order, `clear()` replaces `disposeAll()`
  (the registry owns factories, not instances). The per-page lifecycle is
  documented on the class and on `dispose()`. The **v0.6.0 tag must exist
  before this PR's CI runs** (every `klangk_plugin_api` pin resolves it);
  the git-credential feature's committed `pubspec.lock` is regenerated to
  the tag in this PR as well.
- **Codegen** (`scripts/import_dart_features.py`): the tab aggregator emits
  `(name: …, create: Cls.new)` constructor tear-offs; the stub
  (`scripts/stub_dart_features.sh`) and `scripts/tests/test_build_pipeline.py`
  updated to match. Every `klangk_plugin_api` pin bumped v0.5.1 → v0.6.0
  (frontend pubspec, codegen `FEATURE_API_DEP`, stub, six feature pubspecs).
- **Workspace page** (`workspace_page.dart`): `initState` creates the page's
  tab set via `WorkspaceTabRegistry().createTabs()`; the existing dispose
  loop is now correct by construction — it releases exactly this page's
  instances, and the next page builds from its own fresh set. The comment
  states the contract (contrast #3408's app-lifetime tool plugins).
- **Fixture tab**: boingball (dormant — no default UI change) gains
  `BoingTab`, the first real `WorkspaceTabPlugin`: mixes in
  `ChangeNotifier`, owns a live badge `ValueNotifier` (disposed in
  `dispose()`), and carries a per-page bounce counter — per-workspace state
  on the instance, never statics.

## Verification

- Frontend unit suite: **1360 passed** (`flutter test --coverage`), including
  new tests: registry hands out fresh instances per `createTabs()` call;
  a ChangeNotifier tab disposes terminally and the next page's fresh
  instance is fully usable (badge listener + strip re-render).
- Build-pipeline contract tests: **156 passed** (factory-form aggregator
  assertions, boingball now the checked-in both-shape case).
- Python suites: **8272 passed, 100%** coverage (`-n auto`, unchanged code).
- fmtk e2e: new `test_feature_tab_recreated_across_workspace_close_reopen`
  enables boingball, then in one app session opens `fmtk-verify`, exercises
  the tab (bounce counter 0 → 1), closes the workspace, reopens it — the
  tab renders **0** again (fresh instance, not the disposed one) and the
  suite-level zero-uncaught-Flutter-errors drain passes. Ran green locally
  (6:04).

## Known limitation

Nothing pins that the page's dispose loop itself runs (the full
`WorkspacePage` cannot be mounted in widget tests — see
`workspace_overlays.dart`; and the e2e passes even with the loop deleted,
  since per-page instances make dispose-less tabs merely leak, not throw).
  The loop is two lines beside the tool-plugin comment it mirrors; the
  badge-listener removal it pairs with is pinned by the existing
  `drops the badge subscription` test.

## Fresh-eyes review

Attached below.
