### PR TITLE
Make the xenon gate fail loudly on unparseable files (#3415)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -262,8 +262,9 @@ single definition of the thresholds (`--max-absolute A --max-modules A
 graded `.py` file it grades the **full tree** (`pass_filenames = false` —
 a staged subset's average can exceed 5 while the whole tree passes, so
 partial grading would flap), and it fails when xenon silently skips a
-file it cannot parse (#3415). CI re-runs the gate in the `scripts/tests`
-step (backend-tests.yml), so do not bypass the hook with `--no-verify`.
+file it cannot parse (#3415). The CI workflows that run the scripts/tests
+suite (backend-tests.yml, macos-smoke.yml) re-run the gate there, so do not
+bypass the hook with `--no-verify`.
 
 Check locally before committing:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -255,12 +255,15 @@ Every function, method, and block in `src/klangk/klangk/**/*.py`,
 `src/klangksidecar/klangksidecar/**/*.py`, and
 `scripts/**/*.py` must be xenon rank **A or better** (cyclomatic complexity
 ≤ 5), and the per-module and codebase **averages** must also stay rank A
-(≤ 5). The gate runs as the `xenon` pre-commit hook defined in `devenv.nix`
-(`--max-absolute A --max-modules A --max-average A`); on every commit that
-stages a graded `.py` file it grades the **full tree** (`pass_filenames =
-false` — a staged subset's average can exceed 5 while the whole tree
-passes, so partial grading would flap). Nothing in CI enforces it yet —
-the hook is the only gate, so do not bypass it with `--no-verify`.
+(≤ 5). The gate runs as the `xenon` pre-commit hook (devenv.nix), which
+like the `klangk:xenon` task delegates to `scripts/xenon-gate.sh` — the
+single definition of the thresholds (`--max-absolute A --max-modules A
+--max-average A`) and the graded file set; on every commit that stages a
+graded `.py` file it grades the **full tree** (`pass_filenames = false` —
+a staged subset's average can exceed 5 while the whole tree passes, so
+partial grading would flap), and it fails when xenon silently skips a
+file it cannot parse (#3415). CI re-runs the gate in the `scripts/tests`
+step (backend-tests.yml), so do not bypass the hook with `--no-verify`.
 
 Check locally before committing:
 

--- a/devenv.nix
+++ b/devenv.nix
@@ -270,13 +270,14 @@ in
       after = [ "devenv:python:virtualenv" ];
       before = [ "devenv:enterShell" ];
     };
-    # The complexity gate as a one-word task (#2828): the exact hook
-    # invocation over the exact hook file set, so `devenv shell -- xenon`
-    # (ad hoc) and `pre-commit run xenon` (staged) can't drift. At rank A
-    # (#3052) the hook grades the full tree (pass_filenames=false), so
-    # the two invocations are identical.
+    # The complexity gate as a one-word task (#2828): delegates to
+    # scripts/xenon-gate.sh, the single definition of the invocation
+    # (thresholds + graded file set) that the pre-commit hook also runs,
+    # so `devenv shell` (ad hoc) and `pre-commit run xenon` (staged)
+    # can't drift. The wrapper also fails when xenon silently skips a
+    # file it cannot parse (#3415).
     "klangk:xenon" = {
-      exec = "xenon --max-absolute A --max-modules A --max-average A $(git ls-files 'src/klangk/klangk/*.py' 'src/klangksidecar/klangksidecar/*.py' 'scripts/*.py')";
+      exec = ''exec bash "$DEVENV_ROOT/scripts/xenon-gate.sh"'';
     };
     # Token-clone scan of the backend (#2904): the same invocation the
     # consolidation issues used (--min-tokens 70). Advisory only — the
@@ -820,14 +821,16 @@ in
     # average over only the staged files), but with every block <= 10 no
     # subset's average could exceed 10, so B-level flapping was impossible.
     # At rank A (#3052) that returns: a staged subset's average can exceed 5
-    # while the whole tree passes, so the hook now grades the full tree —
-    # pass_filenames = false, the entry enumerates the same git ls-files set
-    # the klangk:xenon task uses, and `files` stays as the run trigger (only
-    # complexity-relevant commits pay the scan).
+    # while the whole tree passes, so the hook grades the full tree —
+    # pass_filenames = false, the entry delegates to scripts/xenon-gate.sh
+    # (the single definition of thresholds + graded file set, shared with
+    # the klangk:xenon task, which also fails loudly when xenon skips a
+    # file it cannot parse, #3415), and `files` stays as the run trigger
+    # (only complexity-relevant commits pay the scan).
     xenon = {
       enable = true;
       name = "xenon";
-      entry = "bash -c 'xenon --max-absolute A --max-modules A --max-average A $(git ls-files \"src/klangk/klangk/*.py\" \"src/klangksidecar/klangksidecar/*.py\" \"scripts/*.py\")'";
+      entry = "scripts/xenon-gate.sh";
       files = "^src/klangk/klangk/.*\\.py$|^src/klangksidecar/klangksidecar/.*\\.py$|^scripts/.*\\.py$";
       language = "system";
       pass_filenames = false;

--- a/devenv.nix
+++ b/devenv.nix
@@ -277,7 +277,7 @@ in
     # can't drift. The wrapper also fails when xenon silently skips a
     # file it cannot parse (#3415).
     "klangk:xenon" = {
-      exec = ''exec bash "$DEVENV_ROOT/scripts/xenon-gate.sh"'';
+      exec = ''exec bash "$DEVENV_ROOT/scripts/xenon-gate.sh" "$@"'';
     };
     # Token-clone scan of the backend (#2904): the same invocation the
     # consolidation issues used (--min-tokens 70). Advisory only — the

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -2270,6 +2270,15 @@ stop)`) and a `server: stop at 23:00 (in 1h 12m)` status line in the
 
 ### Changed
 
+- **Strict xenon complexity gate (#3415).** The complexity gate now runs
+  through `scripts/xenon-gate.sh` — also the `klangk:xenon` devenv task —
+  which fails when its parser cannot read a graded file instead of
+  silently skipping it: xenon exits 0 on parse failures, so a skipped
+  file used to leave the gate with no signal anywhere. The
+  `scripts/tests` suite re-runs the gate over the graded tree in CI, and
+  the `test` extra now pins `xenon==0.9.3` so that guard runs on stock
+  runners.
+
 - **`dart format` pre-commit hook verifies instead of rewriting
   (#3376).** The hook now runs `dart format --output=none
 --set-exit-if-changed` via `scripts/dart-format-verify.sh` and fails

--- a/scripts/tests/test_xenon_gate.py
+++ b/scripts/tests/test_xenon_gate.py
@@ -1,0 +1,104 @@
+"""Contract tests for the strict xenon gate wrapper (#3415).
+
+xenon exits 0 when its parser cannot read a graded file: it logs a
+"cannot parse" WARNING and silently drops the file from the complexity
+gate. That bit when ruff 0.15's PEP 758 rewrite (``except A, B:`` on
+the py3.14 target) met nixpkgs' python3.13-built xenon — converted
+files left the gate with no signal anywhere. ``scripts/xenon-gate.sh``
+(the single invocation behind both the pre-commit hook and the
+``klangk:xenon`` devenv task) turns any such skip into a hard failure.
+These tests pin the wiring and prove the loud behavior; the graded-set
+run is the CI-side guard the issue asks for (backend-tests.yml runs
+this suite on stock runners, where xenon comes from the ``test`` extra).
+"""
+
+from __future__ import annotations
+
+import os
+import stat
+import subprocess
+import sys
+from pathlib import Path
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_GATE = _REPO_ROOT / "scripts" / "xenon-gate.sh"
+_DEVENV_NIX = _REPO_ROOT / "devenv.nix"
+
+# A file no Python parser accepts: exercises the wrapper's loud path
+# without depending on any specific syntax gap.
+_UNPARSEABLE = "def (:\n"
+
+
+def _run_gate(*args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["bash", str(_GATE), *args],
+        capture_output=True,
+        text=True,
+        cwd=_REPO_ROOT,
+    )
+
+
+def test_script_exists_and_is_executable():
+    assert _GATE.is_file(), "scripts/xenon-gate.sh is missing"
+    mode = _GATE.stat().st_mode
+    assert mode & stat.S_IXUSR, "scripts/xenon-gate.sh must be executable"
+    first = _GATE.read_text().splitlines()[0]
+    assert first.startswith("#!"), "scripts/xenon-gate.sh needs a shebang"
+
+
+def test_devenv_hook_and_task_delegate_to_the_wrapper():
+    """devenv.nix must run the wrapper for both the hook and the task."""
+    nix = _DEVENV_NIX.read_text()
+    assert 'entry = "scripts/xenon-gate.sh"' in nix, (
+        "the xenon pre-commit hook must run scripts/xenon-gate.sh"
+    )
+    assert '"$DEVENV_ROOT/scripts/xenon-gate.sh"' in nix, (
+        "the klangk:xenon task must run scripts/xenon-gate.sh"
+    )
+
+
+def test_wrapper_defines_thresholds_and_graded_set():
+    """One definition of the gate: the rank A thresholds and the graded
+    git ls-files globs live in the wrapper script."""
+    script = _GATE.read_text()
+    for part in (
+        "--max-absolute A",
+        "--max-modules A",
+        "--max-average A",
+        "'src/klangk/klangk/*.py'",
+        "'src/klangksidecar/klangksidecar/*.py'",
+        "'scripts/*.py'",
+    ):
+        assert part in script, f"{part} is missing from the gate wrapper"
+
+
+def test_devenv_carries_no_second_gate_definition():
+    """devenv.nix must delegate, not duplicate: a second copy of the
+    thresholds there could drift from the wrapper's."""
+    nix = _DEVENV_NIX.read_text()
+    assert "--max-absolute" not in nix, (
+        "gate thresholds are defined in scripts/xenon-gate.sh; devenv.nix "
+        "must not carry a second (drifting) copy"
+    )
+
+
+def test_gate_fails_loudly_on_unparseable_file(tmp_path):
+    """The regression the wrapper exists for: plain xenon exits 0 here."""
+    bad = tmp_path / "broken.py"
+    bad.write_text(_UNPARSEABLE)
+    done = _run_gate(str(bad))
+    assert done.returncode != 0, (
+        "xenon silently skips (exit 0) files it cannot parse; the "
+        "wrapper must turn that into a failure"
+    )
+    assert "cannot parse" in done.stderr + done.stdout, (
+        "the failure must name the skipped file"
+    )
+
+
+def test_gate_passes_the_graded_set():
+    """The full graded tree passes the strict gate — CI's loud guard."""
+    done = _run_gate()
+    assert done.returncode == 0, done.stderr + done.stdout

--- a/scripts/xenon-gate.sh
+++ b/scripts/xenon-gate.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# Strict wrapper for the xenon complexity gate (#3415).
+#
+# xenon exits 0 — success — even when its parser cannot read a graded
+# file: it logs a "cannot parse" WARNING and silently drops that file
+# from grading. That bit for real when ruff 0.15's PEP 758 rewrite
+# (``except A, B:`` on the py3.14 target) met nixpkgs' python3.13-built
+# xenon: every converted file left the gate un-graded with no signal
+# anywhere (#3415). The parser gap itself is fixed (devenv builds xenon
+# against python3.14), but the skip is still silent — the next syntax
+# the gate cannot parse would again un-gate files invisibly.
+#
+# This wrapper makes any skip a hard failure and owns the gate
+# invocation: the pre-commit hook and the ``klangk:xenon`` devenv task
+# both run this script, so the thresholds and the graded file set have
+# exactly one definition and cannot drift apart.
+#
+# Usage: xenon-gate.sh [FILE...]
+#   No arguments: grade the full gate file set (git ls-files, run from
+#   the repo root). With arguments: grade exactly those files (the
+#   scripts/tests contract tests use this for targeted runs).
+set -euo pipefail
+
+thresholds=(--max-absolute A --max-modules A --max-average A)
+
+if [ "$#" -gt 0 ]; then
+  set -- "${thresholds[@]}" "$@"
+else
+  # Graded set (#2828): the klangk package (server + CLI), the network
+  # sidecar, and the build scripts.
+  mapfile -t files < <(git ls-files \
+    'src/klangk/klangk/*.py' \
+    'src/klangksidecar/klangksidecar/*.py' \
+    'scripts/*.py')
+  if [ "${#files[@]}" -eq 0 ]; then
+    echo "xenon-gate: no graded .py files found — run from the repo root" >&2
+    exit 1
+  fi
+  set -- "${thresholds[@]}" "${files[@]}"
+fi
+
+log=$(mktemp)
+trap 'rm -f "$log"' EXIT
+
+status=0
+xenon "$@" >"$log" 2>&1 || status=$?
+cat "$log"
+
+# xenon's skip warning (logger "xenon", level WARNING): the file was
+# dropped from grading while the exit code stays 0.
+if grep -q 'WARNING:xenon:cannot parse' "$log"; then
+  cat >&2 <<'MSG'
+xenon-gate: FAIL — xenon skipped at least one graded file it cannot
+parse (on its own this exits 0). The file(s) above left the complexity
+gate un-graded; the gate's parser is probably older than the code's
+syntax. See #3415 (PEP 758 vs a python3.13-built xenon) for the last
+occurrence and its fix.
+MSG
+  exit 1
+fi
+
+exit "$status"

--- a/scripts/xenon-gate.sh
+++ b/scripts/xenon-gate.sh
@@ -27,8 +27,12 @@ if [ "$#" -gt 0 ]; then
   set -- "${thresholds[@]}" "$@"
 else
   # Graded set (#2828): the klangk package (server + CLI), the network
-  # sidecar, and the build scripts.
-  mapfile -t files < <(git ls-files \
+  # sidecar, and the build scripts. bash 3.2 compatible (no mapfile):
+  # the macOS CI runner still ships bash 3.2 as /bin/bash.
+  files=()
+  while IFS= read -r f; do
+    files+=("$f")
+  done < <(git ls-files \
     'src/klangk/klangk/*.py' \
     'src/klangksidecar/klangksidecar/*.py' \
     'scripts/*.py')

--- a/src/klangk/pyproject.toml
+++ b/src/klangk/pyproject.toml
@@ -65,6 +65,12 @@ test = [
     # documented way (`-n auto`, full coverage); this powers the local
     # `--testmon` scoped loop (#2288).
     "pytest-testmon>=2.0.0",
+    # The complexity-gate tool (rank A, #2794). The scripts/tests guard
+    # drives the real gate over the graded tree, and CI stock runners
+    # install only this extra — so the gate ships with the test
+    # toolchain. Pinned to the same 0.9.3 the devenv builds against
+    # python3.14 (#3415); on the py3.14 venv it parses PEP 758 forms.
+    "xenon==0.9.3",
 ]
 
 [project.scripts]

--- a/uv.lock
+++ b/uv.lock
@@ -787,6 +787,7 @@ test = [
     { name = "pytest-testmon" },
     { name = "pytest-timeout" },
     { name = "pytest-xdist" },
+    { name = "xenon" },
 ]
 
 [package.metadata]
@@ -815,6 +816,7 @@ requires-dist = [
     { name = "typer", specifier = ">=0.12.0" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.32.0" },
     { name = "websockets", specifier = ">=14.0" },
+    { name = "xenon", marker = "extra == 'test'", specifier = "==0.9.3" },
 ]
 provides-extras = ["test"]
 
@@ -909,6 +911,18 @@ wheels = [
 [package.optional-dependencies]
 fastapi = [
     { name = "opentelemetry-instrumentation-fastapi" },
+]
+
+[[package]]
+name = "mando"
+version = "0.7.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/35/24/cd70d5ae6d35962be752feccb7dca80b5e0c2d450e995b16abd6275f3296/mando-0.7.1.tar.gz", hash = "sha256:18baa999b4b613faefb00eac4efadcf14f510b59b924b66e08289aa1de8c3500", size = 37868, upload-time = "2022-02-24T08:12:27.316Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/f0/834e479e47e499b6478e807fb57b31cc2db696c4db30557bb6f5aea4a90b/mando-0.7.1-py2.py3-none-any.whl", hash = "sha256:26ef1d70928b6057ee3ca12583d73c63e05c49de8972d620c278a7b206581a8a", size = 28149, upload-time = "2022-02-24T08:12:25.24Z" },
 ]
 
 [[package]]
@@ -1512,6 +1526,19 @@ wheels = [
 ]
 
 [[package]]
+name = "radon"
+version = "6.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama" },
+    { name = "mando" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/6d/98e61600febf6bd929cf04154537c39dc577ce414bafbfc24a286c4fa76d/radon-6.0.1.tar.gz", hash = "sha256:d1ac0053943a893878940fedc8b19ace70386fc9c9bf0a09229a44125ebf45b5", size = 1874992, upload-time = "2023-03-26T06:24:38.868Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/93/f7/d00d9b4a0313a6be3a3e0818e6375e15da6d7076f4ae47d1324e7ca986a1/radon-6.0.1-py2.py3-none-any.whl", hash = "sha256:632cc032364a6f8bb1010a2f6a12d0f14bc7e5ede76585ef29dc0cecf4cd8859", size = 52784, upload-time = "2023-03-26T06:24:33.949Z" },
+]
+
+[[package]]
 name = "referencing"
 version = "0.37.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2024,6 +2051,20 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ab/31/2a7dc5f6abb2fca0b6e1610e120419f603650aceb4f1d3ac4cae0354e162/wrapt-2.2.1-cp314-cp314t-win_amd64.whl", hash = "sha256:fd0135d34387f5fd087d9be368ea77ea89cf2451dc1cd1c622d35021bcb3ab50", size = 83835, upload-time = "2026-05-22T14:49:21.634Z" },
     { url = "https://files.pythonhosted.org/packages/9f/c0/782b86e28d1ceebeb74cccea12d2cd3d2ba0bd68e3dec20b1bc5873f6127/wrapt-2.2.1-cp314-cp314t-win_arm64.whl", hash = "sha256:f70db64e8266d7c45d3b735f2e08eeb434b5e03da9a479ae42b2e2e486a21a00", size = 80722, upload-time = "2026-05-22T14:49:23.59Z" },
     { url = "https://files.pythonhosted.org/packages/53/46/29ac9daf11a86c22a8c38cd9236c62928ccae83f7ceb06bd3b0467cf9d05/wrapt-2.2.1-py3-none-any.whl", hash = "sha256:3aafea2975caef8ca49400640dde02cc7426e798f24870ed01f490bc3cffd32f", size = 61000, upload-time = "2026-05-22T14:49:41.593Z" },
+]
+
+[[package]]
+name = "xenon"
+version = "0.9.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyyaml" },
+    { name = "radon" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c4/7c/2b341eaeec69d514b635ea18481885a956d196a74322a4b0942ef0c31691/xenon-0.9.3.tar.gz", hash = "sha256:4a7538d8ba08aa5d79055fb3e0b2393c0bd6d7d16a4ab0fcdef02ef1f10a43fa", size = 9883, upload-time = "2024-10-21T10:27:53.722Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6f/5d/29ff8665b129cafd147d90b86e92babee32e116e3c84447107da3e77f8fb/xenon-0.9.3-py2.py3-none-any.whl", hash = "sha256:6e2c2c251cc5e9d01fe984e623499b13b2140fcbf74d6c03a613fa43a9347097", size = 8966, upload-time = "2024-10-21T10:27:51.121Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
# Pull request

## What this changes

The xenon complexity gate skipped any graded file its parser could not read,
silently: xenon logs `WARNING:xenon:cannot parse …` and exits 0, so the file
left the gate un-graded with no signal anywhere. ruff 0.15's PEP 758 rewrite
(`except A, B:` on the py3.14 target) turned that latent failure mode real
against nixpkgs' python3.13-built xenon (#3415); main already closed the
parser gap by rebuilding xenon against python3.14 (2859ba629). This PR makes
the skip itself loud, and keeps it loud:

- **`scripts/xenon-gate.sh`** — the single definition of the gate. The
  `xenon` pre-commit hook and the `klangk:xenon` devenv task both run it, so
  thresholds and the graded `git ls-files` set have exactly one definition.
  It grades with the same rank-A flags, and it fails the run when xenon logs
  a `cannot parse` warning — xenon itself exits 0 there — so the next
  parser/syntax gap turns the gate red instead of un-gating files invisibly.
- **`scripts/tests/test_xenon_gate.py`** — contract suite: pins the wiring
  (hook + task delegate to the wrapper; the flags/globs live only there),
  proves the loud behavior against an unparseable file, and re-runs the gate
  over the full graded tree — the CI-side guard.
- **`xenon==0.9.3` joins the `test` extra** — backend-tests.yml runs
  `pytest scripts/tests/` on stock runners with only
  `pip install -e 'src/klangk/[test]'`, so the guard needs the gate tool
  there. Same 0.9.3 as the devenv build; on the py3.14 venv it parses PEP 758
  forms.
- AGENTS.md and docs/changes.md updated: the gate section now describes the
  shared wrapper and the CI-side guard.

## Why

Per AGENTS.md the pre-commit hook was the only complexity enforcement — a
file that slipped out of grading (the #3415 episode: every file the
ruff-format hook converted) had no gate and no warning anywhere. The parser
gap for PEP 758 is fixed, but the silent-skip mechanism in xenon/radon is
upstream behavior (radon has been dormant since 2024), so the gate itself
must treat a parse skip as a failure.

## How it was tested

- `devenv shell -- python -m pytest scripts/tests -v` — 164 passed (163
  existing + the new suite).
- `devenv shell -- pre-commit run xenon --all-files` — Passed, through the
  wrapper; the hook caught a rank-B regression in the first draft of the new
  test file (radon counts asserts), which is the gate doing its job.
- `devenv shell -- devenv tasks run klangk:xenon` — green.
- Loud path proven directly: `bash scripts/xenon-gate.sh <file with a syntax
  error>` exits 1 and names the skipped file; bare `xenon` on the same file
  exits 0.
- Guard proven CI-shaped: the graded-set test resolves `xenon` from PATH
  only, exactly as the stock-runner scripts/tests step will.

## Checklist

- [x] I've described what and why above.
- [x] I've noted how I tested this.
- [x] This is my own, reviewed work — not an unreviewed automated/LLM-generated
      drive-by.
