### PR TITLE
Apply ruff format PEP 758 except-clause style (#3447)

### DIFF
--- a/src/klangk/klangk/api/__init__.py
+++ b/src/klangk/klangk/api/__init__.py
@@ -161,7 +161,7 @@ async def version(app=Depends(get_app_dep)):
         try:
             with open(version_file) as f:
                 info = json.load(f)
-        except (OSError, ValueError):
+        except OSError, ValueError:
             info = None
         if isinstance(info, dict):
             info["features"] = app.state.features.feature_list()

--- a/src/klangk/klangk/api/auth.py
+++ b/src/klangk/klangk/api/auth.py
@@ -65,7 +65,7 @@ def _decode_binding_jwk(raw: str | None):
         return None
     try:
         jwk = json.loads(base64.urlsafe_b64decode(raw + "=" * (-len(raw) % 4)))
-    except (ValueError, json.JSONDecodeError):
+    except ValueError, json.JSONDecodeError:
         return None
     return jwk if isinstance(jwk, dict) else None
 
@@ -1514,7 +1514,7 @@ def _validate_state_cookie(
 
     try:
         cookie_data = json.loads(cookie_raw)
-    except (json.JSONDecodeError, UnicodeDecodeError):
+    except json.JSONDecodeError, UnicodeDecodeError:
         raise HTTPException(
             status_code=400, detail="Invalid OIDC state cookie"
         )

--- a/src/klangk/klangk/api/workspaces.py
+++ b/src/klangk/klangk/api/workspaces.py
@@ -1257,7 +1257,7 @@ async def _estimate_home_size(home_dir) -> int:
         )
         if result.returncode == 0:
             return int(result.stdout.split()[0])
-    except (OSError, ValueError, subprocess.TimeoutExpired):
+    except OSError, ValueError, subprocess.TimeoutExpired:
         pass  # fall back to 0
     return 0
 
@@ -1527,14 +1527,14 @@ async def _read_archive_metadata(archive_path: str) -> dict:
                 f"{_METADATA_MAX_BYTES // (1024 * 1024)} MB metadata bound"
             ),
         )
-    except (subprocess.CalledProcessError, subprocess.TimeoutExpired, OSError):
+    except subprocess.CalledProcessError, subprocess.TimeoutExpired, OSError:
         raise HTTPException(
             status_code=400,
             detail="Archive missing workspace.json or is corrupt",
         )
     try:
         return json.loads(payload)
