### PR TITLE
fmtk e2e: isolate-wedge test must reach login from any state (#3413) (#3414)

### DIFF
--- a/src/frontend/e2e-tests/fmtk/test_harness_recovery.py
+++ b/src/frontend/e2e-tests/fmtk/test_harness_recovery.py
@@ -34,8 +34,24 @@ def gone_error() -> FmtkError:
     )
 
 
-def test_isolate_wedge_recovery(harness, app):
+def at_login(harness, app) -> None:
+    """Land on the usable login form from any prior state — the core
+    suite runs the smoke scenario first and it ends logged in (#3413) —
+    then dismiss any leftover login-banner dialog."""
+    app.ensure_tab_at_app()
+    app.navigate("/login")
+    if not app.has_text("Log In", 5000):
+        try:
+            app.dart_logout()
+        except FmtkError:
+            harness.restart_app()
     app.wait_for_login_page()
+    app.dismiss_login_banner()
+    app.wait_for_text("Email or handle")
+
+
+def test_isolate_wedge_recovery(harness, app):
+    at_login(harness, app)
 
     # the tab is on the app origin with the isolate attached: a gone
     # sighting arms the marker and keeps declining inside the window


### PR DESCRIPTION
Backport of #3414 to stable/2.0. Fixes #3413 on the release branch.

`stable/2.0` carries the same `fmtk-e2e-core.yml` file order as main (the
#3404 suite split is present there), so the deterministic nightly failure
exists on the release branch too: the smoke scenario runs first, ends logged
in, and `test_isolate_wedge_recovery`'s bare `wait_for_login_page()` times out
inheriting that session.

Same one-file fix: the suite's `at_login(harness, app)` preamble so the test
reaches the login form from any prior state. Cherry-picked from main
(da963269c); applies clean, no other files touched.
