### PR TITLE
Backport: fix token input name for korthout/backport-action (#3448)

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -48,7 +48,7 @@ jobs:
           # read/write, this repo only): PRs authored by it trigger workflows
           # with no approval gate (#3448). The || fallback keeps today's
           # approval-gated behavior when the secret is unset.
-          token: ${{ secrets.BACKPORT_TOKEN || github.token }}
+          github_token: ${{ secrets.BACKPORT_TOKEN || github.token }}
           target_branches: stable/2.0
           # Match the hand-made backport PR titles (e.g. #3426): the
           # original PR title unchanged; the squash merge appends the


### PR DESCRIPTION
Follow-up to #3450 (closes #3448 for real).

The run for #3450's own backport (PR #3451) logged:

```
##[warning]Unexpected input(s) 'token', valid inputs are [... 'github_token' ...]
```

`token` is not a korthout/backport-action input — it was silently ignored and the action used the default `github.token`, so #3451 still came out `github-actions[bot]`-authored and approval-gated despite `BACKPORT_TOKEN` being set. The input is `github_token`. One-word rename; the `|| github.token` fallback and everything else from #3450 unchanged.

## Test plan

- [ ] Merge this, then trigger a backport (`/backport 2.0` on a merged PR or the next labeled merge): the backport PR is authored by the PAT account, CI starts with no approval banner, auto-merge completes.