-    except (json.JSONDecodeError, UnicodeDecodeError):
+    except json.JSONDecodeError, UnicodeDecodeError:
         raise HTTPException(
             status_code=400,
             detail="workspace.json is corrupt or contains invalid JSON",
@@ -1983,7 +1983,7 @@ async def import_workspace(
 
     except HTTPException:
         raise
-    except (json.JSONDecodeError, subprocess.TimeoutExpired):
+    except json.JSONDecodeError, subprocess.TimeoutExpired:
         # The metadata read converts its own timeout to a 400 upstream
         # (#3284), so every timeout reaching here has a row to roll
         # back; ws stays None only for the HTTPException paths that

--- a/src/klangk/klangk/auth.py
+++ b/src/klangk/klangk/auth.py
@@ -929,7 +929,7 @@ class Auth:
             return False
         try:
             first_dt = datetime.fromisoformat(first)
-        except (TypeError, ValueError):
+        except TypeError, ValueError:
             return False
         return (
             datetime.now(timezone.utc) - first_dt

--- a/src/klangk/klangk/caddy.py
+++ b/src/klangk/klangk/caddy.py
@@ -195,7 +195,7 @@ def detect_host_ipv4s() -> list[str]:
         out = subprocess.check_output(
             ["ip", "-4", "addr", "show"], text=True, stderr=subprocess.DEVNULL
         )
-    except (OSError, subprocess.CalledProcessError, FileNotFoundError):
+    except OSError, subprocess.CalledProcessError, FileNotFoundError:
         return []
     addrs: list[str] = []
     for line in out.splitlines():
@@ -372,7 +372,7 @@ def csp_policy(frontend_dir: str | Path) -> str:
             .joinpath("index.html")
             .read_text(encoding="utf-8")
         )
-    except (OSError, UnicodeDecodeError):
+    except OSError, UnicodeDecodeError:
         # Unreadable OR non-UTF-8 (a ValueError, not an OSError — a
         # windows-1252 byte would otherwise raise out of the renderer and
         # wedge the watchdog in a kill/respawn loop). Either way: strict
@@ -440,7 +440,7 @@ def classify_caddy_line(line: str) -> tuple[int, str]:
     """
     try:
         obj = json.loads(line)
-    except (json.JSONDecodeError, ValueError):
+    except json.JSONDecodeError, ValueError:
         return logging.ERROR, line
 
     caddy_level = obj.get("level", "info")
@@ -475,7 +475,7 @@ def is_bind_error(line: str) -> bool:
     """
     try:
         obj = json.loads(line)
-    except (json.JSONDecodeError, ValueError):
+    except json.JSONDecodeError, ValueError:
         return False
     msg = f"{obj.get('msg') or ''} {obj.get('error') or ''}".strip().lower()
     if not msg:
@@ -1275,7 +1275,7 @@ def caddy_supports_full_global_block(bin_path: str) -> bool:
             timeout=5,
         )
         return r.returncode == 0
-    except (OSError, subprocess.SubprocessError):
+    except OSError, subprocess.SubprocessError:
         return True  # probe failed to run — assume supported (rare; preserves features)
     finally:
         if probe_path is not None:
@@ -1487,7 +1487,7 @@ class CaddyWatchdog:
                     # real socket — don't let it mask the successful connect.
                     pass
                 return True
-            except (httpx.HTTPError, OSError):
+            except httpx.HTTPError, OSError:
                 await asyncio.sleep(0.2)
         return False
 
@@ -1721,7 +1721,7 @@ class CaddyWatchdog:
         alone when the group is gone or not ours."""
         try:
             os.killpg(proc.pid, sig)
-        except (ProcessLookupError, PermissionError):
+        except ProcessLookupError, PermissionError:
             if sig == signal.SIGTERM:
                 proc.terminate()
             else:

--- a/src/klangk/klangk/cli/account.py
+++ b/src/klangk/klangk/cli/account.py
@@ -190,7 +190,7 @@ def parsed_min_length(config: dict) -> int:
     """The advertised min password length, or the default when unparseable."""
     try:
         return int(config.get("min_password_length") or _DEFAULT_MIN_PASSWORD)
-    except (TypeError, ValueError):
+    except TypeError, ValueError:
         return _DEFAULT_MIN_PASSWORD
 
 
@@ -198,7 +198,7 @@ def parsed_min_changed(config: dict) -> int:
     """The advertised min changed-character count, 0 when unparseable."""
     try:
         return max(0, int(config.get("password_min_changed") or 0))
-    except (TypeError, ValueError):
+    except TypeError, ValueError:
         return 0
 
 
@@ -211,7 +211,7 @@ def parsed_requirements(config: dict) -> dict:
     for key in requirements:
         try:
             requirements[key] = int(reqs.get(key) or 0)
-        except (TypeError, ValueError):
+        except TypeError, ValueError:
             pass
     return requirements
 

--- a/src/klangk/klangk/cli/auth.py
+++ b/src/klangk/klangk/cli/auth.py
@@ -334,7 +334,7 @@ def select_oidc_provider(providers: list) -> dict:
     try:
         idx = int(choice) - 1
         return providers[idx]
-    except (ValueError, IndexError):
+    except ValueError, IndexError:
         _err.print("[red]Invalid choice[/red]")
         raise SystemExit(1)
 
@@ -644,7 +644,7 @@ def proc_ppid(pid: int) -> int | None:
     """One /proc pid's parent pid, or None when unreadable."""
     try:
         return int(open(f"/proc/{pid}/stat", "rb").read().decode().split()[3])
-    except (OSError, ValueError):
+    except OSError, ValueError:
         return None
 
 

--- a/src/klangk/klangk/cli/authcmds.py
+++ b/src/klangk/klangk/cli/authcmds.py
@@ -210,7 +210,7 @@ def _fmt_last_login(iso: str | None) -> str | None:
         return (
             datetime.fromisoformat(iso).astimezone().strftime("%Y-%m-%d %H:%M")
         )
-    except (ValueError, TypeError):
+    except ValueError, TypeError:
         return None
 
 

--- a/src/klangk/klangk/cli/client.py
+++ b/src/klangk/klangk/cli/client.py
@@ -1206,7 +1206,7 @@ async def send_ignore_closed(ws, msg: str) -> None:
     """Send a WebSocket message, ignoring errors if the connection is closed."""
     try:
         await ws.send(msg)
-    except (websockets.ConnectionClosed, OSError):
+    except websockets.ConnectionClosed, OSError:
         pass
 
 
@@ -1296,7 +1296,7 @@ def drain_stdin() -> None:
         finally:
             if old is not None:
                 termios.tcsetattr(fd, termios.TCSADRAIN, old)
-    except (OSError, io.UnsupportedOperation):
+    except OSError, io.UnsupportedOperation:
         pass
 
 
@@ -1946,7 +1946,7 @@ class TerminalSession(_ShellSession):
             disposition, payload = await self._handle_byte(data, st, fd)
             if disposition == "exit":
                 return False
-        except (OSError, io.UnsupportedOperation):
+        except OSError, io.UnsupportedOperation:
             return False
         # The send sits outside the except scope, as in the original loop:
         # a send failure must propagate and tear down the other pumps.
@@ -2149,7 +2149,7 @@ class ExecSession(_ShellSession):
         try:
             if self.stdout is not None:
                 self._stdout_fd = self.stdout.fileno()
-        except (io.UnsupportedOperation, AttributeError):
+        except io.UnsupportedOperation, AttributeError:
             pass
         self._has_stdout_fd = self._stdout_fd >= 0
 
@@ -2157,7 +2157,7 @@ class ExecSession(_ShellSession):
         """stdin's fileno, or None when it has none (BytesIO etc.)."""
         try:
             return self.stdin.fileno()
-        except (io.UnsupportedOperation, AttributeError):
+        except io.UnsupportedOperation, AttributeError:
             return None
 
     async def send_exec_input(self, data: bytes) -> None:

--- a/src/klangk/klangk/cli/context.py
+++ b/src/klangk/klangk/cli/context.py
@@ -149,7 +149,7 @@ def client() -> KlangkClient:
         )
         try:
             entered = Prompt.ask(message, password=True)
