### PR TITLE
Backport: wire PAT into checkout so pushes can touch workflows (#3448)

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -37,7 +37,16 @@ jobs:
       # The action cherry-picks inside a git checkout and fetches the
       # source PR + target branch itself. Checkout the base branch only —
       # never PR code (pull_request_target runs with a write token).
+      # korthout pushes with the credentials checkout persists, so the PAT
+      # must be wired in HERE and not only into the action's github_token
+      # input: GITHUB_TOKEN (the persisted default) is refused any push
+      # that touches .github/workflows/ — and backports of workflow
+      # changes (this file's own backports included) are exactly that
+      # (#3448). The checkout ref stays the base branch, so the token never
+      # runs PR code.
       - uses: actions/checkout@v7
+        with:
+          token: ${{ secrets.BACKPORT_TOKEN || github.token }}
       - name: Create backport pull request
         uses: korthout/backport-action@v4
         with:


### PR DESCRIPTION
Follow-up to #3450/#3452 (closes #3448 for real).

## Root cause of the remaining failures

korthout/backport-action's `github_token` input only feeds its API calls (PR creation, comments, auto-merge). Its `git push origin` authenticates with whatever credentials `actions/checkout` persisted — the `GITHUB_TOKEN`. GitHub refuses GITHUB_TOKEN any push that touches `.github/workflows/` (it cannot hold the workflows permission), so every backport branch carrying a workflow change — including this file's own backports — failed with:

```
! [remote rejected] backport-3450-to-stable/2.0
(refusing to allow a GitHub App to create or update workflow
 `.github/workflows/backport.yml` without `workflows` permission)
```

The one early success (#3451) pushed a `backport.yml` byte-identical to a version already on a repo ref; pushes carrying novel workflow content are what trip the check. The PAT itself is verified good — it pushed a workflow-file change from a local clone.

## Fix

Hand the PAT to `actions/checkout` (the canonical fix), so the persisted push credentials are the PAT:

```yaml
- uses: actions/checkout@v7
  with:
    token: ${{ secrets.BACKPORT_TOKEN || github.token }}
```

The checkout ref stays the base branch (`pull_request_target` default), so the elevated token never executes PR code. The `|| github.token` fallback preserves today's behavior when the secret is unset.

## Test plan

- [ ] Merge this, then `/backport 2.0` on #3450: branch push succeeds, PR is PAT-authored, CI runs with no approval banner, auto-merge completes.
- [ ] Then `/backport 2.0` on #3452 (cherry-picks cleanly once #3450's backport lands).
