### PR TITLE
Add label-driven backport automation for stable/2.0 (#3361) (#3438) [backport]

### DIFF
--- a/.github/workflows/backport-autolabel.yml
+++ b/.github/workflows/backport-autolabel.yml
@@ -1,0 +1,38 @@
+name: "Backport auto-label for the 2.0 pre-release window"
+
+on:
+  pull_request_target:
+    types: [opened]
+
+# Inert unless the repo variable BACKPORT_2_0_DEFAULT == "true" (the
+# pre-release window switch, same pattern as ENABLE_SLOP_POLICY in
+# auto-close.yml). While set, every PR opened against main carries
+# backport/2.0, so a plain merge also backports the squash commit to
+# stable/2.0 (#3361); a PR opts out by removing the label before merge.
+# After the v2.0.0 freeze, remove the variable: the label becomes opt-in
+# and the /backport comment (backport.yml) stays as the rescue path.
+# Enable with: gh variable set BACKPORT_2_0_DEFAULT --body true
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  autolabel:
+    if: ${{ vars.BACKPORT_2_0_DEFAULT == 'true' && github.event.pull_request.base.ref == 'main' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Apply backport/2.0 label
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+
+          # Idempotent, same pattern as auto-close.yml's label step.
+          gh label create "backport/2.0" --repo "$REPO" \
+            --description "Merge also backports the squash commit to stable/2.0 (#3361)" \
+            --color FBCA04 2>/dev/null || true
+
+          gh pr edit "$PR_NUMBER" --repo "$REPO" --add-label "backport/2.0"
+          echo "::notice::labeled #$PR_NUMBER backport/2.0 (2.0 pre-release default)."

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -1,0 +1,55 @@
+name: "Backport merged PRs to stable/2.0"
+
+on:
+  pull_request_target:
+    types: [closed]
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: write # push the cherry-picked branch
+  pull-requests: write # create the backport PR + comment on the original
+
+jobs:
+  backport:
+    name: Backport to stable/2.0
+    runs-on: ubuntu-latest
+    # A merged PR carrying backport/2.0 (the routine path — the label is
+    # auto-applied to PRs against main while BACKPORT_2_0_DEFAULT is set,
+    # see backport-autolabel.yml), or a `/backport` comment on a merged PR
+    # (the rescue path for a merge that happened unlabeled; write-access
+    # authors only — the repo is public and this job holds a write token).
+    # stable/2.0 is the only target during the 2.0 pre-release window, so
+    # the label or comment gates whether the flow runs; the target is
+    # fixed here (#3361).
+    if: >
+      (
+        github.event_name == 'pull_request_target' &&
+        github.event.pull_request.merged &&
+        contains(github.event.pull_request.labels.*.name, 'backport/2.0')
+      ) || (
+        github.event_name == 'issue_comment' &&
+        github.event.issue.pull_request &&
+        contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association) &&
+        startsWith(github.event.comment.body, '/backport')
+      )
+    steps:
+      - name: Create backport pull request
+        uses: korthout/backport-action@v4
+        with:
+          target_branches: stable/2.0
+          # Match the hand-made backport PR titles (e.g. #3426): the
+          # original PR title unchanged; the squash merge appends the
+          # backport PR's own number.
+          pull_title: "${pull_title}"
+          # A conflicted cherry-pick opens a draft PR carrying the first
+          # conflict committed, instead of only a failure comment on the
+          # source PR — the backport is never silently missing (#3361
+          # acceptance criteria).
+          experimental: '{"conflict_resolution": "draft_commit_conflicts"}'
+          # Pre-release window: the backport commit is a cherry-pick of an
+          # already-reviewed main commit, so the PR merges itself (squash)
+          # while BACKPORT_2_0_AUTO_MERGE is set. Remove the variable at
+          # the v2.0.0 freeze to keep backports hand-merged.
+          auto_merge_enabled: ${{ vars.BACKPORT_2_0_AUTO_MERGE == 'true' }}
+          auto_merge_method: squash

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -34,6 +34,10 @@ jobs:
         startsWith(github.event.comment.body, '/backport')
       )
     steps:
+      # The action cherry-picks inside a git checkout and fetches the
+      # source PR + target branch itself. Checkout the base branch only —
+      # never PR code (pull_request_target runs with a write token).
+      - uses: actions/checkout@v7
       - name: Create backport pull request
         uses: korthout/backport-action@v4
         with:

--- a/docs/development/stable-branches.md
+++ b/docs/development/stable-branches.md
@@ -1,6 +1,46 @@
 # Stable Deployment Branches
 
-For deployments that need a fixed release with cherry-picked hotfixes (rather than upgrading to the latest), create a stable branch:
+## Backports to stable/2.0 (2.0 pre-release window)
+
+While 2.0 is in development, changes that must ship in v2.0.0 land on both
+`main` and `stable/2.0` (releases tag from the stable branch). The
+backport runs as automation (#3361):
+
+- Every pull request opened against `main` carries the `backport/2.0`
+  label automatically while the repository variable
+  `BACKPORT_2_0_DEFAULT` is set to `true`. Remove the label before
+  merging to keep a change on `main` only.
+- Merging a labeled pull request cherry-picks its squash commit onto
+  `stable/2.0` and opens a backport pull request
+  (`.github/workflows/backport.yml`, the `korthout/backport-action`
+  workflow). A cherry-pick that conflicts opens a draft pull request
+  that carries the first conflict committed; resolve the conflicts on
+  its branch, then mark it ready and merge it.
+- Only the `backport/2.0` label and the `/backport` comment select the
+  backport; the target is fixed to `stable/2.0` and other labels play
+  no part.
+- While `BACKPORT_2_0_AUTO_MERGE` is set to `true`, the backport pull
+  request merges itself (squash) as soon as it applies cleanly — the
+  commit is a cherry-pick of an already-reviewed `main` commit. The
+  backport pull request carries no test runs: it is opened with the
+  workflow's `GITHUB_TOKEN`, and pull requests and pushes caused by
+  that token start no CI workflows. `stable/2.0` carries no required
+  status checks, so nothing gates the merge. At the freeze, drop
+  `BACKPORT_2_0_AUTO_MERGE` and merge backports by hand, or pass the
+  workflow a PAT (its `github_token` input) so its pull requests run
+  CI and required checks on `stable/2.0` can gate the merge.
+- A `/backport` comment on an already-merged pull request runs the same
+  flow — the rescue path for a merge that happened without the label.
+
+After v2.0.0 ships, remove both variables (`gh variable delete
+BACKPORT_2_0_DEFAULT`, `gh variable delete BACKPORT_2_0_AUTO_MERGE`).
+Backports become opt-in: apply the `backport/2.0` label before merging,
+or comment `/backport` on the merged pull request afterwards.
+
+## Hand-fed stable branches
+
+For deployments that need a fixed release with cherry-picked hotfixes
+(rather than upgrading to the latest), create a stable branch:
 
 ```bash
 git checkout -b stable/0.1 v0.1.0


### PR DESCRIPTION
Backport of #3438 and #3439 to `stable/2.0`.

Done by hand: the automation's `GITHUB_TOKEN` cannot push commits that create or update `.github/workflows/**` files ("refusing to allow a GitHub App to create or update workflow ... without `workflows` permission"), so workflow-touching PRs need a PAT or a manual backport. #3440 (the automated attempt) was closed and its branch deleted.