-        except (EOFError, KeyboardInterrupt):
+        except EOFError, KeyboardInterrupt:
             return None
         return entered or None
 

--- a/src/klangk/klangk/cli/execsync.py
+++ b/src/klangk/klangk/cli/execsync.py
@@ -49,7 +49,7 @@ def sync_denied(client, host: str) -> bool:
     """
     try:
         ws = client.resolve_workspace(host)
-    except (WorkspaceNotFoundError, httpx.HTTPError):
+    except WorkspaceNotFoundError, httpx.HTTPError:
         return False
     resource = f"/workspaces/{ws.id}"
     try:
@@ -57,7 +57,7 @@ def sync_denied(client, host: str) -> bool:
             "/api/v1/my-permissions", params={"resource": resource}
         )
         perms = resp.json().get("permissions", {}).get(resource)
-    except (httpx.HTTPError, ValueError):
+    except httpx.HTTPError, ValueError:
         # ValueError: a non-JSON error body (e.g. an HTML 500 page from
         # a proxy in front of klangkd) must not crash the preflight.
         return False

--- a/src/klangk/klangk/cli/sandbox.py
+++ b/src/klangk/klangk/cli/sandbox.py
@@ -35,7 +35,7 @@ def parse_setup_timeout(sandbox: dict) -> int:
     )
     try:
         return int(setup_timeout)
-    except (TypeError, ValueError):
+    except TypeError, ValueError:
         raise ValueError(
             f"setup-timeout must be an integer, got {setup_timeout!r}"
         )

--- a/src/klangk/klangk/cli/sandboxcmd.py
+++ b/src/klangk/klangk/cli/sandboxcmd.py
@@ -405,7 +405,7 @@ async def wait_for_terminal_start(ws, timeout: float) -> None:
             break
         try:
             raw = await asyncio.wait_for(ws.recv(), timeout=remaining)
-        except (asyncio.TimeoutError, websockets.ConnectionClosed):
+        except asyncio.TimeoutError, websockets.ConnectionClosed:
             break
         if json.loads(raw).get("type") == "terminal_started":
             break

--- a/src/klangk/klangk/cli/shell_popup.py
+++ b/src/klangk/klangk/cli/shell_popup.py
@@ -93,7 +93,7 @@ def host_tmux_version() -> tuple[int, int] | None:
         proc = subprocess.run(
             ["tmux", "-V"], capture_output=True, text=True, timeout=5
         )
-    except (OSError, subprocess.SubprocessError):
+    except OSError, subprocess.SubprocessError:
         return None
     if proc.returncode != 0:
         return None
@@ -172,7 +172,7 @@ def list_session_names(socket: str) -> list[str] | None:
             text=True,
             timeout=5,
         )
-    except (OSError, subprocess.SubprocessError):
+    except OSError, subprocess.SubprocessError:
         return None
     if proc.returncode != 0:
         return None
@@ -348,7 +348,7 @@ def outer_clients(socket: str, hidden: str) -> list[str]:
             text=True,
             timeout=5,
         )
-    except (OSError, subprocess.SubprocessError):
+    except OSError, subprocess.SubprocessError:
         return []
     clients: list[str] = []
     for line in proc.stdout.splitlines():
@@ -367,7 +367,7 @@ def hidden_has_client(socket: str, hidden: str) -> bool:
             text=True,
             timeout=5,
         )
-    except (OSError, subprocess.SubprocessError):
+    except OSError, subprocess.SubprocessError:
         return False
     return bool(proc.stdout.strip())
 

--- a/src/klangk/klangk/cli/shellcmd.py
+++ b/src/klangk/klangk/cli/shellcmd.py
@@ -133,7 +133,7 @@ def member_may_decide(client, workspace_id: str) -> bool:
             "/api/v1/my-permissions", params={"resource": resource}
         )
         perms = resp.json().get("permissions", {}).get(resource)
-    except (httpx.HTTPError, ValueError):
+    except httpx.HTTPError, ValueError:
         # ValueError: a non-JSON error body (e.g. an HTML 500 page from a
         # proxy in front of klangkd) must not skip the decider.
         return True

--- a/src/klangk/klangk/cli/tui/consent.py
+++ b/src/klangk/klangk/cli/tui/consent.py
@@ -402,7 +402,7 @@ class ConsentDeciderController:
         """
         try:
             msg = json.loads(raw)
-        except (json.JSONDecodeError, TypeError):
+        except json.JSONDecodeError, TypeError:
             return IGNORED, None
         if not isinstance(msg, dict):
             return IGNORED, None
