### PR TITLE
Backport PRs: run CI without manual workflow approval (#3448)

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -41,6 +41,14 @@ jobs:
       - name: Create backport pull request
         uses: korthout/backport-action@v4
         with:
+          # A PR authored by github-actions[bot] via the default GITHUB_TOKEN
+          # lands its CI in an approval-required state (GitHub's 2026-06-11
+          # bot-PR rule), which stalls the auto-merge loop on a human click.
+          # BACKPORT_TOKEN is a fine-grained PAT (contents + pull-requests,
+          # read/write, this repo only): PRs authored by it trigger workflows
+          # with no approval gate (#3448). The || fallback keeps today's
+          # approval-gated behavior when the secret is unset.
+          token: ${{ secrets.BACKPORT_TOKEN || github.token }}
           target_branches: stable/2.0
           # Match the hand-made backport PR titles (e.g. #3426): the
           # original PR title unchanged; the squash merge appends the


### PR DESCRIPTION
Closes #3448.

## What changed

One input to `korthout/backport-action@v4` in `backport.yml`:

```yaml
token: ${{ secrets.BACKPORT_TOKEN || github.token }}
```

## Why

GitHub's 2026-06-11 rule puts CI on bot-created PRs (`github-actions[bot]` + `GITHUB_TOKEN`) into an approval-required state — seen on #3446. That click stalls the whole #3361 loop: auto-merge waits on required checks, and the checks wait on approval. A PR authored by the `BACKPORT_TOKEN` PAT is an ordinary same-repo PR from a write-access author: CI starts immediately, auto-merge completes the loop with no manual step.

The `|| github.token` fallback keeps today's approval-gated behavior when the secret is unset, so this can merge before the token exists.

## One-time operator step (the actual unlock)

1. Create a fine-grained PAT scoped to this repository: **Contents: read/write**, **Pull requests: read/write**, long expiry (note the renewal date).
2. `gh secret set BACKPORT_TOKEN` and paste it.

## Test plan

- [x] YAML parses; yamllint passed on commit.
- [ ] With the secret set: merge a `backport/2.0`-labeled PR → backport PR's CI starts with no approval banner, PR auto-merges.
- [ ] Without the secret: behavior unchanged (backport PR opens, CI awaits approval).
