### PR TITLE
Stop devenv 2.3.x running the hook suite on every devenv shell (#3444)

### DIFF
--- a/devenv.nix
+++ b/devenv.nix
@@ -381,6 +381,24 @@ in
         "features/*/klangk/pubspec.yaml"
       ];
     };
+
+    # WORKAROUND (#3444): devenv 2.3.x's RunMode::All scheduler gained a third
+    # selection pass that adds the prerequisites of every visited task --
+    # including the skipped devenv:enterTest (it sits `after` enterShell),
+    # whose prerequisite devenv:git-hooks:run is the full prek suite
+    # (`prek run -a`: 16 hooks over all files, ~14.5s wall / ~5m30s CPU per
+    # shell entry under devenv 2.3.1; under 2.2.2 the task never ran on shell
+    # entry). Clearing the `before` edge keeps that task out of the shell's
+    # task graph; mkForce replaces the upstream list outright (a plain
+    # `before = [ ]` would concatenate with it and change nothing). The
+    # commit-time pre-commit hook keeps enforcing the suite on `git commit`.
+    # `devenv test` loses the suite as well -- that edge was its only path
+    # in; `prek run -a` or an ordinary commit runs a full-suite pass. Remove
+    # this override once an upstream release stops scheduling prerequisites
+    # of skipped tasks.
+    "devenv:git-hooks:run" = lib.mkIf config.git-hooks.enable {
+      before = lib.mkForce [ ];
+    };
   };
 
   processes = {


### PR DESCRIPTION
Closes #3444.

## What changed

One setting in `devenv.nix`:

```nix
tasks."devenv:git-hooks:run".before = lib.mkForce [ ];
```

## Why

devenv 2.3.x added a third selection pass to `RunMode::All` that pulls the prerequisites of every visited task. `devenv shell` runs roots `["devenv:enterShell"]`, the outgoing pass visits the skipped `devenv:enterTest` (it sits `after` enterShell), and the new pass then drags in enterTest's prerequisite `devenv:git-hooks:run` — `prek run -a`, the full 16-hook suite over all files — on **every shell entry**. Clearing the `before` edge keeps that task out of the shell graph. klangk's `devenv.lock` is unchanged; the trigger was the CLI upgrade 2.2.2 → 2.3.1.

## Measured (only variable: the override)

| | before | after |
|---|---|---|
| `devenv:git-hooks:run` in shell task tree | runs, 14.4–14.7s | absent |
| tasks phase | 14.6s | 151ms |
| warm `devenv shell -- true` | 15.4s wall / 5m26s CPU | 0.7s wall |

## Tradeoffs

- `devenv test` no longer runs the hook suite through that task (it never did under devenv 2.2.x — this restores that behavior). Hook enforcement at commit time is unchanged: `devenv:git-hooks:install` still installs prek into `.git/hooks`, and the xenon gate stays a pre-commit hook per AGENTS.md.
- Drop the override once an upstream devenv release stops scheduling prerequisites of skipped tasks.

## Test plan

- [x] Warm `devenv shell -- true` completes in ~0.7s with no `devenv:git-hooks:run` in the task tree.
- [x] `nixfmt --width 80 --check devenv.nix` passes.
- [x] Committing from the worktree ran the full prek suite via the installed hook (the commit itself is the evidence).
- [ ] CI green.