@@ -656,7 +656,7 @@ async def cancel_and_await(task) -> None:
     task.cancel()
     try:
         await task
-    except (asyncio.CancelledError, Exception):
+    except asyncio.CancelledError, Exception:
         pass
 
 

--- a/src/klangk/klangk/cli/tui/screens/main.py
+++ b/src/klangk/klangk/cli/tui/screens/main.py
@@ -257,7 +257,7 @@ def parse_status_event(raw: str) -> dict | None:
     """A dict event from one frame, or None when not JSON / not an object."""
     try:
         event = json.loads(raw)
-    except (TypeError, ValueError):
+    except TypeError, ValueError:
         return None
     if not isinstance(event, dict):
         return None
@@ -1223,7 +1223,7 @@ class MainScreen(StatusScreen):
                 .astimezone()
                 .strftime("%Y-%m-%d %H:%M")
             )
-        except (ValueError, TypeError):
+        except ValueError, TypeError:
             return ""
 
     @staticmethod
@@ -1232,7 +1232,7 @@ class MainScreen(StatusScreen):
         try:
             dt = datetime.datetime.fromisoformat(raw)
             return dt.strftime("%Y-%m-%d")
-        except (ValueError, TypeError):
+        except ValueError, TypeError:
             return ""
 
     @staticmethod

--- a/src/klangk/klangk/cli/tui/screens/workspace_detail.py
+++ b/src/klangk/klangk/cli/tui/screens/workspace_detail.py
@@ -1070,7 +1070,7 @@ class WorkspaceDetailScreen(StatusScreen):
         """
         try:
             idx = int(key)
-        except (TypeError, ValueError):
+        except TypeError, ValueError:
             return None
         for w in self.terminals:
             if w.get("index") == idx:
@@ -1170,7 +1170,7 @@ class WorkspaceDetailScreen(StatusScreen):
         """Friendly label for a list row: the window name, or the key."""
         try:
             idx = int(key)
-        except (TypeError, ValueError):
+        except TypeError, ValueError:
             return key
         for w in self.terminals:
             if w.get("index") == idx:

--- a/src/klangk/klangk/cli/workspaces.py
+++ b/src/klangk/klangk/cli/workspaces.py
@@ -249,7 +249,7 @@ def ensure_autostart_allowed(client, requested) -> None:
         return
     try:
         cfg = client.config()
-    except (httpx.HTTPError, AuthError, ValueError):
+    except httpx.HTTPError, AuthError, ValueError:
         return
     if not isinstance(cfg, dict) or cfg.get("allow_autostart") is not True:
         context.err.print(

--- a/src/klangk/klangk/container/admission.py
+++ b/src/klangk/klangk/container/admission.py
@@ -134,7 +134,7 @@ def _machine_memory_of(entry) -> int | None:
     (>= the 64 MiB unit-mismatch floor), else None."""
     try:
         value = int(entry["Memory"])
-    except (KeyError, TypeError, ValueError):
+    except KeyError, TypeError, ValueError:
         return None
     if value < _MIN_MACHINE_MEMORY_BYTES:
         return None
@@ -228,7 +228,7 @@ async def _measure_machine_memory(podman_bin: str, runner) -> int | None:
         machines = await runner(
             podman_bin, "machine", "ls", "--format", "json"
         )
-    except (OSError, ValueError):
+    except OSError, ValueError:
         return None
     return _pick_machine_memory(machines)
 

--- a/src/klangk/klangk/container/eviction.py
+++ b/src/klangk/klangk/container/eviction.py
@@ -117,7 +117,7 @@ def _cgroup_usage(cgroup_dir: str) -> tuple[int, int, int] | None:
         if v2_max is not None:
             return _cgroup_v2_usage(cgroup_dir, v2_max)
         return _cgroup_v1_usage(cgroup_dir)
-    except (OSError, ValueError):
+    except OSError, ValueError:
         return None
 
 
@@ -160,7 +160,7 @@ def _v2_memory_limit(cgroup_dir: str) -> int | None:
         text = open(f"{cgroup_dir}/memory.max").read().strip()
         if text != "max":
             return int(text)
-    except (OSError, ValueError):
+    except OSError, ValueError:
         pass
     return None
 
@@ -194,7 +194,7 @@ def stat_value(stat_path: str, names: tuple[str, ...]) -> int:
             name, _, value = line.partition(" ")
             if name in names:
                 return int(value)
-    except (OSError, ValueError):
+    except OSError, ValueError:
         pass
     return 0
 

--- a/src/klangk/klangk/container/registry.py
+++ b/src/klangk/klangk/container/registry.py
@@ -156,7 +156,7 @@ def _parse_host_port(entry) -> int | None:
     """Host port from one PortBindings entry, or None when unreadable."""
     try:
         return int(entry["HostPort"])
-    except (KeyError, ValueError, TypeError):
+    except KeyError, ValueError, TypeError:
         return None
 
 
@@ -210,7 +210,7 @@ def _owner_pid_label(c: dict) -> int | None:
         return None
     try:
         return int(label)
