### PR TITLE
backport workflow: check out before cherry-picking (#3361)

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -34,6 +34,10 @@ jobs:
         startsWith(github.event.comment.body, '/backport')
       )
     steps:
+      # The action cherry-picks inside a git checkout and fetches the
+      # source PR + target branch itself. Checkout the base branch only —
+      # never PR code (pull_request_target runs with a write token).
+      - uses: actions/checkout@v7
       - name: Create backport pull request
         uses: korthout/backport-action@v4
         with:


### PR DESCRIPTION
Fixes the run-failure from #3438: `korthout/backport-action` cherry-picks inside the workspace and fetches the source PR + target branch itself, but the workflow shipped without an actions/checkout step, so both the merge-trigger run and the `/backport` rescue run failed with `not a git repository` → `Expected to fetch 'refs/pull/3438/head'`. Checks out the base branch only — PR code is never checked out under the pull_request_target write token.

Merging this PR also exercises the full chain end-to-end (it carries backport/2.0, so its own merge should produce the first automated backport PR).