### PR TITLE
Add label-driven backport automation for stable/2.0 (#3361)

### DIFF
--- a/.github/workflows/backport-autolabel.yml
+++ b/.github/workflows/backport-autolabel.yml
@@ -1,0 +1,38 @@
+name: "Backport auto-label for the 2.0 pre-release window"
+
+on:
+  pull_request_target:
+    types: [opened]
+
+# Inert unless the repo variable BACKPORT_2_0_DEFAULT == "true" (the
+# pre-release window switch, same pattern as ENABLE_SLOP_POLICY in
+# auto-close.yml). While set, every PR opened against main carries
+# backport/2.0, so a plain merge also backports the squash commit to
+# stable/2.0 (#3361); a PR opts out by removing the label before merge.
+# After the v2.0.0 freeze, remove the variable: the label becomes opt-in
+# and the /backport comment (backport.yml) stays as the rescue path.
+# Enable with: gh variable set BACKPORT_2_0_DEFAULT --body true
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  autolabel:
+    if: ${{ vars.BACKPORT_2_0_DEFAULT == 'true' && github.event.pull_request.base.ref == 'main' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Apply backport/2.0 label
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+
+          # Idempotent, same pattern as auto-close.yml's label step.
+          gh label create "backport/2.0" --repo "$REPO" \
+            --description "Merge also backports the squash commit to stable/2.0 (#3361)" \
+            --color FBCA04 2>/dev/null || true
+
+          gh pr edit "$PR_NUMBER" --repo "$REPO" --add-label "backport/2.0"
+          echo "::notice::labeled #$PR_NUMBER backport/2.0 (2.0 pre-release default)."

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -17,9 +17,11 @@ jobs:
     # A merged PR carrying backport/2.0 (the routine path — the label is
     # auto-applied to PRs against main while BACKPORT_2_0_DEFAULT is set,
     # see backport-autolabel.yml), or a `/backport` comment on a merged PR
-    # (the rescue path for a merge that happened unlabeled). stable/2.0 is
-    # the only target during the 2.0 pre-release window, so the label or
-    # comment gates whether the flow runs; the target is fixed here (#3361).
+    # (the rescue path for a merge that happened unlabeled; write-access
+    # authors only — the repo is public and this job holds a write token).
+    # stable/2.0 is the only target during the 2.0 pre-release window, so
+    # the label or comment gates whether the flow runs; the target is
+    # fixed here (#3361).
     if: >
       (
         github.event_name == 'pull_request_target' &&
@@ -28,6 +30,7 @@ jobs:
       ) || (
         github.event_name == 'issue_comment' &&
         github.event.issue.pull_request &&
+        contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association) &&
         startsWith(github.event.comment.body, '/backport')
       )
     steps:
@@ -39,6 +42,11 @@ jobs:
           # original PR title unchanged; the squash merge appends the
           # backport PR's own number.
           pull_title: "${pull_title}"
+          # A conflicted cherry-pick opens a draft PR carrying the first
+          # conflict committed, instead of only a failure comment on the
+          # source PR — the backport is never silently missing (#3361
+          # acceptance criteria).
+          experimental: '{"conflict_resolution": "draft_commit_conflicts"}'
           # Pre-release window: the backport commit is a cherry-pick of an
           # already-reviewed main commit, so the PR merges itself (squash)
           # while BACKPORT_2_0_AUTO_MERGE is set. Remove the variable at

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -1,0 +1,47 @@
+name: "Backport merged PRs to stable/2.0"
+
+on:
+  pull_request_target:
+    types: [closed]
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: write # push the cherry-picked branch
+  pull-requests: write # create the backport PR + comment on the original
+
+jobs:
+  backport:
+    name: Backport to stable/2.0
+    runs-on: ubuntu-latest
+    # A merged PR carrying backport/2.0 (the routine path — the label is
+    # auto-applied to PRs against main while BACKPORT_2_0_DEFAULT is set,
+    # see backport-autolabel.yml), or a `/backport` comment on a merged PR
+    # (the rescue path for a merge that happened unlabeled). stable/2.0 is
+    # the only target during the 2.0 pre-release window, so the label or
+    # comment gates whether the flow runs; the target is fixed here (#3361).
+    if: >
+      (
+        github.event_name == 'pull_request_target' &&
+        github.event.pull_request.merged &&
+        contains(github.event.pull_request.labels.*.name, 'backport/2.0')
+      ) || (
+        github.event_name == 'issue_comment' &&
+        github.event.issue.pull_request &&
+        startsWith(github.event.comment.body, '/backport')
+      )
+    steps:
+      - name: Create backport pull request
+        uses: korthout/backport-action@v4
+        with:
+          target_branches: stable/2.0
+          # Match the hand-made backport PR titles (e.g. #3426): the
+          # original PR title unchanged; the squash merge appends the
+          # backport PR's own number.
+          pull_title: "${pull_title}"
+          # Pre-release window: the backport commit is a cherry-pick of an
+          # already-reviewed main commit, so the PR merges itself (squash)
+          # while BACKPORT_2_0_AUTO_MERGE is set. Remove the variable at
+          # the v2.0.0 freeze to keep backports hand-merged.
+          auto_merge_enabled: ${{ vars.BACKPORT_2_0_AUTO_MERGE == 'true' }}
+          auto_merge_method: squash

--- a/docs/development/stable-branches.md
+++ b/docs/development/stable-branches.md
@@ -13,14 +13,22 @@ backport runs as automation (#3361):
 - Merging a labeled pull request cherry-picks its squash commit onto
   `stable/2.0` and opens a backport pull request
   (`.github/workflows/backport.yml`, the `korthout/backport-action`
-  workflow). A cherry-pick that conflicts opens the pull request with a
-  conflict comment and waits for a manual resolution.
+  workflow). A cherry-pick that conflicts opens a draft pull request
+  that carries the first conflict committed; resolve the conflicts on
+  its branch, then mark it ready and merge it.
+- Only the `backport/2.0` label and the `/backport` comment select the
+  backport; the target is fixed to `stable/2.0` and other labels play
+  no part.
 - While `BACKPORT_2_0_AUTO_MERGE` is set to `true`, the backport pull
   request merges itself (squash) as soon as it applies cleanly — the
-  commit is a cherry-pick of an already-reviewed `main` commit.
-  `stable/2.0` carries no required status checks today, so the merge
-  happens immediately; adding required checks at the freeze turns the
-  same setting into merge-when-green without further changes.
+  commit is a cherry-pick of an already-reviewed `main` commit. The
+  backport pull request carries no test runs: it is opened with the
+  workflow's `GITHUB_TOKEN`, and pull requests and pushes caused by
+  that token start no CI workflows. `stable/2.0` carries no required
+  status checks, so nothing gates the merge. At the freeze, drop
+  `BACKPORT_2_0_AUTO_MERGE` and merge backports by hand, or pass the
+  workflow a PAT (its `github_token` input) so its pull requests run
+  CI and required checks on `stable/2.0` can gate the merge.
 - A `/backport` comment on an already-merged pull request runs the same
   flow — the rescue path for a merge that happened without the label.
 

--- a/docs/development/stable-branches.md
+++ b/docs/development/stable-branches.md
@@ -1,6 +1,38 @@
 # Stable Deployment Branches
 
-For deployments that need a fixed release with cherry-picked hotfixes (rather than upgrading to the latest), create a stable branch:
+## Backports to stable/2.0 (2.0 pre-release window)
+
+While 2.0 is in development, changes that must ship in v2.0.0 land on both
+`main` and `stable/2.0` (releases tag from the stable branch). The
+backport runs as automation (#3361):
+
+- Every pull request opened against `main` carries the `backport/2.0`
+  label automatically while the repository variable
+  `BACKPORT_2_0_DEFAULT` is set to `true`. Remove the label before
+  merging to keep a change on `main` only.
+- Merging a labeled pull request cherry-picks its squash commit onto
+  `stable/2.0` and opens a backport pull request
+  (`.github/workflows/backport.yml`, the `korthout/backport-action`
+  workflow). A cherry-pick that conflicts opens the pull request with a
+  conflict comment and waits for a manual resolution.
+- While `BACKPORT_2_0_AUTO_MERGE` is set to `true`, the backport pull
+  request merges itself (squash) as soon as it applies cleanly — the
+  commit is a cherry-pick of an already-reviewed `main` commit.
+  `stable/2.0` carries no required status checks today, so the merge
+  happens immediately; adding required checks at the freeze turns the
+  same setting into merge-when-green without further changes.
+- A `/backport` comment on an already-merged pull request runs the same
+  flow — the rescue path for a merge that happened without the label.
+
+After v2.0.0 ships, remove both variables (`gh variable delete
+BACKPORT_2_0_DEFAULT`, `gh variable delete BACKPORT_2_0_AUTO_MERGE`).
+Backports become opt-in: apply the `backport/2.0` label before merging,
+or comment `/backport` on the merged pull request afterwards.
+
+## Hand-fed stable branches
+
+For deployments that need a fixed release with cherry-picked hotfixes
+(rather than upgrading to the latest), create a stable branch:
 
 ```bash
 git checkout -b stable/0.1 v0.1.0


### PR DESCRIPTION
# Pull request

## What this changes

Implements #3361: label-driven backports from `main` to `stable/2.0`, so a plain `/merge` is the whole dual-target routine during the 2.0 pre-release window.

- `.github/workflows/backport-autolabel.yml` — while the repo variable `BACKPORT_2_0_DEFAULT` is `true`, every PR opened against `main` gets the `backport/2.0` label applied automatically (the label is created idempotently, same pattern as `auto-close.yml`). Removing the label before merge opts a PR out.
- `.github/workflows/backport.yml` — `korthout/backport-action@v4`: a merged PR carrying `backport/2.0`, or a `/backport` comment on a merged PR (rescue path), cherry-picks the squash commit onto `stable/2.0` and opens a backport PR titled exactly like the hand-made ones (e.g. #3426). While `BACKPORT_2_0_AUTO_MERGE` is `true`, the backport PR merges itself (squash) once it applies cleanly.
- `docs/development/stable-branches.md` documents the flow, the two variables, and the freeze-time switch to opt-in.

Runtime switches already set on the repo (inert until these workflows land on `main`): the `backport/2.0` label, `BACKPORT_2_0_DEFAULT=true`, `BACKPORT_2_0_AUTO_MERGE=true`, and repository `allow_auto_merge`.

## Why

The manual second leg (cherry-pick + hand-opened backport PR, invoked as `/merge to main and stable/2.0`) is pure toil — 30+ backport PRs so far in the 2.0 cycle. The branches have diverged with duplicate-content commits; the fast-forward discipline from #3361's original phase 1 didn't survive the merge cadence, so the automation phase lands now instead of after the freeze.

## How it was tested

- Both workflow files parse (`yaml.safe_load`) and `scripts/tests` passes (164 passed) — including the CI path-filter contract tests over `.github/workflows`.
- Runtime behavior (label application, backport creation, auto-merge) is exercised by CI itself once merged: the next PR opened against `main` gets the label, and its merge produces the first automated backport.

## Review notes

A fresh-eyes review ran on this branch (attached as a comment); its three findings are addressed in d8e3c9848:

- The `/backport` comment arm requires OWNER/MEMBER/COLLABORATOR authors — the repo is public and the job holds a write token.
- A conflicted cherry-pick opens a draft PR carrying the conflict (`experimental.conflict_resolution: draft_commit_conflicts`) instead of only a failure comment, per #3361's acceptance criteria.
- Backport PRs are opened with the workflow's `GITHUB_TOKEN`; PRs and pushes caused by that token start no CI workflows. `stable/2.0` has no required status checks, so auto-merge is immediate and the backport carries no test runs — the trade-off accepted in #3361 for the pre-release window (the commit is a cherry-pick of an already-CI'd `main` commit). The docs state the freeze-time options honestly: hand-merge, or a PAT so backport PRs run CI and required checks can gate the merge.