-    except (TypeError, ValueError):
+    except TypeError, ValueError:
         return None
 
 
@@ -1414,7 +1414,7 @@ class ContainerRegistry(NetworkSidecarMixin):
             containers = await self.app.state.podman.list_containers(
                 f"klangk.workspace={workspace_id}"
             )
-        except (podman.PodmanError, OSError, ValueError):
+        except podman.PodmanError, OSError, ValueError:
             # Best-effort reconcile: a failed ps must not break a start
             # that may legitimately create a fresh container.
             return None

--- a/src/klangk/klangk/dpop.py
+++ b/src/klangk/klangk/dpop.py
@@ -147,7 +147,7 @@ def verify_signature(
         der = _raw_to_der(signature) if len(signature) == 64 else signature
         key.verify(der, signing_input, ec.ECDSA(hashes.SHA256()))
         return True
-    except (ValueError, TypeError, InvalidSignature):
+    except ValueError, TypeError, InvalidSignature:
         return False
 
 
@@ -164,7 +164,7 @@ def decode_proof(proof: str) -> tuple[dict, dict, bytes] | None:
         header = json.loads(_b64url_decode(parts[0]))
         payload = json.loads(_b64url_decode(parts[1]))
         signature = _b64url_decode(parts[2])
-    except (ValueError, TypeError):
+    except ValueError, TypeError:
         return None
     if not isinstance(header, dict) or not isinstance(payload, dict):
         return None

--- a/src/klangk/klangk/features.py
+++ b/src/klangk/klangk/features.py
@@ -193,7 +193,7 @@ class Features:
                 return {}
             with open(path) as f:
                 data = json.load(f)
-        except (FileNotFoundError, json.JSONDecodeError, ValueError, OSError):
+        except FileNotFoundError, json.JSONDecodeError, ValueError, OSError:
             return {}
         if not isinstance(data, dict):
             return {}

--- a/src/klangk/klangk/logger.py
+++ b/src/klangk/klangk/logger.py
@@ -233,7 +233,7 @@ def read_instance_file(path: Path) -> str | None:
     """
     try:
         return path.read_text().strip() or None
-    except (OSError, ValueError):
+    except OSError, ValueError:
         return None
 
 
@@ -252,7 +252,7 @@ def write_instance_file(path: Path) -> str:
         tmp = path.parent / f"{path.name}.tmp"
         tmp.write_text(fresh)
         os.replace(tmp, path)
-    except (OSError, ValueError):
+    except OSError, ValueError:
         return ""
     return fresh
 

--- a/src/klangk/klangk/main.py
+++ b/src/klangk/klangk/main.py
@@ -480,7 +480,7 @@ def _read_instance_id(settings: KlangkSettings) -> str | None:
     instance_id_path = Path(settings.data_dir) / "instance-id"
     try:
         return instance_id_path.read_text().strip() or None
-    except (FileNotFoundError, ValueError):
+    except FileNotFoundError, ValueError:
         return None
 
 
@@ -492,7 +492,7 @@ def _live_foreign_pid(pid_path: Path, pid: int) -> bool:
     """
     try:
         os.kill(pid, 0)
-    except (ProcessLookupError, OverflowError):
+    except ProcessLookupError, OverflowError:
         # Stale PID file — clean it up.
         pid_path.unlink(missing_ok=True)
         return False
@@ -515,7 +515,7 @@ def check_pid_preflight(settings: KlangkSettings) -> int | None:
     pid_path = Path(settings.state_dir) / f"klangk-{instance_id}.pid"
     try:
         pid = int(pid_path.read_text().strip())
-    except (FileNotFoundError, ValueError):
+    except FileNotFoundError, ValueError:
         return None
     return pid if _live_foreign_pid(pid_path, pid) else None
 
@@ -552,7 +552,7 @@ def refusal_already_reported(marker: Path, winner_pid: int) -> bool:
     """True if a refusal for this live winner PID was already logged (#2021)."""
     try:
         return int(marker.read_text().strip()) == winner_pid
-    except (FileNotFoundError, ValueError):
+    except FileNotFoundError, ValueError:
         return False
 
 
@@ -581,7 +581,7 @@ def check_port_preflight(host: str, port: int) -> bool:
     try:
         sock.connect((host, port))
         return True
-    except (ConnectionRefusedError, OSError):
+    except ConnectionRefusedError, OSError:
         return False
     finally:
         sock.close()
@@ -620,7 +620,7 @@ def _brew_prefix() -> str:
             timeout=5,
         )
         return result.stdout.strip()
-    except (subprocess.TimeoutExpired, OSError):
+    except subprocess.TimeoutExpired, OSError:
         return ""
 
 

--- a/src/klangk/klangk/podman.py
+++ b/src/klangk/klangk/podman.py
@@ -1097,10 +1097,10 @@ class ExecSession:
         try:
             self._proc.terminate()
             await asyncio.wait_for(self._proc.wait(), timeout=5)
