### PR TITLE
Backports sync-only: no CI on stable PRs, immediate self-merge (#3456)

### DIFF
--- a/.github/workflows/auto-close.yml
+++ b/.github/workflows/auto-close.yml
@@ -4,6 +4,7 @@ on:
   issues:
     types: [opened]
   pull_request:
+    branches: [main] # PR CI targets main; backport PRs to stable/2.0 run none (#3456)
     types: [opened]
 
 # Inert unless the repo variable ENABLE_SLOP_POLICY == "true".

--- a/.github/workflows/backend-e2e-tests.yml
+++ b/.github/workflows/backend-e2e-tests.yml
@@ -11,6 +11,7 @@ on:
   push:
     branches: [release/**]
   pull_request:
+    branches: [main] # PR CI targets main; backport PRs to stable/2.0 run none (#3456)
     paths:
       - "src/klangk/**"
       - "src/containers/**"

--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches: [release/**]
   pull_request:
+    branches: [main] # PR CI targets main; backport PRs to stable/2.0 run none (#3456)
     paths-ignore:
       # Docs/meta files can never affect what this workflow tests — a
       # PR changing only these starts no run at all (#2957). "*.md" is

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -48,15 +48,16 @@ jobs:
         with:
           token: ${{ secrets.BACKPORT_TOKEN || github.token }}
       - name: Create backport pull request
+        id: backport
         uses: korthout/backport-action@v4
         with:
           # A PR authored by github-actions[bot] via the default GITHUB_TOKEN
           # lands its CI in an approval-required state (GitHub's 2026-06-11
-          # bot-PR rule), which stalls the auto-merge loop on a human click.
-          # BACKPORT_TOKEN is a fine-grained PAT (contents + pull-requests,
-          # read/write, this repo only): PRs authored by it trigger workflows
-          # with no approval gate (#3448). The || fallback keeps today's
-          # approval-gated behavior when the secret is unset.
+          # bot-PR rule), which stalls the loop on a human click.
+          # BACKPORT_TOKEN is a fine-grained PAT (contents + pull-requests +
+          # workflows, read/write, this repo only): PRs authored by it
+          # trigger workflows with no approval gate (#3448). The ||
+          # fallback keeps that gated behavior when the secret is unset.
           github_token: ${{ secrets.BACKPORT_TOKEN || github.token }}
           target_branches: stable/2.0
           # Match the hand-made backport PR titles (e.g. #3426): the
@@ -68,9 +69,18 @@ jobs:
           # source PR — the backport is never silently missing (#3361
           # acceptance criteria).
           experimental: '{"conflict_resolution": "draft_commit_conflicts"}'
-          # Pre-release window: the backport commit is a cherry-pick of an
-          # already-reviewed main commit, so the PR merges itself (squash)
-          # while BACKPORT_2_0_AUTO_MERGE is set. Remove the variable at
-          # the v2.0.0 freeze to keep backports hand-merged.
-          auto_merge_enabled: ${{ vars.BACKPORT_2_0_AUTO_MERGE == 'true' }}
-          auto_merge_method: squash
+      # Backports are sync-only (#3456): the cherry-pick is content main's
+      # CI already passed, so the backport PR runs no CI of its own (every
+      # pull_request-triggered workflow targets main) and this step merges
+      # it in the same run that created it. --auto lands the merge at once
+      # when nothing is pending and after any straggler checks pass on the
+      # rare stable PR that runs some. A conflicted backport opens a draft;
+      # merging a draft fails loudly and points a human at it.
+      - name: Merge backport pull requests
+        if: steps.backport.outputs.created_pull_numbers != ''
+        env:
+          GH_TOKEN: ${{ secrets.BACKPORT_TOKEN || github.token }}
+        run: |
+          for pr in $(echo "${{ steps.backport.outputs.created_pull_numbers }}" | tr ',' ' '); do
+            gh pr merge "$pr" --squash --auto --delete-branch
+          done

--- a/.github/workflows/cli-e2e-tests.yml
+++ b/.github/workflows/cli-e2e-tests.yml
@@ -11,6 +11,7 @@ on:
   push:
     branches: [release/**]
   pull_request:
+    branches: [main] # PR CI targets main; backport PRs to stable/2.0 run none (#3456)
     paths:
       - "src/klangk/**"
       - "src/containers/workspace/**"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [main]
   pull_request:
+    branches: [main] # PR CI targets main; backport PRs to stable/2.0 run none (#3456)
     paths-ignore:
       # Docs/meta files can never affect what this workflow tests — a
       # PR changing only these starts no run at all (#2957). "*.md" is

--- a/.github/workflows/frontend-e2e-tests.yml
+++ b/.github/workflows/frontend-e2e-tests.yml
@@ -19,6 +19,7 @@ on:
   push:
     branches: [release/**]
   pull_request:
+    branches: [main] # PR CI targets main; backport PRs to stable/2.0 run none (#3456)
     paths:
       - "src/klangk/**"
       - "src/frontend/**"

--- a/.github/workflows/frontend-tests.yml
+++ b/.github/workflows/frontend-tests.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches: [release/**]
   pull_request:
+    branches: [main] # PR CI targets main; backport PRs to stable/2.0 run none (#3456)
     paths-ignore:
       # Docs/meta files can never affect what this workflow tests — a
       # PR changing only these starts no run at all (#2957). "*.md" is

--- a/.github/workflows/fuzz-check.yml
+++ b/.github/workflows/fuzz-check.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches: [release/**]
   pull_request:
+    branches: [main] # PR CI targets main; backport PRs to stable/2.0 run none (#3456)
     paths-ignore:
       # Docs/meta files can never affect what this workflow tests — a
       # PR changing only these starts no run at all (#2957). "*.md" is

--- a/.github/workflows/macos-smoke.yml
+++ b/.github/workflows/macos-smoke.yml
@@ -20,6 +20,7 @@ on:
   push:
     branches: [release/**]
   pull_request:
+    branches: [main] # PR CI targets main; backport PRs to stable/2.0 run none (#3456)
     paths-ignore:
       # Docs/meta files can never affect what this workflow tests — a
       # PR changing only these starts no run at all (#2957). "*.md" is

--- a/.github/workflows/python-deps-audit.yml
+++ b/.github/workflows/python-deps-audit.yml
@@ -19,6 +19,7 @@ on:
     # Weekly, Tuesdays 06:00 UTC (trivy scans Mondays 06:00; fuzz is daily).
     - cron: "0 6 * * 2"
   pull_request:
+    branches: [main] # PR CI targets main; backport PRs to stable/2.0 run none (#3456)
     paths-ignore:
       # Docs/meta files can never affect what this workflow tests — a
       # PR changing only these starts no run at all (#2957). "*.md" is

--- a/.github/workflows/sandbox-e2e-tests.yml
+++ b/.github/workflows/sandbox-e2e-tests.yml
@@ -9,6 +9,7 @@ on:
         options: [stock, nix]
         default: stock
   pull_request:
+    branches: [main] # PR CI targets main; backport PRs to stable/2.0 run none (#3456)
     paths:
       - "sandboxes/**"
       - ".github/workflows/sandbox-e2e-tests.yml"

--- a/.github/workflows/sidecar-tests.yml
+++ b/.github/workflows/sidecar-tests.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches: [release/**]
   pull_request:
+    branches: [main] # PR CI targets main; backport PRs to stable/2.0 run none (#3456)
     paths-ignore:
       # Docs/meta files can never affect what this workflow tests — a
       # PR changing only these starts no run at all (#2957). "*.md" is

--- a/docs/development/stable-branches.md
+++ b/docs/development/stable-branches.md
@@ -19,23 +19,22 @@ backport runs as automation (#3361):
 - Only the `backport/2.0` label and the `/backport` comment select the
   backport; the target is fixed to `stable/2.0` and other labels play
   no part.
-- While `BACKPORT_2_0_AUTO_MERGE` is set to `true`, the backport pull
-  request merges itself (squash) as soon as it applies cleanly — the
-  commit is a cherry-pick of an already-reviewed `main` commit. The
-  backport pull request carries no test runs: it is opened with the
-  workflow's `GITHUB_TOKEN`, and pull requests and pushes caused by
-  that token start no CI workflows. `stable/2.0` carries no required
-  status checks, so nothing gates the merge. At the freeze, drop
-  `BACKPORT_2_0_AUTO_MERGE` and merge backports by hand, or pass the
-  workflow a PAT (its `github_token` input) so its pull requests run
-  CI and required checks on `stable/2.0` can gate the merge.
+- Backports are sync-only (#3456): the backport pull request opens under
+  the workflow's PAT (`BACKPORT_TOKEN`) and merges itself (squash) in
+  the same run — the cherry-pick is content `main`'s CI already
+  passed. Every pull-request-triggered workflow targets `main`, so the
+  backport pull request runs no CI, and `stable/2.0` carries no
+  required status checks — nothing gates the merge and nothing waits.
+  A conflicted cherry-pick opens a draft pull request; the merge step
+  fails loudly on it, a human resolves the conflicts, marks it ready,
+  and merges it by hand.
 - A `/backport` comment on an already-merged pull request runs the same
   flow — the rescue path for a merge that happened without the label.
 
-After v2.0.0 ships, remove both variables (`gh variable delete
-BACKPORT_2_0_DEFAULT`, `gh variable delete BACKPORT_2_0_AUTO_MERGE`).
-Backports become opt-in: apply the `backport/2.0` label before merging,
-or comment `/backport` on the merged pull request afterwards.
+After v2.0.0 ships, remove the variable (`gh variable delete
+BACKPORT_2_0_DEFAULT`). Backports become opt-in: apply the
+`backport/2.0` label before merging, or comment `/backport` on the
+merged pull request afterwards.
 
 ## Hand-fed stable branches
 


### PR DESCRIPTION
Closes #3456.

## What changed

- All 12 pull-request-triggered workflows scope their `pull_request` arm to PRs **targeting `main`**. Push triggers were already scoped away from `stable/2.0` (`release/**`, `main`, tags), so merges to stable now start zero CI. `workflow_dispatch` stays available for stable.
- `backport.yml` drops `auto_merge_enabled` (nothing to wait for) and merges the backport PR in the same run that creates it: `gh pr merge --squash --auto --delete-branch` with the PAT, driven by korthout's `created_pull_numbers` output.
- `docs/development/stable-branches.md` describes the new flow.

## Rationale

Backport PRs are mechanical cherry-picks of commits `main`'s CI already passed — re-running the suites buys no signal and costs runner time plus an auto-merge wait. The e2e suites path-filter away from workflow-only backports, which also stalled auto-merge on required contexts that never report (#3455).

## Behavior

- Merge a `backport/2.0`-labeled PR → backport PR opens and merges itself, no CI, no clicks.
- `/backport 2.0` rescue comment → same.
- Conflicted cherry-pick → draft PR with the conflict committed; the merge step fails loudly on the draft, a human resolves it.
- PRs to `main` run CI exactly as before.

## Post-merge operator steps (I'll run them)

1. Clear `stable/2.0` required checks (protection keeps the no-force-push/no-delete floor).
2. `gh variable delete BACKPORT_2_0_AUTO_MERGE` (inert now).
3. Re-trigger the two outstanding backports (#3450 done via #3455; #3452, #3445 via #3446 close+retrigger) to demo the final flow.