-        except (ProcessLookupError, asyncio.TimeoutError, OSError):
+        except ProcessLookupError, asyncio.TimeoutError, OSError:
             try:
                 self._proc.kill()
-            except (ProcessLookupError, OSError):
+            except ProcessLookupError, OSError:
                 pass
         self._save_returncode()
         self._proc = None

--- a/src/klangk/klangk/seed.py
+++ b/src/klangk/klangk/seed.py
@@ -435,7 +435,7 @@ def bundled_dockerfile() -> Path | None:
         res = importlib.resources.files("klangk") / _BUNDLE_DIR / "Dockerfile"
         p = Path(str(res))
         return p if p.is_file() else None
-    except (ModuleNotFoundError, FileNotFoundError):
+    except ModuleNotFoundError, FileNotFoundError:
         return None
 
 

--- a/src/klangk/klangk/server_schedule.py
+++ b/src/klangk/klangk/server_schedule.py
@@ -117,7 +117,7 @@ class ServerScheduler(IntervalWorker):
         for s in schedules:
             try:
                 is_due = parse_fire_at(s["fire_at"]) <= now
-            except (TypeError, ValueError):
+            except TypeError, ValueError:
                 # 7: a malformed fire_at row (manual DB edit) must not
                 # kill the whole tick — skip and log it, keep the healthy
                 # rows working (still broadcast it; never fire it).

--- a/src/klangk/klangk/terminal.py
+++ b/src/klangk/klangk/terminal.py
@@ -1110,7 +1110,7 @@ class ShellProcess:
         pending read, close the fd."""
         try:
             asyncio.get_running_loop().remove_reader(self._master_fd)
-        except (ValueError, RuntimeError):
+        except ValueError, RuntimeError:
             pass  # loop already closed or fd not registered
         if self._read_event is not None:
             self._read_event.set()  # unblock any pending read

--- a/src/klangk/klangk/util.py
+++ b/src/klangk/klangk/util.py
@@ -561,11 +561,11 @@ class Util:
         path = self.pid_file_path()
         try:
             pid = int(path.read_text().strip())
-        except (FileNotFoundError, ValueError):
+        except FileNotFoundError, ValueError:
             return None
         try:
             os.kill(pid, 0)
-        except (ProcessLookupError, OverflowError):
+        except ProcessLookupError, OverflowError:
             # Process is dead or PID is invalid — stale PID file.
             path.unlink(missing_ok=True)
             return None
@@ -592,7 +592,7 @@ class Util:
             # have overwritten it after we were signalled to stop).
             if path.read_text().strip() == str(os.getpid()):
                 path.unlink()
-        except (FileNotFoundError, ValueError, OSError):
+        except FileNotFoundError, ValueError, OSError:
             pass
 
     # --- Proxy trust / forwarded headers ---------------------------------
@@ -991,7 +991,7 @@ class Util:
         raw = self.app.state.settings.bridge_timeout_seconds
         try:
             deploy_default = float(raw) if raw else None
-        except (TypeError, ValueError):
+        except TypeError, ValueError:
             deploy_default = None
         resolved = bridge_ws_settings.resolve_bridge_timeout(
             workspace, deploy_default

--- a/src/klangk/klangk/wshandler/controllers.py
+++ b/src/klangk/klangk/wshandler/controllers.py
@@ -144,7 +144,7 @@ def decode_b64_payload(raw, cmd: str) -> bytes | None:
     """
     try:
         return base64.b64decode(raw, validate=True)
-    except (TypeError, ValueError):
+    except TypeError, ValueError:
         logger.warning("%s: invalid base64 payload, dropping", cmd)
         return None
 
@@ -379,7 +379,7 @@ class SshAgentForwarder:
         try:
             proc.stdin.write(decoded)
             await proc.stdin.drain()
-        except (ConnectionError, RuntimeError):
+        except ConnectionError, RuntimeError:
             logger.warning(
                 "SSH agent relay stdin gone; dropping frame and stopping relay"
             )
@@ -771,7 +771,7 @@ class TerminalController:
                 self._conn.container_id,
                 SERVICE_SESSION,
             )
-        except (TerminalError, OSError):
+        except TerminalError, OSError:
             return False  # service session doesn't exist yet
         if not windows:
             return False
@@ -913,7 +913,7 @@ class TerminalController:
                     except WS_ERRORS:
                         pass
                     return
-                except (TerminalError, OSError):
+                except TerminalError, OSError:
                     logger.exception("_start_terminal: window list failed")
                 ctrl._send_shared_terminals()
             except asyncio.CancelledError:
@@ -921,7 +921,7 @@ class TerminalController:
                 conn.app.state.container_registry.revoke_browser(conn.sock)
                 conn.browser_id = None
                 raise
-            except (SlowClientError, WebSocketDisconnect):
+            except SlowClientError, WebSocketDisconnect:
                 await session.stop()
                 conn.app.state.container_registry.revoke_browser(conn.sock)
                 conn.browser_id = None

--- a/src/klangk/klangk/wshandler/decider.py
+++ b/src/klangk/klangk/wshandler/decider.py
@@ -333,7 +333,7 @@ async def _receive_decider_frame(safe_ws):
     # as WebSocketDisconnect.
     try:
         raw = await safe_ws.receive_text()
-    except (WebSocketDisconnect, RuntimeError):
+    except WebSocketDisconnect, RuntimeError:
         return _FRAME_DISCONNECTED
     try:
         msg = json.loads(raw)

--- a/src/klangk/klangk/wshandler/sidecar.py
+++ b/src/klangk/klangk/wshandler/sidecar.py
@@ -129,7 +129,7 @@ async def _receive_sidecar_frame(websocket) -> tuple[bool, dict | None]:
     (malformed / non-dict)."""
     try:
         raw = await websocket.receive_text()
-    except (WebSocketDisconnect, RuntimeError):
+    except WebSocketDisconnect, RuntimeError:
         # Starlette raises RuntimeError ("WebSocket is not connected...")
         # on a client disconnect during receive_text(); treat it the same
         # as WebSocketDisconnect.

--- a/src/klangk/klangk/wshandler/window_watcher.py
+++ b/src/klangk/klangk/wshandler/window_watcher.py
@@ -51,7 +51,7 @@ async def _terminate_watcher_proc(proc) -> None:
         pass
     try:
         await asyncio.wait_for(proc.wait(), timeout=3)
-    except (asyncio.TimeoutError, ProcessLookupError):
+    except asyncio.TimeoutError, ProcessLookupError:
         try:
             proc.kill()
         except ProcessLookupError:

--- a/src/klangk/klangkc-tests/tests/test_cli_integration.py
+++ b/src/klangk/klangkc-tests/tests/test_cli_integration.py
@@ -2056,7 +2056,7 @@ class TestSSHAgentRelayLoop:
                 stdout=stdout,
                 ssh_agent_sock="/fake/agent.sock",
             )
-        except (websockets.ConnectionClosed, Exception):
+        except websockets.ConnectionClosed, Exception:
             pass
         finally:
             os.close(read_fd)
@@ -2143,7 +2143,7 @@ class TestSSHAgentRelayLoop:
                 stdout=stdout,
                 ssh_agent_sock=agent_path,
             )
-        except (websockets.ConnectionClosed, Exception):
+        except websockets.ConnectionClosed, Exception:
             pass
         finally:
             os.close(read_fd)
@@ -2159,7 +2159,7 @@ class TestSSHAgentRelayLoop:
                 msg = json.loads(call[0][0])
                 if msg.get("cmd") == "ssh_agent_data":
                     agent_data_msgs.append(msg)
-            except (json.JSONDecodeError, IndexError):
+            except json.JSONDecodeError, IndexError:
                 pass
 
         assert len(agent_data_msgs) == 1
@@ -2216,7 +2216,7 @@ class TestSSHAgentRelayLoop:
                 stdout=stdout,
                 ssh_agent_sock=bad_sock,
             )
-        except (websockets.ConnectionClosed, Exception):
+        except websockets.ConnectionClosed, Exception:
             pass
         finally:
             os.close(read_fd)

--- a/src/klangk/klangkc-tests/tests/test_consent_decide.py
+++ b/src/klangk/klangkc-tests/tests/test_consent_decide.py
@@ -2474,7 +2474,7 @@ class TestRulesScreen:
                 task.cancel()
                 try:
                     await task
-                except (asyncio.CancelledError, Exception):
+                except asyncio.CancelledError, Exception:
                     pass
 
     async def test_refresh_rules_before_mount_is_noop(self):

--- a/src/klangk/klangkc-tests/tests/test_tui.py
+++ b/src/klangk/klangkc-tests/tests/test_tui.py
@@ -3101,7 +3101,7 @@ async def _settle(app):
     while app.workers:
         try:
             await app.workers.wait_for_complete()
-        except (WorkerCancelled, WorkerFailed):
+        except WorkerCancelled, WorkerFailed:
             continue
         break
 
@@ -3125,7 +3125,7 @@ async def _quiesce(app, pilot):
     while True:
         try:
             await app.workers.wait_for_complete()
-        except (WorkerCancelled, WorkerFailed):
+        except WorkerCancelled, WorkerFailed:
             continue
         if not len(app.workers):
             await pilot.pause()

--- a/src/klangk/klangkd-tests/e2e-tests/_controlled_dns.py
+++ b/src/klangk/klangkd-tests/e2e-tests/_controlled_dns.py
@@ -283,7 +283,7 @@ def cleanup_stale_containers() -> list[str]:
             text=True,
             timeout=30,
         )
-    except (FileNotFoundError, subprocess.TimeoutExpired):
+    except FileNotFoundError, subprocess.TimeoutExpired:
         return removed
     for name in res.stdout.split():
         # Match only the fixture's own prefixes (``--filter name=`` is a
@@ -299,7 +299,7 @@ def cleanup_stale_containers() -> list[str]:
                 timeout=30,
             )
             removed.append(name)
-        except (FileNotFoundError, subprocess.TimeoutExpired):
+        except FileNotFoundError, subprocess.TimeoutExpired:
             break
     return removed
 

--- a/src/klangk/klangkd-tests/e2e-tests/_e2e_server.py
+++ b/src/klangk/klangkd-tests/e2e-tests/_e2e_server.py
@@ -229,13 +229,13 @@ def _terminate(proc: Popen) -> None:
     try:
         proc.terminate()
         proc.wait(timeout=5)
-    except (ProcessLookupError, subprocess.TimeoutExpired):
+    except ProcessLookupError, subprocess.TimeoutExpired:
         pass
     if proc.poll() is None:  # SIGTERM ignored / not delivered
         try:
             proc.kill()
             proc.wait(timeout=5)
-        except (ProcessLookupError, subprocess.TimeoutExpired):
+        except ProcessLookupError, subprocess.TimeoutExpired:
             pass
 
 
@@ -302,7 +302,7 @@ def _wait_ready(
                         f"(instance mismatch) — a concurrent E2E run "
                         f"grabbed the drawn port (#3057)"
                     )
-            except (ForeignServerError, EarlyExitError):
+            except ForeignServerError, EarlyExitError:
                 raise
             except Exception as exc:  # not up yet
                 last_exc = exc
@@ -649,7 +649,7 @@ def _abandon_attempt(server: dict[str, Any]) -> None:
     try:
         proc.kill()
         proc.wait(timeout=5)
-    except (ProcessLookupError, subprocess.TimeoutExpired):
+    except ProcessLookupError, subprocess.TimeoutExpired:
         pass
     log_file = getattr(proc, "_log_file", None)
     if log_file is not None:
@@ -680,7 +680,7 @@ def stop_server(server: dict[str, Any]) -> None:
     try:
         proc.kill()
         proc.wait(timeout=5)
-    except (ProcessLookupError, subprocess.TimeoutExpired):
+    except ProcessLookupError, subprocess.TimeoutExpired:
         pass
     # Close the log file when one was opened (file-streamed stdout).
     log_file = getattr(proc, "_log_file", None)

--- a/src/klangk/klangkd-tests/super-e2e/_ws.py
+++ b/src/klangk/klangkd-tests/super-e2e/_ws.py
@@ -52,7 +52,7 @@ async def recv_until(ws, predicate, timeout: float = 60.0) -> list[dict]:
             continue
         try:
             msg = json.loads(raw)
-        except (TypeError, ValueError):
+        except TypeError, ValueError:
             continue
         messages.append(msg)
         if predicate(msg):

--- a/src/klangk/klangkd-tests/super-e2e/test_sighup_reload_e2e.py
+++ b/src/klangk/klangkd-tests/super-e2e/test_sighup_reload_e2e.py
@@ -92,7 +92,7 @@ async def test_sighup_closes_ws_with_1012_and_recovers(appliance, api, auth):
                 raw = await asyncio.wait_for(ws.recv(), timeout=90)
                 try:
                     msg = json.loads(raw)
-                except (TypeError, ValueError):
+                except TypeError, ValueError:
                     continue
                 if msg.get("type") == "server_recycle":
                     phases.append(msg.get("phase"))

--- a/src/klangk/klangkd-tests/tests/test_wshandler.py
+++ b/src/klangk/klangkd-tests/tests/test_wshandler.py
@@ -4694,7 +4694,7 @@ class TestSshAgentForwarder:
                 t.cancel()
                 try:
                     await t
-                except (asyncio.CancelledError, Exception):
+                except asyncio.CancelledError, Exception:
                     pass
 
     async def test_start_creates_proc_and_notifies(self):


### PR DESCRIPTION
## Summary

Applies `ruff format` 0.15.14 (nixpkgs-unstable, Python 3.14 toolchain) across the tree as a single style-only commit, closing #3447. Every changed line is the same PEP 758 rewrite — parenthesized `except (A, B):` becomes `except A, B:` — across 43 files (97 insertions / 97 deletions).

## Why

The `ruff-format` prek hook kept rewriting these exact lines, failing with "files were modified by this hook", and leaving the tree dirty on every run; `git checkout -- .` was undone by the next run (#3447). The toolchain already parses the new form: xenon was rebuilt on python3.14 for it (#3415/#3422). This commit aligns the committed source with ruff's output so the hook passes and the tree stays clean.

## Verification

- Diff audit: zero non-except lines changed; every rewrite keeps the same exception tuple, order, and `as` captures.
- Full Python suite, CI invocation: 8289 passed, 100% branch coverage maintained.
- Commit itself went through the full prek suite clean — `ruff format` had nothing left to rewrite.

## Notes

- `except A, B:` requires a Python 3.14 parser; the backend, sidecar, and scripts all run on the devenv python314 toolchain (the xenon rebuild in #3422 pinned this direction).
- No changelog entry: dev-tooling formatting churn, invisible to operators.

## Backport

The `backport/2.0` autolabel (repo default) is intended: stable/2.0 already pins python314 and carries the PEP-758-aware xenon rebuild, and per the fresh-eyes review the cherry-pick fixes the same dirty-hook problem there.
